### PR TITLE
Appreciate property of savedCode more

### DIFF
--- a/packages/app/config/build.js
+++ b/packages/app/config/build.js
@@ -33,14 +33,14 @@ const staticAssets = [
     from: isDev
       ? 'standalone-packages/codesandbox-browserfs/build'
       : 'standalone-packages/codesandbox-browserfs/dist',
-    to: 'static/browserfs4',
+    to: 'static/browserfs5',
   },
   // For caching purposes
   {
     from: isDev
       ? 'standalone-packages/codesandbox-browserfs/build'
       : 'standalone-packages/codesandbox-browserfs/dist',
-    to: 'static/browserfs3',
+    to: 'static/browserfs4',
   },
 ];
 

--- a/packages/app/src/app/components/CodeEditor/Monaco/workers/linter/index.js
+++ b/packages/app/src/app/components/CodeEditor/Monaco/workers/linter/index.js
@@ -3,7 +3,7 @@ import Linter from 'eslint/lib/linter';
 import monkeypatch from './monkeypatch-babel-eslint';
 
 self.importScripts(
-  `${process.env.CODESANDBOX_HOST}/static/browserfs4/browserfs.min.js`
+  `${process.env.CODESANDBOX_HOST}/static/browserfs5/browserfs.min.js`
 );
 
 /* eslint-disable global-require */

--- a/packages/app/src/app/index.html
+++ b/packages/app/src/app/index.html
@@ -48,7 +48,7 @@
 	</script>
 	<!-- End Google Tag Manager -->
 	<!-- <script async src="//cdn.headwayapp.co/widget.js"></script> -->
-	<script src="<%= webpackConfig.output.publicPath %>static/browserfs4/browserfs<%=process.env.NODE_ENV
+	<script src="<%= webpackConfig.output.publicPath %>static/browserfs5/browserfs<%=process.env.NODE_ENV
       === 'development' ? '' : '.min'%>.js"
 	 type="text/javascript"></script>
 

--- a/packages/app/src/app/overmind/effects/api/index.ts
+++ b/packages/app/src/app/overmind/effects/api/index.ts
@@ -28,6 +28,11 @@ import {
   transformModule,
 } from '../utils/sandbox';
 import apiFactory, { Api, ApiConfig } from './apiFactory';
+import {
+  SandboxAPIResponse,
+  IModuleAPIResponse,
+  IDirectoryAPIResponse,
+} from './types';
 
 let api: Api;
 
