### PR TITLE
Fix Like icon alignment in Project Info tab

### DIFF
--- a/packages/app/src/app/pages/common/LikeHeart/index.tsx
+++ b/packages/app/src/app/pages/common/LikeHeart/index.tsx
@@ -13,7 +13,7 @@ import { Sandbox } from '@codesandbox/common/lib/types';
 
 const MaybeTooltip = ({ loggedIn, disableTooltip, title, children }) =>
   loggedIn && !disableTooltip ? (
-    <Tooltip content={title} children={children} />
+    <Tooltip content={title} children={children} style={{ display: 'flex' }} />
   ) : (
     children
   );


### PR DESCRIPTION

**What kind of change does this PR introduce?**
It fixes the alignment of the Like button on the Project Info tab

**What is the current behavior?**

<!-- if this is a feature change -->
![image](https://user-images.githubusercontent.com/2678610/57975199-091e2700-79c5-11e9-91ee-1bada1d1d707.png)


**What is the new behavior?**

<!-- Have you done all of these things?  -->
![image](https://user-images.githubusercontent.com/2678610/57975202-189d7000-79c5-11e9-96f6-5d10d1d5c51b.png)

