### PR TITLE
Use console-feed upstream again

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -106,7 +106,7 @@
     "color": "^0.11.4",
     "compare-versions": "^3.1.0",
     "console": "^0.7.2",
-    "console-feed": "CompuIves/console-feed#build2",
+    "console-feed": "^2.8.10",
     "css-modules-loader-core": "^1.1.0",
     "date-fns": "^2.4.1",
     "date-fns-tz": "^1.0.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8620,9 +8620,10 @@ console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
   integrity sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=
 
-console-feed@CompuIves/console-feed#build2, console-feed@^2.8.5:
-  version "2.8.9"
-  resolved "https://codeload.github.com/CompuIves/console-feed/tar.gz/42f10eb3063f0f26ee9745c4c9e4542cb5591f46"
+console-feed@^2.8.10, console-feed@^2.8.5:
+  version "2.8.10"
+  resolved "https://registry.yarnpkg.com/console-feed/-/console-feed-2.8.10.tgz#a4f215f7972d8855b379fa2e4f31248d5f5a578b"
+  integrity sha512-n1WeWsFUTcVptTR3c9/RYkrH9wVC+X4aEF9WpfKcmDdLorcdEk/N4gO+hdNkBYIzXyWQi2NoFBZTWsOFww4vaQ==
   dependencies:
     emotion "^9.1.1"
     emotion-theming "^9.0.0"


### PR DESCRIPTION
## What kind of change does this PR introduce?
Use [`console-feed`](https://github.com/samdenty/console-feed) package again, since the bugs @CompuIves fixed are fixed upstream too. (see samdenty/console-feed@9136b21 & samdenty/console-feed@a656248)

## What is the current behavior?
@CompuIves' `console-feed` fork is used

## What is the new behavior?
`console-feed` package is used again

## What steps did you take to test this?
N/A

## Checklist
- [N/A] Documentation
- [N/A] Testing
- [x] Ready to be merged
- [N/A] Added myself to contributors table