### PR TITLE
Devtools: Add max limit for height

### DIFF
--- a/packages/app/src/app/components/Preview/DevTools/index.tsx
+++ b/packages/app/src/app/components/Preview/DevTools/index.tsx
@@ -326,8 +326,15 @@ export class DevTools extends React.PureComponent<Props, State> {
     event: MouseEvent & { clientX: number; clientY: number }
   ) => {
     if (this.state.mouseDown) {
-      const newHeight =
-        this.state.startHeight - (event.clientY - this.state.startY);
+      let maxHeight = 0;
+      if (this.node) {
+        maxHeight = this.node.parentElement.getBoundingClientRect().height;
+      }
+
+      const newHeight = Math.min(
+        maxHeight,
+        this.state.startHeight - (event.clientY - this.state.startY)
+      );
 
       this.setState({
         height: Math.max(this.closedHeight() - 2, newHeight),


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes https://github.com/codesandbox/codesandbox-client/issues/2317

## What is the current behavior?

The devtools panel can be resized to a height can go beyond the size of it's container, which makes the `>` console part go under the screen (see gif)

![whered-you-go](https://user-images.githubusercontent.com/1863771/64619563-98bb6b80-d3e2-11e9-86a0-d673cfd915ab.gif)

## What is the new behavior?

The devtools panel stops at the `maxHeight` which is the height of it's container. (See deployed version)

## What steps did you take to test this?

- [x] Tested sandbox
- [x] Tested embed

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [NA] Documentation
- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [NA] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
