### PR TITLE
Cleanup homepage templates

### DIFF
--- a/packages/homepage/src/templates/_docs.elements.js
+++ b/packages/homepage/src/templates/_docs.elements.js
@@ -1,0 +1,212 @@
+import styled, { css } from 'styled-components';
+
+import media from '../utils/media';
+
+export const Container = styled.div`
+  color: rgba(255, 255, 255, 0.9);
+  margin-bottom: 1rem;
+`;
+
+const cardCSS = css`
+  ${({ theme }) => css`
+    background-color: ${theme.background};
+    padding: 1.5rem;
+    box-shadow: 0 3px 3px rgba(0, 0, 0, 0.3);
+    border-radius: 2px;
+    margin-bottom: 1rem;
+  `};
+`;
+
+export const Article = styled.div`
+  flex: 3;
+
+  padding-right: 1rem;
+
+  ${media.phone`
+    padding-right: 0;
+  `};
+`;
+
+export const DocsContainer = styled.div`
+  display: flex;
+
+  ${media.phone`
+    flex-direction: column;
+  `};
+`;
+
+export const DocsNavigation = styled.div`
+  flex: 1;
+  min-width: 250px;
+`;
+
+export const DocumentationContent = styled.div`
+  ${({ theme }) => css`
+    line-height: 1.4;
+    color: rgba(255, 255, 255, 0.8);
+    font-feature-settings: normal;
+
+    iframe {
+      display: block;
+      margin: auto;
+      border: 0;
+      outline: 0;
+    }
+
+    h2 {
+      font-family: 'Poppins', sans-serif;
+      margin: 1.5rem 0;
+      font-weight: 400;
+      color: white;
+
+      &:first-child {
+        margin-top: 0;
+      }
+    }
+
+    h3 {
+      font-weight: 400;
+      font-size: 1.25rem;
+      color: white;
+      margin-top: 2rem;
+    }
+
+    section {
+      ${cardCSS};
+      overflow-x: auto;
+    }
+
+    iframe {
+      margin-bottom: 1rem;
+    }
+
+    code {
+      background-color: rgba(0, 0, 0, 0.3);
+      padding: 0.2em 0.4em;
+      font-size: 85%;
+      margin: 0;
+      border-radius: 3px;
+    }
+
+    code,
+    pre {
+      font-family: source-code-pro, Menlo, Monaco, Consolas, Courier New,
+        monospace;
+    }
+
+    *:last-child {
+      margin-bottom: 0;
+    }
+
+    .anchor {
+      fill: ${theme.secondary};
+    }
+
+    .gatsby-highlight {
+      background-color: rgba(0, 0, 0, 0.3);
+      padding: 0.5rem;
+      border-radius: 4px;
+      margin-bottom: 1rem;
+
+      code {
+        background-color: transparent;
+        padding: 0;
+        margin: 0;
+        font-size: 100%;
+        height: auto !important;
+        line-height: 20px;
+        white-space: pre-wrap;
+        word-break: break-word;
+      }
+    }
+
+    .token.attr-name {
+      color: ${theme.secondary};
+    }
+
+    .token.tag {
+      color: #ec5f67;
+    }
+
+    .token.string {
+      color: #99c794;
+    }
+
+    .token.keyword {
+      color: ${theme.secondary};
+    }
+
+    .token.boolean,
+    .token.function {
+      color: #fac863;
+    }
+
+    .token.property,
+    .token.attribute {
+      color: ${theme.secondary};
+    }
+
+    .token.comment,
+    .token.block-comment,
+    .token.prolog,
+    .token.doctype,
+    .token.cdata {
+      color: #626466;
+    }
+  `};
+`;
+
+export const Edit = styled.a`
+  transition: 0.3s ease color;
+  display: flex;
+  align-items: center;
+  position: absolute;
+  top: 2.5rem;
+  right: 2.5rem;
+  color: rgba(255, 255, 255, 0.9);
+  font-weight: 500;
+  font-size: 1rem;
+  text-decoration: none;
+
+  ${media.phone`
+    display: none;
+  `};
+
+  svg {
+    font-size: 0.875rem;
+    color: rgba(255, 255, 255, 0.75);
+    margin-right: 0.5rem;
+  }
+
+  &:hover {
+    color: white;
+  }
+`;
+
+export const Heading = styled.div`
+  ${({ theme }) => css`
+    ${cardCSS};
+    position: relative;
+
+    background-image: linear-gradient(
+      -45deg,
+      ${theme.secondary.darken(0.1)()} 0%,
+      ${theme.secondary.darken(0.3)()} 100%
+    );
+    padding: 2rem 2rem;
+    color: white;
+  `};
+`;
+
+export const Title = styled.h1`
+  font-family: 'Poppins', sans-serif;
+  font-size: 2rem;
+  font-weight: 500;
+`;
+
+export const Description = styled.p`
+  font-size: 1.125rem;
+  font-weight: 400;
+
+  margin-bottom: 0.25rem;
+`;

