### PR TITLE
🔨 Refactored 🧠 Overmind Hacktober | /app/pages/CliInstructions/index.tsx : refactor to replace Cerebral with Overmind

### DIFF
--- a/packages/app/src/app/pages/CliInstructions/index.tsx
+++ b/packages/app/src/app/pages/CliInstructions/index.tsx
@@ -1,46 +1,47 @@
 import React, { useEffect } from 'react';
 import MaxWidth from '@codesandbox/common/lib/components/flex/MaxWidth';
 import Margin from '@codesandbox/common/lib/components/spacing/Margin';
-import { inject, hooksObserver } from 'app/componentConnectors';
+import { useOvermind } from 'app/overmind';
 import { Title } from 'app/components/Title';
 import { SubTitle } from 'app/components/SubTitle';
 import { Navigation } from 'app/pages/common/Navigation';
 import { Container, Content, Code } from './elements';
 
-const CLIInstructions = inject('signals')(
-  hooksObserver(({ signals: { cliInstructionsMounted } }) => {
-    useEffect(() => {
-      cliInstructionsMounted();
-    }, [cliInstructionsMounted]);
+const CLIInstructions: React.FC = () => {
+  const {
+    actions: { cliInstructionsMounted },
+  } = useOvermind();
 
-    return (
-      <MaxWidth>
-        <Margin vertical={1.5} horizontal={1.5}>
-          <Container>
-            <Navigation title="CLI Import" />
+  useEffect(() => {
+    cliInstructionsMounted();
+  }, [cliInstructionsMounted]);
 
-            <Content vertical>
-              <Title>Import from CLI</Title>
+  return (
+    <MaxWidth>
+      <Margin vertical={1.5} horizontal={1.5}>
+        <Container>
+          <Navigation title="CLI Import" />
 
-              <SubTitle>
-                1. Install the CLI <Code>npm i -g codesandbox</Code>
-              </SubTitle>
+          <Content vertical>
+            <Title>Import from CLI</Title>
 
-              <SubTitle>
-                2. Go to your project <Code>cd path-of-your-project</Code>
-              </SubTitle>
+            <SubTitle>
+              1. Install the CLI <Code>npm i -g codesandbox</Code>
+            </SubTitle>
 
-              <SubTitle>
-                3. Deploy your project to CodeSandbox{' '}
-                <Code>codesandbox ./</Code>
-              </SubTitle>
-            </Content>
-          </Container>
-        </Margin>
-      </MaxWidth>
-    );
-  })
-);
+            <SubTitle>
+              2. Go to your project <Code>cd path-of-your-project</Code>
+            </SubTitle>
+
+            <SubTitle>
+              3. Deploy your project to CodeSandbox <Code>codesandbox ./</Code>
+            </SubTitle>
+          </Content>
+        </Container>
+      </Margin>
+    </MaxWidth>
+  );
+};
 
 // eslint-disable-next-line import/no-default-export
 export default CLIInstructions;

--- a/packages/app/src/app/pages/CliInstructions/index.tsx
+++ b/packages/app/src/app/pages/CliInstructions/index.tsx
@@ -7,7 +7,7 @@ import { SubTitle } from 'app/components/SubTitle';
 import { Navigation } from 'app/pages/common/Navigation';
 import { Container, Content, Code } from './elements';
 
-const CLIInstructions: React.FC = () => {
+export const CLIInstructions: React.FC = () => {
   const {
     actions: { cliInstructionsMounted },
   } = useOvermind();
@@ -42,6 +42,3 @@ const CLIInstructions: React.FC = () => {
     </MaxWidth>
   );
 };
-
-// eslint-disable-next-line import/no-default-export
-export default CLIInstructions;

--- a/packages/app/src/app/pages/index.tsx
+++ b/packages/app/src/app/pages/index.tsx
@@ -43,7 +43,9 @@ const GitHub = Loadable(() =>
   import(/* webpackChunkName: 'page-github' */ './GitHub')
 );
 const CliInstructions = Loadable(() =>
-  import(/* webpackChunkName: 'page-cli-instructions' */ './CliInstructions')
+  import(
+    /* webpackChunkName: 'page-cli-instructions' */ './CliInstructions'
+  ).then(module => ({ default: module.CLIInstructions }))
 );
 const Patron = Loadable(() =>
   import(/* webpackChunkName: 'page-patron' */ './Patron')


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?

<!-- Is it a Bug fix, feature, docs update, ... -->

Refactors code as a part of hacktoberfest mentioned in #2621.
@Saeris @christianalfoni 

## What is the current behavior?

<!-- You can also link to an open issue here -->

`packages/app/src/app/pages/CliInstructions/index.tsx` was using `inject` and `hooksObserver` from `app/componentConnectors`

## What is the new behavior?

<!-- if this is a feature change -->

uses `useOvermind` from `app/overmind`

## What steps did you take to test this?

<!-- Most important part!  -->

run `yarn test`, `yarn typecheck` and through `lint-staged` also tried to run the app with `yarn start`

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
