### PR TITLE
Chore: Add react-router-dom typing

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -239,6 +239,7 @@
     "@types/react-dom": "^16.8.3",
     "@types/react-helmet": "^5.0.11",
     "@types/react-icons": "2.2.7",
+    "@types/react-router-dom": "^4.3.1",
     "@types/react-stripe-elements": "^1.3.2",
     "@types/resolve": "^0.0.8",
     "@types/socket.io-client": "^1.4.32",

--- a/packages/app/src/app/pages/Dashboard/Sidebar/TemplateItem/TemplateItem.tsx
+++ b/packages/app/src/app/pages/Dashboard/Sidebar/TemplateItem/TemplateItem.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { DropTarget } from 'react-dnd';
-import { withRouter } from 'react-router-dom';
+import { withRouter, RouteComponentProps } from 'react-router-dom';
 // @ts-ignore
 import TemplateIcon from '-!svg-react-loader!@codesandbox/common/lib/icons/template.svg';
 import { Item } from '../Item';
@@ -14,13 +14,9 @@ interface ITemplateItemProps {
   connectDropTarget?: any;
 }
 
-const TemplateItemComponent: React.FC<ITemplateItemProps> = ({
-  currentPath,
-  isOver,
-  canDrop,
-  connectDropTarget,
-  teamId,
-}: ITemplateItemProps) => {
+const TemplateItemComponent: React.FC<
+  ITemplateItemProps & RouteComponentProps
+> = ({ currentPath, isOver, canDrop, connectDropTarget, teamId }) => {
   const url = teamId
     ? `/dashboard/teams/${teamId}/templates`
     : `/dashboard/templates`;

--- a/packages/app/src/app/pages/common/ErrorBoundary/ErrorBoundary.tsx
+++ b/packages/app/src/app/pages/common/ErrorBoundary/ErrorBoundary.tsx
@@ -1,9 +1,10 @@
 import React, { Component } from 'react';
+import { RouteComponentProps } from 'react-router-dom';
 import { CodeSadbox } from './CodeSadbox';
 import { IErrorBoundaryProps, ErrorInfo, IErrorBoundaryState } from './types';
 
 export class ErrorBoundary extends Component<
-  IErrorBoundaryProps,
+  RouteComponentProps & IErrorBoundaryProps,
   IErrorBoundaryState
 > {
   static getDerivedStateFromError(error: Error) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4127,6 +4127,23 @@
     "@types/prop-types" "*"
     "@types/react" "*"
 
+"@types/react-router-dom@^4.3.1":
+  version "4.3.5"
+  resolved "https://registry.yarnpkg.com/@types/react-router-dom/-/react-router-dom-4.3.5.tgz#72f229967690c890d00f96e6b85e9ee5780db31f"
+  integrity sha512-eFajSUASYbPHg2BDM1G8Btx+YqGgvROPIg6sBhl3O4kbDdYXdFdfrgQFf/pcBuQVObjfT9AL/dd15jilR5DIEA==
+  dependencies:
+    "@types/history" "*"
+    "@types/react" "*"
+    "@types/react-router" "*"
+
+"@types/react-router@*":
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/@types/react-router/-/react-router-5.1.2.tgz#41e5e6aa333a7b9a2bfdac753c04e1ca4b3e0d21"
+  integrity sha512-euC3SiwDg3NcjFdNmFL8uVuAFTpZJm0WMFUw+4eXMUnxa7M9RGFEG0szt0z+/Zgk4G2k9JBFhaEnY64RBiFmuw==
+  dependencies:
+    "@types/history" "*"
+    "@types/react" "*"
+
 "@types/react-stripe-elements@^1.3.2":
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/@types/react-stripe-elements/-/react-stripe-elements-1.3.2.tgz#02ed6802b16366b4ebc6b85b8bd3e8befa553b79"
@@ -8069,7 +8086,7 @@ console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   integrity sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=
 
 console-feed@CompuIves/console-feed#build2, console-feed@^2.8.5:
-  version "2.8.8"
+  version "2.8.9"
   resolved "https://codeload.github.com/CompuIves/console-feed/tar.gz/42f10eb3063f0f26ee9745c4c9e4542cb5591f46"
   dependencies:
     emotion "^9.1.1"


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?
@Saeris @christianalfoni 
This PR adds `@types/react-router-dom` to `app` repo in order to get correct `react-router-dom` components typing.
Which is necessary to convert current `react-router-dom` components usage in `js` files to `ts` files, such as: `app/src/app/pages/Dashboard/Content/routes/PathedSandboxes/Navigation/elements.js`

<!-- Is it a Bug fix, feature, docs update, ... -->

## What is the current behavior?
Currently there is no typing for all `react-router-dom` components, so there is no type checking for `props` assigned to them.
Also `withRouter()` hoc, can take any components no matter if it expects `RouteComponentProps` or not.

<!-- You can also link to an open issue here -->

## What is the new behavior?
This PR will introduce `react-router-dom` type checking for its usage.
And `withRouter()` hoc would expect component explicitly expects `RouteComponentProps`.
PS: I am not aware of why some of the component is wrapped in `withRouter()` but without using any `RouteComponentProps`, might can be simply removed usage of `withRouter()`, instead of current fix by introducing new `props` to them.

<!-- if this is a feature change -->

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. yarn typecheck
## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
