### PR TITLE
Integration tests improvements

### DIFF
--- a/packages/app/integration-tests/tests/__image_snapshots__/__diff_output__/.gitignore
+++ b/packages/app/integration-tests/tests/__image_snapshots__/__diff_output__/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
~Description to come!~

This explicitly manages the sandbox loading timeouts, instead of only letting `jest` do that. For now, we're trying to load a sandbox twice, with a 30 seconds timeout (the idea being that, even if it times out the first time, it will most probably succeed on the second try). Also logs sandboxes loading times.