### PR TITLE
Delete unnecessary eslint-disable

### DIFF
--- a/packages/app/src/app/components/Preview/DevTools/Problems/index.tsx
+++ b/packages/app/src/app/components/Preview/DevTools/Problems/index.tsx
@@ -1,5 +1,3 @@
-/* eslint import/extensions: "warn", import/no-unresolved: "warn" */
-
 import { listen } from 'codesandbox-api';
 import {
   CorrectionAction,

--- a/packages/app/src/app/utils/corrections.ts
+++ b/packages/app/src/app/utils/corrections.ts
@@ -1,5 +1,3 @@
-/* eslint import/extensions: "warn", import/no-unresolved: "warn" */
-
 import { ModuleCorrection, ModuleError } from '@codesandbox/common/lib/types';
 import { CorrectionClearAction } from 'codesandbox-api/dist/types/actions/correction';
 import { ErrorClearAction } from 'codesandbox-api/dist/types/actions/error';


### PR DESCRIPTION
## What kind of change does this PR introduce?
After 2c137cd these disable statements aren't necessary anymore.

## What is the current behavior?
N/A

## What is the new behavior?
N/A

## What steps did you take to test this?
Run `yarn lint` in the root of the project

## Checklist
- [ ] Documentation N.A
- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions --> N/A

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
