### PR TITLE
🔨 Refactored 🧠 Overmind Hacktober | VisitSiteButton.tsx : refactor to replace Cerebral with Overmind

### DIFF
--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/items/Deployment/Netlify/SiteInfo/Actions/VisitSiteButton/VisitSiteButton.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/items/Deployment/Netlify/SiteInfo/Actions/VisitSiteButton/VisitSiteButton.tsx
@@ -1,13 +1,22 @@
-import { inject, hooksObserver } from 'app/componentConnectors';
-import React from 'react';
+import { useOvermind } from 'app/overmind';
+import React, { FunctionComponent } from 'react';
 import LinkIcon from 'react-icons/lib/fa/external-link';
 import Cogs from 'react-icons/lib/fa/cogs';
 
 import { Link } from '../../../../elements';
 
-export const VisitSiteButton = inject('store')(
-  hooksObserver(({ store: { deployment: { building, netlifySite } } }) => (
-    <Link disabled={building} href={netlifySite.url}>
+export const VisitSiteButton: FunctionComponent = () => {
+  const {
+    state: {
+      deployment: {
+        building,
+        netlifySite: { url },
+      },
+    },
+  } = useOvermind();
+
+  return (
+    <Link disabled={building} href={url}>
       {building ? (
         <>
           <Cogs /> Building...
@@ -18,5 +27,5 @@ export const VisitSiteButton = inject('store')(
         </>
       )}
     </Link>
-  ))
-);
+  );
+};


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?

Refactors code as a part of hacktoberfest mentioned in #2621.
@Saeris @christianalfoni

## What is the current behavior?

`VisitSiteButton.tsx` was using `inject` and `hooksObserver` from `app/componentConnectors`

## What is the new behavior?

uses `useOvermind` hook from `app/overmind`

## What steps did you take to test this? This is required before we can merge.

1. Deployed app on local using `yarn start`.
2. From sandbox workspace deployed `https://csb-ooxu7.netlify.com` using `Netlify beta`.
In this process verified the link text `Building...` and then `Visit`.
3. Checked functionality of `Visit` and it was working fine.
4. Ran `yarn lint`, `yarn test` & `yarn typecheck` successfully.

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
