### PR TITLE
Dashboard: make the search less fuzzy

### DIFF
--- a/packages/app/src/app/pages/Dashboard/Content/routes/SearchSandboxes/index.js
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/SearchSandboxes/index.js
@@ -27,6 +27,8 @@ const SearchSandboxes = ({ store }) => (
             (lastSandboxes === null || lastSandboxes !== sandboxes)
           ) {
             searchIndex = new Fuse(sandboxes, {
+              threshold: 0.1,
+              distance: 1000,
               keys: [
                 { name: 'title', weight: 0.5 },
                 { name: 'description', weight: 0.3 },


### PR DESCRIPTION
At the moment, the search algorithm is too fuzzy in my opinion.

First, it give too much importance to the match being at the beginning of the text. This is why I've increased the distance from 100 (default) to 1000.

Then (and more importantly), it accepts matches that are pretty far. For instance, if I search for `"music"` it will match `"MUI icon bug"` or even more surprisingly `"unistore-rsm"` 🤔. This is why I've decreased the threshold from 0.6 (default) to 0.1. I came up picking this number after outputting the score of each match.

Please try it on your dashboard and let me know if those settings sound reasonable.