### PR TITLE
Use official babel-eslint dependency instead of own fork

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   "devDependencies": {
     "@types/react": "^16.8.12",
     "all-contributors-cli": "^5.4.0",
-    "babel-eslint": "codesandbox/babel-eslint#v10.0.2",
+    "babel-eslint": "^10.0.2",
     "concurrently": "^4.1.0",
     "eslint": "5.16.0",
     "eslint-config-airbnb": "^15.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4289,10 +4289,10 @@ babel-core@^6.0.0, babel-core@^6.24.1, babel-core@^6.26.0, babel-core@^6.26.3:
     slash "^1.0.0"
     source-map "^0.5.7"
 
-babel-eslint@^9.0.0:
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-9.0.0.tgz#7d9445f81ed9f60aff38115f838970df9f2b6220"
-  integrity sha512-itv1MwE3TMbY0QtNfeL7wzak1mV47Uy+n6HtSOO4Xd7rvmO+tsGQSgyOEEgo6Y2vHZKZphaoelNeSVj4vkLA1g==
+babel-eslint@^10.0.2:
+  version "10.0.2"
+  resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-10.0.2.tgz#182d5ac204579ff0881684b040560fdcc1558456"
+  integrity sha512-UdsurWPtgiPgpJ06ryUnuaSXC2s0WoSZnQmEpbAH65XZSdwowgN5MvyP7e88nW07FYXv72erVtpBkxyDVKhH1Q==
   dependencies:
     "@babel/code-frame" "^7.0.0"
     "@babel/parser" "^7.0.0"
@@ -4301,9 +4301,10 @@ babel-eslint@^9.0.0:
     eslint-scope "3.7.1"
     eslint-visitor-keys "^1.0.0"
 
-babel-eslint@codesandbox/babel-eslint#v10.0.2:
-  version "10.0.2"
-  resolved "https://codeload.github.com/codesandbox/babel-eslint/tar.gz/59308eb977bcd1a4cf1c98d29b019ca3a6546267"
+babel-eslint@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-9.0.0.tgz#7d9445f81ed9f60aff38115f838970df9f2b6220"
+  integrity sha512-itv1MwE3TMbY0QtNfeL7wzak1mV47Uy+n6HtSOO4Xd7rvmO+tsGQSgyOEEgo6Y2vHZKZphaoelNeSVj4vkLA1g==
   dependencies:
     "@babel/code-frame" "^7.0.0"
     "@babel/parser" "^7.0.0"


### PR DESCRIPTION
babel/babel-eslint#772 is fixed by babel/babel-eslint#773, so we can use the official `babel-eslint` dependency again instead of [our own fork](https://github.com/codesandbox/babel-eslint).

The fork can be deleted too now.