### PR TITLE
Add tooltip for Notifications button

### DIFF
--- a/packages/app/src/app/pages/common/Navigation/index.js
+++ b/packages/app/src/app/pages/common/Navigation/index.js
@@ -94,10 +94,12 @@ function Navigation({ signals, store, title, searchNoInput }) {
                   style={{ placement: 'relative', fontSize: '1.25rem' }}
                   onClick={open}
                 >
-                  <BellIcon height={35} />
-                  {store.userNotifications.unreadCount > 0 && (
-                    <UnreadIcon count={store.userNotifications.unreadCount} />
-                  )}
+                  <Tooltip placement="bottom" content="Show Notifications">
+                    <BellIcon height={35} />
+                    {store.userNotifications.unreadCount > 0 && (
+                      <UnreadIcon count={store.userNotifications.unreadCount} />
+                    )}
+                  </Tooltip>
                 </Action>
               )}
             </OverlayComponent>

--- a/packages/app/src/app/pages/common/Navigation/index.js
+++ b/packages/app/src/app/pages/common/Navigation/index.js
@@ -94,7 +94,7 @@ function Navigation({ signals, store, title, searchNoInput }) {
                   style={{ placement: 'relative', fontSize: '1.25rem' }}
                   onClick={open}
                 >
-                  <Tooltip placement="bottom" content="Show Notifications">
+                  <Tooltip placement="bottom" content={store.userNotifications.unreadCount > 0 ? 'Show Notifications' : 'No Notifications'}>
                     <BellIcon height={35} />
                     {store.userNotifications.unreadCount > 0 && (
                       <UnreadIcon count={store.userNotifications.unreadCount} />


### PR DESCRIPTION
## What kind of change does this PR introduce?
Fixes #2047 

## What is the current behavior?
Just like the "Explore Sandboxes" and "New Sandbox" buttons, there should also be a tooltip for the notifications button.

## What is the new behavior?
Show Notifications button has a tooltip

## What steps did you take to test this?
Run locally.

## Checklist
- [ ] Documentation - NA
- [x] Testing
- [x] Ready to be merged
- [ ] Added myself to contributors table - NA
