### PR TITLE
Added knobs and additional stories

### DIFF
--- a/packages/common/.storybook/addons.js
+++ b/packages/common/.storybook/addons.js
@@ -1,1 +1,2 @@
 require('@storybook/addon-actions/register');
+require('@storybook/addon-knobs/register');

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -48,6 +48,7 @@
     "@babel/cli": "^7.2.3",
     "@babel/core": "^7.3.4",
     "@storybook/addon-actions": "^5.1.9",
+    "@storybook/addon-knobs": "^5.1.9",
     "@storybook/react": "^5.1.9",
     "@types/color": "0.12.1",
     "@types/humps": "^1.1.2",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -56,6 +56,7 @@
     "@types/lodash": "^4.14.123",
     "@types/react": "^16.8.12",
     "@types/react-icons": "^2.2.7",
+    "@types/storybook__addon-knobs": "^5.0.3",
     "@types/storybook__react": "^4.0.2",
     "@types/styled-components": "^4.1.13",
     "babel-jest": "^23.6.0",

--- a/packages/common/src/components/SandboxCard/fixtures.ts
+++ b/packages/common/src/components/SandboxCard/fixtures.ts
@@ -1,4 +1,5 @@
 import { Sandbox } from './';
+import { TemplateType } from '../../templates';
 
 export const sandbox = (config: Partial<Sandbox> = {}): Sandbox => ({
   id: '1234',
@@ -120,3 +121,41 @@ export const sandboxWithUndefinedScreenshotUrl = (
   sandbox({
     screenshot_url: undefined,
   });
+
+export type TemplateOptions = { [K in TemplateType]: K };
+
+export const templates: TemplateType[] = [
+  'adonis',
+  'create-react-app',
+  'vue-cli',
+  'preact-cli',
+  'svelte',
+  'create-react-app-typescript',
+  'angular-cli',
+  'parcel',
+  'cxjs',
+  '@dojo/cli-create-app',
+  'gatsby',
+  'marko',
+  'nuxt',
+  'next',
+  'reason',
+  'apollo',
+  'sapper',
+  'nest',
+  'static',
+  'styleguidist',
+  'gridsome',
+  'vuepress',
+  'mdx-deck',
+  'quasar',
+  'unibit',
+];
+
+export const templateOptions = templates.reduce<TemplateOptions>(
+  (acc, key) => ({
+    ...acc,
+    [key]: key,
+  }),
+  {} as TemplateOptions
+);

--- a/packages/common/src/components/SandboxCard/index.stories.tsx
+++ b/packages/common/src/components/SandboxCard/index.stories.tsx
@@ -13,7 +13,6 @@ import SandboxCard, { Props, Sandbox } from './';
 import * as fake from './fixtures';
 import { ThemeDecorator } from '../../stories/decorators';
 import { TemplateType } from '../../templates';
-import { template } from 'handlebars';
 
 type TemplateOptions = { [K in TemplateType]: K };
 

--- a/packages/common/src/components/SandboxCard/index.stories.tsx
+++ b/packages/common/src/components/SandboxCard/index.stories.tsx
@@ -57,24 +57,34 @@ const stories = storiesOf('components/SandboxCard', module)
   .addDecorator(ThemeDecorator)
   .addDecorator(withKnobs);
 
-const knobbedSandbox = (defaults: Sandbox): Sandbox => ({
-  id: text('id', defaults.id, 'sandbox'),
-  title: text('title', defaults.title, 'sandbox'),
-  author: defaults.author && {
-    username: text('author.username', defaults.author.username, 'sandbox'),
-    avatar_url: text(
-      'author.avatar_url',
-      defaults.author.avatar_url,
-      'sandbox'
-    ),
+const knobbedSandbox = (
+  {
+    id,
+    title,
+    author,
+    screenshot_url,
+    description,
+    view_count,
+    fork_count,
+    like_count,
+    tags,
+    template,
+  }: Sandbox,
+  group: string = 'sandbox'
+): Sandbox => ({
+  id: text('id', id, group),
+  title: text('title', title, group),
+  author: author && {
+    username: text('author.username', author.username, group),
+    avatar_url: text('author.avatar_url', author.avatar_url, group),
   },
-  description: text('description', defaults.description, 'sandbox'),
-  screenshot_url: text('screenshot_url', defaults.screenshot_url, 'sandbox'),
-  view_count: number('view_count', defaults.view_count, {}, 'sandbox'),
-  fork_count: number('fork_count', defaults.fork_count, {}, 'sandbox'),
-  like_count: number('like_count', defaults.like_count, {}, 'sandbox'),
-  template: select('template', templateOptions, defaults.template, 'sandbox'),
-  tags: array('tags', defaults.tags, ',', 'sandbox'),
+  description: text('description', description, group),
+  screenshot_url: text('screenshot_url', screenshot_url, group),
+  view_count: number('view_count', view_count, {}, group),
+  fork_count: number('fork_count', fork_count, {}, group),
+  like_count: number('like_count', like_count, {}, group),
+  template: select('template', templateOptions, template, group),
+  tags: array('tags', tags, ',', group),
 });
 
 const createSandboxStory = ({

--- a/packages/common/src/components/SandboxCard/index.stories.tsx
+++ b/packages/common/src/components/SandboxCard/index.stories.tsx
@@ -33,10 +33,10 @@ const knobbedAuthor = (
   }
 };
 
-const knobbedSandbox = (group: string, sandbox: Sandbox): Sandbox => ({
+const sandboxWithKnobs = (group: string, sandbox: Sandbox): Sandbox => ({
   id: text('id', sandbox.id, group),
   title: text('title', sandbox.title, group),
-  author: knobbedAuthor(group, sandbox.author),
+  author: authorWithKnobs(group, sandbox.author),
   description: text('description', sandbox.description, group),
   screenshot_url: text('screenshot_url', sandbox.screenshot_url, group),
   view_count: number('view_count', sandbox.view_count, {}, group),

--- a/packages/common/src/components/SandboxCard/index.stories.tsx
+++ b/packages/common/src/components/SandboxCard/index.stories.tsx
@@ -57,34 +57,20 @@ const stories = storiesOf('components/SandboxCard', module)
   .addDecorator(ThemeDecorator)
   .addDecorator(withKnobs);
 
-const knobbedSandbox = (
-  {
-    id,
-    title,
-    author,
-    screenshot_url,
-    description,
-    view_count,
-    fork_count,
-    like_count,
-    tags,
-    template,
-  }: Sandbox,
-  group: string = 'sandbox'
-): Sandbox => ({
-  id: text('id', id, group),
-  title: text('title', title, group),
-  author: author && {
-    username: text('author.username', author.username, group),
-    avatar_url: text('author.avatar_url', author.avatar_url, group),
+const knobbedSandbox = (group: string, sandbox: Sandbox): Sandbox => ({
+  id: text('id', sandbox.id, group),
+  title: text('title', sandbox.title, group),
+  author: sandbox.author && {
+    username: text('author.username', sandbox.author.username, group),
+    avatar_url: text('author.avatar_url', sandbox.author.avatar_url, group),
   },
-  description: text('description', description, group),
-  screenshot_url: text('screenshot_url', screenshot_url, group),
-  view_count: number('view_count', view_count, {}, group),
-  fork_count: number('fork_count', fork_count, {}, group),
-  like_count: number('like_count', like_count, {}, group),
+  description: text('description', sandbox.description, group),
+  screenshot_url: text('screenshot_url', sandbox.screenshot_url, group),
+  view_count: number('view_count', sandbox.view_count, {}, group),
+  fork_count: number('fork_count', sandbox.fork_count, {}, group),
+  like_count: number('like_count', sandbox.like_count, {}, group),
   template: select('template', templateOptions, template, group),
-  tags: array('tags', tags, ',', group),
+  tags: array('tags', sandbox.tags, ',', group),
 });
 
 const createSandboxStory = ({
@@ -96,7 +82,7 @@ const createSandboxStory = ({
   noMargin,
 }: Partial<Props>) => () => (
   <SandboxCard
-    sandbox={knobbedSandbox(sandbox)}
+    sandbox={knobbedSandbox('sandbox', sandbox)}
     selectSandbox={selectSandbox}
     small={boolean('small', small)}
     noHeight={boolean('noHeight', noHeight)}

--- a/packages/common/src/components/SandboxCard/index.stories.tsx
+++ b/packages/common/src/components/SandboxCard/index.stories.tsx
@@ -17,7 +17,7 @@ const stories = storiesOf('components/SandboxCard', module)
   .addDecorator(ThemeDecorator)
   .addDecorator(withKnobs);
 
-const knobbedAuthor = (
+const authorWithKnobs = (
   group: string,
   author: Sandbox['author'] = null
 ): Sandbox['author'] => {
@@ -60,7 +60,7 @@ const createSandboxStory = ({
   noMargin,
 }: Partial<Props>) => () => (
   <SandboxCard
-    sandbox={knobbedSandbox('sandbox', sandbox)}
+    sandbox={sandboxWithKnobs('sandbox', sandbox)}
     selectSandbox={selectSandbox}
     small={boolean('small', small)}
     noHeight={boolean('noHeight', noHeight)}

--- a/packages/common/src/components/SandboxCard/index.stories.tsx
+++ b/packages/common/src/components/SandboxCard/index.stories.tsx
@@ -81,7 +81,7 @@ const knobbedSandbox = (group: string, sandbox: Sandbox): Sandbox => ({
   view_count: number('view_count', sandbox.view_count, {}, group),
   fork_count: number('fork_count', sandbox.fork_count, {}, group),
   like_count: number('like_count', sandbox.like_count, {}, group),
-  template: select('template', templateOptions, template, group),
+  template: select('template', templateOptions, sandbox.template, group),
   tags: array('tags', sandbox.tags, ',', group),
 });
 

--- a/packages/common/src/components/SandboxCard/index.stories.tsx
+++ b/packages/common/src/components/SandboxCard/index.stories.tsx
@@ -57,13 +57,26 @@ const stories = storiesOf('components/SandboxCard', module)
   .addDecorator(ThemeDecorator)
   .addDecorator(withKnobs);
 
+const knobbedAuthor = (
+  group: string,
+  author: Sandbox['author']
+): Sandbox['author'] => {
+  const knobs = {
+    username: text('author.username', author && author.username, group),
+    avatar_url: text('author.avatar_url', author && author.avatar_url, group),
+  };
+
+  if (knobs.username || knobs.avatar_url) {
+    return knobs;
+  } else {
+    return author;
+  }
+};
+
 const knobbedSandbox = (group: string, sandbox: Sandbox): Sandbox => ({
   id: text('id', sandbox.id, group),
   title: text('title', sandbox.title, group),
-  author: sandbox.author && {
-    username: text('author.username', sandbox.author.username, group),
-    avatar_url: text('author.avatar_url', sandbox.author.avatar_url, group),
-  },
+  author: knobbedAuthor(group, sandbox.author),
   description: text('description', sandbox.description, group),
   screenshot_url: text('screenshot_url', sandbox.screenshot_url, group),
   view_count: number('view_count', sandbox.view_count, {}, group),

--- a/packages/common/src/components/SandboxCard/index.stories.tsx
+++ b/packages/common/src/components/SandboxCard/index.stories.tsx
@@ -19,14 +19,14 @@ const stories = storiesOf('components/SandboxCard', module)
 
 const knobbedAuthor = (
   group: string,
-  author: Sandbox['author']
+  author: Sandbox['author'] = null
 ): Sandbox['author'] => {
   const knobs = {
     username: text('author.username', author && author.username, group),
     avatar_url: text('author.avatar_url', author && author.avatar_url, group),
   };
 
-  if (knobs.username || knobs.avatar_url) {
+  if (knobs.username !== null || knobs.avatar_url !== null) {
     return knobs;
   } else {
     return author;

--- a/packages/common/src/components/SandboxCard/index.stories.tsx
+++ b/packages/common/src/components/SandboxCard/index.stories.tsx
@@ -1,13 +1,81 @@
 import * as React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
-import SandboxCard, { Props } from './';
+import {
+  withKnobs,
+  text,
+  select,
+  number,
+  array,
+  boolean,
+} from '@storybook/addon-knobs';
+import SandboxCard, { Props, Sandbox } from './';
 import * as fake from './fixtures';
 import { ThemeDecorator } from '../../stories/decorators';
+import { TemplateType } from '../../templates';
+import { template } from 'handlebars';
 
-const stories = storiesOf('components/SandboxCard', module).addDecorator(
-  ThemeDecorator
+type TemplateOptions = { [K in TemplateType]: K };
+
+const templates: TemplateType[] = [
+  'adonis',
+  'create-react-app',
+  'vue-cli',
+  'preact-cli',
+  'svelte',
+  'create-react-app-typescript',
+  'angular-cli',
+  'parcel',
+  'cxjs',
+  '@dojo/cli-create-app',
+  'gatsby',
+  'marko',
+  'nuxt',
+  'next',
+  'reason',
+  'apollo',
+  'sapper',
+  'nest',
+  'static',
+  'styleguidist',
+  'gridsome',
+  'vuepress',
+  'mdx-deck',
+  'quasar',
+  'unibit',
+];
+
+const templateOptions = templates.reduce<TemplateOptions>(
+  (acc, key) => ({
+    ...acc,
+    [key]: key,
+  }),
+  {} as TemplateOptions
 );
+
+const stories = storiesOf('components/SandboxCard', module)
+  .addDecorator(ThemeDecorator)
+  .addDecorator(withKnobs);
+
+const knobbedSandbox = (defaults: Sandbox): Sandbox => ({
+  id: text('id', defaults.id, 'sandbox'),
+  title: text('title', defaults.title, 'sandbox'),
+  author: defaults.author && {
+    username: text('author.username', defaults.author.username, 'sandbox'),
+    avatar_url: text(
+      'author.avatar_url',
+      defaults.author.avatar_url,
+      'sandbox'
+    ),
+  },
+  description: text('description', defaults.description, 'sandbox'),
+  screenshot_url: text('screenshot_url', defaults.screenshot_url, 'sandbox'),
+  view_count: number('view_count', defaults.view_count, {}, 'sandbox'),
+  fork_count: number('fork_count', defaults.fork_count, {}, 'sandbox'),
+  like_count: number('like_count', defaults.like_count, {}, 'sandbox'),
+  template: select('template', templateOptions, defaults.template, 'sandbox'),
+  tags: array('tags', defaults.tags, ',', 'sandbox'),
+});
 
 const createSandboxStory = ({
   sandbox = fake.sandbox(),
@@ -18,12 +86,12 @@ const createSandboxStory = ({
   noMargin,
 }: Partial<Props>) => () => (
   <SandboxCard
-    sandbox={sandbox}
+    sandbox={knobbedSandbox(sandbox)}
     selectSandbox={selectSandbox}
-    small={small}
-    noHeight={noHeight}
-    defaultHeight={defaultHeight}
-    noMargin={noMargin}
+    small={boolean('small', small)}
+    noHeight={boolean('noHeight', noHeight)}
+    defaultHeight={number('defaultHeight', defaultHeight)}
+    noMargin={boolean('noMargin', noMargin)}
   />
 );
 

--- a/packages/common/src/components/SandboxCard/index.stories.tsx
+++ b/packages/common/src/components/SandboxCard/index.stories.tsx
@@ -10,47 +10,8 @@ import {
   boolean,
 } from '@storybook/addon-knobs';
 import SandboxCard, { Props, Sandbox } from './';
-import * as fake from './fixtures';
+import * as fixtures from './fixtures';
 import { ThemeDecorator } from '../../stories/decorators';
-import { TemplateType } from '../../templates';
-
-type TemplateOptions = { [K in TemplateType]: K };
-
-const templates: TemplateType[] = [
-  'adonis',
-  'create-react-app',
-  'vue-cli',
-  'preact-cli',
-  'svelte',
-  'create-react-app-typescript',
-  'angular-cli',
-  'parcel',
-  'cxjs',
-  '@dojo/cli-create-app',
-  'gatsby',
-  'marko',
-  'nuxt',
-  'next',
-  'reason',
-  'apollo',
-  'sapper',
-  'nest',
-  'static',
-  'styleguidist',
-  'gridsome',
-  'vuepress',
-  'mdx-deck',
-  'quasar',
-  'unibit',
-];
-
-const templateOptions = templates.reduce<TemplateOptions>(
-  (acc, key) => ({
-    ...acc,
-    [key]: key,
-  }),
-  {} as TemplateOptions
-);
 
 const stories = storiesOf('components/SandboxCard', module)
   .addDecorator(ThemeDecorator)
@@ -81,12 +42,17 @@ const knobbedSandbox = (group: string, sandbox: Sandbox): Sandbox => ({
   view_count: number('view_count', sandbox.view_count, {}, group),
   fork_count: number('fork_count', sandbox.fork_count, {}, group),
   like_count: number('like_count', sandbox.like_count, {}, group),
-  template: select('template', templateOptions, sandbox.template, group),
+  template: select(
+    'template',
+    fixtures.templateOptions,
+    sandbox.template,
+    group
+  ),
   tags: array('tags', sandbox.tags, ',', group),
 });
 
 const createSandboxStory = ({
-  sandbox = fake.sandbox(),
+  sandbox = fixtures.sandbox(),
   selectSandbox = action('selectSandbox'),
   small,
   noHeight,
@@ -113,49 +79,52 @@ stories.add('default height', createSandboxStory({ defaultHeight: 500 }));
 
 stories.add('no margin', createSandboxStory({ noMargin: true }));
 
-stories.add('popular', createSandboxStory({ sandbox: fake.popularSandbox() }));
+stories.add(
+  'popular',
+  createSandboxStory({ sandbox: fixtures.popularSandbox() })
+);
 
 stories.add(
   'many tags',
-  createSandboxStory({ sandbox: fake.sandboxWithManyTags() })
+  createSandboxStory({ sandbox: fixtures.sandboxWithManyTags() })
 );
 
 stories.add(
   'long title',
-  createSandboxStory({ sandbox: fake.sandboxWithLongTitle() })
+  createSandboxStory({ sandbox: fixtures.sandboxWithLongTitle() })
 );
 
 stories.add(
   'long description',
   createSandboxStory({
-    sandbox: fake.sandboxWithLongDescription(),
+    sandbox: fixtures.sandboxWithLongDescription(),
   })
 );
 
 stories.add(
   'null author',
   createSandboxStory({
-    sandbox: fake.sandboxWithNullAuthor(),
+    sandbox: fixtures.sandboxWithNullAuthor(),
   })
 );
 
 stories.add(
   'undefined author',
   createSandboxStory({
-    sandbox: fake.sandboxWithUndefinedAuthor(),
+    sandbox: fixtures.sandboxWithUndefinedAuthor(),
   })
 );
 
 stories.add(
   'null screenshot url',
   createSandboxStory({
-    sandbox: fake.sandboxWithNullScreenshotUrl(),
+    sandbox: fixtures.sandboxWithNullScreenshotUrl(),
   })
 );
 
 stories.add(
   'undefined screenshot url',
   createSandboxStory({
-    sandbox: fake.sandboxWithUndefinedScreenshotUrl(),
+    sandbox: fixtures.sandboxWithUndefinedScreenshotUrl(),
   })
 );

--- a/packages/common/src/components/SandboxCard/index.stories.tsx
+++ b/packages/common/src/components/SandboxCard/index.stories.tsx
@@ -13,10 +13,6 @@ import SandboxCard, { Props, Sandbox } from './';
 import * as fixtures from './fixtures';
 import { ThemeDecorator } from '../../stories/decorators';
 
-const stories = storiesOf('components/SandboxCard', module)
-  .addDecorator(ThemeDecorator)
-  .addDecorator(withKnobs);
-
 const authorWithKnobs = (
   group: string,
   author: Sandbox['author'] = null
@@ -69,62 +65,50 @@ const createSandboxStory = ({
   />
 );
 
-stories.add('basic', createSandboxStory({}));
-
-stories.add('small', createSandboxStory({ small: true }));
-
-stories.add('no height', createSandboxStory({ noHeight: true }));
-
-stories.add('default height', createSandboxStory({ defaultHeight: 500 }));
-
-stories.add('no margin', createSandboxStory({ noMargin: true }));
-
-stories.add(
-  'popular',
-  createSandboxStory({ sandbox: fixtures.popularSandbox() })
-);
-
-stories.add(
-  'many tags',
-  createSandboxStory({ sandbox: fixtures.sandboxWithManyTags() })
-);
-
-stories.add(
-  'long title',
-  createSandboxStory({ sandbox: fixtures.sandboxWithLongTitle() })
-);
-
-stories.add(
-  'long description',
-  createSandboxStory({
-    sandbox: fixtures.sandboxWithLongDescription(),
-  })
-);
-
-stories.add(
-  'null author',
-  createSandboxStory({
-    sandbox: fixtures.sandboxWithNullAuthor(),
-  })
-);
-
-stories.add(
-  'undefined author',
-  createSandboxStory({
-    sandbox: fixtures.sandboxWithUndefinedAuthor(),
-  })
-);
-
-stories.add(
-  'null screenshot url',
-  createSandboxStory({
-    sandbox: fixtures.sandboxWithNullScreenshotUrl(),
-  })
-);
-
-stories.add(
-  'undefined screenshot url',
-  createSandboxStory({
-    sandbox: fixtures.sandboxWithUndefinedScreenshotUrl(),
-  })
-);
+storiesOf('components/SandboxCard', module)
+  .addDecorator(ThemeDecorator)
+  .addDecorator(withKnobs)
+  .add('basic', createSandboxStory({}))
+  .add('small', createSandboxStory({ small: true }))
+  .add('no height', createSandboxStory({ noHeight: true }))
+  .add('default height', createSandboxStory({ defaultHeight: 500 }))
+  .add('no margin', createSandboxStory({ noMargin: true }))
+  .add('popular', createSandboxStory({ sandbox: fixtures.popularSandbox() }))
+  .add(
+    'many tags',
+    createSandboxStory({ sandbox: fixtures.sandboxWithManyTags() })
+  )
+  .add(
+    'long title',
+    createSandboxStory({ sandbox: fixtures.sandboxWithLongTitle() })
+  )
+  .add(
+    'long description',
+    createSandboxStory({
+      sandbox: fixtures.sandboxWithLongDescription(),
+    })
+  )
+  .add(
+    'null author',
+    createSandboxStory({
+      sandbox: fixtures.sandboxWithNullAuthor(),
+    })
+  )
+  .add(
+    'undefined author',
+    createSandboxStory({
+      sandbox: fixtures.sandboxWithUndefinedAuthor(),
+    })
+  )
+  .add(
+    'null screenshot url',
+    createSandboxStory({
+      sandbox: fixtures.sandboxWithNullScreenshotUrl(),
+    })
+  )
+  .add(
+    'undefined screenshot url',
+    createSandboxStory({
+      sandbox: fixtures.sandboxWithUndefinedScreenshotUrl(),
+    })
+  );

--- a/packages/common/src/components/flex/fixtures.tsx
+++ b/packages/common/src/components/flex/fixtures.tsx
@@ -1,0 +1,9 @@
+export const justifyContentOptions = [
+  'stretch',
+  'center',
+  'space-between',
+  'space-around',
+  'space-evenly',
+  null,
+];
+export const alignItemsOptions = ['stretch', 'center', 'start', 'end', null];

--- a/packages/common/src/components/flex/index.stories.tsx
+++ b/packages/common/src/components/flex/index.stories.tsx
@@ -27,7 +27,6 @@ const Background = styled.div`
 
 const Content = styled.div`
   background-color: ${() => color('content', 'green', 'colors')};
-  position: absolute;
   height: 100px;
   width: 100px;
 `;

--- a/packages/common/src/components/flex/index.stories.tsx
+++ b/packages/common/src/components/flex/index.stories.tsx
@@ -1,0 +1,105 @@
+import * as React from 'react';
+import styled, { CSSProperties } from 'styled-components';
+import { storiesOf, RenderFunction } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+import {
+  withKnobs,
+  color,
+  boolean,
+  number,
+  select,
+  text,
+} from '@storybook/addon-knobs';
+import Centered from './Centered';
+import Fullscreen from './Fullscreen';
+import Row from './Row';
+import Column from './Column';
+import { ThemeDecorator } from '../../stories/decorators';
+
+const Background = styled.div`
+  background-color: ${() => color('background', 'darkblue', 'colors')};
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 100%;
+  padding: 10px;
+`;
+
+const Content = styled.div`
+  background-color: ${() => color('content', 'green', 'colors')};
+  position: absolute;
+  height: 100px;
+  width: 100px;
+`;
+
+const CenteredBordered = styled(Centered)`
+  border: 2px solid ${() => color('Centered', 'yellow', 'colors')};
+`;
+
+const FullscreenBordered = styled(Fullscreen)`
+  border: 2px solid ${() => color('Fullscreen', 'red', 'colors')};
+`;
+
+const ColumnBordered = styled(Column)`
+  border: 2px solid ${() => color('Column', 'orange', 'colors')};
+`;
+
+const withBackground = (fn: RenderFunction) => <Background>{fn()}</Background>;
+
+const stories = storiesOf('components/flex', module)
+  .addDecorator(withKnobs)
+  .addDecorator(withBackground);
+
+stories.add('Centered', () => (
+  <CenteredBordered
+    horizontal={boolean('horizontal', false, 'Centered Props')}
+    vertical={boolean('vertical', false, 'Centered Props')}
+  >
+    <Content />
+  </CenteredBordered>
+));
+
+stories.add('Fullscreen', () => (
+  <FullscreenBordered>
+    <Content />
+  </FullscreenBordered>
+));
+
+stories.add('Fullscreen > Centered', () => (
+  <FullscreenBordered>
+    <CenteredBordered
+      horizontal={boolean('horizontal', false, 'Centered Props')}
+      vertical={boolean('vertical', false, 'Centered Props')}
+    >
+      <Content />
+    </CenteredBordered>
+  </FullscreenBordered>
+));
+
+stories.add('Column', () => (
+  <ColumnBordered
+    flex={boolean('flex', false, 'Column Props')}
+    alignItems={select(
+      'alignItems',
+      ['stretch', 'center', 'start', 'end', null],
+      null,
+      'Column Props'
+    )}
+    justifyContent={select(
+      'justifyContent',
+      [
+        'stretch',
+        'center',
+        'space-between',
+        'space-around',
+        'space-evenly',
+        null,
+      ],
+      'space-between',
+      'Column Props'
+    )}
+  >
+    <Content>Column A</Content>
+    <Content>Column B</Content>
+  </ColumnBordered>
+));

--- a/packages/common/src/components/flex/index.stories.tsx
+++ b/packages/common/src/components/flex/index.stories.tsx
@@ -1,104 +1,193 @@
 import * as React from 'react';
-import styled, { CSSProperties } from 'styled-components';
+import styled, { AnyStyledComponent } from 'styled-components';
 import { storiesOf, RenderFunction } from '@storybook/react';
-import { action } from '@storybook/addon-actions';
 import {
   withKnobs,
   color,
   boolean,
   number,
   select,
-  text,
 } from '@storybook/addon-knobs';
 import Centered from './Centered';
 import Fullscreen from './Fullscreen';
 import Row from './Row';
 import Column from './Column';
-import { ThemeDecorator } from '../../stories/decorators';
+import { alignItemsOptions, justifyContentOptions } from './fixtures';
+import MaxWidth from './MaxWidth';
 
 const Background = styled.div`
-  background-color: ${() => color('background', 'darkblue', 'colors')};
   position: absolute;
+  left: 0;
   top: 0;
   bottom: 0;
-  width: 100%;
-  padding: 10px;
-`;
-
-const Content = styled.div`
-  background-color: ${() => color('content', 'green', 'colors')};
-  height: 100px;
-  width: 100px;
-`;
-
-const CenteredBordered = styled(Centered)`
-  border: 2px solid ${() => color('Centered', 'yellow', 'colors')};
-`;
-
-const FullscreenBordered = styled(Fullscreen)`
-  border: 2px solid ${() => color('Fullscreen', 'red', 'colors')};
-`;
-
-const ColumnBordered = styled(Column)`
-  border: 2px solid ${() => color('Column', 'orange', 'colors')};
+  right: 0;
 `;
 
 const withBackground = (fn: RenderFunction) => <Background>{fn()}</Background>;
+
+const makeBorderedContainer = (
+  name: string,
+  Component: AnyStyledComponent,
+  defaultColor: string
+) => styled(Component)`
+  border: 5px dashed ${() => color(name, defaultColor, 'colors')};
+  padding: 10px;
+  box-sizing: border-box;
+`;
+
+const Content = makeBorderedContainer(
+  'content',
+  styled.div`
+    display: flex;
+    overflow: hidden;
+    white-space: pre-wrap;
+    justify-content: center;
+    align-items: center;
+    min-height: 100px;
+    min-width: 100px;
+  `,
+  'green'
+);
+
+const makeContent = () => {
+  const count = number('Repeat content', 1, {}, 'other');
+  const letters = ['A', 'B', 'C', 'D', 'E', 'F', 'G'];
+  let contents: JSX.Element[] = [];
+
+  for (let i = 0; i < count; i++) {
+    const letter = letters[i % letters.length];
+    const repeat = Math.trunc(i / letters.length);
+    let label = letter;
+
+    for (let j = 0; j < repeat; j++) {
+      label += ` ${letter}`;
+    }
+
+    contents.push(<Content>{label}</Content>);
+  }
+
+  return <>{contents}</>;
+};
+
+const CenteredBordered = makeBorderedContainer('Centered', Centered, 'yellow');
+
+const withCenteredBordered = (fn: RenderFunction) => (
+  <CenteredBordered
+    horizontal={boolean('horizontal', false, 'Centered Props')}
+    vertical={boolean('vertical', false, 'Centered Props')}
+  >
+    {fn()}
+  </CenteredBordered>
+);
+
+const FullscreenBordered = makeBorderedContainer(
+  'Fullscreen',
+  Fullscreen,
+  'red'
+);
+
+const withFullscreenBordered = (fn: RenderFunction) => (
+  <FullscreenBordered>{fn()}</FullscreenBordered>
+);
+
+const ColumnBordered = makeBorderedContainer('Column', Column, 'yellow');
+
+const withColumnBordered = (fn: RenderFunction) => (
+  <ColumnBordered
+    flex={boolean('flex', false, 'Column Props')}
+    alignItems={select('alignItems', alignItemsOptions, null, 'Column Props')}
+    justifyContent={select(
+      'justifyContent',
+      justifyContentOptions,
+      'space-between',
+      'Column Props'
+    )}
+  >
+    {fn()}
+  </ColumnBordered>
+);
+
+const RowBordered = makeBorderedContainer('Row', Row, 'orange');
+
+const withRowBordered = (fn: RenderFunction) => (
+  <RowBordered
+    alignItems={select('alignItems', alignItemsOptions, null, 'Row Props')}
+    justifyContent={select(
+      'justifyContent',
+      justifyContentOptions,
+      'space-between',
+      'Row Props'
+    )}
+  >
+    {fn()}
+  </RowBordered>
+);
+
+const MaxWidthBordered = makeBorderedContainer(
+  'MaxWidth',
+  MaxWidth as AnyStyledComponent,
+  'blue'
+);
+
+const withMaxWidthBordered = (fn: RenderFunction) => (
+  <MaxWidthBordered
+    responsive={boolean('responsive', undefined, 'MaxWidth props')}
+    width={number('width', undefined, {}, 'MaxWidth props')}
+  >
+    {fn() as JSX.Element}
+  </MaxWidthBordered>
+);
 
 const stories = storiesOf('components/flex', module)
   .addDecorator(withKnobs)
   .addDecorator(withBackground);
 
-stories.add('Centered', () => (
-  <CenteredBordered
-    horizontal={boolean('horizontal', false, 'Centered Props')}
-    vertical={boolean('vertical', false, 'Centered Props')}
-  >
-    <Content />
-  </CenteredBordered>
-));
+stories.add('Centered', () => withCenteredBordered(makeContent));
 
-stories.add('Fullscreen', () => (
-  <FullscreenBordered>
-    <Content />
-  </FullscreenBordered>
-));
+stories.add('Fullscreen', () => withFullscreenBordered(makeContent));
+stories.add('MaxWidth', () => withMaxWidthBordered(makeContent));
 
-stories.add('Fullscreen > Centered', () => (
-  <FullscreenBordered>
-    <CenteredBordered
-      horizontal={boolean('horizontal', false, 'Centered Props')}
-      vertical={boolean('vertical', false, 'Centered Props')}
-    >
-      <Content />
-    </CenteredBordered>
-  </FullscreenBordered>
-));
+stories.add('Column', () => withColumnBordered(makeContent));
 
-stories.add('Column', () => (
-  <ColumnBordered
-    flex={boolean('flex', false, 'Column Props')}
-    alignItems={select(
-      'alignItems',
-      ['stretch', 'center', 'start', 'end', null],
-      null,
-      'Column Props'
-    )}
-    justifyContent={select(
-      'justifyContent',
-      [
-        'stretch',
-        'center',
-        'space-between',
-        'space-around',
-        'space-evenly',
-        null,
-      ],
-      'space-between',
-      'Column Props'
-    )}
-  >
-    <Content>Column A</Content>
-    <Content>Column B</Content>
-  </ColumnBordered>
-));
+stories.add('Row', () => withRowBordered(makeContent));
+
+const repeat = (name: string, fn: RenderFunction) => () => {
+  const times = number(`Repeat ${name}`, 1, {}, 'other');
+  const content: JSX.Element[] = [];
+
+  for (let i = 0; i < times; i++) {
+    content.push(fn() as JSX.Element);
+  }
+
+  return <>{content}</>;
+};
+
+stories.add('Fullscreen > Centered', () =>
+  withFullscreenBordered(
+    repeat('Centered', () => withCenteredBordered(makeContent))
+  )
+);
+
+stories.add('Fullscreen > Column', () =>
+  withFullscreenBordered(
+    repeat('Column', () => withColumnBordered(makeContent))
+  )
+);
+
+stories.add('Fullscreen > Row', () =>
+  withFullscreenBordered(repeat('Row', () => withRowBordered(makeContent)))
+);
+
+stories.add('MaxWidth > Centered', () =>
+  withMaxWidthBordered(
+    repeat('Centered', () => withCenteredBordered(makeContent))
+  )
+);
+
+stories.add('MaxWidth > Column', () =>
+  withMaxWidthBordered(repeat('Column', () => withColumnBordered(makeContent)))
+);
+
+stories.add('MaxWidth > Row', () =>
+  withMaxWidthBordered(repeat('Row', () => withRowBordered(makeContent)))
+);

--- a/packages/common/src/components/flex/index.stories.tsx
+++ b/packages/common/src/components/flex/index.stories.tsx
@@ -37,14 +37,14 @@ const makeBorderedContainer = (
 
 const Content = makeBorderedContainer(
   'content',
-  styled.div`
+  styled.div<{ minWidth: number; minHeight: number }>`
     display: flex;
     overflow: hidden;
     white-space: pre-wrap;
     justify-content: center;
     align-items: center;
-    min-height: 100px;
-    min-width: 100px;
+    min-height: ${props => props.minHeight}px;
+    min-width: ${props => props.minWidth}px;
   `,
   'green'
 );
@@ -63,7 +63,14 @@ const makeContent = () => {
       label += ` ${letter}`;
     }
 
-    contents.push(<Content>{label}</Content>);
+    const width = number(`"${label}".minWidth`, 100, {}, 'content sizes');
+    const height = number(`"${label}".minHeight`, 100, {}, 'content sizes');
+
+    contents.push(
+      <Content minWidth={width} minHeight={height}>
+        {label}
+      </Content>
+    );
   }
 
   return <>{contents}</>;

--- a/packages/common/src/components/flex/index.stories.tsx
+++ b/packages/common/src/components/flex/index.stories.tsx
@@ -145,19 +145,6 @@ const withMaxWidthBordered = (fn: RenderFunction) => (
   </MaxWidthBordered>
 );
 
-const stories = storiesOf('components/flex', module)
-  .addDecorator(withKnobs)
-  .addDecorator(withBackground);
-
-stories.add('Centered', () => withCenteredBordered(makeContent));
-
-stories.add('Fullscreen', () => withFullscreenBordered(makeContent));
-stories.add('MaxWidth', () => withMaxWidthBordered(makeContent));
-
-stories.add('Column', () => withColumnBordered(makeContent));
-
-stories.add('Row', () => withRowBordered(makeContent));
-
 const repeat = (name: string, fn: RenderFunction) => () => {
   const times = number(`Repeat ${name}`, 1, {}, 'other');
   const content: JSX.Element[] = [];
@@ -169,32 +156,37 @@ const repeat = (name: string, fn: RenderFunction) => () => {
   return <>{content}</>;
 };
 
-stories.add('Fullscreen > Centered', () =>
-  withFullscreenBordered(
-    repeat('Centered', () => withCenteredBordered(makeContent))
+storiesOf('components/flex', module)
+  .addDecorator(withKnobs)
+  .addDecorator(withBackground)
+  .add('Centered', () => withCenteredBordered(makeContent))
+  .add('Fullscreen', () => withFullscreenBordered(makeContent))
+  .add('MaxWidth', () => withMaxWidthBordered(makeContent))
+  .add('Column', () => withColumnBordered(makeContent))
+  .add('Row', () => withRowBordered(makeContent))
+  .add('Fullscreen > Centered', () =>
+    withFullscreenBordered(
+      repeat('Centered', () => withCenteredBordered(makeContent))
+    )
   )
-);
-
-stories.add('Fullscreen > Column', () =>
-  withFullscreenBordered(
-    repeat('Column', () => withColumnBordered(makeContent))
+  .add('Fullscreen > Column', () =>
+    withFullscreenBordered(
+      repeat('Column', () => withColumnBordered(makeContent))
+    )
   )
-);
-
-stories.add('Fullscreen > Row', () =>
-  withFullscreenBordered(repeat('Row', () => withRowBordered(makeContent)))
-);
-
-stories.add('MaxWidth > Centered', () =>
-  withMaxWidthBordered(
-    repeat('Centered', () => withCenteredBordered(makeContent))
+  .add('Fullscreen > Row', () =>
+    withFullscreenBordered(repeat('Row', () => withRowBordered(makeContent)))
   )
-);
-
-stories.add('MaxWidth > Column', () =>
-  withMaxWidthBordered(repeat('Column', () => withColumnBordered(makeContent)))
-);
-
-stories.add('MaxWidth > Row', () =>
-  withMaxWidthBordered(repeat('Row', () => withRowBordered(makeContent)))
-);
+  .add('MaxWidth > Centered', () =>
+    withMaxWidthBordered(
+      repeat('Centered', () => withCenteredBordered(makeContent))
+    )
+  )
+  .add('MaxWidth > Column', () =>
+    withMaxWidthBordered(
+      repeat('Column', () => withColumnBordered(makeContent))
+    )
+  )
+  .add('MaxWidth > Row', () =>
+    withMaxWidthBordered(repeat('Row', () => withRowBordered(makeContent)))
+  );


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?

Added storybook knobs to the SandboxCard stories. Also adds stories for the flex package

## What is the current behavior?

This adds a new feature to the existing storybook stories. There were previously no stories for the flex package.

## What is the new behavior?

Adds knobs to SandboxCard stories, that allows Storybook users to edit props and see the changes live in the story. Also adds stories with knobs for the flex package.

## What steps did you take to test this?

Tested locally.

### SandboxCard stories
![storybook-knobs](https://user-images.githubusercontent.com/131928/62414420-d90c1a80-b5e8-11e9-8035-14fa8bbd25ae.gif)

### Flex stories

<img width="1050" alt="Screen Shot 2019-08-08 at 10 10 14 PM" src="https://user-images.githubusercontent.com/131928/62750441-36abc700-ba2e-11e9-9476-9817e8f27e91.png">

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Testing <!-- We can only merge the PR if this is checked -->
- [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
