### PR TITLE
add an information in contributing doc to have the latest version of …

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,6 +64,7 @@ To install the project you need to have `yarn` and `node`
     - you can use [fnm](https://github.com/Schniz/fnm) (`fnm use`) to change
       your current node version to the one specified in `.nvmrc`
 3.  from the root of the project: `yarn` to install all dependencies
+    - make sure you have latest `yarn` version 
 4.  from the root of the project: `yarn start`
     - this builds the dependencies (`codesandbox-api` and
       `codesandbox-browserfs`) and runs the `app` development environment,


### PR DESCRIPTION
…yarn

## What kind of change does this PR introduce?

Added a line in the doc contributing.md to have the latest version of yarn. I had yarn version `1.13` and our app required `1.19`. When I did `yarn install` It didn't work so I had to check and install the latest version of yarn and it fixed the error.

## What is the current behavior?

Currently, if you follow the instruction as I did and try `yarn install` you will probably end up in an error

## What is the new behavior?

Now if you're following instruction and you see Its a requirement to have Node version `10.x.x`. You will also see a point to have yarn latest version

## What steps did you take to test this?

N/A

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [ ] Testing <!-- We can only merge the PR if this is checked -->
- [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

