### PR TITLE
[Dashboard] Keep sidebar open when search input is focused

### DIFF
--- a/packages/app/src/app/pages/Dashboard/Sidebar/index.js
+++ b/packages/app/src/app/pages/Dashboard/Sidebar/index.js
@@ -18,7 +18,7 @@ import { TEAMS_QUERY } from '../queries';
 
 class Sidebar extends React.Component {
   handleSearchFocus = () => {
-    history.push('/dashboard/search');
+    history.push('/dashboard/search', { from: 'sandboxSearchFocused' });
   };
 
   handleSearchChange = e => {

--- a/packages/app/src/app/pages/Dashboard/index.js
+++ b/packages/app/src/app/pages/Dashboard/index.js
@@ -52,7 +52,11 @@ class Dashboard extends React.Component {
     } = this.props;
     const { showSidebar } = this.state;
 
-    history.listen(() => {
+    history.listen(({ state }) => {
+      if (!!state && state.from === 'sandboxSearchFocused') {
+        return;
+      }
+
       this.onRouteChange();
     });
 


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- Is it a Bug fix, feature, docs update, ... -->

**What kind of change does this PR introduce?**
bufix
<!-- You can also link to an open issue here -->

**What is the current behavior?**
https://monosnap.com/file/O9IAIPM33jyxfAo86DvVzSwtHv4n3R
When user focuses on sandboxes search, it closes the side menu. 

<!-- if this is a feature change -->

**What is the new behavior?**
We're passing history.push state to not close sidemenu when it is redirected from sandbox search input focus. 
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation - "N/A" 
- [ ] Tests - "N/A" 
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->

<!-- Thank you for contributing! -->
