### PR TITLE
Update embed docs to be in line with actual implementation

### DIFF
--- a/packages/app/src/app/pages/common/Modals/ShareModal/getCode.js
+++ b/packages/app/src/app/pages/common/Modals/ShareModal/getCode.js
@@ -66,9 +66,13 @@ export const getEmbedUrl = (sandbox, mainModule, state) =>
   getOptionsUrl(sandbox, mainModule, state);
 
 export const getIframeScript = (sandbox, mainModule, state) =>
-  `<iframe src="${getEmbedUrl(sandbox, mainModule, state)}" title="${escapeHtml(
-    getSandboxName(sandbox)
-  )}" allow="geolocation; microphone; camera; midi; vr; accelerometer; gyroscope; payment; ambient-light-sensor; encrypted-media; usb" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>`;
+  `<iframe
+     src="${getEmbedUrl(sandbox, mainModule, state)}"
+     style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
+     title="${escapeHtml(getSandboxName(sandbox))}"
+     allow="geolocation; microphone; camera; midi; vr; accelerometer; gyroscope; payment; ambient-light-sensor; encrypted-media; usb"
+     sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"
+   ></iframe>`;
 
 // eslint-disable-next-line
 export const getButtonMarkdown = (sandbox, mainModule, state) => {

--- a/packages/homepage/content/docs/2-embedding.md
+++ b/packages/homepage/content/docs/2-embedding.md
@@ -62,11 +62,18 @@ This embed is focused on being as light as possible:
 
 Use this code to embed:
 
-`<iframe src="https://codesandbox.io/embed/new?codemirror=1" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>`
+```html
+<iframe
+  src="https://codesandbox.io/embed/new?codemirror=1"
+  style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
+  allow="geolocation; microphone; camera; midi; vr; accelerometer; gyroscope; payment; ambient-light-sensor; encrypted-media; usb"
+  sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"
+></iframe>
+```
 
 That will give to a result like this:
 
-<iframe src="https://codesandbox.io/embed/new?codemirror=1" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>
+<iframe src="https://codesandbox.io/embed/new?codemirror=1" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" allow="geolocation; microphone; camera; midi; vr; accelerometer; gyroscope; payment; ambient-light-sensor; encrypted-media; usb" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>
 
 ### Code Example Embed
 
@@ -77,8 +84,15 @@ is only supported with the CodeMirror editor currently:
 
 Use this code to embed:
 
-`<iframe src="https://codesandbox.io/embed/new?codemirror=1&highlights=11,12,13,14" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>`
+```html
+<iframe
+  src="https://codesandbox.io/embed/new?codemirror=1&highlights=11,12,13,14"
+  style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
+  allow="geolocation; microphone; camera; midi; vr; accelerometer; gyroscope; payment; ambient-light-sensor; encrypted-media; usb"
+  sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"
+></iframe>
+```
 
 That will give to a result like this:
 
-<iframe src="https://codesandbox.io/embed/new?codemirror=1&highlights=11,12,13,14" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>
+<iframe src="https://codesandbox.io/embed/new?codemirror=1&highlights=11,12,13,14" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" allow="geolocation; microphone; camera; midi; vr; accelerometer; gyroscope; payment; ambient-light-sensor; encrypted-media; usb" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>


### PR DESCRIPTION
## What kind of change does this PR introduce?
After @garethx' PR for dev.to (https://github.com/thepracticaldev/dev.to/pull/4575), I figured it might be nice to update the embed docs to be in line with the actual implementation too, so embeds are less error-prone out there.

## What is the current behavior?
Embed docs aren't in line with actual implementation

## What is the new behavior?
Embed docs are in line with actual implementation

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.
1. Go to the [embed docs](https://pr2923.build.csb.dev/docs/embedding)

## Checklist
- [x] Documentation
- [x] Testing
- [x] Ready to be merged
- [N/A] Added myself to contributors table