### PR TITLE
🔨 Refactor, 🧠 Overmind Hactoberfest | Refactor  /app/pages/Sandbox/Editor/Workspace/Files/DirectoryEntry/DirectoryChildren/ModuleEntry.js to use Overmind #2885

### DIFF
--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/Files/DirectoryEntry/DirectoryChildren/ModuleEntry.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/Files/DirectoryEntry/DirectoryChildren/ModuleEntry.tsx
@@ -1,12 +1,28 @@
-import { inject, observer } from 'app/componentConnectors';
+import { Module, Directory } from '@codesandbox/common/lib/types';
+import { useOvermind } from 'app/overmind';
 // eslint-disable-next-line import/extensions
 import getType from 'app/utils/get-type.ts';
 import React from 'react';
 
 import Entry from '../Entry';
 
-const ModuleEntry = ({
-  store,
+interface IModuleEntryProps {
+  module: Module;
+  setCurrentModule: (id: string) => void;
+  markTabsNotDirty: () => void;
+  depth: number;
+  renameModule: (title: string, moduleShortid: string) => void;
+  deleteEntry: (shortid: string, title: string) => void;
+  discardModuleChanges: (shortid: string) => void;
+  getModulePath: (
+    modules: Module[],
+    directories: Directory[],
+    id: string
+  ) => string;
+  renameValidator: (id: string, title: string) => boolean;
+}
+
+const ModuleEntry: React.FC<IModuleEntryProps> = ({
   module,
   setCurrentModule,
   markTabsNotDirty,
@@ -17,15 +33,17 @@ const ModuleEntry = ({
   getModulePath,
   renameValidator,
 }) => {
-  const { currentModuleShortid } = store.editor;
-  const mainModuleId = store.editor.mainModule.id;
-
+  const {
+    state: {
+      editor: { mainModule, currentModuleShortid },
+      live,
+    },
+  } = useOvermind();
   const isActive = module.shortid === currentModuleShortid;
-  const isMainModule = module.id === mainModuleId;
+  const isMainModule = module.id === mainModule.id;
   const type = getType(module.title);
   const hasError = module.errors.length;
-
-  const liveUsers = store.live.liveUsersByModule[module.shortid] || [];
+  const liveUsers = live.liveUsersByModule[module.shortid] || [];
 
   const isNotSynced = module.savedCode && module.code !== module.savedCode;
 
@@ -52,4 +70,4 @@ const ModuleEntry = ({
   );
 };
 
-export default inject('store')(observer(ModuleEntry));
+export default ModuleEntry;


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?
Refactors code as a part of hacktoberfest mentioned in #2621.
@Saeris @christianalfoni
<!-- Is it a Bug fix, feature, docs update, ... -->

## What is the current behavior?

<!-- You can also link to an open issue here -->
package /app/pages/Sandbox/Editor/Workspace/Files/DirectoryEntry/DirectoryChildren/ModuleEntry.js was using Cerebral

## What is the new behavior?
packages /app/pages/Sandbox/Editor/Workspace/Files/DirectoryEntry/DirectoryChildren/ModuleEntry.tsx is using Overmind
<!-- if this is a feature change -->

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. yarn test
2. yarn lint
3. yarn typecheck

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
