### PR TITLE
[Fix] Embed: expandDevTools flag should override template default

### DIFF
--- a/packages/app/src/embed/components/Content/index.tsx
+++ b/packages/app/src/embed/components/Content/index.tsx
@@ -420,8 +420,17 @@ export default class Content extends React.PureComponent<Props, State> {
       }
     }
 
-    if (expandDevTools) {
-      views[1].open = true;
+    /**
+      We can't make assumptions about the default value
+      of open because it's loaded from common/templates.
+
+      Example: server templates have devTools open by default
+
+      If the user wants to override the default, they can
+      do that by using the explicit flag.
+    */
+    if (typeof expandDevTools !== 'undefined') {
+      views[1].open = expandDevTools;
     }
 
     const browserConfig: IViewType = {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes #2338, expects https://github.com/codesandbox/codesandbox-client/pull/2377 to be merged.

## What is the current behavior?

Embed does not respect `expanddevtools` flag. 

You can see this problem in server sandboxes which have the [console open by default](https://github.com/codesandbox/codesandbox-client/blob/master/packages/common/src/templates/template.ts#L71-L83), `expanddevtools=0` does not override that.

Demo: [embed/node?expanddevtools=0](https://codesandbox.io/embed/node?expanddevtools=0)


## What is the new behavior?

Embed uses the default open state from sandbox template (open for server templates), but let's the user override it with the `expanddevtools` flag

Demo: [staging/embed/node?expanddevtools=0](https://pr2378.build.csb.dev/embed/node?expanddevtools=0)

## What steps did you take to test this?

- [x] Tested react embed
- [x] Tested node embed
- [x] Tested react sandbox for regression
- [x] Tested node sandbox for regression

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [NA] Documentation (It's already documented, but doesn't work as documented)
- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
