### PR TITLE
Replaced skewed logo image

### DIFF
--- a/packages/homepage/content/users.json
+++ b/packages/homepage/content/users.json
@@ -91,7 +91,7 @@
   {
     "name": "CollectiveRay",
     "link": "https://www.collectiveray.com/",
-    "logoURL": "https://cdn.collectiveray.com/images/collectiveray-dark-300.jpg"
+    "logoURL": "https://cdn.collectiveray.com/images/collectiveray-dark-300.png"
   },
   {
     "name": "Appbaseio",


### PR DESCRIPTION
Added a transparent square logo in PNG format instead of older, skewed version.


## What kind of change does this PR introduce?

Small update to website logo
