### PR TITLE
🔨 Refactor, 🧠 Overmind | pages/Sandbox/Editor/Workspace/Dependencies/AddVersion/index.js

### DIFF
--- a/packages/app/src/app/overmind/actions.ts
+++ b/packages/app/src/app/overmind/actions.ts
@@ -73,6 +73,7 @@ type ModalName =
   | 'preferences'
   | 'privacyServerWarning'
   | 'share'
+  | 'searchDependencies'
   | 'signInForTemplates';
 export const modalOpened: Action<{ modal: ModalName; message?: string }> = (
   { state, effects },

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/Dependencies/AddVersion/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/Dependencies/AddVersion/index.tsx
@@ -1,11 +1,14 @@
 import React from 'react';
-import { inject, hooksObserver } from 'app/componentConnectors';
+import { useOvermind } from 'app/overmind';
 
 import { Button } from '@codesandbox/common/lib/components/Button';
 
 import { ButtonContainer } from './elements';
 
-function AddVersion({ signals, children }) {
+export const AddVersion: React.FC = ({ children }) => {
+  const {
+    actions: { modalOpened },
+  } = useOvermind();
   return (
     <div style={{ position: 'relative' }}>
       <ButtonContainer>
@@ -13,7 +16,7 @@ function AddVersion({ signals, children }) {
           block
           small
           onClick={() =>
-            signals.modalOpened({
+            modalOpened({
               modal: 'searchDependencies',
             })
           }
@@ -23,6 +26,4 @@ function AddVersion({ signals, children }) {
       </ButtonContainer>
     </div>
   );
-}
-
-export default inject('signals')(hooksObserver(AddVersion));
+};

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/Dependencies/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/Dependencies/index.tsx
@@ -6,7 +6,7 @@ import React, { FunctionComponent } from 'react';
 import { useOvermind } from 'app/overmind';
 import { WorkspaceSubtitle } from '../elements';
 
-import AddVersion from './AddVersion';
+import { AddVersion } from './AddVersion';
 import { VersionEntry } from './VersionEntry';
 import AddResource from './AddResource';
 import ExternalResource from './ExternalResource';


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?

Refactors code as a part of hacktoberfest mentioned in #2621.
@Saeris @christianalfoni

## What is the current behavior?

`app/pages/Sandbox/Editor/Workspace/Dependencies/AddVersion/index.js` was using Cerebral

## What is the new behavior?

`AddVersion` now uses `overmind` hook from the new state management tool, Overmind.

## What steps did you take to test this? This is required before we can merge.

1. Replaced inject and hooksObserver with useOvermind
2. Convert `AddVersion` class component to functional component.
3. Add `searchDependencies` to the list of values the `ModalName` type can take in `app/overmind/actions.ts`
4. Use named export in `AddVersion` and update `pages/Sandbox/Editor/Workspace/Dependencies/index.tsx` accordingly.
5. Ran `yarn test`
6. Ran `yarn lint`
## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
