### PR TITLE
🔨 Refactored, 🧠 Overmind, Hacktober | Refactor SearchDependenciesModal which now uses useOvermind

### DIFF
--- a/packages/app/src/app/pages/common/Modals/SearchDependenciesModal/index.js
+++ b/packages/app/src/app/pages/common/Modals/SearchDependenciesModal/index.js
@@ -1,15 +1,18 @@
 import React from 'react';
-import { inject, hooksObserver } from 'app/componentConnectors';
+import { useOvermind } from 'app/overmind';
 import SearchDependencies from 'app/pages/Sandbox/SearchDependencies';
 
-function SearchDependenciesModal({ signals }) {
+function SearchDependenciesModal() {
+  const {
+    actions: {
+      editor: { addNpmDependency },
+    },
+  } = useOvermind();
   return (
     <SearchDependencies
-      onConfirm={(name, version) =>
-        signals.editor.addNpmDependency({ name, version })
-      }
+      onConfirm={(name, version) => addNpmDependency({ name, version })}
     />
   );
 }
 
-export default inject('signals')(hooksObserver(SearchDependenciesModal));
+export default SearchDependenciesModal;


### PR DESCRIPTION
🔨 Refactored, 🧠 Overmind, Hacktober | Refactor SearchDependenciesModal which now uses useOvermind

<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?
Refactors code as a part of hacktoberfest mentioned in #2621.
@Saeris @christianalfoni @SaraVieira 
<!-- Is it a Bug fix, feature, docs update, ... -->

## What is the current behavior?
`app/pages/common/Modals/SearchDependenciesModal/index.js` was using `inject` and `hookObserver` from `app/componentConnectors`

<!-- You can also link to an open issue here -->

## What is the new behavior?
Uses `useOvermind` hook from `app/overmind`

<!-- if this is a feature change -->

## What steps did you take to test this? This is required before we can merge.
1. Checked whether the functionality is working or not by opening add dependency modal in sandbox
2. Ran `yarn lint`
3. Ran `yarn test`

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation: N/A
- [ ] Testing <!-- We can only merge the PR if this is checked -->
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
