### PR TITLE
fix: add vendor prefix for file tab styling

### DIFF
--- a/packages/app/src/app/components/CodeEditor/VSCode/workbench-theme.css
+++ b/packages/app/src/app/components/CodeEditor/VSCode/workbench-theme.css
@@ -19,6 +19,16 @@
   box-sizing: border-box;
 }
 
+.monaco-workbench
+  .part.editor
+  > .content
+  .editor-group-container
+  > .title
+  .tabs-container
+  > .tab.sizing-fit {
+  min-width: -moz-fit-content;
+}
+
 .monaco-font-aliasing-antialiased {
   -webkit-font-smoothing: antialiased;
 }


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- Is it a Bug fix, feature, docs update, ... -->

**What kind of change does this PR introduce?**
Styling issue in firefox

<!-- You can also link to an open issue here -->

**What is the current behavior?**
File tab on editor requires a firefox prefix for `min-width`
![image](https://user-images.githubusercontent.com/22376783/58683542-608fa000-8392-11e9-859b-c7f5c7750cd8.png)

<!-- if this is a feature change -->

**What is the new behavior?**
![image](https://user-images.githubusercontent.com/22376783/58683598-99c81000-8392-11e9-84ee-ecb3e6cf959e.png)


<!-- Have you done all of these things?  -->

**What steps did you take to test this?**
- Checked the developer tools which was saying `invalid property`,  than checked the browser compatibility over [here](https://developer.mozilla.org/en-US/docs/Web/CSS/min-width#Browser_compatibility)
- Tested it over localhost:3000 on both chrome and firefox

<!-- Most important part!  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation - N/A
- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table - N/A <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
Using CodeSandbox for more than a year. Really awesome work guys 💯 

<!-- Thank you for contributing! -->
