### PR TITLE
Add Search to user menu

### DIFF
--- a/packages/app/src/app/pages/common/UserMenu/Menu/index.tsx
+++ b/packages/app/src/app/pages/common/UserMenu/Menu/index.tsx
@@ -4,6 +4,7 @@ import UserIcon from 'react-icons/lib/ti/user';
 import ExitIcon from 'react-icons/lib/md/exit-to-app';
 import FolderIcon from 'react-icons/lib/md/folder';
 import SettingsIcon from 'react-icons/lib/md/settings';
+import SearchIcon from 'react-icons/lib/go/search';
 import BookIcon from 'react-icons/lib/md/library-books';
 
 import {
@@ -11,6 +12,7 @@ import {
   patronUrl,
   curatorUrl,
   dashboardUrl,
+  searchUrl,
 } from '@codesandbox/common/lib/utils/url-generator';
 import PatronBadge from '@codesandbox/common/lib/utils/badges/PatronBadge';
 import track from '@codesandbox/common/lib/utils/analytics';
@@ -77,6 +79,13 @@ export const Menu = ({
             <BookIcon />
           </Icon>
           Documentation
+        </MenuItem>
+
+        <MenuItem {...menuProps} to={searchUrl()} as={ItemLink}>
+          <Icon>
+            <SearchIcon />
+          </Icon>
+          Search Sandboxes
         </MenuItem>
 
         {curator && (


### PR DESCRIPTION
Add an item to user menu to go to search, it was pretty hard to find initially:
![image](https://user-images.githubusercontent.com/587016/67013327-334e4f00-f0f3-11e9-839e-9bea6f84999f.png)
