### PR TITLE
Refactored PRModal to use overmind 🔨 Refactor 🧠 Overmind Hacktoberfest

### DIFF
--- a/packages/app/src/app/pages/common/Modals/PRModal/index.tsx
+++ b/packages/app/src/app/pages/common/Modals/PRModal/index.tsx
@@ -1,12 +1,18 @@
-import React from 'react';
-import { inject, observer } from 'app/componentConnectors';
+import React, { FunctionComponent } from 'react';
 import { GitProgress } from 'app/components/GitProgress';
+import { useOvermind } from 'app/overmind';
 
-function PRModal({ store }) {
+const PRModal: FunctionComponent = () => {
+  const {
+    state: {
+      git: { isCreatingPr, pr },
+    },
+  } = useOvermind();
+
   let result = null;
 
-  if (!store.git.isCreatingPr) {
-    const newUrl = store.git.pr.prURL;
+  if (!isCreatingPr) {
+    const newUrl = pr.prURL;
 
     result = (
       <div>
@@ -27,6 +33,6 @@ function PRModal({ store }) {
       message="Forking Repository & Creating PR..."
     />
   );
-}
+};
 
-export default inject('store')(observer(PRModal));
+export default PRModal;


### PR DESCRIPTION
## What kind of change does this PR introduce?
Refactored PRModal to use overmind #2621  
@Saeris @christianalfoni

## What is the current behavior?

It uses HoCs for state management 

## What is the new behavior?

Shifted the component to overmind and typescript.

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. ran `yarn lint`
2. ran `yarn test`
3. ran `yarn typecheck`
4. ran a local instance. Tried to create a PR and verified that the modal is working.

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Testing 
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
