### PR TITLE
🔨 Refactored 🧠 Overmind Hacktober | app/pages/index.tsx : refactor to replace Cerebral with Overmind

### DIFF
--- a/packages/app/src/app/pages/index.tsx
+++ b/packages/app/src/app/pages/index.tsx
@@ -8,7 +8,7 @@ import send, { DNT } from '@codesandbox/common/lib/utils/analytics';
 import theme from '@codesandbox/common/lib/theme';
 import { Button } from '@codesandbox/common/lib/components/Button';
 import Loadable from 'app/utils/Loadable';
-import { inject, hooksObserver } from 'app/componentConnectors';
+import { useOvermind } from 'app/overmind';
 import { ErrorBoundary } from './common/ErrorBoundary';
 import HTML5Backend from './common/HTML5BackendWithFolderSupport';
 import Modals from './common/Modals';
@@ -55,7 +55,10 @@ const CodeSadbox = () => this[`💥`].kaboom();
 
 const Boundary = withRouter(ErrorBoundary);
 
-const RoutesComponent = ({ signals: { appUnmounted } }) => {
+const RoutesComponent: React.FC = () => {
+  const {
+    actions: { appUnmounted },
+  } = useOvermind();
   useEffect(() => () => appUnmounted(), [appUnmounted]);
 
   return (
@@ -120,6 +123,6 @@ const RoutesComponent = ({ signals: { appUnmounted } }) => {
   );
 };
 
-export const Routes = inject('signals')(
-  DragDropContext(HTML5Backend)(withRouter(hooksObserver(RoutesComponent)))
+export const Routes = DragDropContext(HTML5Backend)(
+  withRouter(RoutesComponent)
 );


### PR DESCRIPTION
## What kind of change does this PR introduce?

Refactors code as a part of hacktoberfest mentioned in #2621.
@Saeris @christianalfoni

## What is the current behavior?

`app/pages/index.tsx` was using `inject` and `hooksObserver` from `app/componentConnectors`

## What is the new behavior?

uses `useOvermind` from `app/overmind`

## What steps did you take to test this?

Opened the homepage, /s/new page
ran `yarn lint` and `yarn typecheck`

## Checklist

- [ ] Documentation: N/A
- [x] Testing
- [x] Ready to be merged
- [ ] Added myself to contributors table

