### PR TITLE
fix handle browser tabs overflow 

### DIFF
--- a/packages/app/src/app/components/Preview/DevTools/Tabs/elements.ts
+++ b/packages/app/src/app/components/Preview/DevTools/Tabs/elements.ts
@@ -4,6 +4,7 @@ export const Container = styled.div`
   display: flex;
   flex: auto;
   margin-right: 1rem;
+  overflow-x: auto;
 `;
 
 export const Tabs = styled.div`

--- a/packages/app/src/app/pages/Sandbox/Editor/Content/index.js
+++ b/packages/app/src/app/pages/Sandbox/Editor/Content/index.js
@@ -493,8 +493,9 @@ class EditorPreview extends React.Component {
             }
             pane2Style={{
               visibility: windowVisible ? 'visible' : 'hidden',
-              maxWidth: windowVisible ? 'inherit' : 0,
-              width: windowVisible ? 'inherit' : 0,
+              maxWidth: windowVisible ? '100%' : 0,
+              width: windowVisible ? '100%' : 0,
+              overflow: 'hidden',
               zIndex: 0, // For VSCode hovers, beware this is also dynamically changed in PreviewTabs
             }}
           >


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?

<!-- Is it a Bug fix, feature, docs update, ... -->
Bugfix

## What is the current behavior?

if you open a few browser tabs, you can access all of them

![](http://g.recordit.co/MoRFtgVHYu.gif)

<!-- You can also link to an open issue here -->

## What is the new behavior?

![](http://g.recordit.co/QvlNxXB3dk.gif)

<!-- if this is a feature change -->

## What steps did you take to test this? This is required before we can merge.

1. Create a gatsby sandbox
2. Add a lot of graphiQL tabs
3. Try to access all browser tabs

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Testing <!-- We can only merge the PR if this is checked -->
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
