### PR TITLE
fix: templates custom loading on new sandbox modal

### DIFF
--- a/packages/app/src/app/pages/Dashboard/Content/CreateNewSandbox/NewSandboxModal/MyTemplates/MyTemplates.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/CreateNewSandbox/NewSandboxModal/MyTemplates/MyTemplates.tsx
@@ -23,6 +23,10 @@ export const MyTemplates = ({ selectTemplate }: Props) => {
     fetchPolicy: 'cache-and-network',
   });
 
+  if (!data.me) {
+    return null;
+  }
+
   if (data.me && !data.me.templates.length) {
     return null;
   }


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?

<!-- Is it a Bug fix, feature, docs update, ... -->
Not a Bug but can be treated as UX Enhancement.  ( I am not sure if this was intentional )

## What is the current behavior?
If the user doesn't have templates and go to `/s` route he sees a blink of 3 templates loading box which is not visible for a long time. You can check the gif:
![CSBTemplateLoading](https://user-images.githubusercontent.com/22376783/64922956-7f575c80-d7f2-11e9-9e6b-d9226174bbdd.gif)


<!-- You can also link to an open issue here -->

## What is the new behavior?
Fixed the logic to not show loader. Check gif below:
![CSBTemplatesLoadingFix](https://user-images.githubusercontent.com/22376783/64922962-8d0ce200-d7f2-11e9-9da7-7c907064bb3e.gif)


<!-- if this is a feature change -->

## What steps did you take to test this?
Tested Locally

<!-- Most important part!  -->

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation - N/A
- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
