### PR TITLE
fix: box-sizing for Select Sandbox Modal

### DIFF
--- a/packages/app/src/app/pages/common/Modals/SelectSandboxModal/Sandbox/elements.js
+++ b/packages/app/src/app/pages/common/Modals/SelectSandboxModal/Sandbox/elements.js
@@ -11,6 +11,7 @@ export const Button = styled.button`
   background-color: ${props => (props.active ? '#eee' : 'white')};
   padding: 1rem;
   color: rgba(0, 0, 0, 0.9);
+  box-sizing: border-box;
   border-bottom: 1px solid #ddd;
   text-align: left;
   ${props => props.active && 'font-weight: 600'};


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?

<!-- Is it a Bug fix, feature, docs update, ... -->
Bug Fix

## What is the current behavior?
While Changing the showcase sandbox, the date is cropped because of box sizing. Check the below screenshot: 
![image](https://user-images.githubusercontent.com/22376783/64922511-acedd700-d7ed-11e9-8c5b-bddcd01bb7a1.png)

<!-- You can also link to an open issue here -->

## What is the new behavior?
Added CSS to fix it. Check screenshot below: 
![image](https://user-images.githubusercontent.com/22376783/64922515-b8410280-d7ed-11e9-99a4-cd6bac9c73fd.png)

<!-- if this is a feature change -->

## What steps did you take to test this?
Tested Locally

<!-- Most important part!  -->

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation - N/A
- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
