### PR TITLE
Fix bug where deploying to Now breaks binary files

### DIFF
--- a/packages/app/src/app/store/modules/deployment/actions.js
+++ b/packages/app/src/app/store/modules/deployment/actions.js
@@ -132,9 +132,9 @@ export async function createApiData({ props, state }) {
     const file = contents.files[filePath];
 
     if (!file.dir && filePath !== 'package.json') {
-      const data = await file.async('text'); // eslint-disable-line no-await-in-loop
+      const data = await file.async('base64'); // eslint-disable-line no-await-in-loop
 
-      apiData.files.push({ file: filePath, data });
+      apiData.files.push({ file: filePath, data, encoding: 'base64' });
     }
   }
 


### PR DESCRIPTION
Unfortunately in `createApiData()` (I think) we lose the `module.isBinary` flag, so I ended up sending all files to the Now API with `base64` encoding, which has a bit of overhead for text files.

@CompuIves Is there any easy way to determine if a file is text or binary in `createApiData()`?