### PR TITLE
Fix the string_decoder dependency missing

### DIFF
--- a/packages/node-services/package.json
+++ b/packages/node-services/package.json
@@ -10,6 +10,7 @@
     "constants-browserify": "^1.0.0",
     "events": "^3.0.0",
     "resolve": "^1.10.0",
+    "string_decoder": "^1.3.0",
     "util": "^0.12.1",
     "ws": "^6.1.0"
   },

--- a/packages/node-services/src/module.ts
+++ b/packages/node-services/src/module.ts
@@ -154,6 +154,10 @@ export default class Module {
       return require('assert');
     }
 
+    if (request === 'string_decoder') {
+      return require('string_decoder');
+    }
+
     if (request === 'diagnostics') {
       return require('debug');
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -19694,6 +19694,11 @@ safe-buffer@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.0.1.tgz#d263ca54696cd8a306b5ca6551e92de57918fbe7"
 
+safe-buffer@~5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.0.tgz#b74daec49b1148f88c64b68d49b1e815c1f2f519"
+  integrity sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==
+
 safe-regex@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/safe-regex/-/safe-regex-1.1.0.tgz#40a3669f3b077d1e943d44629e157dd48023bf2e"
@@ -20900,6 +20905,13 @@ string_decoder@^1.0.0, string_decoder@^1.1.1:
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.2.0.tgz#fe86e738b19544afe70469243b2a1ee9240eae8d"
   dependencies:
     safe-buffer "~5.1.0"
+
+string_decoder@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
+  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
+  dependencies:
+    safe-buffer "~5.2.0"
 
 string_decoder@~0.10.x:
   version "0.10.31"


### PR DESCRIPTION
Fixes #2288

Due to our dependency clean we actually lost some random dependencies like `string_decoder`. This adds it explicitly