### PR TITLE
Fix babel warning when downloading dynamic files in worker

### DIFF
--- a/packages/app/config/build.js
+++ b/packages/app/config/build.js
@@ -33,6 +33,13 @@ const staticAssets = [
     from: isDev
       ? 'standalone-packages/codesandbox-browserfs/build'
       : 'standalone-packages/codesandbox-browserfs/dist',
+    to: 'static/browserfs4',
+  },
+  // For caching purposes
+  {
+    from: isDev
+      ? 'standalone-packages/codesandbox-browserfs/build'
+      : 'standalone-packages/codesandbox-browserfs/dist',
     to: 'static/browserfs3',
   },
 ];

--- a/packages/app/src/app/components/CodeEditor/Monaco/workers/linter/index.js
+++ b/packages/app/src/app/components/CodeEditor/Monaco/workers/linter/index.js
@@ -3,7 +3,7 @@ import Linter from 'eslint/lib/linter';
 import monkeypatch from './monkeypatch-babel-eslint';
 
 self.importScripts(
-  `${process.env.CODESANDBOX_HOST}/static/browserfs3/browserfs.min.js`
+  `${process.env.CODESANDBOX_HOST}/static/browserfs4/browserfs.min.js`
 );
 
 /* eslint-disable global-require */

--- a/packages/app/src/app/index.html
+++ b/packages/app/src/app/index.html
@@ -48,7 +48,7 @@
 	</script>
 	<!-- End Google Tag Manager -->
 	<!-- <script async src="//cdn.headwayapp.co/widget.js"></script> -->
-	<script src="<%= webpackConfig.output.publicPath %>static/browserfs3/browserfs<%=process.env.NODE_ENV
+	<script src="<%= webpackConfig.output.publicPath %>static/browserfs4/browserfs<%=process.env.NODE_ENV
       === 'development' ? '' : '.min'%>.js"
 	 type="text/javascript"></script>
 

--- a/packages/app/src/app/vscode/extensionHostWorker/common/global.ts
+++ b/packages/app/src/app/vscode/extensionHostWorker/common/global.ts
@@ -1,3 +1,4 @@
+/* eslint-disable global-require */
 import { EventEmitter } from 'events';
 import requirePolyfills from '@codesandbox/common/lib/load-dynamic-polyfills';
 
