### PR TITLE
add codesandboxer-fs docs

### DIFF
--- a/packages/homepage/content/docs/2-importing.md
+++ b/packages/homepage/content/docs/2-importing.md
@@ -177,7 +177,7 @@ example sandbox of that is here:
 You can export a local component to CodeSandbox by using our other
 [CLI](https://github.com/codesandbox/codesandboxer/tree/master/packages/codesandboxer-fs).
 
-You can install our CLI by running `npm install -g codesandbox`. Then you can
+You can install our CLI by running `npm install -g codesandboxer-fs`. Then you can
 export a project by running `codesandboxer {filePath}`.
 
 ```

--- a/packages/homepage/content/docs/2-importing.md
+++ b/packages/homepage/content/docs/2-importing.md
@@ -185,7 +185,7 @@ $ npm install -g codesandboxer-fs
 $ codesandboxer docs/examples/my-single-component.js
 ```
 
-This will print out the id of a sandbox that does nothing but render the targeted component, along with a link to that sandbox.
+This will print out the id of a sandbox that does nothing but render the targeted component, along with a link to that sandbox. This will also bundle in other local files used by the component to ensure render.
 
 
 ## Import Using React-Codesandboxer

--- a/packages/homepage/content/docs/2-importing.md
+++ b/packages/homepage/content/docs/2-importing.md
@@ -172,6 +172,22 @@ example sandbox of that is here:
 
 <iframe src="https://codesandbox.io/embed/9loovqj5oy?editorsize=70&fontsize=14&hidenavigation=1&runonclick=1" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>
 
+## Import single Component as a Sandbox
+
+You can export a local component to CodeSandbox by using our other
+[CLI](https://github.com/codesandbox/codesandboxer/tree/master/packages/codesandboxer-fs).
+
+You can install our CLI by running `npm install -g codesandbox`. Then you can
+export a project by running `codesandboxer {filePath}`.
+
+```
+$ npm install -g codesandboxer-fs
+$ codesandboxer docs/examples/my-single-component.js
+```
+
+This will print out the id of a sandbox that does nothing but render the targeted component, along with a link to that sandbox.
+
+
 ## Import Using React-Codesandboxer
 
 Import from a single file from a git repository, along with supplemental files


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?

Small docs update to include `codesandboxer-fs` as a way to upload files (I think this is realistically more useful than the `react-codesandboxer` docs beneath it)
## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->

Quick note on this: the fragmentation of tools is weird here, dating back to legacy stuff on `codesandboxer` being built out mostly independently of codesandbox itself more as an extension. It seems like it would make sense to make the `codesandbox` CLI itself work for both directories and files, to avoid recommending two different installs, but this was a quick fix to at least document this capability.