### PR TITLE
Fix carriage returns with live

### DIFF
--- a/packages/app/src/app/components/CodeEditor/Monaco/event-to-transform.js
+++ b/packages/app/src/app/components/CodeEditor/Monaco/event-to-transform.js
@@ -13,7 +13,7 @@ export default function convertChangeEventToOperation(
   for (const change of [...changeEvent.changes]) {
     const newOt = new TextOperation();
     const cursorStartOffset = lineAndColumnToIndex(
-      composedCode.split(/\r?\n/),
+      composedCode.split(/\n/),
       change.range.startLineNumber,
       change.range.startColumn
     );
@@ -29,8 +29,7 @@ export default function convertChangeEventToOperation(
     }
 
     if (change.text) {
-      const normalizedChangeText = change.text.split(/\r?\n/).join('\n');
-      newOt.insert(normalizedChangeText);
+      newOt.insert(change.text);
     }
 
     const remaining = composedCode.length - newOt.baseLength;


### PR DESCRIPTION
It seems like the one remaining issue with live is different carriage returns. We would already normalize CRLF to LF, but sometimes this would lead to transformations to the transforms and would cause some miscommunication between the server and the client. With this change we start accepting CRLF again, and the server knows how to handle it this time (Elixir apparently reads `\r\n` as 1 byte).

People don't have an issue with CRLF normally when using Live, but whenever they paste code with double carriage returns, the editor used to act up. This time it's fixed! Hopefully we can do some real testing tomorrow to see if everything works properly.