### PR TITLE
🔨 Switch CodeSadbox to useOvermind, Remove title, add label to Report

### DIFF
--- a/packages/app/src/app/overmind/actions.ts
+++ b/packages/app/src/app/overmind/actions.ts
@@ -2,9 +2,10 @@ import {
   NotificationType,
   convertTypeToStatus,
 } from '@codesandbox/common/lib/utils/notifications';
-import { Action, AsyncAction } from '.';
-import * as internalActions from './internalActions';
+
 import { withLoadApp } from './factories';
+import * as internalActions from './internalActions';
+import { Action, AsyncAction } from '.';
 
 export const internal = internalActions;
 
@@ -15,6 +16,8 @@ export const appUnmounted: AsyncAction = async ({ effects, actions }) => {
 export const sandboxPageMounted: AsyncAction = withLoadApp();
 
 export const searchMounted: AsyncAction = withLoadApp();
+
+export const codesadboxMounted: AsyncAction = withLoadApp();
 
 export const cliMounted: AsyncAction = withLoadApp(
   async ({ state, actions }) => {

--- a/packages/app/src/app/pages/common/ErrorBoundary/CodeSadbox/CodeSadbox.tsx
+++ b/packages/app/src/app/pages/common/ErrorBoundary/CodeSadbox/CodeSadbox.tsx
@@ -1,4 +1,3 @@
-// @ts-ignore
 import { Button } from '@codesandbox/common/lib/components/Button';
 import { dashboardUrl } from '@codesandbox/common/lib/utils/url-generator';
 import { useOvermind } from 'app/overmind';
@@ -6,6 +5,7 @@ import { Navigation } from 'app/pages/common/Navigation';
 import React, { useEffect } from 'react';
 import GoHome from 'react-icons/lib/go/home';
 import GoIssueOpened from 'react-icons/lib/go/issue-opened';
+// @ts-ignore
 import Dashboard from '-!svg-react-loader!@codesandbox/common/lib/icons/dashboard.svg';
 
 import { IFallbackComponentProps } from '../types';

--- a/packages/app/src/app/pages/common/ErrorBoundary/CodeSadbox/CodeSadbox.tsx
+++ b/packages/app/src/app/pages/common/ErrorBoundary/CodeSadbox/CodeSadbox.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import GoHome from 'react-icons/lib/go/home';
 import GoIssueOpened from 'react-icons/lib/go/issue-opened';
-import { inject, hooksObserver } from 'app/componentConnectors';
+import { useOvermind } from 'app/overmind';
 import { Button } from '@codesandbox/common/lib/components/Button';
 import { dashboardUrl } from '@codesandbox/common/lib/utils/url-generator';
 import { Navigation } from 'app/pages/common/Navigation';
@@ -21,51 +21,56 @@ import {
   ButtonIcon,
 } from './elements';
 
-export const CodeSadbox = inject('store')(
-  hooksObserver(
-    ({ error, trace, store }: IFallbackComponentProps & { store: any }) => (
-      <Container>
-        <Header>
-          <Nav>
-            <Navigation title="CodeSadbox" />
-          </Nav>
-        </Header>
-        <Content>
-          <Title>Oh no! Something broke!</Title>
-          <Sadbox scale={3} />
-          <Subtitle>CodeSadbox</Subtitle>
-          <Actions>
-            {store.isLoggedIn ? (
-              <Button small secondary href={dashboardUrl()}>
-                <ButtonIcon>
-                  <Dashboard />
-                </ButtonIcon>
-                Go to Dashboard
-              </Button>
-            ) : (
-              <Button small secondary href="/">
-                <ButtonIcon>
-                  <GoHome />
-                </ButtonIcon>
-                Back to Home
-              </Button>
-            )}
-            {/*
-          // @ts-ignore */}
-            <Button
-              small
-              target="_blank"
-              rel="noopener"
-              href={buildCrashReport({ error, trace })}
-            >
+export const CodeSadbox: React.FC<IFallbackComponentProps> = ({
+  error,
+  trace,
+}) => {
+  const {
+    state: { isLoggedIn },
+  } = useOvermind();
+
+  return (
+    <Container>
+      <Header>
+        <Nav>
+          <Navigation title="CodeSadbox" />
+        </Nav>
+      </Header>
+      <Content>
+        <Title>Oh no! Something broke!</Title>
+        <Sadbox scale={3} />
+        <Subtitle>CodeSadbox</Subtitle>
+        <Actions>
+          {isLoggedIn ? (
+            <Button small secondary href={dashboardUrl()}>
               <ButtonIcon>
-                <GoIssueOpened />
+                <Dashboard />
               </ButtonIcon>
-              Report Crash
+              Go to Dashboard
             </Button>
-          </Actions>
-        </Content>
-      </Container>
-    )
-  )
-);
+          ) : (
+            <Button small secondary href="/">
+              <ButtonIcon>
+                <GoHome />
+              </ButtonIcon>
+              Back to Home
+            </Button>
+          )}
+          {/*
+              // @ts-ignore */}
+          <Button
+            small
+            target="_blank"
+            rel="noopener"
+            href={buildCrashReport({ error, trace })}
+          >
+            <ButtonIcon>
+              <GoIssueOpened />
+            </ButtonIcon>
+            Report Crash
+          </Button>
+        </Actions>
+      </Content>
+    </Container>
+  );
+};

--- a/packages/app/src/app/pages/common/ErrorBoundary/CodeSadbox/CodeSadbox.tsx
+++ b/packages/app/src/app/pages/common/ErrorBoundary/CodeSadbox/CodeSadbox.tsx
@@ -1,33 +1,39 @@
-import React from 'react';
-import GoHome from 'react-icons/lib/go/home';
-import GoIssueOpened from 'react-icons/lib/go/issue-opened';
-import { useOvermind } from 'app/overmind';
+// @ts-ignore
 import { Button } from '@codesandbox/common/lib/components/Button';
 import { dashboardUrl } from '@codesandbox/common/lib/utils/url-generator';
+import { useOvermind } from 'app/overmind';
 import { Navigation } from 'app/pages/common/Navigation';
-// @ts-ignore
+import React, { useEffect } from 'react';
+import GoHome from 'react-icons/lib/go/home';
+import GoIssueOpened from 'react-icons/lib/go/issue-opened';
 import Dashboard from '-!svg-react-loader!@codesandbox/common/lib/icons/dashboard.svg';
-import { Sadbox } from './Sadbox';
+
 import { IFallbackComponentProps } from '../types';
 import { buildCrashReport } from './buildCrashReport';
 import {
-  Container,
-  Header,
-  Nav,
-  Content,
-  Title,
-  Subtitle,
   Actions,
   ButtonIcon,
+  Container,
+  Content,
+  Header,
+  Nav,
+  Subtitle,
+  Title,
 } from './elements';
+import { Sadbox } from './Sadbox';
 
 export const CodeSadbox: React.FC<IFallbackComponentProps> = ({
   error,
   trace,
 }) => {
   const {
+    actions: { codesadboxMounted },
     state: { isLoggedIn },
   } = useOvermind();
+
+  useEffect(() => {
+    codesadboxMounted();
+  }, [codesadboxMounted]);
 
   return (
     <Container>

--- a/packages/app/src/app/pages/common/ErrorBoundary/CodeSadbox/buildCrashReport.ts
+++ b/packages/app/src/app/pages/common/ErrorBoundary/CodeSadbox/buildCrashReport.ts
@@ -9,45 +9,49 @@ export const buildCrashReport = ({
   error,
   trace,
 }: IbuildCrashReport): string => {
+  const url = new URL(
+    `https://github.com/codesandbox/codesandbox-client/issues/new`
+  );
   const { name, version, os } = browser();
 
-  const title = `💥 Crash Report: <Please Add a Short Description of Crash Circumstances>`;
+  url.searchParams.set(
+    `body`,
+    `<h1>💥 Crash Report</h1>
 
-  const body = `<h1>💥 Crash Report</h1>
+  <h2>What were you trying to accomplish when the crash occurred?</h2>
 
-<h2>What were you trying to accomplish when the crash occurred?</h2>
+  > Please use this issue template to describe what you were doing when you encountered this crash. While we are able to fill in some details automatically, it's not always enough to reproduce!
 
-> Please use this issue template to describe what you were doing when you encountered this crash. While we are able to fill in some details automatically, it's not always enough to reproduce!
+  <h3>Link to sandbox: [link]() (optional)</h3>
 
-<h3>Link to sandbox: [link]() (optional)</h3>
+  <h3>Crash Details</h3>
 
-<h3>Crash Details</h3>
+  <details>
+  <summary>Environment</summary>
 
-<details>
-<summary>Environment</summary>
+  | Browser |  Version  | Operating System |
+  | ------- | --------- | ---------------- |
+  | ${name} | ${version} | ${os}           |
 
-| Browser |  Version  | Operating System |
-| ------- | --------- | ---------------- |
-| ${name} | ${version} | ${os}           |
+  **Route:**
+  ${window.location.href}
 
-**Route:**
-${window.location.href}
+  </details>
 
-</details>
+  <details>
+  <summary>Error Message</summary>
 
-<details>
-<summary>Error Message</summary>
+  ${'```'}bash
+  ${error}
+  ${error.stack}
+  ${trace}
+  ${'```'}
 
-${'```'}bash
-${error}
-${error.stack}
-${trace}
-${'```'}
+  </details>
+  `
+  );
 
-</details>
-`;
+  url.searchParams.set(`labels`, `💥 Crash Report`);
 
-  return `https://github.com/codesandbox/codesandbox-client/issues/new?title=${encodeURI(
-    title
-  )}&body=${encodeURI(body)}`;
+  return url.toString();
 };


### PR DESCRIPTION
Small refactor to make the switch to Overmind.

Removed the title from the generated crash report, which will now require users to enter their own in order to be able to submit the report. Hopefully this makes crash reports more descriptive. Crash Reports now include the proper label automatically when they are generated.

@christianalfoni there appears to be an issue with Overmind in this component, as isLoggedIn returns false even when the user is in fact logged in (test this by running locally and navigating to http://localhost:3000/codesadbox from another page). Not quite sure how to solve this one, so I'd appreciate it if you can investigate! Probably has something to do with the error boundary.