### PR TITLE
Export sandboxes from dashboard

### DIFF
--- a/packages/app/src/app/pages/Dashboard/Content/SandboxCard/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/SandboxCard/index.tsx
@@ -45,6 +45,7 @@ type Props = {
   ) => void;
   selectedCount: number;
   deleteSandboxes: () => void;
+  exportSandboxes: () => void;
   permanentlyDeleteSandboxes: () => void;
   collectionPath: string; // eslint-disable-line react/no-unused-prop-types
   collectionTeamId: string | undefined;
@@ -217,6 +218,13 @@ class SandboxItem extends React.PureComponent<Props, State> {
             },
             color: theme.red.darken(0.2)(),
           },
+          {
+            title: `Export ${selectedCount} Sandboxes`,
+            action: () => {
+              this.props.exportSandboxes()
+              return true;
+            },
+          },
         ],
       ];
     }
@@ -229,7 +237,7 @@ class SandboxItem extends React.PureComponent<Props, State> {
             if (this.props.collectionTeamId) {
               history.push(
                 `/dashboard/teams/${this.props.collectionTeamId}/sandboxes${
-                  this.props.collectionPath
+                this.props.collectionPath
                 }`
               );
             } else {
@@ -250,31 +258,38 @@ class SandboxItem extends React.PureComponent<Props, State> {
             return true;
           },
         },
+        {
+          title: 'Export Sandbox',
+          action: () => {
+            this.props.exportSandboxes();
+            return true;
+          },
+        },
       ],
       this.props.isPatron &&
-        [
-          this.props.privacy !== 0 && {
-            title: `Make Sandbox Public`,
-            action: () => {
-              this.props.setSandboxesPrivacy(0);
-              return true;
-            },
+      [
+        this.props.privacy !== 0 && {
+          title: `Make Sandbox Public`,
+          action: () => {
+            this.props.setSandboxesPrivacy(0);
+            return true;
           },
-          this.props.privacy !== 1 && {
-            title: `Make Sandbox Unlisted`,
-            action: () => {
-              this.props.setSandboxesPrivacy(1);
-              return true;
-            },
+        },
+        this.props.privacy !== 1 && {
+          title: `Make Sandbox Unlisted`,
+          action: () => {
+            this.props.setSandboxesPrivacy(1);
+            return true;
           },
-          this.props.privacy !== 2 && {
-            title: `Make Sandbox Private`,
-            action: () => {
-              this.props.setSandboxesPrivacy(2);
-              return true;
-            },
+        },
+        this.props.privacy !== 2 && {
+          title: `Make Sandbox Private`,
+          action: () => {
+            this.props.setSandboxesPrivacy(2);
+            return true;
           },
-        ].filter(Boolean),
+        },
+      ].filter(Boolean),
       [
         {
           title: `Rename Sandbox`,
@@ -533,10 +548,10 @@ class SandboxItem extends React.PureComponent<Props, State> {
                           }}
                         </Mutation>
                       ) : (
-                        <SandboxTitle>
-                          {title} {this.getPrivacyIcon()}
-                        </SandboxTitle>
-                      )}
+                          <SandboxTitle>
+                            {title} {this.getPrivacyIcon()}
+                          </SandboxTitle>
+                        )}
                     </div>
                     <SandboxDetails>{details}</SandboxDetails>
                   </div>

--- a/packages/app/src/app/pages/Dashboard/Content/SandboxCard/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/SandboxCard/index.tsx
@@ -211,20 +211,22 @@ class SandboxItem extends React.PureComponent<Props, State> {
         ...items,
         [
           {
-            title: `Move ${selectedCount} Sandboxes To Trash`,
-            action: () => {
-              this.props.deleteSandboxes();
-              return true;
-            },
-            color: theme.red.darken(0.2)(),
-          },
-          {
             title: `Export ${selectedCount} Sandboxes`,
             action: () => {
               this.props.exportSandboxes()
               return true;
             },
           },
+        ],
+        [
+          {
+            title: `Move ${selectedCount} Sandboxes To Trash`,
+            action: () => {
+              this.props.deleteSandboxes();
+              return true;
+            },
+            color: theme.red.darken(0.2)(),
+          }
         ],
       ];
     }