--- a/packages/homepage/src/templates/_job.elements.js
+++ b/packages/homepage/src/templates/_job.elements.js
@@ -1,0 +1,40 @@
+import { Button } from '@codesandbox/common/lib/components/Button';
+import styled, { css } from 'styled-components';
+
+export const Title = styled.h1`
+  ${({ theme }) => css`
+    font-weight: 600;
+    font-family: 'Poppins', sans-serif;
+    font-size: 36px;
+    margin-bottom: 2em;
+    margin-top: 1em;
+    padding-bottom: 0;
+    color: ${theme.lightText};
+  `};
+`;
+
+export const ContentBlock = styled.div`
+  ${({ theme }) => css`
+    h2 {
+      font-weight: 600;
+      font-family: 'Poppins', sans-serif;
+      font-size: 24px;
+      margin-top: 36px;
+      color: ${theme.lightText};
+    }
+
+    font-family: 'Open Sans', sans-serif;
+    font-weight: 400;
+    font-size: 18px;
+    line-height: 1.5;
+    color: ${theme.lightText};
+    margin-bottom: 36px;
+  `};
+`;
+
+export const ApplyButton = styled(Button)`
+  display: inline-block;
+  font-size: 14px;
+  line-height: 1;
+  margin-bottom: 50px;
+`;

--- a/packages/homepage/src/templates/_post.elements.js
+++ b/packages/homepage/src/templates/_post.elements.js
@@ -1,82 +1,95 @@
 import styled, { css } from 'styled-components';
 
-export const mainStyle = css`
-  margin: auto;
-  color: white;
-  overflow: hidden;
-  line-height: 1.7;
-
-  font-weight: 500;
-  font-size: 18px;
-
-  color: rgba(255, 255, 255, 0.9);
-
-  h1,
-  h2,
-  h3,
-  h4,
-  h5,
-  h6 {
+export const PostContainer = styled.div`
+  ${({ theme }) => css`
+    margin: auto;
     color: white;
-    font-weight: 800;
-  }
+    overflow: hidden;
+    line-height: 1.7;
 
-  h1,
-  h2,
-  h3 {
-    font-family: 'Poppins', sans-serif;
-  }
+    font-weight: 500;
+    font-size: 18px;
 
-  h2 {
-    margin-top: 3rem;
-    font-size: 28px;
-  }
+    color: rgba(255, 255, 255, 0.9);
 
-  h3 {
-    margin-top: 3.5rem;
-    margin-bottom: 1.5rem;
-    font-size: 26px;
-  }
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6 {
+      color: white;
+      font-weight: 800;
+    }
 
-  h4 {
-    margin-top: 2rem;
-    margin-bottom: 0.5rem;
-    font-size: 20px;
-    font-weight: 600;
-  }
+    h1,
+    h2,
+    h3 {
+      font-family: 'Poppins', sans-serif;
+    }
 
-  ul,
-  ol {
-    margin-bottom: 28px;
-  }
+    h2 {
+      margin-top: 3rem;
+      font-size: 28px;
+    }
 
-  p {
-    margin-bottom: 28px;
-    word-break: break-word;
-  }
+    h3 {
+      margin-top: 3.5rem;
+      margin-bottom: 1.5rem;
+      font-size: 26px;
+    }
 
-  p,
-  li {
-    font-family: 'Open Sans', sans-serif;
-    color: rgba(255, 255, 255, 0.8);
-  }
+    h4 {
+      margin-top: 2rem;
+      margin-bottom: 0.5rem;
+      font-size: 20px;
+      font-weight: 600;
+    }
 
-  img {
-    display: block;
-    margin: 20px auto;
-  }
+    ul,
+    ol {
+      margin-bottom: 28px;
+    }
 
-  figcaption {
-    text-align: center;
-    color: rgba(255, 255, 255, 0.6);
-  }
+    p {
+      margin-bottom: 28px;
+      word-break: break-word;
+    }
 
-  a {
-    color: ${props => props.theme.shySecondary};
-  }
+    p,
+    li {
+      font-family: 'Open Sans', sans-serif;
+      color: rgba(255, 255, 255, 0.8);
+    }
+
+    img {
+      display: block;
+      margin: 20px auto;
+    }
+
+    figcaption {
+      text-align: center;
+      color: rgba(255, 255, 255, 0.6);
+    }
+
+    a {
+      color: ${theme.shySecondary};
+    }
+  `};
 `;
 
 export const Image = styled.img`
   display: block;
   margin: 20px auto;
