### PR TITLE
🔨 Refactored 🧠 Overmind Hacktober | /app/pages/Sandbox/Editor/Workspace/items/Deployment/Netlify/SiteInfo/SiteInfo.tsx : replace Cerebral with Overmind & fixes NetlifySite id type

### DIFF
--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/items/Deployment/Netlify/SiteInfo/SiteInfo.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/items/Deployment/Netlify/SiteInfo/SiteInfo.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { inject, hooksObserver } from 'app/componentConnectors';
+import React, { FunctionComponent } from 'react';
+import { useOvermind } from 'app/overmind';
 
 import getNetlifyConfig from 'app/utils/getNetlifyConfig';
 
@@ -29,43 +29,43 @@ const getFunctionDir = sandbox => {
   }
 };
 
-export const SiteInfo = inject('store')(
-  hooksObserver(
-    ({
-      store: {
-        deployment: { building, netlifyLogs, netlifySite },
-        editor: { currentSandbox },
+export const SiteInfo: FunctionComponent = () => {
+  const {
+    state: {
+      deployment: {
+        building,
+        netlifyLogs,
+        netlifySite: { id, name },
       },
-    }) => {
-      const functionDirectory = getFunctionDir(currentSandbox);
-      const functions = functionDirectory
-        ? currentSandbox.modules.filter(
-            ({ directoryShortid }) =>
-              directoryShortid === functionDirectory.shortid
-          )
-        : [];
+      editor: { currentSandbox },
+    },
+  } = useOvermind();
+  const functionDirectory = getFunctionDir(currentSandbox);
+  const functions = functionDirectory
+    ? currentSandbox.modules.filter(
+        ({ directoryShortid }) => directoryShortid === functionDirectory.shortid
+      )
+    : [];
 
-      return (
-        <SiteInfoWrapper>
-          <WorkspaceSubtitle>Sandbox Site</WorkspaceSubtitle>
+  return (
+    <SiteInfoWrapper>
+      <WorkspaceSubtitle>Sandbox Site</WorkspaceSubtitle>
 
-          <WorkspaceInputContainer>
-            <Deploys>
-              <Deploy key={netlifySite.uid}>
-                <Name light>{netlifySite.name}</Name>
+      <WorkspaceInputContainer>
+        <Deploys>
+          <Deploy key={id}>
+            <Name light>{name}</Name>
 
-                {!building && <div>Building</div>}
+            {!building && <div>Building</div>}
 
-                {functions.length ? <Functions functions={functions} /> : null}
+            {functions.length ? <Functions functions={functions} /> : null}
 
-                <Actions />
+            <Actions />
 
-                {netlifyLogs ? <ViewLogsButton /> : null}
-              </Deploy>
-            </Deploys>
-          </WorkspaceInputContainer>
-        </SiteInfoWrapper>
-      );
-    }
-  )
-);
+            {netlifyLogs ? <ViewLogsButton /> : null}
+          </Deploy>
+        </Deploys>
+      </WorkspaceInputContainer>
+    </SiteInfoWrapper>
+  );
+};


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?

Refactors code as a part of hacktoberfest mentioned in #2621.
@Saeris @christianalfoni @SaraVieira 

## What is the current behavior?

`/app/pages/Sandbox/Editor/Workspace/items/Deployment/Netlify/SiteInfo/SiteInfo.tsx` was using `inject` and `hooksObserver` from `app/componentConnectors` and was failing typecheck while accessing `netlifySite.uid` as `uid` is present on `ZeitDeployment`.

## What is the new behavior?

uses `useOvermind` hook from `app/overmind` and replaces `uid` with `id` present on `NetlifySite` type.

## What steps did you take to test this? This is required before we can merge.

1. Deployed the codesandbox app locally.
2. Used Netlify deployment to test Site Info. ([Recording](https://www.loom.com/share/bc518301e47d4a78b8c26ea0b087038e))
3. Ran `yarn lint`, `yarn test` & `yarn typecheck` successfully.

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
