### PR TITLE
Fix dynamic downloading of babel dependencies

### DIFF
--- a/packages/app/src/sandbox/compile.ts
+++ b/packages/app/src/sandbox/compile.ts
@@ -1,4 +1,5 @@
 import { dispatch, reattach, clearErrorTransformers } from 'codesandbox-api';
+import { flatten } from 'lodash';
 import { absolute } from '@codesandbox/common/lib/utils/path';
 import _debug from '@codesandbox/common/lib/utils/debug';
 import parseConfigurations from '@codesandbox/common/lib/templates/configuration/parse';
@@ -195,7 +196,6 @@ const PREINSTALLED_DEPENDENCIES = [
   'babel-plugin-detective',
   'babel-plugin-transform-prevent-infinite-loops',
   'babel-plugin-transform-vue-jsx',
-  'babel-plugin-jsx-pragmatic',
   'flow-bin',
   ...BABEL_DEPENDENCIES,
 ];
@@ -213,7 +213,7 @@ function getDependencies(parsedPackage, templateDefinition, configurations) {
 
   // Add all babel plugins/presets to whitelisted dependencies
   if (configurations && configurations.babel && configurations.babel.parsed) {
-    (configurations.babel.parsed.presets || [])
+    flatten(configurations.babel.parsed.presets || [])
       .filter(p => typeof p === 'string')
       .forEach(p => {
         const [first, ...parts] = p.split('/');
@@ -225,7 +225,7 @@ function getDependencies(parsedPackage, templateDefinition, configurations) {
         foundWhitelistedDevDependencies.push(prefixedName);
       });
 
-    (configurations.babel.parsed.plugins || [])
+    flatten(configurations.babel.parsed.plugins || [])
       .filter(p => typeof p === 'string')
       .forEach(p => {
         const [first, ...parts] = p.split('/');

--- a/packages/app/src/sandbox/eval/transpilers/babel/worker/evaluate.js
+++ b/packages/app/src/sandbox/eval/transpilers/babel/worker/evaluate.js
@@ -64,7 +64,7 @@ export default function evaluate(
       availablePlugins[requirePath.replace('babel-plugin-', '')] ||
       availablePlugins[requirePath.replace('@babel/plugin-', '')];
     if (plugin && requirePath !== 'react') {
-      return plugin;
+      return plugin.__esModule ? plugin.default : plugin;
     }
 
     const preset =
@@ -72,7 +72,7 @@ export default function evaluate(
       availablePresets[requirePath.replace('babel-preset-', '')] ||
       availablePresets[requirePath.replace('@babel/preset-', '')];
     if (preset && requirePath !== 'react') {
-      return preset;
+      return preset.__esModule ? preset.default : preset;
     }
 
     const dirName = dirname(path);


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- Is it a Bug fix, feature, docs update, ... -->

**What kind of change does this PR introduce?**

Bug fix for sandboxes that use babel plugins from the `devDependencies`. Test case: https://codesandbox.io/s/hyperapp-playground-utmms.

The problem here was that we:

1. Didn't detect which devDependencies we need to download. We normally only download dependencies and download devDependencies that we see fit, this check didn't work for babel since it didn't flatten the config and wasn't able to find babel plugins defined in arrays.
2. Didn't convert the existing babel plugins from esModules to commonjs when running it in the babel-worker.

<!-- You can also link to an open issue here -->

**What is the current behavior?**

It will show a "Module Not Found".

<!-- if this is a feature change -->

**What is the new behavior?**

We download the babel dependency and resolve it from the babel-worker.

<!-- Have you done all of these things?  -->

**What steps did you take to test this?**

Ran the given sandbox

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->

<!-- Thank you for contributing! -->
