### PR TITLE
Make sure to load the last screenshot in the dashboard

### DIFF
--- a/packages/app/src/app/pages/Dashboard/Content/SandboxGrid/index.js
+++ b/packages/app/src/app/pages/Dashboard/Content/SandboxGrid/index.js
@@ -333,6 +333,7 @@ class SandboxGridComponent extends React.Component<*, State> {
         privacy={item.privacy}
         isPatron={this.props.store.isPatron}
         screenshotUrl={item.screenshotUrl}
+        screenshotOutdated={item.screenshotOutdated}
       />
     );
   };

--- a/packages/app/src/app/pages/Dashboard/queries.js
+++ b/packages/app/src/app/pages/Dashboard/queries.js
@@ -22,6 +22,7 @@ const SANDBOX_FRAGMENT = gql`
     updatedAt
     privacy
     screenshotUrl
+    screenshotOutdated
 
     source {
       template


### PR DESCRIPTION
    Normally we've loaded the cached screenshot of a sandbox in the dashboard,
    this change ensures that we try to download a new version of a screenshot
    if the sandboxcard has been in the screen long enough and we know that the
    screenshot is outdated.