### PR TITLE
This one weird trick will fix console height issues

### DIFF
--- a/packages/app/src/app/components/Preview/DevTools/index.tsx
+++ b/packages/app/src/app/components/Preview/DevTools/index.tsx
@@ -274,6 +274,7 @@ export class DevTools extends React.PureComponent<Props, State> {
     event: React.MouseEvent & { clientX: number; clientY: number }
   ) => {
     if (!this.state.mouseDown && typeof this.state.height === 'number') {
+      event.persist();
       unFocus(document, window);
       // @ts-ignore
       this.setState(state => ({


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix #2522 

## What is the current behavior?

Oh boy, strap in

This bug was introduced in #2451 which makes ESLint happy

We have an eslint rule - [no-access-state-in-setstate.md](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-access-state-in-setstate.md) which asks for a straightforward change like this - 

```diff
- this.setState({
+ this.setState(state => ({
    startY: event.clientY,
	... a few more
  })
+ )
```

The trouble is that passing a callback runs it asynchronously.

This is the warning we see in dev mode:

```
Warning: This synthetic event is reused for performance reasons. If you're seeing this, you're accessing the property `clientY` on a released/nullified synthetic event. This is set to null. If you must keep the original synthetic event around, use event.persist(). See https://fb.me/react-event-pooling for more information
```

Following the docs:

> The SyntheticEvent is pooled. This means that the SyntheticEvent object will be reused and all properties will be nullified after the event callback has been invoked. This is for performance reasons. As such, you cannot access the event in an asynchronous way.

> If you want to access the event properties in an asynchronous way, you should call event.persist() on the event, which will remove the synthetic event from the pool and allow references to the event to be retained by user code.

## What is the new behavior?

Added `event.persist()` which makes it available for height calculations. (and also makes it future-proof for concurrent mode)

There might be performance regressions because of this which ~~I haven't tested yet~~ aren't noticeable to the eye

## Open questions

Should we go this route or should we undo this and use the `setState({object})` and disable the eslint rule for this block.


## What steps did you take to test this?

- [x] Resized the console after making the fix
- [x] Test for performance regressions in sync mode

## Checklist

- [NA] Documentation
- [x] Testing <!-- We can only merge the PR if this is checked -->
- [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [NA] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->