### PR TITLE
🔨 Refactored 🧠 Overmind : /editor/content/preview/index to replace Cerebral with Overmind

### DIFF
--- a/packages/app/src/app/pages/Sandbox/Editor/Content/Preview/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Content/Preview/index.tsx
@@ -182,9 +182,7 @@ const PreviewComponent: React.FC<Props> = ({
       );
       const disposeDependenciesHandler = reaction(
         ({ editor: { currentSandbox: _currentSandbox } }) =>
-          _currentSandbox.npmDependencies.keys
-            ? _currentSandbox.npmDependencies.keys().length
-            : Object.keys(_currentSandbox.npmDependencies),
+          Object.keys(_currentSandbox.npmDependencies),
         () => handleDependenciesChange(preview)
       );
 

--- a/packages/app/src/app/pages/Sandbox/Editor/Content/Preview/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Content/Preview/index.tsx
@@ -8,7 +8,7 @@ import BasePreview from '@codesandbox/common/lib/components/Preview';
 import RunOnClick from '@codesandbox/common/lib/components/RunOnClick';
 import getTemplate from '@codesandbox/common/lib/templates';
 
-type Props = {
+type IPreviewProps = {
   hidden?: boolean;
   runOnClick?: boolean;
   options: { url?: string };
@@ -32,7 +32,7 @@ const useForceUpdate = () => {
   return forceUpdate;
 };
 
-const PreviewComponent: React.FC<Props> = ({
+export const Preview: React.FC<IPreviewProps> = ({
   hidden,
   runOnClick,
   options: { url },
@@ -257,5 +257,3 @@ const PreviewComponent: React.FC<Props> = ({
     <RunOnClick onClick={handleRunOnClick} />
   );
 };
-
-export const Preview = PreviewComponent;

--- a/packages/app/src/app/pages/Sandbox/Editor/Content/Preview/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Content/Preview/index.tsx
@@ -1,6 +1,7 @@
 // @flow
 import React, { useState, useCallback, useEffect } from 'react';
 import _property from 'lodash/property';
+import _isFunction from 'lodash/isFunction';
 import { useOvermind } from 'app/overmind';
 
 import BasePreview from '@codesandbox/common/lib/components/Preview';
@@ -23,7 +24,9 @@ const useForceUpdate = () => {
   );
 
   useEffect(() => {
-    callback();
+    if (_isFunction(callback)) {
+      callback();
+    }
   }, [callback]);
 
   return forceUpdate;


### PR DESCRIPTION
## What kind of change does this PR introduce?

Refactors code as a part of hacktoberfest mentioned in #2621.
@Saeris @christianalfoni

## What is the current behavior?

/editor/content/preview/index.tsx was using app/componentConnectors

## What is the new behavior?

uses `useOvermind` from `app/overmind`

## What steps did you take to test this?

Tested the Preview component by making changes in the code, adding/removing dependencies

## Checklist

- [ ] Documentation
- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
