### PR TITLE
Refactor GraphQL Result Param Reassignment

### DIFF
--- a/packages/app/src/app/graphql/client.js
+++ b/packages/app/src/app/graphql/client.js
@@ -24,14 +24,11 @@ const authLink = setContext((_, { headers }) => {
 });
 
 const absintheAfterware = new ApolloLink((operation, forward) =>
-  forward(operation).map(result => {
-    /* eslint-disable no-param-reassign */
-    result.errors = result.payload.errors;
-    result.data = result.payload.data;
-    /* eslint-enable */
-
-    return result;
-  })
+  forward(operation).map(({ payload, ...result }) => ({
+    ...result,
+    errors: payload.errors,
+    data: payload.data
+  }))
 );
 
 const errorHandler = onError(({ graphQLErrors, networkError }) => {


### PR DESCRIPTION
Instead of reassigning values on the result object, which previously required disabling eslint, this refactor uses ES6 object destructuring  and rest/spread to create a new result object.

<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- Is it a Bug fix, feature, docs update, ... -->
**What kind of change does this PR introduce?**

<!-- You can also link to an open issue here -->
**What is the current behavior?**

<!-- if this is a feature change -->
**What is the new behavior?**


<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->

<!-- Thank you for contributing! -->
