### PR TITLE
Fix sass/scss

### DIFF
--- a/packages/app/src/sandbox/eval/transpilers/sass/worker/sass-worker.js
+++ b/packages/app/src/sandbox/eval/transpilers/sass/worker/sass-worker.js
@@ -4,9 +4,7 @@ import { extname } from 'path';
 import delay from '@codesandbox/common/lib/utils/delay';
 
 self.importScripts([
-  process.env.NODE_ENV === 'production'
-    ? 'https://cdnjs.cloudflare.com/ajax/libs/sass.js/0.10.13/sass.sync.min.js'
-    : 'https://cdnjs.cloudflare.com/ajax/libs/sass.js/0.10.13/sass.sync.js',
+  'https://cdnjs.cloudflare.com/ajax/libs/sass.js/0.11.0/sass.sync.js',
 ]);
 
 self.postMessage('ready');


### PR DESCRIPTION
Fixes #2184 .

So this is weird: while trying to debug the above issue, I've noticed that, while it breaks on prod, it works fine on dev. Looking at the [sass/scss worker](https://github.com/codesandbox/codesandbox-client/blob/49645df97753c867652da1a030c7e5570990ecab/packages/app/src/sandbox/eval/transpilers/sass/worker/sass-worker.js#L6-L10), we're loading different (minified on prod vs. unminified on dev) `sass.js` bundles, and it seems like the minified one doesn't work?! Like I said - weird.

This PR uses the unminified bundle, regardless of environment, and also updates `sass.js` to the very next / latest `0.11.0` version.

You can see the test sandbox from the issue above failing in prod https://codesandbox.io/s/vue-template-set68 , and working in this PR build: https://pr2188.build.csb.dev/s/vue-template-set68 .
