### PR TITLE
Remove Svelte extension from html files

### DIFF
--- a/packages/app/config/webpack.common.js
+++ b/packages/app/config/webpack.common.js
@@ -467,12 +467,12 @@ module.exports = {
       [
         {
           from: '../../standalone-packages/vscode-editor/release/min/vs',
-          to: 'public/vscode21/vs',
+          to: 'public/vscode22/vs',
           force: true,
         },
         {
           from: '../../standalone-packages/vscode-extensions/out',
-          to: 'public/vscode-extensions/v7',
+          to: 'public/vscode-extensions/v8',
           force: true,
         },
         {

--- a/packages/app/config/webpack.prod.js
+++ b/packages/app/config/webpack.prod.js
@@ -136,7 +136,7 @@ module.exports = merge(commonConfig, {
           },
         },
         {
-          urlPattern: /\/vscode21/,
+          urlPattern: /\/vscode22/,
           handler: 'cacheFirst',
           options: {
             cache: {

--- a/packages/app/src/app/index.html
+++ b/packages/app/src/app/index.html
@@ -70,9 +70,9 @@
       }
 	</script>
 
-	<link data-name="/public/vscode21/vs/editor/editor.main" rel="preload" as="style" href="/public/vscode21/vs/editor/codesandbox.editor.main.css">
+	<link data-name="/public/vscode22/vs/editor/editor.main" rel="preload" as="style" href="/public/vscode22/vs/editor/codesandbox.editor.main.css">
 	</link>
-	<link rel="preload" as="script" href="/public/vscode21/vs/editor/codesandbox.editor.main.js">
+	<link rel="preload" as="script" href="/public/vscode22/vs/editor/codesandbox.editor.main.js">
 	</link>
 </head>
 

--- a/packages/app/src/app/vscode/constants.ts
+++ b/packages/app/src/app/vscode/constants.ts
@@ -1,3 +1,3 @@
 export const EXTENSIONS_LOCATION = process.env.VSCODE
   ? '/vscode/extensions-bundle'
-  : '/public/vscode-extensions/v7';
+  : '/public/vscode-extensions/v8';

--- a/packages/app/src/app/vscode/metadata.ts
+++ b/packages/app/src/app/vscode/metadata.ts
@@ -1,7 +1,7 @@
 const VSCODE_METADATA = {
   CORE: {
     paths: {
-      src: process.env.VSCODE ? '/vscode/out/vs' : '/public/vscode21/vs',
+      src: process.env.VSCODE ? '/vscode/out/vs' : '/public/vscode22/vs',
       'npm/dev': 'node_modules/monaco-editor-core/dev/vs',
       'npm/min': 'node_modules/monaco-editor-core/min/vs',
       built: '/vscode/out-monaco-editor-core/min/vs',

--- a/standalone-packages/vscode-extensions/out/extensions/jamesbirtles.svelte-vscode-0.7.1/package.json
+++ b/standalone-packages/vscode-extensions/out/extensions/jamesbirtles.svelte-vscode-0.7.1/package.json
@@ -188,7 +188,6 @@
 					"svelte"
 				],
 				"extensions": [
-					".html",
 					".svelte"
 				],
 				"configuration": "./language-configuration.json"


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Remove HTML ownership from svelte vscode extension.

**What is the current behavior?**

The VSCode extension for Svelte overrode html files, which caused linting errors to appear in html files for other templates.

**What is the new behavior?**

Svelte extension doesn't activate for html files.

**What steps did you take to test this?**

Tested /s/vanilla and opened html files, tested autocomplete.
Tested /s/svelte and opened svelte files, tested autocomplete.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->


I had to force a new cache for vscode extensions, and because that path now changed we also need to update the cache of vscode itself.
<!-- feel free to add additional comments -->

<!-- Thank you for contributing! -->
