### PR TITLE
Fix: React embed breaks with expanddevtools (only in dev mode)

### DIFF
--- a/packages/common/src/templates/template.ts
+++ b/packages/common/src/templates/template.ts
@@ -1,5 +1,3 @@
-import immer from 'immer';
-
 import { absolute } from '../utils/path';
 import {
   ConfigurationFile,
@@ -67,6 +65,10 @@ const CLIENT_VIEWS: ViewConfig[] = [
     views: [{ id: 'codesandbox.console' }, { id: 'codesandbox.problems' }],
   },
 ];
+
+// React sandboxes have an additional devtool on top of CLIENT_VIEWS
+const REACT_CLIENT_VIEWS: ViewConfig[] = [...CLIENT_VIEWS];
+REACT_CLIENT_VIEWS[1].views.push({ id: 'codesandbox.react-devtools' });
 
 const SERVER_VIEWS: ViewConfig[] = [
   {
@@ -204,10 +206,9 @@ export default class Template {
       configurationFiles.package &&
       configurationFiles.package.parsed &&
       configurationFiles.package.parsed.dependencies;
+
     if (dependencies && dependencies.react) {
-      return immer(CLIENT_VIEWS, draft => {
-        draft[1].views.push({ id: 'codesandbox.react-devtools' });
-      });
+      return REACT_CLIENT_VIEWS;
     }
 
     return CLIENT_VIEWS;


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?

Development bug, not production bug 🤷‍♀ 

## What is the current behavior?

View options for React sandboxes are immutable, even though they are mutated in embed.
(introduced here: [#2252](https://github.com/codesandbox/codesandbox-client/pull/2252/commits/14c9111bf4ee88050a49f790de247e1cf65e2b32#diff-f304719feae663f65f8b7f1ae8a2ecc5R208))

## What is the new behavior?

Keep the options mutable. See story below

## What steps did you take to test this?

~~WoRkS oN My mAChiNe~~ Have tested that it doesn't break in dev mode anymore.

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [NA] Documentation
- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

----

### Implementation details

How embed options work: 

1. We load a config for view options from [templates](https://github.com/codesandbox/codesandbox-client/tree/master/packages/common/src/templates)

2. We manipulate this config based on the URL parameters of the embed url. There are only a [few of these](https://github.com/codesandbox/codesandbox-client/blob/master/packages/app/src/embed/components/Content/index.tsx#L414-L425), (i think).

The one I ran into was `embed/new?expanddevtools=1`, open in [localhost](http://localhost:3000/embed/new?expanddevtools=1) to see it break

So, by design, we can't make the view options mutable.

### How does this even work on production?!?!

Well, fun thing about immer is that disables only works on development mode 

> Immer automatically freezes any state trees that are modified using produce. This comes with a performance impact, so it is recommended to disable this option in production. By default, it is turned on during local development and turned off in production. - [Immer docs on Auto freezing](https://github.com/immerjs/immer#auto-freezing)

So, also the embed only breaks in dev mode 🙃

Anywho, we might want to find a nicer mechanism to merge view options with embed options. Until then, mutate away.

Oh, also I created a new variable to give it a little more importance.

