### PR TITLE
Don't make a fuss about duplicate saving

### DIFF
--- a/packages/app/src/app/store/modules/editor/sequences.js
+++ b/packages/app/src/app/store/modules/editor/sequences.js
@@ -256,10 +256,7 @@ export const saveCode = [
     ],
 
     error: [callVSCodeCallbackError],
-    codeOutdated: [
-      addNotification(props`message`, 'warning'),
-      callVSCodeCallbackError,
-    ],
+    codeOutdated: [callVSCodeCallback],
   },
 ];
 


### PR DESCRIPTION
Right now we have some protection for duplicate saving, but I think they're not needed anymore now that we use VSCode by default. This removes the logic, and could possibly fix the 'file changed locally' logic.