### PR TITLE
Live: Don't send userEnter notification if notifications are turned off

### DIFF
--- a/packages/app/src/app/overmind/namespaces/live/liveMessageOperators.ts
+++ b/packages/app/src/app/overmind/namespaces/live/liveMessageOperators.ts
@@ -64,10 +64,12 @@ export const onUserEntered: Operator<
 
   const user = data.users.find(u => u.id === data.joined_user_id);
 
-  effects.notificationToast.add({
-    message: `${user.username} joined the live session.`,
-    status: NotificationStatus.NOTICE,
-  });
+  if (!state.live.notificationsHidden) {
+    effects.notificationToast.add({
+      message: `${user.username} joined the live session.`,
+      status: NotificationStatus.NOTICE,
+    });
+  }
 });
 
 export const onUserLeft: Operator<


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?

Fix #2719

## What is the current behavior?

We send a notification about user entering the session even if it's turned off in notifications. Seems like the check was missing from `onUserEnter` (it's present in `onUserLeft`)

It might be worth looking at other notifications as well. 


## What steps did you take to test this? This is required before we can merge.

Could not test this on local (can't start live session on local), will test on staging

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [NA] Documentation
- [ ] Testing <!-- We can only merge the PR if this is checked -->
- [ ] Ready to be merged