### PR TITLE
Fix <Preference /> component props typing

### DIFF
--- a/packages/common/src/components/Preference/index.tsx
+++ b/packages/common/src/components/Preference/index.tsx
@@ -1,133 +1,87 @@
 import React from 'react';
 import Tooltip from '../../components/Tooltip';
 
-import PreferenceSwitch from './PreferenceSwitch';
-import PreferenceDropdown, { NameMapper } from './PreferenceDropdown';
-import PreferenceNumber from './PreferenceNumber';
-import PreferenceText from './PreferenceText';
-import PreferenceKeybinding from './PreferenceKeybinding';
+import PreferenceSwitch, { Props as SwitchProps } from './PreferenceSwitch';
+import PreferenceDropdown, {
+  Props as DropdownProps,
+} from './PreferenceDropdown';
+import PreferenceNumber, { Props as NumberProps } from './PreferenceNumber';
+import PreferenceText, { Props as TextProps } from './PreferenceText';
+import PreferenceKeybinding, {
+  Props as KeybindingProps,
+} from './PreferenceKeybinding';
 import { Container } from './elements';
 
-export type Props = {
+type PreferenceType =
+  | 'boolean'
+  | 'string'
+  | 'dropdown'
+  | 'keybinding'
+  | 'number';
+
+type PreferenceProps<TString extends PreferenceType> = {
+  type: TString;
   title: string;
   style?: React.CSSProperties;
   className?: string;
   tooltip?: string;
-} & (
+};
+
+export type BooleanPreference = PreferenceProps<'boolean'> & SwitchProps;
+
+export type StringPreference = PreferenceProps<'string'> & TextProps;
+
+export type DropdownPreference = PreferenceProps<'dropdown'> & DropdownProps;
+
+export type KeybindingPreference = PreferenceProps<'keybinding'> &
+  KeybindingProps;
+
+export type NumberPreference = PreferenceProps<'number'> & NumberProps;
+
+export type Props =
   | BooleanPreference
   | StringPreference
   | DropdownPreference
   | KeybindingPreference
-  | NumberPreference);
+  | NumberPreference;
 
-type SetValueT<T> = (value: T) => void;
+const Preference = (props: Props) => {
+  const { title, style, className, tooltip, ...contentProps } = props;
 
-export type BooleanPreference = {
-  type: 'boolean';
-  value: boolean;
-  defaultValue?: boolean;
-  setValue: SetValueT<boolean>;
-};
-
-export type StringPreference = {
-  type: 'string';
-  value: string;
-  defaultValue?: string;
-  setValue: SetValueT<string>;
-};
-
-export type DropdownPreference = {
-  type: 'dropdown';
-  options: string[];
-  value: string;
-  defaultValue?: string;
-  setValue: SetValueT<string>;
-  mapName?: NameMapper;
-};
-
-export type KeybindingPreference = {
-  type: 'keybinding';
-  value: string[][];
-  defaultValue?: string[][];
-  setValue: SetValueT<string[][]>;
-};
-
-export type NumberPreference = {
-  type: 'number';
-  value: number;
-  defaultValue?: number;
-  setValue: SetValueT<number>;
-};
-
-export default class Preference extends React.Component<Props> {
-  getOptionComponent = () => {
-    const { props } = this;
-    if (props.type === 'boolean') {
-      return (
-        <PreferenceSwitch
-          {...props}
-          setValue={props.setValue}
-          value={props.value}
-        />
-      );
-    }
-
-    if (props.type === 'string') {
-      return (
-        <PreferenceText
-          {...props}
-          setValue={props.setValue}
-          value={props.value}
-        />
-      );
-    }
-
-    if (props.type === 'dropdown') {
-      return (
-        <PreferenceDropdown
-          {...props}
-          options={props.options}
-          setValue={props.setValue}
-          value={props.value}
-        />
-      );
-    }
-
-    if (props.type === 'keybinding') {
-      return (
-        <PreferenceKeybinding
-          {...props}
-          setValue={props.setValue}
-          value={props.value}
-        />
-      );
-    }
-
-    return (
-      <PreferenceNumber
-        {...props}
-        setValue={props.setValue}
-        value={props.value}
-      />
-    );
-  };
-
-  render() {
-    const { title, style, className, tooltip } = this.props;
-
-    const Title = tooltip ? (
-      <Tooltip placement="right" content={tooltip}>
-        {title}
-      </Tooltip>
-    ) : (
-      <span>{title}</span>
-    );
-
-    return (
-      <Container style={style} className={className}>
-        {Title}
-        <div>{this.getOptionComponent()}</div>
-      </Container>
-    );
+  let content: React.ReactNode;
+  switch (
+    contentProps.type // need 'type' as discriminant of union type
+  ) {
+    case 'boolean':
+      content = <PreferenceSwitch {...contentProps} />;
+      break;
+    case 'string':
+      content = <PreferenceText {...contentProps} />;
+      break;
+    case 'dropdown':
+      content = <PreferenceDropdown {...contentProps} />;
+      break;
+    case 'keybinding':
+      content = <PreferenceKeybinding {...contentProps} />;
+      break;
+    default:
+      content = <PreferenceNumber {...contentProps} />;
   }
-}
+
+  const Title = tooltip ? (
+    <Tooltip placement="right" content={tooltip}>
+      {title}
+    </Tooltip>
+  ) : (
+    <span>{title}</span>
+  );
+
+  return (
+    <Container style={style} className={className}>
+      {Title}
+      <div>{content}</div>
+    </Container>
+  );
+};
+
+export default Preference;


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?
@Saeris @christianalfoni 
Fix bug where the props variants are not in sync with actual individual `Preference` component props, which needs to be fixed in order to refactor different `styled-components` styling `Preference` to `tsx` files.
eg. `src/app/pages/common/Modals/PreferencesModal/elements.js`

<!-- Is it a Bug fix, feature, docs update, ... -->

## What is the current behavior?
Current `*Preference` props types are redefined in `packages/common/src/components/Preference/index.tsx` which are not in sync with actual `*Preference` components props.

<!-- You can also link to an open issue here -->

## What is the new behavior?
Using different `Props` from actual `*Preference` component, and refactor `Preference` to be a `React.FC` without `children` prop.

<!-- if this is a feature change -->

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. yarn test
2. yarn lint
3. yarn typecheck

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
