### PR TITLE
fix(getters): Do not use store.jwt to compute hasLogIn

### DIFF
--- a/packages/app/src/app/store/getters.js
+++ b/packages/app/src/app/store/getters.js
@@ -1,5 +1,3 @@
-import store from 'store/dist/store.modern';
-
 export function isPatron() {
   return Boolean(
     this.user && this.user.subscription && this.user.subscription.since
@@ -11,5 +9,5 @@ export function isLoggedIn() {
 }
 
 export function hasLogIn() {
-  return !!this.jwt || !!store.get('jwt');
+  return !!this.jwt;
 }


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- Is it a Bug fix, feature, docs update, ... -->
**What kind of change does this PR introduce?**

This PR aims to fix two bugs I noticed related to sign out that are described below.

<!-- You can also link to an open issue here -->
**What is the current behavior?**
- When you're on the dashboard and signs out, the dashboard doesn't update;
- When you're on a sandbox page and signs out, the sidebar doesn't update;

I believe the problem it's in how `hasLogIn` is computed, because it uses `store.jwt`, which doesn't get updated in the `signOut` sequence. I'm not sure if removing it from the computation is the proper fix to these problems, but since in [this commit](https://github.com/codesandbox/codesandbox-client/commit/705679b88d6057583587b8ab32539f3062a4a479#diff-fcc68a385e98ecb8fed8d41e68d69c39L14) the logic was changed to add `!!this.jwt` and not only use `!!store.get('jwt')` I thought that maybe it is.

<!-- if this is a feature change -->
**What is the new behavior?**

When you sign out in the situations described above, the UI is updated as expected.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->

<!-- Thank you for contributing! -->
