### PR TITLE
✨ Add URL to Crash Report, Add CodeSadbox route in Development

### DIFF
--- a/packages/app/src/app/pages/common/ErrorBoundary/CodeSadbox/CodeSadbox.tsx
+++ b/packages/app/src/app/pages/common/ErrorBoundary/CodeSadbox/CodeSadbox.tsx
@@ -69,5 +69,3 @@ export const CodeSadbox = inject('store')(
     )
   )
 );
-
-CodeSadbox.displayName = `CodeSadbox`;

--- a/packages/app/src/app/pages/common/ErrorBoundary/CodeSadbox/buildCrashReport.ts
+++ b/packages/app/src/app/pages/common/ErrorBoundary/CodeSadbox/buildCrashReport.ts
@@ -11,11 +11,13 @@ export const buildCrashReport = ({
 }: IbuildCrashReport): string => {
   const { name, version, os } = browser();
 
-  const title = `💥 Crash Report: <Short Description of Crash Circumstances>`;
+  const title = `💥 Crash Report: <Please Add a Short Description of Crash Circumstances>`;
 
   const body = `<h1>💥 Crash Report</h1>
 
 <h2>What were you trying to accomplish when the crash occurred?</h2>
+
+> Please use this issue template to describe what you were doing when you encountered this crash. While we are able to fill in some details automatically, it's not always enough to reproduce!
 
 <h3>Link to sandbox: [link]() (optional)</h3>
 
@@ -27,6 +29,9 @@ export const buildCrashReport = ({
 | Browser |  Version  | Operating System |
 | ------- | --------- | ---------------- |
 | ${name} | ${version} | ${os}           |
+
+**Route:**
+${window.location.href}
 
 </details>
 

--- a/packages/app/src/app/pages/index.tsx
+++ b/packages/app/src/app/pages/index.tsx
@@ -48,6 +48,7 @@ const Patron = Loadable(() =>
 const Curator = Loadable(() =>
   import(/* webpackChunkName: 'page-curator' */ './Curator')
 );
+const CodeSadbox = () => this[`💥`].kaboom();
 
 const Boundary = withRouter(ErrorBoundary);
 
@@ -95,6 +96,9 @@ const Routes = ({ signals: { appUnmounted } }) => {
             <Route path="/patron" component={Patron} />
             <Route path="/cli/login" component={CLI} />
             <Route path="/auth/zeit" component={ZeitSignIn} />
+            {process.env.NODE_ENV === `development` && (
+              <Route path="/codesadbox" component={CodeSadbox} />
+            )}
             <Route component={NotFound} />
           </Switch>
         </Content>


### PR DESCRIPTION
Updated the crash report template to include the current URL so as to make it easier to hunt down where crashes are occurring. Also updated the template copy to make it more explicit that the user should use the template to write up a crash report.

When running the client locally, the `/codesadbox` route will now be available to make it easier to test changes to the error boundary components. This route is removed in production builds.