### PR TITLE
Fix live syncing issues

### DIFF
--- a/docker/run-docker.sh
+++ b/docker/run-docker.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 yarn
-yarn run start:dev_api
+NODE_OPTIONS=--max_old_space_size=8192 yarn run start:dev_api

--- a/packages/app/src/app/store/modules/editor/sequences.js
+++ b/packages/app/src/app/store/modules/editor/sequences.js
@@ -210,7 +210,7 @@ export const saveCode = [
   ensureOwnedEditable,
   when(state`preferences.settings.experimentVSCode`),
   {
-    true: [changeCode],
+    true: [],
     false: [
       when(state`preferences.settings.prettifyOnSaveEnabled`),
       {

--- a/packages/app/src/app/store/modules/live/actions.js
+++ b/packages/app/src/app/store/modules/live/actions.js
@@ -31,7 +31,7 @@ export function listen({ props, live }) {
 
 export function consumeModuleState({ props }) {
   return {
-    moduleState: camelizeKeys(props.data.module_state),
+    moduleState: props.data.module_state,
   };
 }
 
@@ -363,11 +363,22 @@ export function updateModule({ props, state }) {
   );
 }
 
-export function sendTransform({ ot, props }) {
+export function sendTransform({ ot, props, live }) {
   if (!props.operation) {
     return {};
   }
-  ot.applyClient(props.moduleShortid, props.operation);
+
+  try {
+    ot.applyClient(props.moduleShortid, props.operation);
+  } catch (e) {
+    // Something went wrong, probably a sync mismatch. Request new version
+    console.error(
+      'Something went wrong with applying OT operation',
+      props.moduleShortid,
+      props.operation
+    );
+    live.send('live:module_state', {});
+  }
 
   return {};
 }


### PR DESCRIPTION
There were two big problems with the current live implementation:

1. We camelized keys in module sync, and the keys for shortids. So sometimes the wrong modules got synced back
2. Adding a dependency called changeCode two times, which caused an operation mismatch
3. For applyClient we didn't do an automatic repair, it could even crash the whole editor

This PR fixes those issues


