### PR TITLE
🔨 Refactor, 🧠 Overmind | /app/pages/Sandbox/Editor/Workspace/items/ConfigurationFiles/index.js

### DIFF
--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/items/ConfigurationFiles/elements.ts
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/items/ConfigurationFiles/elements.ts
@@ -1,16 +1,18 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 export const FilesContainer = styled.div`
   margin-top: 1rem;
 `;
 
-export const File = styled.div`
-  position: relative;
-  transition: 0.3s ease background-color;
-  padding: 0.75rem 1rem;
+export const File = styled.div<{ created: boolean }>`
+  ${({ created }) => css`
+    position: relative;
+    transition: 0.3s ease background-color;
+    padding: 0.75rem 1rem;
 
-  ${props => props.created && `cursor: pointer`};
-  ${props => !props.created && `opacity: 0.9`};
+    ${created && `cursor: pointer`};
+    ${!created && `opacity: 0.9`};
+  `}
 `;
 
 export const CreateButton = styled.button`

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/items/ConfigurationFiles/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/items/ConfigurationFiles/index.tsx
@@ -4,7 +4,7 @@ import getUI from '@codesandbox/common/lib/templates/configuration/ui';
 import { Module, Configuration } from '@codesandbox/common/lib/types';
 import { resolveModule } from '@codesandbox/common/lib/sandbox/modules';
 
-import { inject, observer } from 'app/componentConnectors';
+import { useOvermind } from 'app/overmind';
 
 import BookIcon from 'react-icons/lib/md/library-books';
 import UIIcon from 'react-icons/lib/md/dvr';
@@ -21,12 +21,13 @@ import {
 } from './elements';
 
 type FileConfigProps = {
-  path: string,
+  path: string;
   info: {
-    module?: Module,
-    config: Configuration,
-  },
-  createModule: (title: string) => void,
+    module?: Module;
+    config: Configuration;
+  };
+  createModule?: (title: string) => void;
+  openModule?: (id: string) => void;
 };
 
 const FileConfig = ({
@@ -82,8 +83,13 @@ const FileConfig = ({
   );
 };
 
-const ConfigurationFiles = ({ store, signals }) => {
-  const sandbox = store.editor.currentSandbox;
+const ConfigurationFiles = () => {
+  const {
+    state,
+    actions: { files, editor },
+  } = useOvermind();
+
+  const sandbox = state.editor.currentSandbox;
   const { configurationFiles } = getDefinition(sandbox.template);
 
   const createdPaths = {};
@@ -123,7 +129,7 @@ const ConfigurationFiles = ({ store, signals }) => {
             <FileConfig
               key={path}
               openModule={id => {
-                signals.editor.moduleSelected({ id });
+                editor.moduleSelected({ id });
               }}
               path={path}
               info={info}
@@ -140,7 +146,7 @@ const ConfigurationFiles = ({ store, signals }) => {
             <FileConfig
               key={path}
               createModule={title => {
-                signals.files.moduleCreated({ title });
+                files.moduleCreated({ title, directoryShortid: null });
               }}
               path={path}
               info={info}
@@ -152,4 +158,4 @@ const ConfigurationFiles = ({ store, signals }) => {
   );
 };
 
-export default inject('signals', 'store')(observer(ConfigurationFiles));
+export default ConfigurationFiles;

--- a/packages/common/src/types/index.ts
+++ b/packages/common/src/types/index.ts
@@ -61,6 +61,13 @@ export type Module = {
   type: 'file';
 };
 
+export type Configuration = {
+  title: string;
+  moreInfoUrl: string;
+  type: string;
+  description: string;
+};
+
 export type Directory = {
   id: string;
   title: string;


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?

Refactors code as a part of hacktoberfest mentioned in #2621.
@Saeris @christianalfoni

## What is the current behavior?

`/app/pages/Sandbox/Editor/Workspace/items/ConfigurationFiles/index.js` was using `Cerebral`

## What is the new behavior?

`/app/pages/Sandbox/Editor/Workspace/items/ConfigurationFiles/index.tsx` now using `Overmind`

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Replaced `inject` and `observer` with `useOvermind`
2. Converted `js` files to `ts` and `tsx`
3. Added some missing types!
`files.moduleCreated()` also expected `directoryShortid` to be a `string` or `null`
4. Ran `yarn test`
5. Ran `yarn lint`
6. Ran `yarn typecheck`

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