--- a/packages/app/src/app/pages/Dashboard/Content/SandboxGrid/index.js
+++ b/packages/app/src/app/pages/Dashboard/Content/SandboxGrid/index.js
@@ -4,12 +4,15 @@ import { inject, observer } from 'mobx-react';
 import moment from 'moment';
 import { uniq } from 'lodash-es';
 import { basename } from 'path';
+import { camelizeKeys } from 'humps';
 
 import track from '@codesandbox/common/lib/utils/analytics';
+import { protocolAndHost } from '@codesandbox/common/lib/utils/url-generator';
 import Grid from 'react-virtualized/dist/commonjs/Grid';
 import Column from 'react-virtualized/dist/commonjs/Table/Column';
 import Table from 'react-virtualized/dist/commonjs/Table';
 import AutoSizer from 'react-virtualized/dist/commonjs/AutoSizer';
+import downloadZip from 'app/store/providers/Utils/create-zip';
 import 'react-virtualized/styles.css';
 
 import SandboxItem from '../SandboxCard';
@@ -44,6 +47,8 @@ class SandboxGrid extends React.Component<*, State> {
   state = {
     selection: undefined,
   };
+
+  loadedSandboxes = {};
 
   setSandboxesSelected = (ids, { additive = false, range = false } = {}) => {
     const { store, sandboxes, signals } = this.props;
@@ -114,6 +119,39 @@ class SandboxGrid extends React.Component<*, State> {
 
   setSandboxesPrivacy = (privacy: number) => {
     setSandboxesPrivacy(this.props.store.dashboard.selectedSandboxes, privacy);
+  };
+
+  getSandbox = async sandboxId => {
+    if (this.loadedSandboxes[sandboxId]) {
+      return Promise.resolve(this.loadedSandboxes[sandboxId]);
+    }
+
+    return fetch(`${protocolAndHost()}/api/v1/sandboxes/${sandboxId}`, {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${JSON.parse(localStorage.getItem('jwt'))}`,
+      },
+    })
+      .then(x => x.json())
+      .then(x => {
+        const data = camelizeKeys(x.data);
+        this.loadedSandboxes[data.id] = data;
+        return data;
+      });
+  };
+
+  exportSandboxes = async () => {
+    const sandboxIds = uniq(
+      this.props.sandboxes
+        .filter(sandbox => this.selectedSandboxesObject[sandbox.id])
+        .map(s => s.id)
+    );
+    const sandboxes = await Promise.all(
+      sandboxIds.map(s => this.getSandbox(s))
+    );
+    return Promise.all(
+      sandboxes.map(s => downloadZip(s, s.modules, s.directories))
+    );
   };
 
   onMouseDown = (event: MouseEvent) => {
@@ -262,6 +300,7 @@ class SandboxGrid extends React.Component<*, State> {
         deleteSandboxes={this.deleteSandboxes}
         undeleteSandboxes={this.undeleteSandboxes}
         permanentlyDeleteSandboxes={this.permanentlyDeleteSandboxes}
+        exportSandboxes={this.exportSandboxes}
         setSandboxesPrivacy={this.setSandboxesPrivacy}
         page={this.props.page}
         privacy={item.privacy}


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- Is it a Bug fix, feature, docs update, ... -->
**What kind of change does this PR introduce?**
Feature

<!-- You can also link to an open issue here -->
**What is the current behavior?**
#1844

<!-- if this is a feature change -->
**What is the new behavior?**
Allows exporting a single Sandbox and multiple Sandboxes from the dashboard


<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
The getSandbox function is copied from here (with track removed):
https://github.com/codesandbox/codesandbox-client/blob/5f09dec3a59fdec5b4f63c48feed6b050047c0f3/packages/homepage/src/screens/explore/SandboxModal.js#L46

Not sure if this should be duplicated here? 
<!-- Thank you for contributing! -->
