### PR TITLE
Cleanup createPages in the gatsby-node file

### DIFF
--- a/packages/homepage/gatsby-node.js
+++ b/packages/homepage/gatsby-node.js
@@ -164,43 +164,40 @@ exports.onCreateNode = ({ actions: { createNodeField }, getNode, node }) => {
   }
 };
 
-const createBlogPages = ({ createPage, data: { edges: blogPosts } }) => {
-  const template = resolve(__dirname, './src/templates/post.js');
-
-  blogPosts.forEach(({ node: { fields: { slug }, id } }) => {
+const createPages = ({ createPage, data, getContext, getPath, template }) => {
+  data.forEach(({ node }) => {
     createPage({
-      path: `post/${slug}`,
+      path: getPath(node),
       component: template,
-      context: {
-        id,
-      },
+      context: getContext(node),
     });
+  });
+};
+const createBlogPages = ({ createPage, data: { edges: blogPosts } }) => {
+  createPages({
+    createPage,
+    data: blogPosts,
+    getContext: ({ fields: { slug } }) => `post/${slug}`,
+    getPath: ({ id }) => ({ id }),
+    template: resolve(__dirname, './src/templates/post.js'),
   });
 };
 const createDocsPages = ({ createPage, data: { edges: docs } }) => {
-  const template = resolve(__dirname, './src/templates/docs.js');
-
-  docs.forEach(({ node: { fields: { slug } } }) => {
-    createPage({
-      path: `docs${slug}`,
-      component: template,
-      context: {
-        slug,
-      },
-    });
+  createPages({
+    createPage,
+    data: docs,
+    getContext: ({ fields: { slug } }) => `docs${slug}`,
+    getPath: ({ fields: { slug } }) => ({ slug }),
+    template: resolve(__dirname, './src/templates/docs.js'),
   });
 };
-const createJobsPages = ({ createPage, data: { edges: jobs } }) => {
-  const template = resolve(__dirname, './src/templates/job.js');
-
-  jobs.forEach(({ node: { fields: { slug }, id } }) => {
-    createPage({
-      path: `job/${slug}`,
-      component: template,
-      context: {
-        id,
-      },
-    });
+const createJobsPages = ({ createPage, data: { edges: blogPosts } }) => {
+  createPages({
+    createPage,
+    data: blogPosts,
+    getContext: ({ fields: { slug } }) => `job/${slug}`,
+    getPath: ({ id }) => ({ id }),
+    template: resolve(__dirname, './src/templates/job.js'),
   });
 };
 exports.createPages = async ({


### PR DESCRIPTION
## What kind of change does this PR introduce?
As a follow-up of #2420, I cleaned up the `createPages` method in the `gatsby-node` file too.
This way the code is a bit cleaner and is easier to reason about and to make changes in the appropriate place.

## What is the current behavior?
All pages are created inside the `createPages` method in the `gatsby-node` file.

## What is the new behavior?
All page-creation is done in separate methods for each type of page.

## What steps did you take to test this?
Go through all pages (blogposts, docs & jobs) to see if everything is still working as it should be.

## Checklist
- [N/A] Documentation
- [x] Testing
- [x] Ready to be merged
- [N/A] Added myself to contributors table