### PR TITLE
Download missing plugins from error

### DIFF
--- a/packages/app/src/sandbox/eval/transpilers/babel/worker/babel-worker.js
+++ b/packages/app/src/sandbox/eval/transpilers/babel/worker/babel-worker.js
@@ -140,8 +140,8 @@ async function installPlugin(Babel, BFSRequire, plugin, currentPath, isV7) {
     console.warn(firstError);
 
     try {
-      /** Fast fallback - We assume that the user has the shortcode
-          styled-components = babel-plugin-styled-components
+      /** We assume that the user has the shortcode
+          react = @babel/react or styled-components = babel-plugin-styled-components
           and try to fetch the correct plugin for them
        */
 
@@ -160,7 +160,7 @@ async function installPlugin(Babel, BFSRequire, plugin, currentPath, isV7) {
       console.warn('Long path also failed ' + plugin + ' went wrong, got:');
       console.warn(secondError);
 
-      /** Slow fallback - If we still didn't get it, this means plugin wasn't downloaded
+      /** If we still didn't get it, this means plugin wasn't downloaded
           and that's why it could not be resolved.
 
           We can try to download it based on the first error
@@ -204,41 +204,17 @@ async function installPreset(Babel, BFSRequire, preset, currentPath, isV7) {
       Babel.availablePlugins,
       Babel.availablePresets
     );
-  } catch (firstError) {
-    try {
-      /** Fast fallback - We assume that the user has the shortcode
-          react = @babel/react and try to fetch the correct plugin for them
-       */
-      const prefixedName = getPrefixedPresetName(preset, isV7);
+  } catch (e) {
+    const prefixedName = getPrefixedPresetName(preset, isV7);
 
-      evaluatedPreset = evaluateFromPath(
-        fs,
-        BFSRequire,
-        prefixedName,
-        currentPath,
-        Babel.availablePlugins,
-        Babel.availablePresets
-      );
-
-      console.log('Second try succeeded');
-    } catch (secondError) {
-      console.warn('Long path also failed ' + preset + ' went wrong, got:');
-      console.warn(secondError);
-
-      /** Slow fallback - If we still didn't get it, this means preset wasn't downloaded
-          and that's why it could not be resolved.
-
-          We can try to download it based on the first error
-      */
-
-      console.warn('Downloading ' + preset);
-
-      evaluatedPreset = await downloadFromError(firstError).then(() => {
-        console.warn('Downloaded ' + preset);
-        resetCache();
-        return installPreset(Babel, BFSRequire, preset, currentPath, isV7);
-      });
-    }
+    evaluatedPreset = evaluateFromPath(
+      fs,
+      BFSRequire,
+      prefixedName,
+      currentPath,
+      Babel.availablePlugins,
+      Babel.availablePresets
+    );
   }
 
   if (!evaluatedPreset) {
@@ -249,8 +225,6 @@ async function installPreset(Babel, BFSRequire, preset, currentPath, isV7) {
     preset,
     evaluatedPreset.default ? evaluatedPreset.default : evaluatedPreset
   );
-
-  return evaluatedPreset;
 }
 
 function stripParams(regexp) {

--- a/packages/app/src/sandbox/eval/transpilers/babel/worker/babel-worker.js
+++ b/packages/app/src/sandbox/eval/transpilers/babel/worker/babel-worker.js
@@ -135,21 +135,45 @@ async function installPlugin(Babel, BFSRequire, plugin, currentPath, isV7) {
       Babel.availablePlugins,
       Babel.availablePresets
     );
-  } catch (e) {
+  } catch (firstError) {
     console.warn('First time compiling ' + plugin + ' went wrong, got:');
-    console.warn(e);
-    const prefixedName = getPrefixedPluginName(plugin, isV7);
+    console.warn(firstError);
 
-    evaluatedPlugin = evaluateFromPath(
-      fs,
-      BFSRequire,
-      prefixedName,
-      currentPath,
-      Babel.availablePlugins,
-      Babel.availablePresets
-    );
+    try {
+      /** We assume that the user has the shortcode
+          react = @babel/react or styled-components = babel-plugin-styled-components
+          and try to fetch the correct plugin for them
+       */
 
-    console.log('Second try succeeded');
+      const prefixedName = getPrefixedPluginName(plugin, isV7);
+      evaluatedPlugin = evaluateFromPath(
+        fs,
+        BFSRequire,
+        prefixedName,
+        currentPath,
+        Babel.availablePlugins,
+        Babel.availablePresets
+      );
+
+      console.log('Second try succeeded');
+    } catch (secondError) {
+      console.warn('Long path also failed ' + plugin + ' went wrong, got:');
+      console.warn(secondError);
+
+      /** If we still didn't get it, this means plugin wasn't downloaded
+          and that's why it could not be resolved.
+
+          We can try to download it based on the first error
+      */
+
+      console.warn('Downloading ' + plugin);
+
+      evaluatedPlugin = await downloadFromError(firstError).then(() => {
+        console.warn('Downloaded ' + plugin);
+        resetCache();
+        return installPlugin(Babel, BFSRequire, plugin, currentPath, isV7);
+      });
+    }
   }
 
   if (!evaluatedPlugin) {
@@ -160,6 +184,8 @@ async function installPlugin(Babel, BFSRequire, plugin, currentPath, isV7) {
     plugin,
     evaluatedPlugin.default ? evaluatedPlugin.default : evaluatedPlugin
   );
+
+  return evaluatedPlugin;
 }
 
 async function installPreset(Babel, BFSRequire, preset, currentPath, isV7) {

--- a/packages/app/src/sandbox/eval/transpilers/babel/worker/babel-worker.js
+++ b/packages/app/src/sandbox/eval/transpilers/babel/worker/babel-worker.js
@@ -140,8 +140,8 @@ async function installPlugin(Babel, BFSRequire, plugin, currentPath, isV7) {
     console.warn(firstError);
 
     try {
-      /** We assume that the user has the shortcode
-          react = @babel/react or styled-components = babel-plugin-styled-components
+      /** Fast fallback - We assume that the user has the shortcode
+          styled-components = babel-plugin-styled-components
           and try to fetch the correct plugin for them
        */
 
@@ -160,7 +160,7 @@ async function installPlugin(Babel, BFSRequire, plugin, currentPath, isV7) {
       console.warn('Long path also failed ' + plugin + ' went wrong, got:');
       console.warn(secondError);
 
-      /** If we still didn't get it, this means plugin wasn't downloaded
+      /** Slow fallback - If we still didn't get it, this means plugin wasn't downloaded
           and that's why it could not be resolved.
 
           We can try to download it based on the first error
@@ -204,17 +204,41 @@ async function installPreset(Babel, BFSRequire, preset, currentPath, isV7) {
       Babel.availablePlugins,
       Babel.availablePresets
     );
-  } catch (e) {
-    const prefixedName = getPrefixedPresetName(preset, isV7);
+  } catch (firstError) {
+    try {
+      /** Fast fallback - We assume that the user has the shortcode
+          react = @babel/react and try to fetch the correct plugin for them
+       */
+      const prefixedName = getPrefixedPresetName(preset, isV7);
 
-    evaluatedPreset = evaluateFromPath(
-      fs,
-      BFSRequire,
-      prefixedName,
-      currentPath,
-      Babel.availablePlugins,
-      Babel.availablePresets
-    );
+      evaluatedPreset = evaluateFromPath(
+        fs,
+        BFSRequire,
+        prefixedName,
+        currentPath,
+        Babel.availablePlugins,
+        Babel.availablePresets
+      );
+
+      console.log('Second try succeeded');
+    } catch (secondError) {
+      console.warn('Long path also failed ' + preset + ' went wrong, got:');
+      console.warn(secondError);
+
+      /** Slow fallback - If we still didn't get it, this means preset wasn't downloaded
+          and that's why it could not be resolved.
+
+          We can try to download it based on the first error
+      */
+
+      console.warn('Downloading ' + preset);
+
+      evaluatedPreset = await downloadFromError(firstError).then(() => {
+        console.warn('Downloaded ' + preset);
+        resetCache();
+        return installPreset(Babel, BFSRequire, preset, currentPath, isV7);
+      });
+    }
   }
 
   if (!evaluatedPreset) {
@@ -225,6 +249,8 @@ async function installPreset(Babel, BFSRequire, preset, currentPath, isV7) {
     preset,
     evaluatedPreset.default ? evaluatedPreset.default : evaluatedPreset
   );
+
+  return evaluatedPreset;
 }
 
 function stripParams(regexp) {


### PR DESCRIPTION
Merged after https://github.com/codesandbox/codesandbox-client/pull/2464

TODO: 
- [x] Do the same for presets
- [ ] Refactor the file to make it easier to follow (another PR?)

## What kind of change does this PR introduce?

Fixes #1935

## What is the current behavior?

The current behavior is the find the plugin from the list of resolved modules. This works really well for files that are in the dependency path of either

1. entry file of the project
2. entry file of the dependency

`babel` allows you to omit `babel-plugin-` while added it to babel config. So, if you add the `react` plugin, we will try to find `react` but fallback to `babel-plugin-react` or `@babel/react` based on the babel version.

This works for 99% of babel plugins because the entry file of the plugin itself can be used.

Example: [`babel-plugin-jsx`](https://www.npmjs.com/package/babel-plugin-jsx) resolves to it's [`index.js`](https://unpkg.com/babel-plugin-jsx@1.2.0/index.js)

Buuuut, you can also put your babel config outside the entry "tree"

Example: [styled-jsx](https://www.npmjs.com/styled-jsx) has a babel plugin that sits in [styled-jsx/babel](https://runpkg.com/?styled-jsx@3.2.2/babel.js). We don't resolve it by default and that's why `installPlugin` in `babel-worker` fails.

To make things worse, we try to fallback to `babel-plugin-styled-jsx`, which leads to a confusing error message 😓


## What is the new behavior?

After trying the path fallback (`babel-plugin-*`) which should work for 99%, added a fallback for the 1% case which:

1. download the package from error
2. reset module cache
3. move forward

The code is getting really hairy, will refactor it in another pull request because it would take me forever 😅

## What steps did you take to test this?

Tested broken sandbox from #1935

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [NA] Documentation
- [x] Testing <!-- We can only merge the PR if this is checked -->
- ❌  Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [NA] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->
