### PR TITLE
Make eslint happy in app

### DIFF
--- a/packages/app/src/app/pages/common/Modals/PreferencesModal/Experiments/index.tsx
+++ b/packages/app/src/app/pages/common/Modals/PreferencesModal/Experiments/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import track from '@codesandbox/common/lib/utils/analytics';
 // import { inject, observer } from 'app/componentConnectors';
 
 import {
@@ -8,7 +9,6 @@ import {
   PreferenceContainer,
   PaddedPreference,
 } from '../elements';
-import track from '@codesandbox/common/lib/utils/analytics';
 
 const windowWithOvermind: {
   useOvermind?: (val?: boolean) => 'true' | null;


### PR DESCRIPTION
Master's build failing = all future builds are failing. Fixed.

> Absolute imports should come before relative imports  import/first

I'm not saying this rule is silly, but it's not super wise either 😋 