### PR TITLE
🔨 Refactor, 🧠 Overmind Hactoberfest | Refactor /app/pages/Dashboard/Content/routes/RecentSandboxes/index.js to use Overmind, Typescript, and Apollo hooks

### DIFF
--- a/packages/app/src/app/pages/Dashboard/Content/Sandboxes/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/Sandboxes/index.tsx
@@ -44,7 +44,7 @@ export class Content extends React.Component<IContentProps> {
       <Container>
         <HeaderContainer>
           <HeaderTitle>
-            {Header}{' '}
+            {Header}
             {sandboxes && !isLoading && (
               <span
                 style={{

--- a/packages/app/src/app/pages/Dashboard/Content/Sandboxes/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/Sandboxes/index.tsx
@@ -6,22 +6,26 @@ import { Filters } from './Filters';
 import { DashboardActions } from './Actions';
 import { ITemplate } from './types';
 
-interface Props {
+interface IContentProps {
   sandboxes: any[];
-  Header: React.ComponentType;
-  SubHeader: React.ComponentType;
-  ExtraElement: React.ComponentType;
+  Header: React.ComponentType | string;
+  SubHeader?: React.ComponentType;
+  ExtraElement: React.ComponentType<IExtraElementProps>;
 
-  possibleTemplates: ITemplate[];
+  possibleTemplates?: ITemplate[];
   isLoading?: boolean;
   hideOrder?: boolean;
   hideFilters?: boolean;
-  page?: number;
+  page?: number | string;
   actions?: any[];
 }
 
+interface IExtraElementProps {
+  style: React.CSSProperties;
+}
+
 // eslint-disable-next-line react/prefer-stateless-function
-export class Content extends React.Component<Props> {
+export class Content extends React.Component<IContentProps> {
   render() {
     const {
       sandboxes,

--- a/packages/app/src/app/pages/Dashboard/Content/index.js
+++ b/packages/app/src/app/pages/Dashboard/Content/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Route, Switch, Redirect, withRouter } from 'react-router-dom';
 
-import RecentSandboxes from './routes/RecentSandboxes';
+import { RecentSandboxes } from './routes/RecentSandboxes';
 import PathedSandboxes from './routes/PathedSandboxes';
 import { Templates } from './routes/Templates';
 import DeletedSandboxes from './routes/DeletedSandboxes';

--- a/packages/app/src/app/pages/Dashboard/Content/routes/RecentSandboxes/index.js
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/RecentSandboxes/index.js
@@ -1,66 +1,66 @@
 import React from 'react';
-import { observer, inject } from 'app/componentConnectors';
 import Helmet from 'react-helmet';
-
 import { Query } from 'react-apollo';
 
+import { useOvermind } from 'app/overmind';
 import getMostUsedTemplate from '../../../utils/get-most-used-template';
-
 import { Content as Sandboxes } from '../../Sandboxes';
-
 import CreateNewSandbox from '../../CreateNewSandbox';
 import { RECENT_SANDBOXES_CONTENT_QUERY } from '../../../queries';
 
-const RecentSandboxes = ({ store }) => (
-  <>
-    <Helmet>
-      <title>Recent Sandboxes - CodeSandbox</title>
-    </Helmet>
-    <Query
-      variables={{
-        orderField: store.dashboard.orderBy.field,
-        orderDirection: store.dashboard.orderBy.order.toUpperCase(),
-      }}
-      query={RECENT_SANDBOXES_CONTENT_QUERY}
-    >
-      {({ loading, error, data }) => {
-        if (error) {
-          return <div>Error!</div>;
-        }
+const RecentSandboxes = () => {
+  const { state } = useOvermind();
+  return (
+    <>
+      <Helmet>
+        <title>Recent Sandboxes - CodeSandbox</title>
+      </Helmet>
+      <Query
+        variables={{
+          orderField: state.dashboard.orderBy.field,
+          orderDirection: state.dashboard.orderBy.order.toUpperCase(),
+        }}
+        query={RECENT_SANDBOXES_CONTENT_QUERY}
+      >
+        {({ loading, error, data }) => {
+          if (error) {
+            return <div>Error!</div>;
+          }
 
-        const sandboxes = loading
-          ? []
-          : (data && data.me && data.me.sandboxes) || [];
+          const sandboxes = loading
+            ? []
+            : (data && data.me && data.me.sandboxes) || [];
 
-        let mostUsedTemplate = null;
-        try {
-          mostUsedTemplate = getMostUsedTemplate(sandboxes);
-        } catch (e) {
-          // Not critical
-        }
+          let mostUsedTemplate = null;
+          try {
+            mostUsedTemplate = getMostUsedTemplate(sandboxes);
+          } catch (e) {
+            // Not critical
+          }
 
-        // We want to hide all templates
-        // TODO: make this a query variable for graphql and move the logic to the server
-        const noTemplateSandboxes = sandboxes.filter(s => !s.customTemplate);
+          // We want to hide all templates
+          // TODO: make this a query variable for graphql and move the logic to the server
+          const noTemplateSandboxes = sandboxes.filter(s => !s.customTemplate);
 
-        return (
-          <Sandboxes
-            isLoading={loading}
-            Header="Recent Sandboxes"
-            ExtraElement={({ style }) => (
-              <CreateNewSandbox
-                mostUsedSandboxTemplate={mostUsedTemplate}
-                style={style}
-              />
-            )}
-            hideFilters
-            sandboxes={noTemplateSandboxes}
-            page="recent"
-          />
-        );
-      }}
-    </Query>
-  </>
-);
+          return (
+            <Sandboxes
+              isLoading={loading}
+              Header="Recent Sandboxes"
+              ExtraElement={({ style }) => (
+                <CreateNewSandbox
+                  mostUsedSandboxTemplate={mostUsedTemplate}
+                  style={style}
+                />
+              )}
+              hideFilters
+              sandboxes={noTemplateSandboxes}
+              page="recent"
+            />
+          );
+        }}
+      </Query>
+    </>
+  );
+};
 
-export default inject('signals', 'store')(observer(RecentSandboxes));
+export default RecentSandboxes;

--- a/packages/app/src/app/pages/Dashboard/Content/routes/RecentSandboxes/index.js
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/RecentSandboxes/index.js
@@ -8,7 +8,7 @@ import { Content as Sandboxes } from '../../Sandboxes';
 import CreateNewSandbox from '../../CreateNewSandbox';
 import { RECENT_SANDBOXES_CONTENT_QUERY } from '../../../queries';
 
-const RecentSandboxes = () => {
+export const RecentSandboxes = () => {
   const { state } = useOvermind();
   return (
     <>
@@ -62,5 +62,3 @@ const RecentSandboxes = () => {
     </>
   );
 };
-
-export default RecentSandboxes;

--- a/packages/app/src/app/pages/Dashboard/Content/routes/RecentSandboxes/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/RecentSandboxes/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Helmet from 'react-helmet';
+import { Helmet } from 'react-helmet';
 import { useQuery } from '@apollo/react-hooks';
 
 import { useOvermind } from 'app/overmind';
@@ -16,6 +16,11 @@ export const RecentSandboxes = () => {
       orderDirection: state.dashboard.orderBy.order.toUpperCase(),
     },
   });
+
+  if (error) {
+    return <div>Error!</div>;
+  }
+
   const sandboxes = loading ? [] : (data && data.me && data.me.sandboxes) || [];
 
   let mostUsedTemplate = null;
@@ -28,13 +33,11 @@ export const RecentSandboxes = () => {
   // We want to hide all templates
   // TODO: make this a query variable for graphql and move the logic to the server
   const noTemplateSandboxes = sandboxes.filter(s => !s.customTemplate);
-
   return (
     <>
       <Helmet>
         <title>Recent Sandboxes - CodeSandbox</title>
       </Helmet>
-      {error && <div>Error!</div>}
       <Sandboxes
         isLoading={loading}
         Header="Recent Sandboxes"


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?

Changing `RecentSandboxes` component to use Typescript and Overmind, as well as Apollo's new React hook API as part of #2621 @Saeris @christianalfoni

<!-- Is it a Bug fix, feature, docs update, ... -->

## What is the current behavior?

`RecentSandboxes` component uses `inject` and `observer` and does not benefit from types. It also uses legacy render props API for Apollo query.

<!-- You can also link to an open issue here -->

## What is the new behavior?

`RecentSandboxes` component uses `useOvermind`, Typescript and recommended Apollo hooks API.

<!-- if this is a feature change -->

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. `yarn lint`
2. `yarn test`
3. opened the component at `http://localhost:3000/dashboard/recent` and tested manually.

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->

Tried to add myself to the list of contributors, but looks like `all-contributors add` is broken in `6.9.1`. Fixed this in https://github.com/codesandbox/codesandbox-client/pull/2892 while I was at it :)

<!-- Thank you for contributing! -->
