### PR TITLE
Add allow="usb" to Preview iframe

### DIFF
--- a/packages/app/src/app/pages/common/Modals/ShareModal/getCode.js
+++ b/packages/app/src/app/pages/common/Modals/ShareModal/getCode.js
@@ -66,7 +66,7 @@ export const getEmbedUrl = (sandbox, mainModule, state) =>
 export const getIframeScript = (sandbox, mainModule, state) =>
   `<iframe src="${getEmbedUrl(sandbox, mainModule, state)}" title="${escapeHtml(
     getSandboxName(sandbox)
-  )}" allow="geolocation; microphone; camera; midi; vr; accelerometer; gyroscope; payment; ambient-light-sensor; encrypted-media" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>`;
+  )}" allow="geolocation; microphone; camera; midi; vr; accelerometer; gyroscope; payment; ambient-light-sensor; encrypted-media; usb" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>`;
 
 // eslint-disable-next-line
 export const getButtonMarkdown = (sandbox, mainModule, state) => {

--- a/packages/common/src/components/Preview/index.tsx
+++ b/packages/common/src/components/Preview/index.tsx
@@ -533,7 +533,7 @@ class BasePreview extends React.Component<Props, State> {
             <React.Fragment>
               <StyledFrame
                 sandbox="allow-forms allow-scripts allow-same-origin allow-modals allow-popups allow-presentation"
-                allow="geolocation; microphone; camera;midi; vr; accelerometer; gyroscope; payment; ambient-light-sensor; encrypted-media"
+                allow="geolocation; microphone; camera;midi; vr; accelerometer; gyroscope; payment; ambient-light-sensor; encrypted-media; usb"
                 src={this.currentUrl()}
                 ref={this.setIframeElement}
                 title={getSandboxName(sandbox)}


### PR DESCRIPTION
Closes #2304

## What kind of change does this PR introduce?

Bugfix

## What is the current behavior?

See #2304. USB permission is blocked, so the only way to develop WebUSB sandboxes is to use the "open in new window" pop-out.

## What is the new behavior?

WebUSB is now allowed in the integrated preview window.

## What steps did you take to test this?

See repro steps in #2304. Using Chrome or Brave, enter `window.navigator.usb.requestDevice({ filters: []})` in the Preview console. It should open the browser's WebUSB device picker.

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation (N/A?)
- [x] Testing <!-- We can only merge the PR if this is checked -->
- [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
