### PR TITLE
fix: Navbar and Explore Modal overlap

### DIFF
--- a/packages/homepage/src/components/layout.js
+++ b/packages/homepage/src/components/layout.js
@@ -11,7 +11,7 @@ import '../css/global.css';
 const TemplateWrapper = ({ children }) => (
   <ThemeProvider theme={theme}>
     <div>
-      <div style={{ position: 'absolute', left: 0, right: 0, zIndex: 20 }}>
+      <div style={{ position: 'absolute', left: 0, right: 0, zIndex: 10 }}>
         <Navigation />
       </div>
 


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?
CSS Fix
<!-- Is it a Bug fix, feature, docs update, ... -->

## What is the current behavior?
![image](https://user-images.githubusercontent.com/22376783/59286368-380a7e80-8c8d-11e9-9152-22c505ad2b2e.png)

<!-- You can also link to an open issue here -->

## What is the new behavior?
![image](https://user-images.githubusercontent.com/22376783/59286388-43f64080-8c8d-11e9-825e-7f69090416ad.png)


<!-- if this is a feature change -->

## What steps did you take to test this?
Explore Modal does not open locally it gives the error of accessing from undefined. And I don't see any data on explore page. 
So I first tested it on live site using developer tools as in the above screenshot and did the required changes locally. 

<!-- Most important part!  -->

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation - N/A
- [x] Testing <!-- We can only merge the PR if this is checked -->
- [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table - Already a contributor<!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
