### PR TITLE
🔨 Refactored app/pages/CLI/index.tsx

### DIFF
--- a/packages/app/src/app/pages/CLI/index.tsx
+++ b/packages/app/src/app/pages/CLI/index.tsx
@@ -1,43 +1,37 @@
 import React, { useEffect } from 'react';
-
-import { inject, hooksObserver } from 'app/componentConnectors';
 import { Navigation } from 'app/pages/common/Navigation';
-
+import { useOvermind } from 'app/overmind';
 import { Container } from './elements';
 import { Prompt } from './Prompt';
 
-interface Props {
+interface CliProps {
   small: boolean;
-  store: any;
-  signals: any;
 }
 
-const CLI = inject('store', 'signals')(
-  hooksObserver(
-    ({
-      signals: { cliMounted, signInCliClicked },
-      store: { user, authToken, isLoadingCLI, error },
-    }: Props) => {
-      useEffect(() => {
-        cliMounted();
-      }, [cliMounted]);
+const CLI: React.FunctionComponent<CliProps> = ({ small }) => {
+  const {
+    state: { user, authToken, isLoadingCLI, error },
+    actions: { cliMounted, signInCliClicked },
+  } = useOvermind();
 
-      return (
-        <Container>
-          <Navigation title="CLI Authorization" />
+  useEffect(() => {
+    cliMounted();
+  }, [cliMounted]);
 
-          <Prompt
-            error={error}
-            loading={isLoadingCLI}
-            signIn={signInCliClicked}
-            token={authToken}
-            username={user && user.username}
-          />
-        </Container>
-      );
-    }
-  )
-);
+  return (
+    <Container>
+      <Navigation title="CLI Authorization" />
+
+      <Prompt
+        error={error}
+        loading={isLoadingCLI}
+        signIn={signInCliClicked}
+        token={authToken}
+        username={user && user.username}
+      />
+    </Container>
+  );
+};
 
 // eslint-disable-next-line import/no-default-export
 export default CLI;


### PR DESCRIPTION
## What kind of change does this PR introduce?

<!-- Is it a Bug fix, feature, docs update, ... -->
This is part of the requested refactor for hacktoberfest mentioned in #2621.
@Saeris @christianalfoni 

## What is the current behavior?
Previously it was utilizing `inject` and `hooksObserver` from `app/componentConnectors`.

<!-- You can also link to an open issue here -->
#2621 

## What is the new behavior?
Prefers `useOvermind` over `inject` and other small stylistic choices mentioned in #2621 

## What steps did you take to test this?

<!-- Most important part!  -->
- `yarn:lint`: There were several linting errors, but none relevant to the scope of this PR
- `yarn:test`: Ran successfully

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation - N/A
- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
I was unable to add the 🔨 Refactor, 🧠 Overmind, or Hacktoberfest labels.