### PR TITLE
🔨 Refactor, 🧠 Overmind, Hactoberfest | /app/pages/common/Modals/PreferencesModal/elements.js, /app/pages/common/Modals/PreferencesModalEditorPageSettings/EditorSettings/index.js

### DIFF
--- a/packages/app/src/app/pages/common/Modals/PreferencesModal/Appearance/index.tsx
+++ b/packages/app/src/app/pages/common/Modals/PreferencesModal/Appearance/index.tsx
@@ -53,7 +53,6 @@ export const Appearance: React.FC = () => {
               title="Font Family"
               type="dropdown"
               options={['Custom'].concat(fontOptions)}
-              placeholder="Source Code Pro"
               {...bindValue('fontFamily')}
             />
             <SubDescription>
@@ -96,8 +95,7 @@ export const Appearance: React.FC = () => {
             <PaddedPreference
               title="Line Height"
               type="number"
-              placeholder="1.15"
-              step="0.05"
+              step={0.05}
               {...bindValue('lineHeight')}
             />
             <Rule />

--- a/packages/app/src/app/pages/common/Modals/PreferencesModal/Appearance/index.tsx
+++ b/packages/app/src/app/pages/common/Modals/PreferencesModal/Appearance/index.tsx
@@ -95,6 +95,7 @@ export const Appearance: React.FC = () => {
             <PaddedPreference
               title="Line Height"
               type="number"
+              placeholder="1.15"
               step={0.05}
               {...bindValue('lineHeight')}
             />

--- a/packages/app/src/app/pages/common/Modals/PreferencesModal/EditorPageSettings/EditorSettings/index.tsx
+++ b/packages/app/src/app/pages/common/Modals/PreferencesModal/EditorPageSettings/EditorSettings/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { useOvermind } from 'app/overmind';
 
 import {
@@ -26,10 +26,17 @@ export const EditorSettings: React.FC = () => {
     },
   } = useOvermind();
 
-  const bindValue = (name: string) => ({
-    value: settings[name],
-    setValue: (value: any) => settingChanged({ name, value }),
-  });
+  const bindValue = useMemo(
+    () => (name: string) => ({
+      value: settings[name],
+      setValue: (value: any) =>
+        settingChanged({
+          name,
+          value,
+        }),
+    }),
+    [settings, settingChanged]
+  );
 
   return (
     <div>

--- a/packages/app/src/app/pages/common/Modals/PreferencesModal/elements.tsx
+++ b/packages/app/src/app/pages/common/Modals/PreferencesModal/elements.tsx
@@ -1,5 +1,8 @@
+import React from 'react';
 import styled, { css } from 'styled-components';
-import Preference from '@codesandbox/common/lib/components/Preference';
+import Preference, {
+  Props as PreferenceProps,
+} from '@codesandbox/common/lib/components/Preference';
 
 export const SubContainer = styled.div`
   color: ${props => props.theme.white};
@@ -20,7 +23,7 @@ export const Subheading = styled.div`
   text-transform: uppercase;
 `;
 
-export const PreferenceContainer = styled.div`
+export const PreferenceContainer = styled.div<{ disabled?: boolean }>`
   padding-top: 0.5rem;
 
   ${props =>
@@ -35,7 +38,7 @@ export const PreferenceContainer = styled.div`
 export const PaddedPreference = styled(Preference)`
   padding: 0;
   font-weight: 400;
-`;
+` as React.FC<PreferenceProps>; // TODO: remove when styled() can infer union type Props correctly
 
 export const SubDescription = styled.div`
   margin-top: 0.25rem;

--- a/packages/common/src/components/Preference/PreferenceNumber.tsx
+++ b/packages/common/src/components/Preference/PreferenceNumber.tsx
@@ -4,6 +4,7 @@ import { StyledInput } from './elements';
 export type Props = {
   setValue: (value: number) => void;
   value: number;
+  placeholder?: string;
   step?: number;
   style?: React.CSSProperties;
 };
@@ -18,7 +19,7 @@ export default class PreferenceInput extends React.PureComponent<Props> {
   };
 
   render() {
-    const { value, style, step } = this.props;
+    const { value, placeholder, style, step } = this.props;
 
     return (
       <StyledInput
@@ -26,6 +27,7 @@ export default class PreferenceInput extends React.PureComponent<Props> {
         style={{ width: '3rem', ...style }}
         type="number"
         value={value}
+        placeholder={placeholder}
         onChange={this.handleChange}
       />
     );

--- a/packages/common/src/components/Preference/__snapshots__/index.test.tsx.snap
+++ b/packages/common/src/components/Preference/__snapshots__/index.test.tsx.snap
@@ -4,6 +4,8 @@ exports[`<Preference /> rendering boolean 1`] = `ReactWrapper {}`;
 
 exports[`<Preference /> rendering dropdown 1`] = `ReactWrapper {}`;
 
+exports[`<Preference /> rendering number 1`] = `ReactWrapper {}`;
+
 exports[`<Preference /> rendering string 1`] = `ReactWrapper {}`;
 
 exports[`<Preference /> rendering string 2`] = `ReactWrapper {}`;

--- a/packages/common/src/components/Preference/index.stories.tsx
+++ b/packages/common/src/components/Preference/index.stories.tsx
@@ -43,4 +43,14 @@ stories
       value="one"
       options={['one', 'two']}
     />
+  ))
+  .add('Number Preference', () => (
+    <Preference
+      title="Line Height"
+      setValue={noop}
+      type="number"
+      value={0}
+      placeholder="1.15"
+      step={0.05}
+    />
   ));

--- a/packages/common/src/components/Preference/index.test.tsx
+++ b/packages/common/src/components/Preference/index.test.tsx
@@ -56,4 +56,17 @@ describe('<Preference /> rendering', () => {
       expect(wrapper).toMatchSnapshot();
     })
   );
+  it('number', () => {
+    const wrapper = mountWithTheme(
+      <Preference
+        title="Line Height"
+        setValue={noop}
+        type="number"
+        value={0}
+        placeholder="1.15"
+        step={0.05}
+      />
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?
Refactor for #2621 @Saeris @christianalfoni 
It is based on #2861 
<!-- Is it a Bug fix, feature, docs update, ... -->

## What is the current behavior?
They are in `js` with `cerebral`
There is no `placeholder` prop for `<PreferenceNumber />`.

<!-- You can also link to an open issue here -->

## What is the new behavior?
They are changed to `ts` files with `Overmind`
Add `placeholder` prop for `<PreferenceNumber />`.
<!-- if this is a feature change -->

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. `yarn test`
2. `yarn lint`
3. `yarn typecheck`
4. `yarn start`, go to `Preference/EditorSettings` modal, it seems working

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
