### PR TITLE
Overflow styling for templates | HacktoberFest

### DIFF
--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/WorkspaceItem/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/WorkspaceItem/index.tsx
@@ -43,15 +43,7 @@ export class WorkspaceItem extends React.Component<Props, State> {
   toggleOpen = () => this.setState(state => ({ open: !state.open }));
 
   render() {
-    const {
-      children,
-      title,
-      keepState,
-      disabled,
-      actions,
-      style,
-      showOverflow,
-    } = this.props;
+    const { children, title, keepState, disabled, actions, style } = this.props;
     const { open } = this.state;
 
     return (
@@ -65,7 +57,7 @@ export class WorkspaceItem extends React.Component<Props, State> {
         <ReactShow
           style={{
             height: 'auto',
-            overflow: showOverflow ? 'initial' : 'hidden',
+            overflow: 'hidden',
           }}
           transitionOnMount
           start={{


### PR DESCRIPTION
Fixed overflow styling for Template /Dependencies dropdown.

<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?
This PR changes the overflow property, from the ReactShow component inside a WorkspaceItem, to 'hidden'.
<!-- Is it a Bug fix, feature, docs update, ... -->

## What is the current behavior?
![ezgif com-resize](https://user-images.githubusercontent.com/15114122/66783864-2bb35e00-eed9-11e9-9c68-42dca66cb8e0.gif)


When a user is on the editor page and on the Template info side-menu, the template dropdown doesn't properly set the overflow property to hidden.
<!-- You can also link to an open issue here -->

## What is the new behavior?
![ezgif com-resize (1)](https://user-images.githubusercontent.com/15114122/66784046-a7ada600-eed9-11e9-9286-91aeb5d81dc8.gif)

The property used to be assigned using props.

Toggling a dropdown could toggle the overflow property between 'initial' and 'hidden', but this property can't be transitioned. 

That's why the default is changed to 'hidden', so that the toggling of the dropdown will always "look pretty".

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation **N/A**
- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
