### PR TITLE
fix filter options in deleted sandboxes

### DIFF
--- a/packages/app/src/app/pages/Dashboard/Content/Sandboxes/Filters/FilterOptions/index.js
+++ b/packages/app/src/app/pages/Dashboard/Content/Sandboxes/Filters/FilterOptions/index.js
@@ -24,54 +24,60 @@ const FilterOptions = ({ possibleTemplates, hideFilters, store, signals }) => {
 
   const Overlay = () => (
     <OverlayContainer>
-      {orderBy(
-        Object.keys(templates)
-          .filter(x => x !== 'default')
-          .map(name => templates[name])
-          .filter(
-            x =>
-              possibleTemplates.length === 0 ||
-              possibleTemplates.indexOf(x.name) > -1
-          ),
-        'niceName'
-      ).map(template => {
-        const selected = store.dashboard.isTemplateSelected(template.name);
+      {possibleTemplates.length > 0 ? (
+        <React.Fragment>
+          {orderBy(
+            Object.keys(templates)
+              .filter(x => x !== 'default')
+              .map(name => templates[name])
+              .filter(
+                x =>
+                  possibleTemplates.length === 0 ||
+                  possibleTemplates.indexOf(x.name) > -1
+              ),
+            'niceName'
+          ).map(template => {
+            const selected = store.dashboard.isTemplateSelected(template.name);
 
-        return (
+            return (
+              <Option
+                toggleTemplate={toggleTemplate}
+                selected={selected}
+                key={template.name}
+                color={template.color}
+                name={template.name}
+                niceName={template.niceName}
+              />
+            );
+          })}
+
           <Option
-            toggleTemplate={toggleTemplate}
-            selected={selected}
-            key={template.name}
-            color={template.color}
-            name={template.name}
-            niceName={template.niceName}
+            toggleTemplate={() => {
+              if (!allSelected) {
+                signals.dashboard.blacklistedTemplatesCleared();
+              } else {
+                signals.dashboard.blacklistedTemplatesChanged({
+                  templates: possibleTemplates || [],
+                });
+              }
+            }}
+            selected={allSelected}
+            color="#374140"
+            name="all"
+            style={{ marginTop: '1rem' }}
+            niceName="Select All"
           />
-        );
-      })}
-
-      <Option
-        toggleTemplate={() => {
-          if (!allSelected) {
-            signals.dashboard.blacklistedTemplatesCleared();
-          } else {
-            signals.dashboard.blacklistedTemplatesChanged({
-              templates: possibleTemplates || [],
-            });
-          }
-        }}
-        selected={allSelected}
-        color="#374140"
-        name="all"
-        style={{ marginTop: '1rem' }}
-        niceName="Select All"
-      />
+        </React.Fragment>
+      ) : (
+        'No templates found'
+      )}
     </OverlayContainer>
   );
 
   const { blacklistedTemplates } = store.dashboard.filters;
   const templateCount = possibleTemplates.length - blacklistedTemplates.length;
   const templateMessage =
-    templateCount === possibleTemplates.length
+    templateCount === possibleTemplates.length && templateCount > 0
       ? 'all templates'
       : `${Math.max(0, templateCount)} ${
           templateCount === 1 ? 'template' : 'templates'


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

Looks like a bug, but I am not sure if this was intentional 

**What kind of change does this PR introduce?**
Updating Filter option message when there are no deleted sandboxes

<!-- You can also link to an open issue here -->

**What is the current behavior?**
We currently see all the templates even when we don't have a deleted sandbox and when we deselect a template it shows message `Showing 0 templates` and in `OverlayContainer`, select all option is always checked. 
![image](https://user-images.githubusercontent.com/22376783/58759230-4e556380-8544-11e9-8169-c22ce6d89073.png)


<!-- if this is a feature change -->

**What is the new behavior?**
Now if we don't have sandboxes it shows `Showing 0 templates` with message `No templates found`.Check the below gif :
![CSB](https://user-images.githubusercontent.com/22376783/58759036-8d35ea00-8541-11e9-816a-575e74f0d4ff.gif)


<!-- Have you done all of these things?  -->

**What steps did you take to test this?**

<!-- Most important part!  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation - N/A
- [x] Testing - Have added a gif to show the working <!-- We can only merge the PR if this is checked -->
- [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table  - Already Contributor for Code<!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->

<!-- Thank you for contributing! -->
