### PR TITLE
Add directory details to the package.json of all packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "0.1.0",
   "license": "GPL-3.0",
   "private": true,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/codesandbox/codesandbox-client"
+  },
   "scripts": {
     "build": "cross-env NODE_OPTIONS=\"--max-old-space-size=4096\" yarn build:deps && yarn build:prod",
     "build:prod": "cross-env NODE_OPTIONS=\"--max-old-space-size=4096\" lerna run build  --scope homepage --stream && lerna run build --scope app --stream && lerna run copy-assets --scope app --stream",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -3,6 +3,11 @@
   "version": "0.1.1",
   "license": "MIT",
   "private": true,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/codesandbox/codesandbox-client",
+    "directory": "packages/app"
+  },
   "scripts": {
     "start": "cross-env LOCAL_SERVER=1 LOCAL_DEV=1 NODE_OPTIONS=\"--max-old-space-size=4096\" node scripts/start.js",
     "start:sandbox": "cross-env SANDBOX_ONLY=true node scripts/start.js",

--- a/packages/codesandbox-api/package.json
+++ b/packages/codesandbox-api/package.json
@@ -12,7 +12,8 @@
   "author": "Ives van Hoorne <ives.v.h@gmail.com>",
   "repository": {
     "type": "git",
-    "url": ""
+    "url": "https://github.com/codesandbox/codesandbox-client",
+    "directory": "packages/codesandbox-api"
   },
   "license": "MIT",
   "engines": {

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@codesandbox/common",
   "version": "1.0.5",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/codesandbox/codesandbox-client",
+    "directory": "packages/common"
+  },
   "source": true,
   "files": [
     "lib"

--- a/packages/deps/package.json
+++ b/packages/deps/package.json
@@ -3,6 +3,11 @@
   "version": "0.1.1",
   "license": "MIT",
   "private": true,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/codesandbox/codesandbox-client",
+    "directory": "packages/deps"
+  },
   "main": "dist/index.js",
   "scripts": {
     "build": "yarn build:clean && yarn build:rollup",

--- a/packages/dynamic-pages/package.json
+++ b/packages/dynamic-pages/package.json
@@ -2,6 +2,11 @@
   "name": "dynamic-pages",
   "version": "1.0.0",
   "private": true,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/codesandbox/codesandbox-client",
+    "directory": "packages/dynamic-pages"
+  },
   "source": true,
   "scripts": {
     "dev": "cross-env LOCAL_SERVER=1 LOCAL_DEV=1 node server.js",

--- a/packages/executors/package.json
+++ b/packages/executors/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@codesandbox/executors",
   "version": "0.1.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/codesandbox/codesandbox-client",
+    "directory": "packages/executors"
+  },
   "main": "dist/index.js",
   "umd:main": "dist/codesandboxexecutors.umd.production.js",
   "module": "dist/codesandboxexecutors.es.production.js",

--- a/packages/homepage/package.json
+++ b/packages/homepage/package.json
@@ -1,9 +1,14 @@
 {
-  "name": "homepage",
+  "name": "codesandbox-homepage",
   "description": "CodeSandbox Homepage",
   "private": true,
   "version": "1.0.0",
   "author": "Ives van Hoorne <ives.v.h@gmail.com>",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/codesandbox/codesandbox-client",
+    "directory": "packages/homepage"
+  },
   "dependencies": {
     "@babel/preset-flow": "^7.0.0",
     "@codesandbox/common": "^1.0.5",

--- a/packages/node-services/package.json
+++ b/packages/node-services/package.json
@@ -1,6 +1,11 @@
 {
   "name": "node-services",
   "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/codesandbox/codesandbox-client",
+    "directory": "packages/node-services"
+  },
   "dependencies": {
     "constants-browserify": "^1.0.0",
     "events": "^3.0.0",

--- a/packages/notifications/package.json
+++ b/packages/notifications/package.json
@@ -3,6 +3,11 @@
   "version": "1.0.3",
   "main": "lib/index.js",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/codesandbox/codesandbox-client",
+    "directory": "packages/notifications"
+  },
   "scripts": {
     "start": "tsc --watch",
     "build": "rimraf lib && tsc",

--- a/packages/react-embed/package.json
+++ b/packages/react-embed/package.json
@@ -3,6 +3,11 @@
   "version": "0.0.14",
   "license": "MIT",
   "private": false,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/codesandbox/codesandbox-client",
+    "directory": "packages/react-embed"
+  },
   "sideEffects": false,
   "main": "dist/index",
   "module": "dist-es/index",

--- a/packages/react-sandpack/package.json
+++ b/packages/react-sandpack/package.json
@@ -16,7 +16,8 @@
   "author": "Ives van Hoorne <ives.v.h@gmail.com>",
   "repository": {
     "type": "git",
-    "url": ""
+    "url": "https://github.com/codesandbox/codesandbox-client",
+    "directory": "packages/react-sandpack"
   },
   "engines": {
     "node": ">=6.0.0"

--- a/packages/sandbox-hooks/package.json
+++ b/packages/sandbox-hooks/package.json
@@ -2,6 +2,11 @@
   "name": "sandbox-hooks",
   "version": "0.1.0",
   "private": true,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/codesandbox/codesandbox-client",
+    "directory": "packages/sandbox-hooks"
+  },
   "dependencies": {
     "codesandbox-api": "^0.0.22",
     "console-feed": "^2.8.5"

--- a/packages/sandpack/package.json
+++ b/packages/sandpack/package.json
@@ -15,7 +15,8 @@
   "author": "Ives van Hoorne <ives.v.h@gmail.com>",
   "repository": {
     "type": "git",
-    "url": "https://github.com/codesandbox/codesandbox-client/tree/master/packages/sandpack"
+    "url": "https://github.com/codesandbox/codesandbox-client",
+    "directory": "packages/sandpack"
   },
   "engines": {
     "node": ">=6.0.0"

--- a/packages/sse-hooks/package.json
+++ b/packages/sse-hooks/package.json
@@ -2,6 +2,11 @@
   "name": "sse-hooks",
   "version": "0.1.0",
   "private": true,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/codesandbox/codesandbox-client",
+    "directory": "packages/sse-hooks"
+  },
   "main": "dist/index.js",
   "source": "index.js",
   "scripts": {


### PR DESCRIPTION
## What kind of change does this PR introduce?
Specifying the directory as part of the `repository` field in a `package.json` allows third party tools to provide better support when working with monorepos. For example, it allows them to correctly construct a commit diff for a specific package.

This format was accepted by `npm` in npm/rfcs#19.

## What is the current behavior?
N/A

## What is the new behavior?
N/A

## What steps did you take to test this?
N/A

## Checklist
- [ ] Documentation N/A
- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions --> N/A