### PR TITLE
Make getMode return undefined as default instead of 'typescript'

### DIFF
--- a/packages/app/src/app/components/CodeEditor/CodeMirror/index.js
+++ b/packages/app/src/app/components/CodeEditor/CodeMirror/index.js
@@ -319,7 +319,7 @@ class CodemirrorEditor extends React.Component<Props, State> implements Editor {
     const currentModule = this.currentModule;
 
     if (!documentCache[currentModule.id]) {
-      const mode = await this.getMode(currentModule.title);
+      const mode = (await this.getMode(currentModule.title)) || 'typescript';
 
       documentCache[currentModule.id] = new CodeMirror.Doc(
         currentModule.code || '',
@@ -421,7 +421,7 @@ class CodemirrorEditor extends React.Component<Props, State> implements Editor {
       CodeMirror.commands.save = this.handleSaveCode;
     }
 
-    const mode = await this.getMode(title);
+    const mode = (await this.getMode(title)) || 'typescript';
 
     documentCache[id] = new CodeMirror.Doc(code || '', mode);
 
@@ -452,7 +452,7 @@ class CodemirrorEditor extends React.Component<Props, State> implements Editor {
 
   configureEmmet = async () => {
     const { title } = this.currentModule;
-    const mode = await this.getMode(title);
+    const mode = (await this.getMode(title)) || 'typescript';
 
     const newMode = mode === 'htmlmixed' ? 'html' : mode;
     const addon = newMode === 'jsx' ? { jsx: true } : null;

--- a/packages/app/src/app/components/CodeEditor/Monaco/index.js
+++ b/packages/app/src/app/components/CodeEditor/Monaco/index.js
@@ -33,7 +33,7 @@ import defineTheme from './define-theme';
 import getSettings from './settings';
 
 import type { Props, Editor } from '../types';
-import getMode from './mode';
+import getMode from './mode.ts';
 import { liftOff } from './grammars/configure-tokenizer';
 import {
   lineAndColumnToIndex,
@@ -1023,7 +1023,7 @@ class MonacoEditor extends React.Component<Props, State> implements Editor {
   }
 
   lint = async (code: string, title: string, version: number) => {
-    const mode = await getMode(title, this.monaco);
+    const mode = (await getMode(title, this.monaco)) || 'typescript';
     if (this.settings.lintEnabled) {
       if (mode === 'javascript' || mode === 'vue') {
         if (this.lintWorker) {
@@ -1219,7 +1219,8 @@ class MonacoEditor extends React.Component<Props, State> implements Editor {
           // Related issue: https://github.com/Microsoft/monaco-editor/issues/461
           const lib = this.addLib(module.code || '', path);
 
-          const mode = await getMode(module.title, this.monaco);
+          const mode =
+            (await getMode(module.title, this.monaco)) || 'typescript';
 
           if (
             mode !== 'javascript' &&

--- a/packages/app/src/app/components/CodeEditor/Monaco/index.js
+++ b/packages/app/src/app/components/CodeEditor/Monaco/index.js
@@ -33,7 +33,7 @@ import defineTheme from './define-theme';
 import getSettings from './settings';
 
 import type { Props, Editor } from '../types';
-import getMode from './mode.ts';
+import getMode from './mode';
 import { liftOff } from './grammars/configure-tokenizer';
 import {
   lineAndColumnToIndex,

--- a/packages/app/src/app/components/CodeEditor/Monaco/mode.ts
+++ b/packages/app/src/app/components/CodeEditor/Monaco/mode.ts
@@ -1,5 +1,5 @@
 const requireAMDModule = paths =>
-  new Promise(resolve => window.require(paths, () => resolve()));
+  new Promise(resolve => (window as any).require(paths, () => resolve()));
 
 export default async (title: string, monaco) => {
   if (title == null) return 'javascript';

--- a/packages/app/src/app/components/CodeEditor/Monaco/mode.ts
+++ b/packages/app/src/app/components/CodeEditor/Monaco/mode.ts
@@ -11,6 +11,7 @@ export default async (title: string, monaco) => {
     if (kind[1] === 'scss') return 'scss';
     if (kind[1] === 'json') return 'json';
     if (kind[1] === 'html') return 'html';
+    if (kind[1] === 'svelte') return 'html';
     if (kind[1] === 'vue') {
       if (
         monaco.languages.getLanguages &&
@@ -26,5 +27,5 @@ export default async (title: string, monaco) => {
     if (/tsx?$/.test(kind[1])) return 'typescript';
   }
 
-  return 'typescript';
+  return undefined;
 };

--- a/packages/app/src/app/components/CodeEditor/MonacoDiff/index.js
+++ b/packages/app/src/app/components/CodeEditor/MonacoDiff/index.js
@@ -59,7 +59,7 @@ export default class MonacoDiff extends React.Component<Props>
     modifiedCode: string,
     title: string
   ) => {
-    const mode = await getMode(title, this.monaco);
+    const mode = (await getMode(title, this.monaco)) || 'typescript';
     const originalModel = this.monaco.editor.createModel(originalCode, mode);
     const modifiedModel = this.monaco.editor.createModel(modifiedCode, mode);
 


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- Is it a Bug fix, feature, docs update, ... -->

**What kind of change does this PR introduce?**

Instead of returning `typescript` from `getMode` we return `undefined`, this makes it possible for the caller to set a default if `undefined` is returned.

**What is the current behavior?**

We return `typescript` as default value for `getMode`, this causes our new linter (which supports `.ts`) to lint `package.json` and `.html` files etc. 

**What is the new behavior?**

We return `undefined` in `getMode` if the mode is unknown, and change the existing calls to default to `typescript` to not break any existing behaviour.

**What steps did you take to test this?**

- Tested if linting stopped happening in `package.json`
- Tested if linting happens in JavaScript/TypeScript
- Tested if syntax highlighting worked in CodeMirror editor (since CodeMirror uses `mode` to determine syntax and autocomplete)


**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->

<!-- Thank you for contributing! -->
