### PR TITLE
fix: devtool constant value reference

### DIFF
--- a/packages/common/src/templates/template.ts
+++ b/packages/common/src/templates/template.ts
@@ -67,7 +67,9 @@ const CLIENT_VIEWS: ViewConfig[] = [
 ];
 
 // React sandboxes have an additional devtool on top of CLIENT_VIEWS
-const REACT_CLIENT_VIEWS: ViewConfig[] = [...CLIENT_VIEWS];
+const REACT_CLIENT_VIEWS: ViewConfig[] = JSON.parse(
+  JSON.stringify(CLIENT_VIEWS)
+);
 REACT_CLIENT_VIEWS[1].views.push({ id: 'codesandbox.react-devtools' });
 
 const SERVER_VIEWS: ViewConfig[] = [


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?
Bug Fix
<!-- Is it a Bug fix, feature, docs update, ... -->

## What is the current behavior?
React Devtools are shown on every template. 

`Reason`: When manipulating `REACT_VIEWS` it also updates `CLIENT_VIEWS` because of same reference ( nested object ) thus we see react devtools on every template. 

Check this vue template: 
![image](https://user-images.githubusercontent.com/22376783/66806337-e88ed480-ef44-11e9-8576-3952cb15a6c5.png)

<!-- You can also link to an open issue here -->

## What is the new behavior?
Fixed the same reference issue.

![image](https://user-images.githubusercontent.com/22376783/66806558-78cd1980-ef45-11e9-91c5-725ecc4bc5b3.png)


<!-- if this is a feature change -->

## What steps did you take to test this? This is required before we can merge.

1. Open Angular, Vue and few other templates for checking
2. Open react templates to check if devtools show up

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation - N/A
- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