@@ -67,7 +72,7 @@ export default {
     return api.get(`/dependencies/${name}@latest`);
   },
   async getSandbox(id: string): Promise<Sandbox> {
-    const sandbox = await api.get<Sandbox>(`/sandboxes/${id}`);
+    const sandbox = await api.get<SandboxAPIResponse>(`/sandboxes/${id}`);
 
     // We need to add client side properties for tracking
     return transformSandbox(sandbox);
@@ -77,13 +82,13 @@ export default {
       ? `/sandboxes/fork/${id}`
       : `/sandboxes/${id}/fork`;
 
-    const sandbox = await api.post<Sandbox>(url, body || {});
+    const sandbox = await api.post<SandboxAPIResponse>(url, body || {});
 
     return transformSandbox(sandbox);
   },
   createModule(sandboxId: string, module: Module): Promise<Module> {
     return api
-      .post(`/sandboxes/${sandboxId}/modules`, {
+      .post<IModuleAPIResponse>(`/sandboxes/${sandboxId}/modules`, {
         module: {
           title: module.title,
           directoryShortid: module.directoryShortid,
@@ -93,14 +98,19 @@ export default {
       })
       .then(transformModule);
   },
-  deleteModule(sandboxId: string, moduleShortid: string): Promise<void> {
-    return api.delete(`/sandboxes/${sandboxId}/modules/${moduleShortid}`);
+  async deleteModule(sandboxId: string, moduleShortid: string): Promise<void> {
+    await api.delete<IModuleAPIResponse>(
+      `/sandboxes/${sandboxId}/modules/${moduleShortid}`
+    );
   },
   saveModuleCode(sandboxId: string, module: Module): Promise<Module> {
     return api
-      .put(`/sandboxes/${sandboxId}/modules/${module.shortid}`, {
-        module: { code: module.code },
-      })
+      .put<IModuleAPIResponse>(
+        `/sandboxes/${sandboxId}/modules/${module.shortid}`,
+        {
+          module: { code: module.code },
+        }
+      )
       .then(transformModule);
   },
   saveModules(sandboxId: string, modules: Module[]) {
@@ -131,14 +141,14 @@ export default {
     });
   },
   savePrivacy(sandboxId: string, privacy: 0 | 1 | 2) {
-    return api.patch(`/sandboxes/${sandboxId}/privacy`, {
+    return api.patch<SandboxAPIResponse>(`/sandboxes/${sandboxId}/privacy`, {
       sandbox: {
         privacy,
       },
     });
   },
   saveFrozen(sandboxId: string, isFrozen: boolean) {
-    return api.put(`/sandboxes/${sandboxId}`, {
+    return api.put<SandboxAPIResponse>(`/sandboxes/${sandboxId}`, {
       sandbox: {
         is_frozen: isFrozen,
       },
@@ -176,9 +186,12 @@ export default {
     );
   },
   saveModuleTitle(sandboxId: string, moduleShortid: string, title: string) {
-    return api.put(`/sandboxes/${sandboxId}/modules/${moduleShortid}`, {
-      module: { title },
-    });
+    return api.put<IModuleAPIResponse>(
+      `/sandboxes/${sandboxId}/modules/${moduleShortid}`,
+      {
+        module: { title },
+      }
+    );
   },
   getPopularSandboxes(date: string): Promise<PopularSandboxes> {
     return api.get(`/sandboxes/popular?start_date=${date}`);
@@ -202,7 +215,7 @@ export default {
     title: string
   ): Promise<Directory> {
     return api
-      .post(`/sandboxes/${sandboxId}/directories`, {
+      .post<IDirectoryAPIResponse>(`/sandboxes/${sandboxId}/directories`, {
         directory: {
           title,
           directoryShortid,
@@ -215,16 +228,19 @@ export default {
     moduleShortid: string,
     directoryShortid: string
   ) {
-    return api.put(`/sandboxes/${sandboxId}/modules/${moduleShortid}`, {
-      module: { directoryShortid },
-    });
+    return api.put<IDirectoryAPIResponse>(
+      `/sandboxes/${sandboxId}/modules/${moduleShortid}`,
+      {
+        module: { directoryShortid },
+      }
+    );
   },
   saveDirectoryDirectory(
     sandboxId: string,
     sourceDirectoryShortid: string,
     targetDirectoryShortId: string
   ) {
-    return api.put(
+    return api.put<IDirectoryAPIResponse>(
       `/sandboxes/${sandboxId}/directories/${sourceDirectoryShortid}`,
       {
         directory: { directoryShortid: targetDirectoryShortId },
@@ -241,9 +257,12 @@ export default {
     directoryShortid: string,
     title: string
   ) {
-    return api.put(`/sandboxes/${sandboxId}/directories/${directoryShortid}`, {
-      directory: { title },
-    });
+    return api.put<IDirectoryAPIResponse>(
+      `/sandboxes/${sandboxId}/directories/${directoryShortid}`,
+      {
+        directory: { title },
+      }
+    );
   },
   getUploads(): Promise<UploadedFilesInfo> {
     return api.get('/users/current_user/uploads');
@@ -271,13 +290,14 @@ export default {
       modules,
       directories,
     })) as {
-      modules: Module[];
-      directories: Directory[];
+      modules: IModuleAPIResponse[];
+      directories: IDirectoryAPIResponse[];
     };
 
-    data.modules = data.modules.map(transformModule);
-    data.directories = data.directories.map(transformDirectory);
-    return data;
+    return {
+      modules: data.modules.map(transformModule),
+      directories: data.directories.map(transformDirectory),
+    };
   },
   createGit(
     sandboxId: string,

--- a/packages/app/src/app/overmind/effects/api/types.ts
+++ b/packages/app/src/app/overmind/effects/api/types.ts
@@ -1,0 +1,28 @@
+import { Sandbox } from '@codesandbox/common/lib/types';
+
+export interface IModuleAPIResponse {
+  id: string;
+  shortid: string;
+  code: string | null;
+  directoryShortid: string | null;
+  isBinary: boolean;
+  sourceId: string;
+  title: string;
+  insertedAt: string;
+  updatedAt: string;
+}
+
+export interface IDirectoryAPIResponse {
+  id: string;
+  shortid: string;
+  directoryShortid: string | null;
+  sourceId: string;
+  title: string;
+  insertedAt: string;
+  updatedAt: string;
+}
+
+export type SandboxAPIResponse = Omit<Sandbox, 'environmentVariables'> & {
+  modules: IModuleAPIResponse[];
+  directories: IDirectoryAPIResponse[];
+};

--- a/packages/app/src/app/overmind/effects/live/index.ts
+++ b/packages/app/src/app/overmind/effects/live/index.ts
@@ -7,12 +7,13 @@ import {
   Module,
   Directory,
   RoomInfo,
-  Sandbox,
   LiveMessageEvent,
+  Sandbox,
 } from '@codesandbox/common/lib/types';
 import { getTextOperation } from '@codesandbox/common/lib/utils/diff';
 import clientsFactory from './clients';
 import { transformSandbox } from '../utils/sandbox';
+import { SandboxAPIResponse } from '../api/types';
 
 type Options = {
   onApplyOperation(args: { moduleShortid: string; operation: any }): void;
@@ -21,10 +22,14 @@ type Options = {
 
 type JoinChannelResponse = {
   sandboxId: string;
-  sandbox: Sandbox;
+  sandbox: SandboxAPIResponse;
   moduleState: object;
   liveUserId: string;
   roomInfo: RoomInfo;
+};
+
+type JoinChannelTransformedResponse = JoinChannelResponse & {
+  sandbox: Sandbox;
 };
 
 declare global {
@@ -102,7 +107,7 @@ export default {
         .receive('error', resp => reject(resp));
     });
   },
-  joinChannel(roomId: string): Promise<JoinChannelResponse> {
+  joinChannel(roomId: string): Promise<JoinChannelTransformedResponse> {
     channel = this.getSocket().channel(`live:${roomId}`, {});
 
     return new Promise((resolve, reject) => {
@@ -110,8 +115,9 @@ export default {
         .join()
         .receive('ok', resp => {
           const result = camelizeKeys(resp) as JoinChannelResponse;
+          // @ts-ignore
           result.sandbox = transformSandbox(result.sandbox);
-          resolve(result);
+          resolve(result as JoinChannelTransformedResponse);
         })
         .receive('error', resp => reject(camelizeKeys(resp)));
     });

--- a/packages/app/src/app/overmind/effects/moduleRecover.ts
+++ b/packages/app/src/app/overmind/effects/moduleRecover.ts
@@ -1,7 +1,15 @@
+import { Module } from '@codesandbox/common/lib/types';
+
 const getKey = (id, moduleShortid) => `recover:${id}:${moduleShortid}:code`;
 
 export default {
-  save(currentId, version, module, code, savedCode) {
+  save(
+    currentId: string,
+    version: number,
+    module: Module,
+    code: string,
+    savedCode: string | null
+  ) {
     try {
       localStorage.setItem(
         getKey(currentId, module.shortid),
@@ -18,7 +26,7 @@ export default {
     }
   },
 
-  remove(currentId, module) {
+  remove(currentId: string, module: Module) {
     try {
       localStorage.removeItem(getKey(currentId, module.shortid));
     } catch (e) {
@@ -26,7 +34,7 @@ export default {
     }
   },
 
-  clearSandbox(currentId) {
+  clearSandbox(currentId: string) {
     try {
       Object.keys(localStorage)
         .filter(key => key.startsWith(`recover:${currentId}`))
@@ -38,7 +46,7 @@ export default {
     }
   },
 
-  getRecoverList(currentId, modules) {
+  getRecoverList(currentId: string, modules: Module[]) {
     const localKeys = Object.keys(localStorage).filter(key =>
       key.startsWith(`recover:${currentId}`)
     );

--- a/packages/app/src/app/overmind/effects/utils/sandbox.ts
+++ b/packages/app/src/app/overmind/effects/utils/sandbox.ts
@@ -1,6 +1,11 @@
-import { Sandbox, Module, Directory } from '@codesandbox/common/lib/types';
+import { Module, Directory } from '@codesandbox/common/lib/types';
+import {
+  IModuleAPIResponse,
+  SandboxAPIResponse,
+  IDirectoryAPIResponse,
+} from '../api/types';
 
-export function transformModule(module: Module) {
+export function transformModule(module: IModuleAPIResponse): Module {
   return {
     ...module,
     code: typeof module.code === 'string' ? module.code : '',
@@ -12,14 +17,16 @@ export function transformModule(module: Module) {
   };
 }
 
-export function transformDirectory(directory: Directory) {
+export function transformDirectory(
+  directory: IDirectoryAPIResponse
+): Directory {
   return {
     ...directory,
     type: 'directory' as 'directory',
   };
 }
 
-export function transformSandbox(sandbox: Sandbox) {
+export function transformSandbox(sandbox: SandboxAPIResponse) {
   // We need to add client side properties for tracking
   return {
     ...sandbox,

--- a/packages/app/src/app/overmind/effects/utils/sandbox.ts
+++ b/packages/app/src/app/overmind/effects/utils/sandbox.ts
@@ -3,6 +3,7 @@ import { Sandbox, Module, Directory } from '@codesandbox/common/lib/types';
 export function transformModule(module: Module) {
   return {
     ...module,
+    code: typeof module.code === 'string' ? module.code : '',
     savedCode: null,
     isNotSynced: false,
     errors: [],

--- a/packages/app/src/app/overmind/namespaces/editor/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/editor/actions.ts
@@ -443,8 +443,9 @@ export const discardModuleChanges: Action<{
     return;
   }
 
+  const code = module.savedCode === null ? module.code || '' : module.savedCode;
   actions.editor.codeChanged({
-    code: module.savedCode || module.code || '',
+    code,
     moduleShortid,
   });
 

--- a/packages/app/src/app/overmind/namespaces/editor/internalActions.ts
+++ b/packages/app/src/app/overmind/namespaces/editor/internalActions.ts
@@ -242,7 +242,7 @@ export const setModuleCode: Action<{
     module.shortid
   );
 
-  if (!module.savedCode) {
+  if (module.savedCode === null) {
     module.savedCode = module.code;
   }
 

--- a/packages/app/src/app/vscode/extensionHostWorker/common/global.ts
+++ b/packages/app/src/app/vscode/extensionHostWorker/common/global.ts
@@ -20,7 +20,7 @@ export const initializePolyfills = () => {
 
 export const loadBrowserFS = () => {
   ctx.importScripts(
-    `${process.env.CODESANDBOX_HOST}/static/browserfs4/browserfs.js`
+    `${process.env.CODESANDBOX_HOST}/static/browserfs5/browserfs.js`
   );
 };
 

--- a/packages/app/src/embed/index.html
+++ b/packages/app/src/embed/index.html
@@ -37,7 +37,7 @@
     </script>
     <!-- End Google Tag Manager -->
 
-    <script src="<%= webpackConfig.output.publicPath %>static/browserfs4/browserfs<%=process.env.NODE_ENV
+    <script src="<%= webpackConfig.output.publicPath %>static/browserfs5/browserfs<%=process.env.NODE_ENV
       === 'development' ? '' : '.min'%>.js"
       type="text/javascript"></script>
 

--- a/packages/app/src/sandbox/eval/transpilers/babel/worker/index.js
+++ b/packages/app/src/sandbox/eval/transpilers/babel/worker/index.js
@@ -3,7 +3,7 @@ import loadPolyfills from '@codesandbox/common/lib/load-dynamic-polyfills';
 require('app/config/polyfills');
 
 self.importScripts(
-  `${process.env.CODESANDBOX_HOST}/static/browserfs4/browserfs.min.js`
+  `${process.env.CODESANDBOX_HOST}/static/browserfs5/browserfs.min.js`
 );
 
 self.process = self.BrowserFS.BFSRequire('process');

--- a/packages/app/src/sandbox/eval/transpilers/sass/worker/index.js
+++ b/packages/app/src/sandbox/eval/transpilers/sass/worker/index.js
@@ -1,5 +1,5 @@
 self.importScripts(
-  `${process.env.CODESANDBOX_HOST}/static/browserfs4/browserfs.min.js`
+  `${process.env.CODESANDBOX_HOST}/static/browserfs5/browserfs.min.js`
 );
 
 self.process = self.BrowserFS.BFSRequire('process');

--- a/packages/app/src/sandbox/index.html
+++ b/packages/app/src/sandbox/index.html
@@ -7,7 +7,7 @@
     <title>Sandbox - CodeSandbox</title>
     <link rel="manifest" href="/manifest.json">
     <link rel="shortcut icon" href="/favicon.ico">
-    <script src="<%= webpackConfig.output.publicPath %>static/browserfs4/browserfs.min.js"
+    <script src="<%= webpackConfig.output.publicPath %>static/browserfs5/browserfs.min.js"
       type="text/javascript"></script>
 
     <script>

--- a/packages/common/src/types/index.ts
+++ b/packages/common/src/types/index.ts
@@ -50,7 +50,7 @@ export type Module = {
   shortid: string;
   errors: ModuleError[];
   corrections: ModuleCorrection[];
-  directoryShortid: string | undefined;
+  directoryShortid: string | null;
   isNotSynced: boolean;
   sourceId: string;
   isBinary: boolean;
@@ -64,7 +64,7 @@ export type Module = {
 export type Directory = {
   id: string;
   title: string;
-  directoryShortid: string | undefined;
+  directoryShortid: string | null;
   shortid: string;
   sourceId: string;
   type: 'directory';
@@ -78,7 +78,6 @@ export type Template = {
   main: boolean;
   color: string;
   backgroundColor: () => string | undefined;
-
   popular: boolean;
   showOnHomePage: boolean;
   distDir: string;
@@ -97,19 +96,17 @@ export type Badge = {
 };
 
 export type CurrentUser = {
-  id: string | undefined;
-  email: string | undefined;
-  name: string | undefined;
+  id: string | null;
+  email: string | null;
+  name: string | null;
   username: string;
-  avatarUrl: string | undefined;
-  jwt: string | undefined;
-  subscription:
-    | {
-        since: string;
-        amount: number;
-        cancelAtPeriodEnd: boolean;
-      }
-    | undefined;
+  avatarUrl: string | null;
+  jwt: string | null;
+  subscription: {
+    since: string;
+    amount: number;
+    cancelAtPeriodEnd: boolean;
+  } | null;
   curatorAt: string;
   badges: Array<Badge>;
   integrations: {
@@ -142,8 +139,8 @@ export type GitInfo = {
 export type SmallSandbox = {
   id: string;
   alias: string | null;
+  title: string | null;
   customTemplate: CustomTemplate | null;
-  title: string;
   insertedAt: string;
   updatedAt: string;
   likeCount: number;
@@ -163,7 +160,8 @@ export type User = {
   username: string;
   name: string;
   avatarUrl: string;
-  showcasedSandboxShortid: string | undefined;
+  twitter: string | null;
+  showcasedSandboxShortid: string | null;
   sandboxCount: number;
   givenLikeCount: number;
   receivedLikeCount: number;
@@ -172,10 +170,10 @@ export type User = {
   forkedCount: number;
   sandboxes: PaginatedSandboxes;
   likedSandboxes: PaginatedSandboxes;
-  badges: Array<Badge>;
+  badges: Badge[];
+  topSandboxes: SmallSandbox[];
   subscriptionSince: string;
   selection: Selection | null;
-  color: any;
 };
 
 export type LiveUser = {
@@ -271,9 +269,9 @@ export type PickedSandboxDetails = {
 
 export type Sandbox = {
   id: string;
-  alias: string | undefined;
-  title: string | undefined;
-  description: string;
+  alias: string | null;
+  title: string | null;
+  description: string | null;
   viewCount: number;
   likeCount: number;
   forkCount: number;
@@ -290,18 +288,18 @@ export type Sandbox = {
   customTemplate: CustomTemplate | null;
   forkedTemplate: CustomTemplate | null;
   externalResources: string[];
-  team?: {
+  team: {
     id: string;
     name: string;
-  };
-  roomId: string;
+  } | null;
+  roomId: string | null;
   privacy: 0 | 1 | 2;
-  author: User | undefined;
-  forkedFromSandbox: SmallSandbox | undefined;
-  git: GitInfo | undefined;
+  author: User | null;
+  forkedFromSandbox: SmallSandbox | null;
+  git: GitInfo | null;
   tags: string[];
   isFrozen: boolean;
-  environmentVariables: EnvironmentVariable[];
+  environmentVariables: EnvironmentVariable[] | null;
   /**
    * This is the source it's assigned to, a source contains all dependencies, modules and directories
    *
@@ -313,18 +311,16 @@ export type Sandbox = {
   };
   template: TemplateType;
   entry: string;
-  originalGit: GitInfo | undefined;
-  originalGitCommitSha: string | undefined;
-  originalGitChanges:
-    | {
-        added: string[];
-        modified: string[];
-        deleted: string[];
-        rights: 'none' | 'read' | 'write' | 'admin';
-      }
-    | undefined;
+  originalGit: GitInfo | null;
+  originalGitCommitSha: string | null;
+  originalGitChanges: {
+    added: string[];
+    modified: string[];
+    deleted: string[];
+    rights: 'none' | 'read' | 'write' | 'admin';
+  } | null;
   version: number;
-  screenshotUrl: string | undefined;
+  screenshotUrl: string | null;
 };
 
 export type PrettierConfig = {

--- a/packages/common/src/types/index.ts
+++ b/packages/common/src/types/index.ts
@@ -45,8 +45,8 @@ export type ModuleCorrection = {
 export type Module = {
   id?: string;
   title: string;
-  code: string | undefined;
-  savedCode: string | undefined;
+  code: string;
+  savedCode: string | null;
   shortid: string;
   errors: ModuleError[];
   corrections: ModuleCorrection[];

--- a/standalone-packages/codesandbox-browserfs/src/backend/CodeSandboxEditorFS.ts
+++ b/standalone-packages/codesandbox-browserfs/src/backend/CodeSandboxEditorFS.ts
@@ -62,6 +62,14 @@ export interface IManager {
 
 const warn = console.warn;
 
+function getCode(savedCode: string | null, code: string | undefined) {
+  if (savedCode !== null) {
+    return savedCode;
+  }
+
+  return code || '';
+}
+
 class CodeSandboxFile extends PreloadFile<CodeSandboxEditorFS> implements File {
   constructor(
     _fs: CodeSandboxEditorFS,
@@ -123,7 +131,7 @@ export default class CodeSandboxEditorFS extends SynchronousFileSystem
         if (opt) {
           cb();
         } else {
-          cb(new ApiError(ErrorCode.EINVAL, `Manager is invalid`));
+          cb(new ApiError(ErrorCode.EINVAL, 'Manager is invalid'));
         }
       },
     },
@@ -168,11 +176,11 @@ export default class CodeSandboxEditorFS extends SynchronousFileSystem
   }
 
   public empty(mainCb: BFSOneArgCallback): void {
-    throw new Error("Empty not supported");
+    throw new Error('Empty not supported');
   }
 
   public renameSync(oldPath: string, newPath: string) {
-    throw new Error("Rename not supported");
+    throw new Error('Rename not supported');
   }
 
   public statSync(p: string, isLstate: boolean): Stats {
@@ -199,11 +207,11 @@ export default class CodeSandboxEditorFS extends SynchronousFileSystem
         +new Date(),
         +new Date(moduleInfo.updatedAt),
         +new Date(moduleInfo.insertedAt)
-      )
+      );
     } else {
       return new Stats(
         FileType.FILE,
-        (moduleInfo.savedCode || moduleInfo.code || '').length,
+        getCode(moduleInfo.savedCode, moduleInfo.code).length,
         undefined,
         +new Date(),
         +new Date(moduleInfo.updatedAt),
@@ -213,7 +221,7 @@ export default class CodeSandboxEditorFS extends SynchronousFileSystem
   }
 
   public createFileSync(p: string, flag: FileFlag, mode: number): File {
-    throw new Error("Create file not supported");
+    throw new Error('Create file not supported');
   }
 
   public open(p: string, flag: FileFlag, mode: number, cb: BFSCallback<File>): void {
@@ -228,10 +236,10 @@ export default class CodeSandboxEditorFS extends SynchronousFileSystem
       const stats = new Stats(FileType.DIRECTORY, 4096, undefined, +new Date(), +new Date(moduleInfo.updatedAt), +new Date(moduleInfo.insertedAt));
       cb(null, new CodeSandboxFile(this, p, flag, stats));
     } else {
-      const { isBinary, savedCode, code = '' } = moduleInfo;
+      const { isBinary, savedCode, code } = moduleInfo;
 
       if (isBinary) {
-        fetch(savedCode || code).then(x => x.blob()).then(blob => {
+        fetch(getCode(savedCode, code)).then(x => x.blob()).then(blob => {
           const stats = new Stats(FileType.FILE, blob.size, undefined, +new Date(), +new Date(moduleInfo.updatedAt), +new Date(moduleInfo.insertedAt));
 
           blobToBuffer(blob, (err, r) => {
@@ -246,7 +254,7 @@ export default class CodeSandboxEditorFS extends SynchronousFileSystem
         return;
       }
 
-      const buffer = Buffer.from(savedCode || code || '');
+      const buffer = Buffer.from(getCode(savedCode, code));
       const stats = new Stats(FileType.FILE, buffer.length, undefined, +new Date(), +new Date(moduleInfo.updatedAt), +new Date(moduleInfo.insertedAt));
 
       cb(null, new CodeSandboxFile(this, p, flag, stats, buffer));
@@ -265,8 +273,8 @@ export default class CodeSandboxEditorFS extends SynchronousFileSystem
 
       return new CodeSandboxFile(this, p, flag, stats);
     } else {
-      const { savedCode, code = '' } = moduleInfo;
-      const buffer = Buffer.from(savedCode || code || '');
+      const { savedCode, code } = moduleInfo;
+      const buffer = Buffer.from(getCode(savedCode, code));
       const stats = new Stats(FileType.FILE, buffer.length, undefined, +new Date(), +new Date(moduleInfo.updatedAt), +new Date(moduleInfo.insertedAt));
 
       return new CodeSandboxFile(this, p, flag, stats, buffer);

--- a/standalone-packages/monaco-typescript/src/tsWorker.ts
+++ b/standalone-packages/monaco-typescript/src/tsWorker.ts
@@ -40,7 +40,7 @@ declare global {
 // @ts-ignore
 const oldamd = self.define.amd;
 (self as any).define.amd = null;
-(self as any).importScripts(`/static/browserfs4/browserfs.min.js`);
+(self as any).importScripts(`/static/browserfs5/browserfs.min.js`);
 (self as any).define.amd = oldamd;
 
 (self as any).BrowserFS = BrowserFS;


### PR DESCRIPTION
`savedCode` can be `null` whenever `savedCode === code`. However, we often get values this way: `savedCode || code || ''`. This doesn't work when `savedCode` is `''`, and `code` is a filled string. I'm not sure if this has caused many bugs before, but this definitely can cause inconsistencies. This change adds explicit checks.

I also created specific types for the API, also updated some existing types to use `null` instead of `undefined` (elixir doesn't know what undefined is). We need to look out for cases where properties are added to sandbox which are not included in the API, this can cause performance problems (all components using the sandbox update). This is an attempt at making that more clear, but maybe we should just put the whole API response inside the API typings and then make the sandbox type extend that type? That would explicitly show that fields are added in the end result.