### PR TITLE
Add react elements support for the alert component

### DIFF
--- a/packages/app/src/app/components/Alert/Alert.tsx
+++ b/packages/app/src/app/components/Alert/Alert.tsx
@@ -4,7 +4,7 @@ import { Container, Title, Text, Buttons } from './elements';
 
 interface IAlertProps {
   title: string;
-  body: string;
+  body: string | React.ReactNode;
   confirmMessage?: string;
   onCancel: (event: React.MouseEvent<HTMLButtonElement>) => void;
   onConfirm: (event: React.MouseEvent<HTMLButtonElement>) => void;


### PR DESCRIPTION
The typings of the Alert component didn't support eg. `<span>aa</span>` according to the typings, but it works in the component and is used this way in some places. This adds it as an option.