### PR TITLE
fix(dashboard): Properly highlight the trash menu when the route is active

### DIFF
--- a/packages/app/src/app/pages/Dashboard/Sidebar/TrashItem/index.js
+++ b/packages/app/src/app/pages/Dashboard/Sidebar/TrashItem/index.js
@@ -7,11 +7,12 @@ import { inject, observer } from 'mobx-react';
 
 import Item from '../Item';
 
-const TrashItem = ({ isOver, canDrop, connectDropTarget }) =>
+const TrashItem = ({ currentPath, isOver, canDrop, connectDropTarget }) =>
   connectDropTarget(
     <div>
       <Item
-        path={'/dashboard/trash'}
+        active={currentPath === '/dashboard/trash'}
+        path="/dashboard/trash"
         Icon={TrashIcon}
         name="Trash"
         style={

--- a/packages/app/src/app/pages/Dashboard/Sidebar/index.js
+++ b/packages/app/src/app/pages/Dashboard/Sidebar/index.js
@@ -69,7 +69,7 @@ class Sidebar extends React.Component {
                     currentTeamId={currentTeamId}
                     openByDefault
                   />
-                  <TrashItem />
+                  <TrashItem currentPath={path} />
                 </Items>
 
                 <Query query={TEAMS_QUERY}>


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?
Bug fix.
<!-- Is it a Bug fix, feature, docs update, ... -->

## What is the current behavior?
When you are in a dashboard route that's not `dashboard/trash` (e.g `dashboard/recent`) and switch to the trash route, the menu doesn't update properly because the `TrashItem` component doesn't rerender.

And if you start in the `dashboard/trash` route and switch to another menu, the menu stays highlighted for the same reason above.
<!-- You can also link to an open issue here -->

## What is the new behavior?
The menu updates properly in both cases described.

Note: Only passing down the `currentPath` prop would solve the problem, but I decided to add the `active` computation to prevent someone from thinking that the prop is useless and remove it, bringing back the bug.
<!-- if this is a feature change -->

## What steps did you take to test this?
Follow the use cases described in the current behaviour section.
<!-- Most important part!  -->

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Testing <!-- We can only merge the PR if this is checked -->
- [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
