### PR TITLE
Add a check to make sure that versions are strings in version UI

### DIFF
--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/Dependencies/VersionEntry/index.js
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/Dependencies/VersionEntry/index.js
@@ -126,6 +126,10 @@ export default class VersionEntry extends React.PureComponent {
   render() {
     const { dependencies, dependency } = this.props;
 
+    if (typeof dependencies[dependency] !== 'string') {
+      return null;
+    }
+
     const { hovering, version, size, open, versions } = this.state;
     return (
       <Fragment>


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- Is it a Bug fix, feature, docs update, ... -->

Bug fix, fixes #1908

**What kind of change does this PR introduce?**

We check if a version is a string, if it's not a string we don't render the dependency in the dependency overview.

<!-- You can also link to an open issue here -->

**What is the current behavior?**

There is no check for a string, which causes React to error since we try to render an object.

<!-- if this is a feature change -->

**What is the new behavior?**

No crashing editor on object for version :)

<!-- Have you done all of these things?  -->

**What steps did you take to test this?**

Loaded https://codesandbox.io/s/88zo93kxz0

<!-- Most important part!  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->

<!-- Thank you for contributing! -->
