### PR TITLE
Add dev auth for localhost

### DIFF
--- a/packages/app/src/app/overmind/internalActions.ts
+++ b/packages/app/src/app/overmind/internalActions.ts
@@ -98,10 +98,11 @@ export const signInGithub: Action<
   { useExtraScopes: boolean },
   Promise<string>
 > = ({ effects }, options) => {
-  const popup = effects.browser.openPopup(
-    `/auth/github${options.useExtraScopes ? '?scope=user:email,repo' : ''}`,
-    'sign in'
-  );
+  const authPath = process.env.LOCAL_SERVER
+    ? '/auth/dev'
+    : `/auth/github${options.useExtraScopes ? '?scope=user:email,repo' : ''}`;
+
+  const popup = effects.browser.openPopup(authPath, 'sign in');
 
   return effects.browser
     .waitForMessage<{ jwt: string }>('signin')

--- a/packages/app/src/app/pages/DevAuth/elements.ts
+++ b/packages/app/src/app/pages/DevAuth/elements.ts
@@ -1,0 +1,12 @@
+import styled from 'styled-components';
+
+export const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  height: 100%;
+  width: 100%;
+  margin: 1rem;
+  margin-top: 10%;
+`;

--- a/packages/app/src/app/pages/DevAuth/index.tsx
+++ b/packages/app/src/app/pages/DevAuth/index.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+
+import { Title } from 'app/components/Title';
+import { SubTitle } from 'app/components/SubTitle';
+import Input from '@codesandbox/common/lib/components/Input';
+import { Button } from '@codesandbox/common/lib/components/Button';
+import { protocolAndHost } from '@codesandbox/common/lib/utils/url-generator';
+
+import { Container } from './elements';
+
+export const DevAuthPage = () => {
+  const [authCode, setAuthCode] = React.useState('');
+
+  const getJWTToken = () => {
+    fetch(`/api/v1/auth/verify/${authCode}`)
+      .then(res => res.json())
+      .then(res => {
+        if (
+          window.opener &&
+          window.opener.location.origin === window.location.origin
+        ) {
+          window.opener.postMessage(
+            {
+              type: 'signin',
+              data: {
+                jwt: res.data.token,
+              },
+            },
+            protocolAndHost()
+          );
+        }
+      });
+  };
+
+  return (
+    <Container>
+      <Title>Developer Sign In</Title>
+      <SubTitle style={{ width: 800 }}>
+        Please enter the token you get from{' '}
+        <a
+          href="https://codesandbox.io/cli/login"
+          target="popup"
+          rel="noreferrer noopener"
+          onClick={e => {
+            e.preventDefault();
+            window.open(
+              'https://codesandbox.io/cli/login',
+              'popup',
+              'width=600,height=600'
+            );
+            return false;
+          }}
+        >
+          here
+        </a>
+        . This token will sign you in with your account from codesandbox.io.
+      </SubTitle>
+      <div
+        style={{ display: 'flex', justifyContent: 'center', marginTop: '2rem' }}
+      >
+        <Input
+          style={{ width: 600, fontSize: '1.5rem' }}
+          placeholder="Auth Code"
+          value={authCode}
+          onChange={e => {
+            setAuthCode(e.target.value);
+          }}
+        />
+        <Button onClick={getJWTToken}>Submit</Button>
+      </div>
+    </Container>
+  );
+};

--- a/packages/app/src/app/pages/DevAuth/index.tsx
+++ b/packages/app/src/app/pages/DevAuth/index.tsx
@@ -10,11 +10,16 @@ import { Container } from './elements';
 
 export const DevAuthPage = () => {
   const [authCode, setAuthCode] = React.useState('');
+  const [error, setError] = React.useState<string | null>(null);
 
   const getJWTToken = () => {
+    setError(null);
     fetch(`/api/v1/auth/verify/${authCode}`)
       .then(res => res.json())
       .then(res => {
+        if (!res.ok) {
+          throw new Error(res.errors.detail[0]);
+        }
         if (
           window.opener &&
           window.opener.location.origin === window.location.origin
@@ -29,6 +34,9 @@ export const DevAuthPage = () => {
             protocolAndHost()
           );
         }
+      })
+      .catch(e => {
+        setError(e.message);
       });
   };
 
@@ -68,6 +76,8 @@ export const DevAuthPage = () => {
         />
         <Button onClick={getJWTToken}>Submit</Button>
       </div>
+
+      {error && <div style={{ marginTop: '1rem' }}>Error: {error}</div>}
     </Container>
   );
 };

--- a/packages/app/src/app/pages/DevAuth/index.tsx
+++ b/packages/app/src/app/pages/DevAuth/index.tsx
@@ -14,10 +14,14 @@ export const DevAuthPage = () => {
 
   const getJWTToken = () => {
     setError(null);
+    let ok = true;
     fetch(`/api/v1/auth/verify/${authCode}`)
-      .then(res => res.json())
       .then(res => {
-        if (!res.ok) {
+        ok = res.ok;
+        return res.json();
+      })
+      .then(res => {
+        if (!ok) {
           throw new Error(res.errors.detail[0]);
         }
         if (

--- a/packages/app/src/app/pages/index.tsx
+++ b/packages/app/src/app/pages/index.tsx
@@ -15,6 +15,7 @@ import Modals from './common/Modals';
 import Sandbox from './Sandbox';
 import NewSandbox from './NewSandbox';
 import Dashboard from './Dashboard';
+import { DevAuthPage } from './DevAuth';
 import { Container, Content } from './elements';
 
 const routeDebugger = _debug('cs:app:router');
@@ -112,7 +113,10 @@ const RoutesComponent: React.FC = () => {
             <Route path="/cli/login" component={CLI} />
             <Route path="/auth/zeit" component={ZeitSignIn} />
             {process.env.NODE_ENV === `development` && (
-              <Route path="/codesadbox" component={CodeSadbox} />
+              <>
+                <Route path="/auth/dev" component={DevAuthPage} />
+                <Route path="/codesadbox" component={CodeSadbox} />
+              </>
             )}
             <Route component={NotFound} />
           </Switch>


### PR DESCRIPTION
Before it wouldn't be possible to sign in a dev environment on `localhost` without copying over the `jwt`. This allows you to actually do it.

Instead of the normal flow we open a new path (only for dev) called `/auth/dev`. This popup prompts you to open `codesandbox.io/cli/login`, which will generate a token we can use to sign in. If you give this token we will do the API call to do get the `jwt` to return that.

This way we can test the sign in flow in localhost!

I tested this with my own account.

![AuthFlow](https://user-images.githubusercontent.com/587016/66704573-0f66c400-ed15-11e9-96e1-eab48eb7c032.gif)
