### PR TITLE
fix(ember): display ember in the client framework

### DIFF
--- a/packages/common/src/templates/ember.ts
+++ b/packages/common/src/templates/ember.ts
@@ -24,7 +24,7 @@ export default new Template(
   'github/mike-north/ember-new-output',
   decorateSelector(() => '#E04E39'),
   {
-    isServer: true,
+    isServer: false,
     showOnHomePage: true,
     main: false,
     netlify: false,


### PR DESCRIPTION
... instead of the server framework

<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- Is it a Bug fix, feature, docs update, ... -->
Bug fix (?)

<!-- You can also link to an open issue here -->
**What is the current behavior?**
Ember is primarily a client web framework thus it would be easy to list it under the client framework for better discoverability

<!-- if this is a feature change -->
**What is the new behavior?**
Display Ember in the client framework section

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->

<!-- Thank you for contributing! -->
