### PR TITLE
Observe deployment components

### DIFF
--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/items/Deployment/Netlify/DeployButton/DeployButton.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/items/Deployment/Netlify/DeployButton/DeployButton.tsx
@@ -1,3 +1,4 @@
+import { observer } from 'mobx-react-lite';
 import React from 'react';
 
 import { DeploymentIntegration } from 'app/components/DeploymentIntegration';
@@ -6,7 +7,7 @@ import { useSignals, useStore } from 'app/store';
 
 import { DeployButtonContainer } from '../../elements';
 
-export const DeployButton = ({ isOpen, toggle }) => {
+export const DeployButton = observer(({ isOpen, toggle }) => {
   const {
     deployment: { deployWithNetlify },
   } = useSignals();
@@ -34,4 +35,4 @@ export const DeployButton = ({ isOpen, toggle }) => {
       </DeploymentIntegration>
     </DeployButtonContainer>
   );
-};
+});

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/items/Deployment/Netlify/DeployButton/DeployButton.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/items/Deployment/Netlify/DeployButton/DeployButton.tsx
@@ -7,7 +7,11 @@ import { useSignals, useStore } from 'app/store';
 
 import { DeployButtonContainer } from '../../elements';
 
-export const DeployButton = observer(({ isOpen, toggle }) => {
+type Props = {
+  isOpen: boolean;
+  toggle: () => void;
+};
+export const DeployButton = observer<Props>(({ isOpen, toggle }) => {
   const {
     deployment: { deployWithNetlify },
   } = useSignals();

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/items/Deployment/Netlify/SiteInfo/Actions/Actions.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/items/Deployment/Netlify/SiteInfo/Actions/Actions.tsx
@@ -1,3 +1,4 @@
+import { observer } from 'mobx-react-lite';
 import React from 'react';
 
 import { useStore } from 'app/store';
@@ -9,7 +10,7 @@ import { SubTitle } from '../elements';
 import { ClaimSiteButton } from './ClaimSiteButton';
 import { VisitSiteButton } from './VisitSiteButton';
 
-export const Actions = () => {
+export const Actions = observer(() => {
   const {
     deployment: { netlifyClaimUrl },
   } = useStore();
@@ -25,4 +26,4 @@ export const Actions = () => {
       </ButtonContainer>
     </>
   );
-};
+});

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/items/Deployment/Netlify/SiteInfo/Actions/ClaimSiteButton/ClaimSiteButton.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/items/Deployment/Netlify/SiteInfo/Actions/ClaimSiteButton/ClaimSiteButton.tsx
@@ -1,10 +1,11 @@
+import { observer } from 'mobx-react-lite';
 import React from 'react';
 
 import { useStore } from 'app/store';
 
 import { Link } from '../../../../elements';
 
-export const ClaimSiteButton = () => {
+export const ClaimSiteButton = observer(() => {
   const {
     deployment: { building, netlifyClaimUrl },
   } = useStore();
@@ -14,4 +15,4 @@ export const ClaimSiteButton = () => {
       Claim Site
     </Link>
   );
-};
+});

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/items/Deployment/Netlify/SiteInfo/Actions/VisitSiteButton/VisitSiteButton.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/items/Deployment/Netlify/SiteInfo/Actions/VisitSiteButton/VisitSiteButton.tsx
@@ -1,3 +1,4 @@
+import { observer } from 'mobx-react-lite';
 import React from 'react';
 import LinkIcon from 'react-icons/lib/fa/external-link';
 import Cogs from 'react-icons/lib/fa/cogs';
@@ -6,7 +7,7 @@ import { useStore } from 'app/store';
 
 import { Link } from '../../../../elements';
 
-export const VisitSiteButton = () => {
+export const VisitSiteButton = observer(() => {
   const {
     deployment: { building, netlifySite },
   } = useStore();
@@ -24,4 +25,4 @@ export const VisitSiteButton = () => {
       )}
     </Link>
   );
-};
+});

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/items/Deployment/Netlify/SiteInfo/Functions/Function/Function.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/items/Deployment/Netlify/SiteInfo/Functions/Function/Function.tsx
@@ -1,3 +1,4 @@
+import { observer } from 'mobx-react-lite';
 import React from 'react';
 import LightningIcon from 'react-icons/lib/md/flash-on';
 
@@ -5,7 +6,7 @@ import { useStore } from 'app/store';
 
 import { Link } from '../../../../elements';
 
-export const Function = ({ function: { title } }) => {
+export const Function = observer(({ function: { title } }) => {
   const {
     deployment: {
       building,
@@ -25,4 +26,4 @@ export const Function = ({ function: { title } }) => {
       {functionName}
     </Link>
   );
-};
+});

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/items/Deployment/Netlify/SiteInfo/Functions/Function/Function.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/items/Deployment/Netlify/SiteInfo/Functions/Function/Function.tsx
@@ -6,7 +6,12 @@ import { useStore } from 'app/store';
 
 import { Link } from '../../../../elements';
 
-export const Function = observer(({ function: { title } }) => {
+type Props = {
+  function: {
+    title: string;
+  };
+};
+export const Function = observer<Props>(({ function: { title } }) => {
   const {
     deployment: {
       building,

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/items/Deployment/Zeit/DeployButton/DeployButton.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/items/Deployment/Zeit/DeployButton/DeployButton.tsx
@@ -9,7 +9,11 @@ import { DeployButtonContainer } from '../../elements';
 
 import { Overlay, CreateFile } from './elements';
 
-export const DeployButton = observer(({ isOpen, toggle }) => {
+type Props = {
+  isOpen: boolean;
+  toggle: () => void;
+};
+export const DeployButton = observer<Props>(({ isOpen, toggle }) => {
   const {
     files,
     deployment: { deploySandboxClicked },

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/items/Deployment/Zeit/DeployButton/DeployButton.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/items/Deployment/Zeit/DeployButton/DeployButton.tsx
@@ -1,3 +1,4 @@
+import { observer } from 'mobx-react-lite';
 import React from 'react';
 
 import { DeploymentIntegration } from 'app/components/DeploymentIntegration';
@@ -8,7 +9,7 @@ import { DeployButtonContainer } from '../../elements';
 
 import { Overlay, CreateFile } from './elements';
 
-export const DeployButton = ({ isOpen, toggle }) => {
+export const DeployButton = observer(({ isOpen, toggle }) => {
   const {
     files,
     deployment: { deploySandboxClicked },
@@ -67,4 +68,4 @@ export const DeployButton = ({ isOpen, toggle }) => {
       </DeploymentIntegration>
     </DeployButtonContainer>
   );
-};
+});

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/items/Deployment/Zeit/Deploys/Actions/Actions.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/items/Deployment/Zeit/Deploys/Actions/Actions.tsx
@@ -8,8 +8,12 @@ import { ButtonContainer } from '../../../elements';
 import { AliasDeploymentButton } from './AliasDeploymentButton';
 import { DeleteDeploymentButton } from './DeleteDeploymentButton';
 import { VisitDeploymentButton } from './VisitDeploymentButton';
+import { Deploy } from './types';
 
-export const Actions = observer(({ deploy }) => {
+type Props = {
+  deploy: Deploy;
+};
+export const Actions = observer<Props>(({ deploy }) => {
   const {
     deployment: { hasAlias },
   } = useStore();

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/items/Deployment/Zeit/Deploys/Actions/Actions.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/items/Deployment/Zeit/Deploys/Actions/Actions.tsx
@@ -1,3 +1,4 @@
+import { observer } from 'mobx-react-lite';
 import React from 'react';
 
 import { useStore } from 'app/store';
@@ -8,7 +9,7 @@ import { AliasDeploymentButton } from './AliasDeploymentButton';
 import { DeleteDeploymentButton } from './DeleteDeploymentButton';
 import { VisitDeploymentButton } from './VisitDeploymentButton';
 
-export const Actions = ({ deploy }) => {
+export const Actions = observer(({ deploy }) => {
   const {
     deployment: { hasAlias },
   } = useStore();
@@ -24,4 +25,4 @@ export const Actions = ({ deploy }) => {
       ) : null}
     </ButtonContainer>
   );
-};
+});

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/items/Deployment/Zeit/Deploys/Actions/AliasDeploymentButton/AliasDeploymentButton.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/items/Deployment/Zeit/Deploys/Actions/AliasDeploymentButton/AliasDeploymentButton.tsx
@@ -4,14 +4,24 @@ import { useSignals } from 'app/store';
 
 import { Action } from '../../../../elements';
 
-export const AliasDeploymentButton = ({ deploy: { alias, uid: id } }) => {
+import { Deploy } from '../types';
+
+type Props = {
+  deploy: Deploy;
+};
+export const AliasDeploymentButton = ({
+  deploy: { alias: aliases, uid: id },
+}: Props) => {
   const {
     deployment: { aliasDeployment },
   } = useSignals();
 
   return (
-    <Action disabled={alias.length > 0} onClick={() => aliasDeployment({ id })}>
-      {alias.length > 0 ? 'Aliased' : 'Alias'}
+    <Action
+      disabled={aliases.length > 0}
+      onClick={() => aliasDeployment({ id })}
+    >
+      {aliases.length > 0 ? 'Aliased' : 'Alias'}
     </Action>
   );
 };

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/items/Deployment/Zeit/Deploys/Actions/DeleteDeploymentButton/DeleteDeploymentButton.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/items/Deployment/Zeit/Deploys/Actions/DeleteDeploymentButton/DeleteDeploymentButton.tsx
@@ -1,3 +1,4 @@
+import { observer } from 'mobx-react-lite';
 import React from 'react';
 import TrashIcon from 'react-icons/lib/fa/trash';
 
@@ -5,7 +6,7 @@ import { useSignals, useStore } from 'app/store';
 
 import { Action } from '../../../../elements';
 
-export const DeleteDeploymentButton = ({ id }) => {
+export const DeleteDeploymentButton = observer(({ id }) => {
   const {
     deployment: { setDeploymentToDelete },
     modalOpened,
@@ -29,4 +30,4 @@ export const DeleteDeploymentButton = ({ id }) => {
       )}
     </Action>
   );
-};
+});

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/items/Deployment/Zeit/Deploys/Actions/DeleteDeploymentButton/DeleteDeploymentButton.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/items/Deployment/Zeit/Deploys/Actions/DeleteDeploymentButton/DeleteDeploymentButton.tsx
@@ -6,7 +6,10 @@ import { useSignals, useStore } from 'app/store';
 
 import { Action } from '../../../../elements';
 
-export const DeleteDeploymentButton = observer(({ id }) => {
+type Props = {
+  id: string;
+};
+export const DeleteDeploymentButton = observer<Props>(({ id }) => {
   const {
     deployment: { setDeploymentToDelete },
     modalOpened,

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/items/Deployment/Zeit/Deploys/Actions/types.ts
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/items/Deployment/Zeit/Deploys/Actions/types.ts
@@ -1,0 +1,6 @@
+export type Deploy = {
+  alias: string[];
+  state: string;
+  uid: string;
+  url: string;
+};

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/items/Deployment/Zeit/Deploys/Deploys.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/items/Deployment/Zeit/Deploys/Deploys.tsx
@@ -1,4 +1,5 @@
 import distanceInWordsToNow from 'date-fns/distance_in_words_to_now';
+import { observer } from 'mobx-react-lite';
 import React from 'react';
 
 import { useStore } from 'app/store';
@@ -19,7 +20,7 @@ import {
 import { Actions } from './Actions';
 import { Alias } from './Alias';
 
-export const Deploys = () => {
+export const Deploys = observer(() => {
   const {
     deployment: { sandboxDeploys },
   } = useStore();
@@ -49,4 +50,4 @@ export const Deploys = () => {
       </WorkspaceInputContainer>
     </DeploysContainer>
   );
-};
+});


### PR DESCRIPTION
## What kind of change does this PR introduce?
Follow-up of #1969

Observe components that use the `useStore` hook

## What is the current behavior?
Components that use the `useStore` hook aren't observed

## What is the new behavior?
Components that use the `useStore` hook are observed

## What steps did you take to test this?
### ZEIT Deploys
- [x] Verify that deployment modal of ZEIT says you need to sign in
- [x] Sign into ZEIT
- [x] Deploy to ZEIT
- [x] Make change to sandbox
- [x] Deploy again, verify new URL

### Netlify Deploys
- [x] Deploy to Netlify
- [x] Check that logs show
- [x] Check that deployment is added
- [x] Make change
- [x] Deploy again, see if deployment is added
- [x] Claim deployment, see if it works

## Checklist
- [ ] Documentation
- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions --> N/A