@@ -19,13 +20,12 @@ export const initializePolyfills = () => {
 
 export const loadBrowserFS = () => {
   ctx.importScripts(
-    `${process.env.CODESANDBOX_HOST}/static/browserfs3/browserfs.js`
+    `${process.env.CODESANDBOX_HOST}/static/browserfs4/browserfs.js`
   );
 };
 
 export const initializeGlobals = () => {
   // We need to initialize some node environment stubs
-  ctx.BrowserFS = ctx.BrowserFS;
   ctx.process = ctx.BrowserFS.BFSRequire('process');
   ctx.process.platform = 'linux';
   ctx.process.stdin = new EventEmitter();

--- a/packages/app/src/embed/index.html
+++ b/packages/app/src/embed/index.html
@@ -37,7 +37,7 @@
     </script>
     <!-- End Google Tag Manager -->
 
-    <script src="<%= webpackConfig.output.publicPath %>static/browserfs3/browserfs<%=process.env.NODE_ENV
+    <script src="<%= webpackConfig.output.publicPath %>static/browserfs4/browserfs<%=process.env.NODE_ENV
       === 'development' ? '' : '.min'%>.js"
       type="text/javascript"></script>
 

--- a/packages/app/src/sandbox/eval/npm/fetch-npm-module.ts
+++ b/packages/app/src/sandbox/eval/npm/fetch-npm-module.ts
@@ -79,7 +79,7 @@ const urlProtocols = {
   },
   unpkg: {
     file: async (name: string, version: string, path: string) =>
-      `https://unpkg.com/${name}@${version}/${path}`,
+      `https://unpkg.com/${name}@${version}${path}`,
     meta: async (name: string, version: string) =>
       `https://unpkg.com/${name}@${version}/?meta`,
     normalizeMeta: normalize,

--- a/packages/app/src/sandbox/eval/transpilers/babel/worker/index.js
+++ b/packages/app/src/sandbox/eval/transpilers/babel/worker/index.js
@@ -3,7 +3,7 @@ import loadPolyfills from '@codesandbox/common/lib/load-dynamic-polyfills';
 require('app/config/polyfills');
 
 self.importScripts(
-  `${process.env.CODESANDBOX_HOST}/static/browserfs3/browserfs.min.js`
+  `${process.env.CODESANDBOX_HOST}/static/browserfs4/browserfs.min.js`
 );
 
 self.process = self.BrowserFS.BFSRequire('process');

--- a/packages/app/src/sandbox/eval/transpilers/sass/worker/index.js
+++ b/packages/app/src/sandbox/eval/transpilers/sass/worker/index.js
@@ -1,5 +1,5 @@
 self.importScripts(
-  `${process.env.CODESANDBOX_HOST}/static/browserfs3/browserfs.min.js`
+  `${process.env.CODESANDBOX_HOST}/static/browserfs4/browserfs.min.js`
 );
 
 self.process = self.BrowserFS.BFSRequire('process');

--- a/packages/app/src/sandbox/index.html
+++ b/packages/app/src/sandbox/index.html
@@ -7,7 +7,7 @@
     <title>Sandbox - CodeSandbox</title>
     <link rel="manifest" href="/manifest.json">
     <link rel="shortcut icon" href="/favicon.ico">
-    <script src="<%= webpackConfig.output.publicPath %>static/browserfs3/browserfs.min.js"
+    <script src="<%= webpackConfig.output.publicPath %>static/browserfs4/browserfs.min.js"
       type="text/javascript"></script>
 
     <script>

--- a/standalone-packages/codesandbox-browserfs/src/core/backends.ts
+++ b/standalone-packages/codesandbox-browserfs/src/core/backends.ts
@@ -10,7 +10,7 @@ import InMemory from '../backend/InMemory';
 import IndexedDB from '../backend/IndexedDB';
 import LocalStorage from '../backend/LocalStorage';
 import MountableFileSystem from '../backend/MountableFileSystem';
-// import OverlayFS from '../backend/OverlayFS';
+import OverlayFS from '../backend/OverlayFS';
 import WorkerFS from '../backend/WorkerFS';
 import HTTPRequest from '../backend/HTTPRequest';
 import BundledHTTPRequest from '../backend/BundledHTTPRequest';
@@ -22,10 +22,10 @@ import CodeSandboxEditorFS from '../backend/CodeSandboxEditorFS';
 import DynamicHTTPRequest from '../backend/DynamicHTTPRequest';
 
 // Monkey-patch `Create` functions to check options before file system initialization.
-[AsyncMirror, InMemory, IndexedDB, FolderAdapter, LocalStorage, MountableFileSystem, WorkerFS, BundledHTTPRequest, HTTPRequest, UNPKGRequest, ZipFS, CodeSandboxFS, CodeSandboxEditorFS, DynamicHTTPRequest].forEach((fsType: FileSystemConstructor) => {
+[AsyncMirror, InMemory, IndexedDB, FolderAdapter, OverlayFS, LocalStorage, MountableFileSystem, WorkerFS, BundledHTTPRequest, HTTPRequest, UNPKGRequest, ZipFS, CodeSandboxFS, CodeSandboxEditorFS, DynamicHTTPRequest].forEach((fsType: FileSystemConstructor) => {
   const create = fsType.Create;
   fsType.Create = function(opts?: any, cb?: BFSCallback<FileSystem>): void {
-    const oneArg = typeof(opts) === "function";
+    const oneArg = typeof(opts) === 'function';
     const normalizedCb = oneArg ? opts : cb;
     const normalizedOpts = oneArg ? {} : opts;
 
@@ -44,7 +44,7 @@ import DynamicHTTPRequest from '../backend/DynamicHTTPRequest';
 /**
  * @hidden
  */
-const Backends = { AsyncMirror, FolderAdapter, InMemory, IndexedDB, LocalStorage, MountableFileSystem, WorkerFS, BundledHTTPRequest, HTTPRequest, UNPKGRequest, XmlHttpRequest: HTTPRequest, ZipFS, CodeSandboxFS, CodeSandboxEditorFS, DynamicHTTPRequest};
+const Backends = { AsyncMirror, FolderAdapter, InMemory, IndexedDB, OverlayFS, LocalStorage, MountableFileSystem, WorkerFS, BundledHTTPRequest, HTTPRequest, UNPKGRequest, XmlHttpRequest: HTTPRequest, ZipFS, CodeSandboxFS, CodeSandboxEditorFS, DynamicHTTPRequest};
 // Make sure all backends cast to FileSystemConstructor (for type checking)
 const _: {[name: string]: FileSystemConstructor} = Backends;
 // tslint:disable-next-line:no-unused-expression

--- a/standalone-packages/monaco-typescript/src/tsWorker.ts
+++ b/standalone-packages/monaco-typescript/src/tsWorker.ts
@@ -1,3 +1,4 @@
+/* eslint-disable */
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
@@ -39,7 +40,7 @@ declare global {
 // @ts-ignore
 const oldamd = self.define.amd;
 (self as any).define.amd = null;
-(self as any).importScripts(`/static/browserfs3/browserfs.min.js`);
+(self as any).importScripts(`/static/browserfs4/browserfs.min.js`);
 (self as any).define.amd = oldamd;
 
 (self as any).BrowserFS = BrowserFS;


### PR DESCRIPTION
Whenever we try to download dynamic files in a worker we need to write the
downloaded files to the filesystem. The reason for this is that we have a
separate fs in the worker that's synced eagerly (because when we need to execute
files in the worker we can only retrieve the files synchronously). We used to
save the files to the WorkerFS, the WorkerFS is responsible for downloading the
files from the main thread. But this FS would get confused by also writing to it
from the worker, and then get out of sync.

I now wrapped the WorkerFS with an OverlayFS so that writes are written on top of
the FS, but not to the FS. I had to bump our browserfs version for this.
