### PR TITLE
client test performance improvement, reduce screen freezing

### DIFF
--- a/packages/app/src/app/components/Preview/DevTools/Tests/index.tsx
+++ b/packages/app/src/app/components/Preview/DevTools/Tests/index.tsx
@@ -4,6 +4,7 @@ import { actions, dispatch, listen } from 'codesandbox-api';
 import SplitPane from 'react-split-pane';
 
 import immer from 'immer';
+import { debounce } from 'lodash-es';
 
 import { Container, TestDetails, TestContainer } from './elements';
 
@@ -68,6 +69,7 @@ type State = {
 
 type SandboxMessage = { type: 'test' | 'done' } & (
   | InitializedTestsMessage
+  | CompilationDoneMessage
   | TestCountMessage
   | TotalTestStartMessage
   | TotalTestEndMessage
@@ -84,46 +86,50 @@ interface InitializedTestsMessage {
   event: messages.INITIALIZE;
 }
 
+interface CompilationDoneMessage {
+  compilatonError: boolean;
+}
+
 interface TestCountMessage {
   event: 'test_count';
   count: number;
 }
 
 interface TotalTestStartMessage {
-  event: 'total_test_start';
+  event: messages.TOTAL_TEST_START;
 }
 
 interface TotalTestEndMessage {
-  event: 'total_test_end';
+  event: messages.TOTAL_TEST_END;
 }
 
 interface AddFileMessage {
-  event: 'add_file';
+  event: messages.ADD_FILE;
   path: string;
 }
 
 interface RemoveFileMessage {
-  event: 'remove_file';
+  event: messages.REMOVE_FILE;
   path: string;
 }
 
 interface FileErrorMessage {
-  event: 'file_error';
+  event: messages.FILE_ERROR;
   path: string;
   error: TestError;
 }
 
 interface DescribeStartMessage {
-  event: 'describe_start';
+  event: messages.DESCRIBE_START;
   blockName: string;
 }
 
 interface DescribeEndMessage {
-  event: 'describe_end';
+  event: messages.DESCRIBE_END;
 }
 
 interface AddTestMessage {
-  event: 'add_test';
+  event: messages.ADD_TEST;
   testName: string;
   path: string;
 }
@@ -135,12 +141,12 @@ type TestMessage = Test & {
 };
 
 interface TestStartMessage {
-  event: 'test_start';
+  event: messages.TEST_START;
   test: TestMessage;
 }
 
 interface TestEndMessage {
-  event: 'test_end';
+  event: messages.TEST_END;
   test: TestMessage;
 }
 
@@ -201,7 +207,19 @@ class Tests extends React.Component<DevToolProps, State> {
 
   handleMessage = (data: SandboxMessage) => {
     if (data.type === 'done' && this.state.watching && !this.props.hidden) {
-      this.runAllTests();
+      let delay = 1000;
+
+      if (data.compilatonError) {
+        delay = 2 * delay;
+      }
+
+      debounce(
+        () => {
+          this.runAllTests();
+        },
+        delay,
+        { maxWait: 4 * delay }
+      )();
     } else if (data.type === 'test') {
       switch (data.event) {
         case messages.INITIALIZE: {
@@ -220,7 +238,7 @@ class Tests extends React.Component<DevToolProps, State> {
           }
           break;
         }
-        case 'total_test_start': {
+        case messages.TOTAL_TEST_START: {
           this.currentDescribeBlocks = [];
           if (this.props.updateStatus) {
             this.props.updateStatus('clear');
@@ -231,7 +249,7 @@ class Tests extends React.Component<DevToolProps, State> {
           });
           break;
         }
-        case 'total_test_end': {
+        case messages.TOTAL_TEST_END: {
           this.setState({
             ...this.state,
             running: false,
@@ -259,7 +277,7 @@ class Tests extends React.Component<DevToolProps, State> {
           break;
         }
 
-        case 'add_file': {
+        case messages.ADD_FILE: {
           this.setState(
             immer(this.state, state => {
               state.files[data.path] = {
@@ -272,7 +290,7 @@ class Tests extends React.Component<DevToolProps, State> {
           );
           break;
         }
-        case 'remove_file': {
+        case messages.REMOVE_FILE: {
           this.setState(
             immer(this.state, state => {
               if (state.files[data.path]) {
@@ -284,7 +302,7 @@ class Tests extends React.Component<DevToolProps, State> {
           );
           break;
         }
-        case 'file_error': {
+        case messages.FILE_ERROR: {
           this.setState(
             immer(this.state, state => {
               if (state.files[data.path]) {
@@ -294,15 +312,15 @@ class Tests extends React.Component<DevToolProps, State> {
           );
           break;
         }
-        case 'describe_start': {
+        case messages.DESCRIBE_START: {
           this.currentDescribeBlocks.push(data.blockName);
           break;
         }
-        case 'describe_end': {
+        case messages.DESCRIBE_END: {
           this.currentDescribeBlocks.pop();
           break;
         }
-        case 'add_test': {
+        case messages.ADD_TEST: {
           const testName = [...this.currentDescribeBlocks, data.testName];
 
           this.setState(
@@ -326,7 +344,7 @@ class Tests extends React.Component<DevToolProps, State> {
           );
           break;
         }
-        case 'test_start': {
+        case messages.TEST_START: {
           const test = data.test;
           const testName = [...test.blocks, test.name];
 
@@ -356,7 +374,7 @@ class Tests extends React.Component<DevToolProps, State> {
           );
           break;
         }
-        case 'test_end': {
+        case messages.TEST_END: {
           const test = data.test;
           const testName = [...test.blocks, test.name];
 

--- a/packages/app/src/app/components/Preview/DevTools/Tests/index.tsx
+++ b/packages/app/src/app/components/Preview/DevTools/Tests/index.tsx
@@ -213,6 +213,8 @@ class Tests extends React.Component<DevToolProps, State> {
         delay = 2 * delay;
       }
 
+      // avoid to often test run in file watching mode,
+      // very frequent test runs cause screen freezing
       debounce(
         () => {
           this.runAllTests();

--- a/packages/app/src/sandbox/compile.ts
+++ b/packages/app/src/sandbox/compile.ts
@@ -724,7 +724,7 @@ async function compile({
   firstLoad = false;
 
   dispatch({ type: 'status', status: 'idle' });
-  dispatch({ type: 'done' });
+  dispatch({ type: 'done', compilatonError: hadError });
 
   if (typeof (window as any).__puppeteer__ === 'function') {
     (window as any).__puppeteer__('done');

--- a/packages/app/src/sandbox/eval/tests/jest-lite.ts
+++ b/packages/app/src/sandbox/eval/tests/jest-lite.ts
@@ -465,21 +465,24 @@ export default class TestRunner {
   };
 
   handleCodeSandboxMessage = (message: any) => {
-    if (message) {
-      if (message.type === 'set-test-watching') {
+    switch (message.type) {
+      case 'set-test-watching':
         this.watching = message.watching;
         if (message.watching === true) {
           this.ranTests.clear();
           this.runTests(true);
         }
-      } else if (message.type === 'run-all-tests') {
+        break;
+      case 'run-all-tests':
         this.ranTests.clear();
         this.runTests(true);
-      } else if (message.type === 'run-tests') {
+        break;
+      case 'run-tests': {
         const path = message.path;
 
         this.ranTests.delete(path);
         this.runTests();
+        break;
       }
     }
   };


### PR DESCRIPTION
## What kind of change does this PR introduce?
Bug fix.

## What is the current behavior?
Preconditions:
- 15 files in the project
- 50 tests in 8 different files
- Tests tab is open
- Watching for tests is **on**

Editor freeze, sometimes quite often, when you write code because it runs tests after each editing

## What is the new behavior?

Editor freeze less often (at least twice less)

## What steps did you take to test this?

Test methodology described here with few test output:
https://gist.github.com/batiskafff/925f07637485ffc88940d47b36872bd1

Brief description:
- use sandbox https://codesandbox.io/s/boring-dawn-fzvzd 
- include performance meter component in UI
- edit code

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added me to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

It is proposal fix. It solves some issues, however, it is not the best possible solution for this issue.
The best possible solution from my opinion is added webworkers as test runner env, however, quite a big amount of dependency's and not simple implementation could unreasonable increase complexity of this part of the project.