### PR TITLE
🔨 Refactor, 🧠 Overmind Hactoberfest | Refactor app/pages/common/Modals/PreferencesModal/EditorPageSettings/EditorSettings/index.js to use Overmind

### DIFF
--- a/packages/app/src/app/pages/common/Modals/PreferencesModal/EditorPageSettings/EditorSettings/index.tsx
+++ b/packages/app/src/app/pages/common/Modals/PreferencesModal/EditorPageSettings/EditorSettings/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { inject, observer } from 'app/componentConnectors';
+import { useOvermind } from 'app/overmind';
 
 import {
   Title,
@@ -11,17 +11,24 @@ import {
 } from '../../elements';
 import VSCodePlaceholder from '../../VSCodePlaceholder';
 
-const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
-const isFF = navigator.userAgent.toLowerCase().includes('firefox');
+const isSafari: boolean = /^((?!chrome|android).)*safari/i.test(
+  navigator.userAgent
+);
+const isFF: boolean = navigator.userAgent.toLowerCase().includes('firefox');
 
-function EditorSettingsComponent({ store, signals }) {
-  const bindValue = name => ({
-    value: store.preferences.settings[name],
-    setValue: value =>
-      signals.preferences.settingChanged({
-        name,
-        value,
-      }),
+export const EditorSettings: React.FC = () => {
+  const {
+    state: {
+      preferences: { settings },
+    },
+    actions: {
+      preferences: { settingChanged },
+    },
+  } = useOvermind();
+
+  const bindValue = (name: string) => ({
+    value: settings[name],
+    setValue: (value: any) => settingChanged({ name, value }),
   });
 
   return (
@@ -97,8 +104,4 @@ function EditorSettingsComponent({ store, signals }) {
       </SubContainer>
     </div>
   );
-}
-
-export const EditorSettings = inject('store', 'signals')(
-  observer(EditorSettingsComponent)
-);
+};


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?
This is a refactor related to #2621
@Saeris  @christianalfoni 

## What is the current behavior?

EditorSettings component was using inject and hooksObserver from app/componentConnectors.

## What is the new behavior?

- Refactored to use useOvermind from app/overmind

- Changed extension of the file from .js to .tsx

<!-- if this is a feature change -->

1. Run yarn test
2. Run yarn lint
3. Run yarn typecheck

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation

- [X] Testing <!-- We can only merge the PR if this is checked -->

- [X] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
