### PR TITLE
Refactors app\pages\common\Modals\PreferencesModal\Badges\index.js (#2621)

### DIFF
--- a/packages/app/src/app/pages/common/Modals/PreferencesModal/Badges/index.tsx
+++ b/packages/app/src/app/pages/common/Modals/PreferencesModal/Badges/index.tsx
@@ -1,12 +1,21 @@
 import React from 'react';
-import { inject, observer } from 'app/componentConnectors';
+import { useOvermind } from 'app/overmind';
 
 import Margin from '@codesandbox/common/lib/components/spacing/Margin';
 import Badge from '@codesandbox/common/lib/utils/badges/Badge';
 import { Title } from '../elements';
 
-function BadgesComponent({ store, signals }) {
-  const badgesCount = store.user.badges.length;
+export const Badges = () => {
+  const {
+    state: {
+      user: { badges },
+    },
+    actions: {
+      preferences: { setBadgeVisibility },
+    },
+  } = useOvermind();
+
+  const badgesCount = badges.length;
 
   return (
     <div>
@@ -17,12 +26,12 @@ function BadgesComponent({ store, signals }) {
         visibility.
       </strong>
       <Margin top={2}>
-        {store.user.badges.map(badge => (
+        {badges.map(badge => (
           <Badge
             key={badge.id}
             tooltip={false}
             onClick={b =>
-              signals.preferences.setBadgeVisibility({
+              setBadgeVisibility({
                 ...b,
                 visible: !b.visible,
               })
@@ -35,6 +44,4 @@ function BadgesComponent({ store, signals }) {
       </Margin>
     </div>
   );
-}
-
-export const Badges = inject('store', 'signals')(observer(BadgesComponent));
+};


### PR DESCRIPTION
This refactor is part of #2621.
@Saeris @christianalfoni

## What kind of change does this PR introduce?

* Renames `app\pages\common\Modals\PreferencesModal\Badges\index.js` -> `app\pages\common\Modals\PreferencesModal\Badges\index.tsx`
* Removes use of `inject` and `hooksObserver` and replaces them with `useOvermind()` to pass state to components.

## What is the current behavior?

Currently the state is passed to the components through `app/componentConnectors`'s `inject` and `hooksObserver` functions.

## What is the new behavior?

The state is now retrieved from the Overmind instance.

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. `yarn lint`
2. `yarn test`

I tried verifying that the changes worked well but I couldn't see any way to mock the logged in functionality in the sandbox.

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->

Let me know if this needs any more changes!

Edit: I couldn't add the labels for this PR, if someone could help I'd appreciate it.
