### PR TITLE
Fix local development build

### DIFF
--- a/packages/app/scripts/start.js
+++ b/packages/app/scripts/start.js
@@ -229,7 +229,7 @@ function addMiddleware(devServer, index) {
     devServer.use(
       '/api',
       proxy({
-        target: 'https://codesandbox.stream',
+        target: 'https://codesandbox.io',
         changeOrigin: true,
       })
     );

--- a/packages/common/src/components/Preview/index.tsx
+++ b/packages/common/src/components/Preview/index.tsx
@@ -61,7 +61,7 @@ type State = {
 const getSSEUrl = (sandbox?: Sandbox, initialPath: string = '') =>
   `https://${sandbox ? `${sandbox.id}.` : ''}sse.${
     process.env.NODE_ENV === 'development' || process.env.STAGING
-      ? 'codesandbox.stream'
+      ? 'codesandbox.io'
       : host()
   }${initialPath}`;
 

--- a/packages/executors/src/serverExecutor.ts
+++ b/packages/executors/src/serverExecutor.ts
@@ -72,7 +72,7 @@ export class ServerExecutor implements IExecutor {
   }
 
   private initializeSocket() {
-    return io(`https://sse.codesandbox.stream`, {
+    return io(`https://sse.codesandbox.io`, {
       autoConnect: false,
       transports: ['websocket', 'polling'],
     });


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?

Fixes a problem of running local development build. After opening http://localhost:3000/s/new fails with a 404 because https://codesandbox.stream/api/v1/sandboxes/new returns a 404.

> `curl -i 'https://codesandbox.stream/api/v1/sandboxes/new'`
```
HTTP/2 404
date: Thu, 11 Jul 2019 14:44:20 GMT
content-length: 17
set-cookie: __cfduid=d18d203693b38a69bbdda5b58d427e9661562856260; expires=Fri, 10-Jul-20 14:44:20 GMT; path=/; domain=.codesandbox.stream; HttpOnly; Secure
cache-control: max-age=0, private, must-revalidate
x-request-id: 2mo62v80q6r814dai8007nbh
via: 1.1 google
alt-svc: clear
expect-ct: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
server: cloudflare
cf-ray: 4f4b8e0a2c92dbeb-LHR
```

## What is the current behavior?

/api requests are forwarded to to http://codesandbox.stream/api

## What is the new behavior?

/api requests are forwarded to to http://codesandbox.io/api

<!-- if this is a feature change -->

Run local build according to CONTRIBUTING.md, after opening http://localhost:3000/s/new, codesandbox loads fine with a react template.

<!-- Most important part!  -->

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Testing <!-- We can only merge the PR if this is checked -->
- [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
**This PR is just to make you aware of the problem and a potential workaround.**
I do not understand the purpose of codesandbox.stream or and how it differs from codesandbox.io. I assume the problem is in the infrastructure rather than the code.

<!-- Thank you for contributing! -->
