### PR TITLE
embed: make folders collapsable

### DIFF
--- a/packages/app/src/embed/components/File/index.js
+++ b/packages/app/src/embed/components/File/index.js
@@ -29,13 +29,16 @@ export default class File extends React.PureComponent<Props> {
   };
 
   render() {
-    const { title, depth, type, active, alternative } = this.props;
+    const { title, depth, type, active, alternative, onClick } = this.props;
     return (
       <div>
         <Entry
           alternative={alternative}
           active={active}
-          onClick={this.setCurrentModule}
+          onClick={() => {
+            onClick && onClick();
+            this.setCurrentModule();
+          }}
           type={type}
         >
           <LeftOffset depth={depth}>

--- a/packages/app/src/embed/components/File/index.js
+++ b/packages/app/src/embed/components/File/index.js
@@ -7,25 +7,18 @@ import EntryTitle from 'app/pages/Sandbox/Editor/Workspace/Files/DirectoryEntry/
 import { LeftOffset } from './elements';
 
 type Props = {
-  id: string,
-  setCurrentModule: (id: string) => void,
   title: string,
   depth: number,
   type: string,
   active?: boolean,
   alternative?: boolean,
+  onClick?: () => void,
 };
 
 export default class File extends React.PureComponent<Props> {
   static defaultProps = {
     active: false,
     alternative: false,
-  };
-
-  setCurrentModule = () => {
-    const { id, setCurrentModule } = this.props;
-
-    setCurrentModule(id);
   };
 
   render() {
@@ -35,11 +28,8 @@ export default class File extends React.PureComponent<Props> {
         <Entry
           alternative={alternative}
           active={active}
-          onClick={() => {
-            onClick && onClick();
-            this.setCurrentModule();
-          }}
           type={type}
+          onClick={onClick}
         >
           <LeftOffset depth={depth}>
             <EntryIcons type={type} />

--- a/packages/app/src/embed/components/Files/index.js
+++ b/packages/app/src/embed/components/Files/index.js
@@ -112,17 +112,16 @@ function Directory({
   depth,
 }) {
   /** directory should be open by default if currentModule is inside it */
+  const [open, setOpen] = React.useState(function() {
+    const currentModule = getCurrentModule(modules, currentModuleId);
+    const currentModuleTree = getCurrentModuleTree(directories, currentModule);
 
-  const currentModule = getCurrentModule(modules, currentModuleId);
-
-  const currentModuleTree = getCurrentModuleTree(directories, currentModule);
-
-  let openByDefault = false;
-  if (currentModuleTree.find(module => module.id === directory.id)) {
-    openByDefault = true;
-  }
-
-  const [open, setOpen] = React.useState(openByDefault);
+    let openByDefault = false;
+    if (currentModuleTree.find(module => module.id === directory.id)) {
+      openByDefault = true;
+    }
+    return openByDefault;
+  });
 
   return (
     <div>

--- a/packages/app/src/embed/components/Files/index.js
+++ b/packages/app/src/embed/components/Files/index.js
@@ -91,33 +91,11 @@ function Directory({
 }) {
   /** directory should be open by default if currentModule is inside it */
 
-  // TODO:
-  // 1. Create the current module tree
-  // 2. Check if directory is in that array
-
-  const getParentDirectory = (directories, child) => {
-    return directories.find(directory => {
-      return directory.shortid === child.directoryShortid;
-    });
-  };
-
-  const getCurrentModuleTree = (modules, currentModuleId) => {
-    const currentModule = modules.find(module => module.id === currentModuleId);
-
-    const currentModuleTree = [currentModule];
-
-    let parentDirectory = getParentDirectory(directories, currentModule);
-
-    while (parentDirectory) {
-      currentModuleTree.push(parentDirectory);
-      // get parent directory of the parent directory
-      parentDirectory = getParentDirectory(directories, parentDirectory);
-    }
-
-    return currentModuleTree;
-  };
-
-  const currentModuleTree = getCurrentModuleTree(modules, currentModuleId);
+  const currentModuleTree = getCurrentModuleTree(
+    modules,
+    directories,
+    currentModuleId
+  );
 
   let openByDefault = false;
   if (currentModuleTree.find(module => module.id === directory.id)) {
@@ -154,3 +132,27 @@ function Directory({
 }
 
 export default Files;
+
+/** Utils to help identify module tree */
+
+const getParentDirectory = (directories, child) => {
+  return directories.find(directory => {
+    return directory.shortid === child.directoryShortid;
+  });
+};
+
+const getCurrentModuleTree = (modules, directories, currentModuleId) => {
+  const currentModule = modules.find(module => module.id === currentModuleId);
+
+  const currentModuleTree = [currentModule];
+
+  let parentDirectory = getParentDirectory(directories, currentModule);
+
+  while (parentDirectory) {
+    currentModuleTree.push(parentDirectory);
+    // get parent directory of the parent directory
+    parentDirectory = getParentDirectory(directories, parentDirectory);
+  }
+
+  return currentModuleTree;
+};

--- a/packages/app/src/embed/components/Files/index.js
+++ b/packages/app/src/embed/components/Files/index.js
@@ -3,7 +3,10 @@
 import * as React from 'react';
 import { sortBy } from 'lodash-es';
 
-import type { Module, Directory } from '@codesandbox/common/lib/types';
+import type {
+  Module,
+  Directory as DirectoryType,
+} from '@codesandbox/common/lib/types';
 
 import { isMainModule } from '@codesandbox/common/lib/sandbox/modules';
 // eslint-disable-next-line import/extensions
@@ -15,7 +18,7 @@ import { Container } from './elements';
 
 type Props = {
   modules: Array<Module>,
-  directories: Array<Directory>,
+  directories: Array<DirectoryType>,
   directoryId: ?string,
   depth?: number,
   currentModule: string,
@@ -44,28 +47,21 @@ function Files({
 
   return (
     <Container>
-      {sortBy(childrenDirectories, d => d.title).map(d => (
-        <div key={d.shortid}>
-          <File
-            id={d.id}
-            shortid={d.shortid}
-            title={d.title}
-            type="directory-open"
-            depth={depth}
+      {sortBy(childrenDirectories, directory => directory.title).map(
+        directory => (
+          <Directory
+            key={directory.shortid}
+            directory={directory}
+            currentModuleId={currentModule}
             setCurrentModule={setCurrentModule}
-          />
-          <Files
-            modules={modules}
-            directories={directories}
-            directoryId={d.shortid}
-            depth={depth + 1}
-            setCurrentModule={setCurrentModule}
-            currentModule={currentModule}
             template={template}
             entry={entry}
+            modules={modules}
+            directories={directories}
+            depth={depth}
           />
-        </div>
-      ))}
+        )
+      )}
       {sortBy(childrenModules, m => m.title).map(m => (
         <File
           id={m.id}
@@ -80,6 +76,80 @@ function Files({
         />
       ))}
     </Container>
+  );
+}
+
+function Directory({
+  directory,
+  currentModuleId,
+  setCurrentModule,
+  template,
+  entry,
+  modules,
+  directories,
+  depth,
+}) {
+  /** directory should be open by default if currentModule is inside it */
+
+  // TODO:
+  // 1. Create the current module tree
+  // 2. Check if directory is in that array
+
+  const getParentDirectory = (directories, child) => {
+    return directories.find(directory => {
+      return directory.shortid === child.directoryShortid;
+    });
+  };
+
+  const getCurrentModuleTree = (modules, currentModuleId) => {
+    const currentModule = modules.find(module => module.id === currentModuleId);
+
+    const currentModuleTree = [currentModule];
+
+    let parentDirectory = getParentDirectory(directories, currentModule);
+
+    while (parentDirectory) {
+      currentModuleTree.push(parentDirectory);
+      // get parent directory of the parent directory
+      parentDirectory = getParentDirectory(directories, parentDirectory);
+    }
+
+    return currentModuleTree;
+  };
+
+  const currentModuleTree = getCurrentModuleTree(modules, currentModuleId);
+
+  let openByDefault = false;
+  if (currentModuleTree.find(module => module.id === directory.id)) {
+    openByDefault = true;
+  }
+
+  const [open, setOpen] = React.useState(openByDefault);
+
+  return (
+    <div>
+      <File
+        id={directory.id}
+        shortid={directory.shortid}
+        title={directory.title}
+        type={open ? 'directory-open' : 'directory'}
+        depth={depth}
+        setCurrentModule={setCurrentModule}
+        onClick={_ => setOpen(!open)}
+      />
+      {open ? (
+        <Files
+          modules={modules}
+          directories={directories}
+          directoryId={directory.shortid}
+          depth={depth + 1}
+          setCurrentModule={setCurrentModule}
+          currentModule={currentModuleId}
+          template={template}
+          entry={entry}
+        />
+      ) : null}
+    </div>
   );
 }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Enhancement in `Embed` sidebar

Fixes #2342 

## What is the current behavior?

All folders are open by default

## What is the new behavior?

Makes folders collapsable in the sidebar.

Demo: [staging](https://pr2370.build.csb.dev/embed/currying-violet-cvgmq?fontsize=14&module=%2Fpublic%2Fanother%2Fjust-messing.js)

By default, the folder containing the open file is open.

## What steps did you take to test this?

Manually test the embed 😅 
(tested with nested directories as well)

## Checklist

- [NA] Documentation
- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->


## Known bug / missing feature

Nested folders don't remember their open states. Not sure if that's something we should fix here.

<img alt="forgetful folders" src="https://user-images.githubusercontent.com/1863771/64244125-cac35e00-cf08-11e9-8cd8-2745086e5f40.gif" height="300"/>
