### PR TITLE
🔨 Refactor ConnectionNotice to use hooks

### DIFF
--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/ConnectionNotice/ConnectionNotice.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/ConnectionNotice/ConnectionNotice.tsx
@@ -1,11 +1,15 @@
+import { observer } from 'mobx-react-lite';
 import React from 'react';
-import { inject, observer } from 'mobx-react';
+
+import { useStore } from 'app/store';
 
 import { Container } from './elements';
 
-function ConnectionNotice({ store }) {
+export const ConnectionNotice = observer(() => {
+  const { connected } = useStore();
+
   return (
-    !store.connected && (
+    !connected && (
       <Container>
         You{"'"}re not connected to the internet. You can still edit, but you
         cannot save. We recommend using the {"'"}Download{"'"} function to keep
@@ -13,6 +17,4 @@ function ConnectionNotice({ store }) {
       </Container>
     )
   );
-}
-
-export default inject('store')(observer(ConnectionNotice));
+});

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/ConnectionNotice/elements.js
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/ConnectionNotice/elements.js
@@ -1,8 +1,0 @@
-import styled from 'styled-components';
-
-export const Container = styled.div`
-  color: ${props => props.theme.red};
-  background-color: ${props => props.theme.redBackground};
-  padding: 1rem;
-  font-size: 0.75rem;
-`;

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/ConnectionNotice/elements.ts
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/ConnectionNotice/elements.ts
@@ -1,0 +1,10 @@
+import styled, { css } from 'styled-components';
+
+export const Container = styled.div`
+  ${({ theme }) => css`
+    color: ${theme.red};
+    background-color: ${theme.redBackground};
+    padding: 1rem;
+    font-size: 0.75rem;
+  `}
+`;

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/ConnectionNotice/index.ts
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/ConnectionNotice/index.ts
@@ -1,0 +1,1 @@
+export { ConnectionNotice } from './ConnectionNotice';


### PR DESCRIPTION
**What kind of change does this PR introduce?**
I've extracted @Saeris' changes to `ConnectionNotice` out of #1925.

> Small example refactor showing how to use Cerebral with React Hooks

**What is the current behavior?**
- Use `mobx-react`
- Use `inject` HOC

**What is the new behavior?**
- Use `mobx-react-lite`
- Use new `useStore ` hook

**Checklist**:
- [ ] Documentation N/A
- [ ] Tests
- [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions --> N/A