### PR TITLE
Use cross-env to run tests

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -20,7 +20,7 @@
     "prepublish": "yarn build",
     "start": "(yarn tsc --watch & yarn babel src --out-dir lib --watch & yarn cpx \"src/**/*.{css,svg,png,jpg}\" lib --watch)",
     "start:storybook": "start-storybook",
-    "test": "NODE_ENV=test jest",
+    "test": "cross-env NODE_ENV=test jest",
     "typecheck": "tsc --noEmit"
   },
   "jest": {


### PR DESCRIPTION
This lets `yarn test` work on Windows (without installing something like `win-node-env`).


## What kind of change does this PR introduce?
Fix to test script to let tests run on Windows .

## What is the current behavior?
Running `yarn test` returns an error:
> @codesandbox/common@1.0.8 test C:\repos\open-source\codesandbox-client\packages\common        
> NODE_ENV=test jest                                                                            
                                                                                                
                                                                                                
lerna ERR! npm run test stderr:                                                                 
'NODE_ENV' is not recognized as an internal or external command,                                
operable program or batch file.    

## What is the new behavior?
Tests run successfully on Windows!

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Ran `yarn test` and verified successful output.
2. Ran `yarn start` to verify app still runs.

## Checklist
- [ ] Documentation N/A
- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged
- [ ] Added myself to contributors table
