### PR TITLE
Add mobx-react-lite

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -200,6 +200,7 @@
     "memoize-one": "^4.0.0",
     "mobx": "^4.0.0",
     "mobx-react": "^5.2.3",
+    "mobx-react-lite": "^1.3.2",
     "mobx-state-tree": "^3.3.0",
     "moment": "^2.18.1",
     "monaco-editor-textmate": "^2.0.0",

--- a/packages/app/src/app/index.js
+++ b/packages/app/src/app/index.js
@@ -11,6 +11,7 @@ import {
 } from '@codesandbox/common/lib/utils/analytics';
 import '@codesandbox/common/lib/global.css';
 
+import { Signals, Store } from 'app/store';
 import history from 'app/utils/history';
 import { client } from 'app/graphql/client';
 import registerServiceWorker from '@codesandbox/common/lib/registerServiceWorker';
@@ -119,16 +120,21 @@ function boot() {
     });
 
     try {
+      const { signals, store } = controller.provide();
       render(
-        <Provider {...controller.provide()}>
-          <ApolloProvider client={client}>
-            <ThemeProvider theme={theme}>
-              <Router history={history}>
-                <App />
-              </Router>
-            </ThemeProvider>
-          </ApolloProvider>
-        </Provider>,
+        <Signals.Provider value={signals}>
+          <Store.Provider value={store}>
+            <Provider {...{ signals, store }}>
+              <ApolloProvider client={client}>
+                <ThemeProvider theme={theme}>
+                  <Router history={history}>
+                    <App />
+                  </Router>
+                </ThemeProvider>
+              </ApolloProvider>
+            </Provider>
+          </Store.Provider>
+        </Signals.Provider>,
         rootEl
       );
     } catch (e) {

--- a/packages/app/src/app/store/index.js
+++ b/packages/app/src/app/store/index.js
@@ -1,5 +1,6 @@
-import { Module } from 'cerebral';
 import HttpProvider from '@cerebral/http';
+import { Module } from 'cerebral';
+import { createContext, useContext } from 'react';
 
 import model from './model';
 import ApiProvider from './providers/Api';
@@ -38,6 +39,12 @@ import files from './modules/files';
 import live from './modules/live';
 import dashboard from './modules/dashboard';
 import userNotifications from './modules/user-notifications';
+
+export const Signals = createContext();
+export const Store = createContext();
+
+export const useSignals = () => useContext(Signals);
+export const useStore = () => useContext(Store);
 
 export default Module({
   model,

--- a/yarn.lock
+++ b/yarn.lock
@@ -16740,6 +16740,11 @@ mkdirp@0.5.1, mkdirp@0.5.x, mkdirp@0.x.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdir
   dependencies:
     minimist "0.0.8"
 
+mobx-react-lite@^1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/mobx-react-lite/-/mobx-react-lite-1.3.2.tgz#4366048b5d283d12a82053367638b5d79281951f"
+  integrity sha512-D8VZEsxSxMNYDJmw2SgUXVAgpOlVYmp3hBCusoe+LuBDYUqyn2K3RPrMEF0rIzYJAvqpyv7YRrH8I3eBsPPx1A==
+
 mobx-react@^5.2.3:
   version "5.4.3"
   resolved "https://registry.yarnpkg.com/mobx-react/-/mobx-react-5.4.3.tgz#6709b7dd89670c40e9815914ac2ca49cc02bfb47"


### PR DESCRIPTION
**What kind of change does this PR introduce?**
I extracted @Saeris' changes to use `mobx-react-lite` out of #1925, so other PR's (like #1949 & #1951) can already make use of it.

**What is the current behavior?**
It's not possible to use hooks whenever a component is wrapped in an `observer`.

**What is the new behavior?**
It _is_ possible to use hooks whenever a component is wrapped in an `observer`.

**Checklist**:
- [ ] Documentation N/A
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions --> N/A