+`;
+
+export const MetaData = styled.aside`
+  align-items: center;
+  display: flex;
+`;
+
+export const AuthorContainer = styled.div`
+  align-items: center;
+  display: flex;
+  flex: 1;
 `;

--- a/packages/homepage/src/templates/docs.js
+++ b/packages/homepage/src/templates/docs.js
@@ -208,59 +208,55 @@ const Description = styled.p`
   margin-bottom: 0.25rem;
 `;
 
-// eslint-disable-next-line
-export default class Docs extends React.Component {
-  render() {
-    const {
-      allDocs: { edges: docs },
-      doc: {
-        fields: { description, editLink, title },
-        html,
-      },
-    } = this.props.data;
+const Docs = ({
+  data: {
+    allDocs: { edges: docs },
+    doc: {
+      fields: { description, editLink, title },
+      html,
+    },
+  },
+}) => (
+  <Layout>
+    <Container style={{ overflowX: 'auto' }}>
+      <TitleAndMetaTags
+        description={description}
+        title={`${title} - CodeSandbox Documentation`}
+      />
 
-    return (
-      <Layout>
-        <Container style={{ overflowX: 'auto' }}>
-          <TitleAndMetaTags
-            description={description}
-            title={`${title} - CodeSandbox Documentation`}
-          />
-          <PageContainer>
-            <DocsContainer>
-              <div
-                style={{
-                  flex: 1,
-                  minWidth: 250,
-                }}
-              >
-                <DocSearch />
-                <StickyNavigation docs={docs} />
-              </div>
-              <Article>
-                <Heading>
-                  <Title>{title}</Title>
-                  <Edit
-                    href={editLink}
-                    rel="noreferrer noopener"
-                    target="_blank"
-                  >
-                    <EditIcon /> Edit this page
-                  </Edit>
-                  <Description>{description}</Description>
-                </Heading>
+      <PageContainer>
+        <DocsContainer>
+          <div
+            style={{
+              flex: 1,
+              minWidth: 250,
+            }}
+          >
+            <DocSearch />
 
-                <DocumentationContent
-                  dangerouslySetInnerHTML={{ __html: html }}
-                />
-              </Article>
-            </DocsContainer>
-          </PageContainer>
-        </Container>
-      </Layout>
-    );
-  }
-}
+            <StickyNavigation docs={docs} />
+          </div>
+
+          <Article>
+            <Heading>
+              <Title>{title}</Title>
+
+              <Edit href={editLink} rel="noreferrer noopener" target="_blank">
+                <EditIcon /> Edit this page
+              </Edit>
+
+              <Description>{description}</Description>
+            </Heading>
+
+            <DocumentationContent dangerouslySetInnerHTML={{ __html: html }} />
+          </Article>
+        </DocsContainer>
+      </PageContainer>
+    </Container>
+  </Layout>
+);
+
+export default Docs;
 
 export const pageQuery = graphql`
   query Docs($slug: String!) {

--- a/packages/homepage/src/templates/docs.js
+++ b/packages/homepage/src/templates/docs.js
@@ -1,212 +1,24 @@
-import React from 'react';
-import styled, { css } from 'styled-components';
-import EditIcon from 'react-icons/lib/go/pencil';
 import { graphql } from 'gatsby';
+import React from 'react';
+import EditIcon from 'react-icons/lib/go/pencil';
 
-import media from '../utils/media';
-
-import DocSearch from '../components/DocSearch';
-import TitleAndMetaTags from '../components/TitleAndMetaTags';
 import Layout from '../components/layout';
+import DocSearch from '../components/DocSearch';
 import PageContainer from '../components/PageContainer';
 import StickyNavigation from '../components/StickyNavigation';
+import TitleAndMetaTags from '../components/TitleAndMetaTags';
 
-const Container = styled.div`
-  color: rgba(255, 255, 255, 0.9);
-  margin-bottom: 1rem;
-`;
-
-const cardCSS = css`
-  background-color: ${props => props.theme.background};
-  padding: 1.5rem;
-  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.3);
-  border-radius: 2px;
-  margin-bottom: 1rem;
-`;
-
-const Article = styled.div`
-  flex: 3;
-
-  padding-right: 1rem;
-
-  ${media.phone`
-    padding-right: 0;
-  `};
-`;
-
-const DocsContainer = styled.div`
-  display: flex;
-  ${media.phone`
-    flex-direction: column;
-  `};
-`;
-
-const DocumentationContent = styled.div`
-  line-height: 1.4;
-  color: rgba(255, 255, 255, 0.8);
-  font-feature-settings: normal;
-
-  iframe {
-    display: block;
-    margin: auto;
-    border: 0;
-    outline: 0;
-  }
-
-  h2 {
-    font-family: 'Poppins', sans-serif;
-    margin: 1.5rem 0;
-    font-weight: 400;
-    color: white;
-
-    &:first-child {
-      margin-top: 0rem;
-    }
-  }
-
-  h3 {
-    font-weight: 400;
-    font-size: 1.25rem;
-    color: white;
-    margin-top: 2rem;
-  }
-
-  section {
-    ${cardCSS};
-    overflow-x: auto;
-  }
-
-  iframe {
-    nargin-bottom: 1rem;
-  }
-
-  code {
-    background-color: rgba(0, 0, 0, 0.3);
-    padding: 0.2em 0.4em;
-    font-size: 85%;
-    margin: 0;
-    border-radius: 3px;
-  }
-
-  code,
-  pre {
-    font-family: source-code-pro, Menlo, Monaco, Consolas, Courier New,
-      monospace;
-  }
-
-  *:last-child {
-    margin-bottom: 0;
-  }
-
-  .anchor {
-    fill: ${props => props.theme.secondary};
-  }
-
-  .gatsby-highlight {
-    background-color: rgba(0, 0, 0, 0.3);
-    padding: 0.5rem;
-    border-radius: 4px;
-    margin-bottom: 1rem;
-
-    code {
-      background-color: transparent;
-      padding: 0;
-      margin: 0;
-      font-size: 100%;
-      height: auto !important;
-      line-height: 20px;
-      white-space: pre-wrap;
-      word-break: break-word;
-    }
-  }
-
-  .token.attr-name {
-    color: ${props => props.theme.secondary};
-  }
-
-  .token.tag {
-    color: #ec5f67;
-  }
-
-  .token.string {
-    color: #99c794;
-  }
-
-  .token.keyword {
-    color: ${props => props.theme.secondary};
-  }
-
-  .token.boolean,
-  .token.function {
-    color: #fac863;
-  }
-
-  .token.property,
-  .token.attribute {
-    color: ${props => props.theme.secondary};
-  }
-
-  .token.comment,
-  .token.block-comment,
-  .token.prolog,
-  .token.doctype,
-  .token.cdata {
-    color: #626466;
-  }
-`;
-
-const Edit = styled.a`
-  transition: 0.3s ease color;
-  display: flex;
-  align-items: center;
-  position: absolute;
-  top: 2.5rem;
-  right: 2.5rem;
-  color: rgba(255, 255, 255, 0.9);
-  font-weight: 500;
-  font-size: 1rem;
-  text-decoration: none;
-
-  ${media.phone`
-    display: none;
-  `};
-
-  svg {
-    font-size: 0.875rem;
-    color: rgba(255, 255, 255, 0.75);
-    margin-right: 0.5rem;
-  }
-
-  &:hover {
-    color: white;
-  }
-`;
-
-const Heading = styled.div`
-  ${cardCSS};
-  position: relative;
-
-  background-image: linear-gradient(
-    -45deg,
-    ${({ theme }) => theme.secondary.darken(0.1)()} 0%,
-    ${({ theme }) => theme.secondary.darken(0.3)()} 100%
-  );
-  padding: 2rem 2rem;
-  color: white;
-`;
-
-const Title = styled.h1`
-  font-family: 'Poppins', sans-serif;
-  font-size: 2rem;
-  font-weight: 500;
-`;
-
-const Description = styled.p`
-  font-size: 1.125rem;
-  font-weight: 400;
-
-  margin-bottom: 0.25rem;
-`;
+import {
+  Article,
+  Container,
+  Description,
+  DocsContainer,
+  DocsNavigation,
+  DocumentationContent,
+  Edit,
+  Heading,
+  Title,
+} from './_docs.elements';
 
 const Docs = ({
   data: {
@@ -226,16 +38,11 @@ const Docs = ({
 
       <PageContainer>
         <DocsContainer>
-          <div
-            style={{
-              flex: 1,
-              minWidth: 250,
-            }}
-          >
+          <DocsNavigation>
             <DocSearch />
 
             <StickyNavigation docs={docs} />
-          </div>
+          </DocsNavigation>
 
           <Article>
             <Heading>

--- a/packages/homepage/src/templates/job.js
+++ b/packages/homepage/src/templates/job.js
@@ -1,37 +1,12 @@
-import React from 'react';
 import { Button } from '@codesandbox/common/lib/components/Button';
 import { graphql, Link } from 'gatsby';
-import styled, { css } from 'styled-components';
-import TitleAndMetaTags from '../components/TitleAndMetaTags';
+import React from 'react';
+
 import Layout from '../components/layout';
 import PageContainer from '../components/PageContainer';
+import TitleAndMetaTags from '../components/TitleAndMetaTags';
 
-export const Title = styled.h1`
-  font-weight: 600;
-  font-family: 'Poppins', sans-serif;
-  font-size: 36px;
-  margin-bottom: 2em;
-  margin-top: 1em;
-  padding-bottom: 0;
-  color: ${props => props.theme.lightText};
-`;
-
-const styles = css`
-  h2 {
-    font-weight: 600;
-    font-family: 'Poppins', sans-serif;
-    font-size: 24px;
-    margin-top: 36px;
-    color: ${props => props.theme.lightText};
-  }
-
-  font-family: 'Open Sans', sans-serif;
-  font-weight: 400;
-  font-size: 18px;
-  line-height: 1.5;
-  color: ${props => props.theme.lightText};
-  margin-bottom: 36px;
-`;
+import { ApplyButton, ContentBlock, Title } from './_job.elements';
 
 export default ({
   data: {
@@ -43,31 +18,27 @@ export default ({
 }) => (
   <Layout>
     <TitleAndMetaTags title={`${title} - CodeSandbox Careers`} />
+
     <PageContainer width={800}>
       <Button small as={Link} to="/jobs">
         See all jobs
       </Button>
+
       <Title>{title}</Title>
-      <div css={styles} dangerouslySetInnerHTML={{ __html: html }} />
-      <div css={styles}>
+
+      <ContentBlock dangerouslySetInnerHTML={{ __html: html }} />
+
+      <ContentBlock>
         <h2>Applying</h2>
+
         <p>
           Not sure you meet 100% of our qualifications? Please apply anyway!
         </p>
-      </div>
-      <Button
-        css={`
-          display: inline-block;
-          font-size: 14px;
-          line-height: 1;
-          margin-bottom: 50px;
-        `}
-        href={applyLink}
-        small
-        target="_blank"
-      >
+      </ContentBlock>
+
+      <ApplyButton href={applyLink} small target="_blank">
         Apply now
-      </Button>
+      </ApplyButton>
     </PageContainer>
   </Layout>
 );

--- a/packages/homepage/src/templates/post.js
+++ b/packages/homepage/src/templates/post.js
@@ -13,7 +13,12 @@ import {
 } from '../components/PostElements';
 import TitleAndMetaTags from '../components/TitleAndMetaTags';
 
-import { mainStyle, Image } from './_post.elements';
+import {
+  AuthorContainer,
+  Image,
+  MetaData,
+  PostContainer,
+} from './_post.elements';
 
 export default ({
   data: {
@@ -37,30 +42,19 @@ export default ({
       <PageContainer width={800}>
         <Title>{title}</Title>
 
-        <aside
-          css={`
-            align-items: center;
-            display: flex;
-          `}
-        >
-          <div
-            css={`
-              align-items: center;
-              display: flex;
-              flex: 1;
-            `}
-          >
+        <MetaData>
+          <AuthorContainer>
             <AuthorImage alt={author} src={photo} />
 
             <Author>{author}</Author>
-          </div>
+          </AuthorContainer>
 
           <PostDate>{format(date, 'MMM DD, YYYY')}</PostDate>
-        </aside>
+        </MetaData>
 
         <Image alt={title} src={banner} />
 
-        <div css={mainStyle} dangerouslySetInnerHTML={{ __html: html }} />
+        <PostContainer dangerouslySetInnerHTML={{ __html: html }} />
       </PageContainer>
     </Container>
   </Layout>


### PR DESCRIPTION
## What kind of change does this PR introduce?
This is the follow-up of #2420, where I've make the `docs` template a function component and put all styles in their own `.elements` file.
 
## What is the current behavior?
- `docs` is a class component
- most styles are in the templates themselves

## What is the new behavior?
- `docs` is a function component
- all styles are in their own `.elements` file.

## What steps did you take to test this?
Check if the pages still look the same

## Checklist
- [ ] Documentation N/A
- [x] Testing
- [x] Ready to be merged
- [ ] Added myself to contributors table N/A