### PR TITLE
Fix creating a sandbox in overmind from dashboard as a team

### DIFF
--- a/packages/app/src/app/overmind/actions.ts
+++ b/packages/app/src/app/overmind/actions.ts
@@ -218,17 +218,8 @@ export const refetchSandboxInfo: AsyncAction = async ({
     sandbox.userLiked = updatedSandbox.userLiked;
     sandbox.title = updatedSandbox.title;
     sandbox.team = updatedSandbox.team;
-
-    state.live.isTeam = Boolean(sandbox.team);
-
-    if (sandbox.roomId === updatedSandbox.roomId) {
-      return;
-    }
-
     sandbox.roomId = updatedSandbox.roomId;
-    await actions.live.internal.disconnect();
-    if (updatedSandbox.owned && updatedSandbox.roomId) {
-      await actions.live.internal.initialize(sandbox.roomId);
-    }
+
+    await actions.editor.internal.initializeLiveSandbox(sandbox);
   }
 };

--- a/packages/app/src/app/overmind/effects/api/index.ts
+++ b/packages/app/src/app/overmind/effects/api/index.ts
@@ -71,12 +71,12 @@ export default {
       })),
     };
   },
-  forkSandbox(id: string): Promise<Sandbox> {
+  forkSandbox(id: string, body?: unknown): Promise<Sandbox> {
     const url = id.includes('/')
       ? `/sandboxes/fork/${id}`
       : `/sandboxes/${id}/fork`;
 
-    return api.post(url, {});
+    return api.post(url, body || {});
   },
   createModule(sandboxId: string, module: Module): Promise<Module> {
     return api.post(`/sandboxes/${sandboxId}/modules`, {

--- a/packages/app/src/app/overmind/factories.ts
+++ b/packages/app/src/app/overmind/factories.ts
@@ -77,7 +77,9 @@ export const withOwnedSandbox = <T>(
         'This sandbox is frozen, and will be forked. Do you want to continue?'
       ))
   ) {
-    await actions.editor.internal.forkSandbox(state.editor.currentId);
+    await actions.editor.internal.forkSandbox({
+      sandboxId: state.editor.currentId,
+    });
   }
 
   return continueAction(context, payload);

--- a/packages/app/src/app/overmind/namespaces/dashboard/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/dashboard/actions.ts
@@ -64,7 +64,8 @@ export const searchChanged: Action<{ search: string }> = (
   state.dashboard.filters.search = search;
 };
 
-export const createSandboxClicked: AsyncAction<{ sandboxId: string }> = (
-  { actions },
-  { sandboxId }
-) => actions.editor.internal.forkSandbox(sandboxId);
+export const createSandboxClicked: AsyncAction<{
+  sandboxId: string;
+  body: { collectionId: string | undefined };
+}> = ({ actions }, { sandboxId, body }) =>
+  actions.editor.internal.forkSandbox({ sandboxId, body });

--- a/standalone-packages/vscode-textmate/package-lock.json
+++ b/standalone-packages/vscode-textmate/package-lock.json
@@ -57,7 +57,6 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
-      "optional": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -1288,8 +1287,7 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "is-builtin-module": {
       "version": "1.0.0",
@@ -1513,7 +1511,6 @@
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
-      "optional": true,
       "requires": {
         "is-buffer": "^1.1.5"
       }
@@ -1717,8 +1714,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "loose-envify": {
       "version": "1.3.1",
@@ -2437,8 +2433,7 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "repeating": {
       "version": "2.0.1",


### PR DESCRIPTION
This PR allows us to give a body to the `fork` call to the server, this way if you as a team create a sandbox we automatically assign the sandbox to the team. There was also some logic with `refetchSandboxInfo` that didn't set `editor.isLoading` to `false`, so added that too. Lastly I extracted our logic to join a live session as a team so we can reuse it in multiple places.