### PR TITLE
Restrict modal opened action

### DIFF
--- a/packages/app/src/app/overmind/actions.ts
+++ b/packages/app/src/app/overmind/actions.ts
@@ -60,7 +60,19 @@ export const connectionChanged: Action<boolean> = ({ state }, connected) => {
   state.connected = connected;
 };
 
-export const modalOpened: Action<{ modal: string; message?: string }> = (
+type ModalName =
+  | 'deleteDeployment'
+  | 'feedback'
+  | 'forkServerModal'
+  | 'liveSessionEnded'
+  | 'moveSandbox'
+  | 'netlifyLogs'
+  | 'newSandbox'
+  | 'preferences'
+  | 'privacyServerWarning'
+  | 'share'
+  | 'signInForTemplates';
+export const modalOpened: Action<{ modal: ModalName; message?: string }> = (
   { state, effects },
   { modal, message }
 ) => {


### PR DESCRIPTION
As requested by @christianalfoni in https://github.com/codesandbox/codesandbox-client/pull/2532#discussion_r328996362

Not sure if I should extract the new `ModalName` type into `@codesandbox/common` so I just kept it in `actions.ts` for now.