### PR TITLE
🔨 Refactor, 🧠 Overmind | Modals/PreferencesModal/EditorPageSettings/PreviewSettings/index.js

### DIFF
--- a/packages/app/src/app/pages/common/Modals/PreferencesModal/EditorPageSettings/PreviewSettings/index.tsx
+++ b/packages/app/src/app/pages/common/Modals/PreferencesModal/EditorPageSettings/PreviewSettings/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { inject, observer } from 'app/componentConnectors';
+import { useOvermind } from 'app/overmind';
 
 import {
   Title,
@@ -10,14 +10,19 @@ import {
   Rule,
 } from '../../elements';
 
-function PreviewSettingsComponent({ store, signals }) {
-  const bindValue = name => ({
-    value: store.preferences.settings[name],
-    setValue: value =>
-      signals.preferences.settingChanged({
-        name,
-        value,
-      }),
+export const PreviewSettings: React.FC = () => {
+  const {
+    state: {
+      preferences: { settings },
+    },
+    actions: {
+      preferences: { settingChanged },
+    },
+  } = useOvermind();
+
+  const bindValue = (name: string) => ({
+    value: settings[name],
+    setValue: (value: any) => settingChanged({ name, value }),
   });
 
   return (
@@ -56,8 +61,4 @@ function PreviewSettingsComponent({ store, signals }) {
       </SubContainer>
     </div>
   );
-}
-
-export const PreviewSettings = inject('store', 'signals')(
-  observer(PreviewSettingsComponent)
-);
+};


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?

Refactors code as a part of hacktoberfest mentioned in #2621.
@Saeris @christianalfoni

## What is the current behavior?

`/app/pages/common/Modals/PreferencesModal/EditorPageSettings/PreviewSettings/index.js` was using `Cerebral`

## What is the new behavior?

`/app/pages/common/Modals/PreferencesModal/EditorPageSettings/PreviewSettings/index.tsx` now using `Overmind`

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Replaced `inject` and `observer` with `useOvermind`
2. Ran `yarn test`
3. Ran `yarn lint`
4. Ran `yarn typecheck`

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
