### PR TITLE
fix: add max 50 for number input in Patron Page

### DIFF
--- a/packages/app/src/app/pages/Patron/PricingModal/PricingChoice/index.tsx
+++ b/packages/app/src/app/pages/Patron/PricingModal/PricingChoice/index.tsx
@@ -52,6 +52,7 @@ const PricingChoice = observer<Props>(({ badge }) => {
             onChange={e => priceChanged({ price: Number(e.target.value) })}
             value={patron.price}
             min={5}
+            max={50}
             type="number"
           />
           <Month>/month</Month>


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?
Bug Fix
<!-- Is it a Bug fix, feature, docs update, ... -->

## What is the current behavior?
Currently when we press Arrow up price gets over 50 but range slider is limited to 50 only.
<!-- You can also link to an open issue here -->

## What is the new behavior?
After setting `max={50}` it limits the input to 50 when increasing from Arrow up Key.
<!-- if this is a feature change -->

## What steps did you take to test this?
Tested it locally on `localhost:3000/patron`
<!-- Most important part!  -->

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
