### PR TITLE
fix(share): Text generation when sharing on Twitter

### DIFF
--- a/packages/app/src/app/pages/common/Modals/ShareModal/index.js
+++ b/packages/app/src/app/pages/common/Modals/ShareModal/index.js
@@ -317,8 +317,12 @@ class ShareView extends React.Component {
                     small
                     target="_blank"
                     href={`https://twitter.com/intent/tweet?text=${encodeURIComponent(
-                      sandbox.title || sandbox.id
-                    )}.+${getEditorUrl(sandbox, mainModule, this.state)}`}
+                      `${sandbox.title || sandbox.id}. ${getEditorUrl(
+                        sandbox,
+                        mainModule,
+                        this.state
+                      )}`
+                    )}`}
                   >
                     Share on Twitter
                   </Button>


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?
Bug fix.
<!-- Is it a Bug fix, feature, docs update, ... -->

## What is the current behavior?
When sharing on Twitter, if the `text` query string contains `&` characters, they will be interpreted as another parameter to the `intent/tweet` URL.
<!-- You can also link to an open issue here -->

## What is the new behavior?
The link created works as expected.
<!-- if this is a feature change -->

## What steps did you take to test this?
Current URL: https://twitter.com/intent/tweet?text=7kj86.+https://codesandbox.io/s/purple-worker-7kj86?autoresize=1&fontsize=14&hidenavigation=1

New URL: https://twitter.com/intent/tweet?text=7kj86.%2Bhttps%3A%2F%2Fcodesandbox.io%2Fs%2Fpurple-worker-7kj86%3Fautoresize%3D1%26fontsize%3D14%26hidenavigation%3D1
<!-- Most important part!  -->

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
