### PR TITLE
Improve showing of commit sha

### DIFF
--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/Project/Project.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/Project/Project.tsx
@@ -83,6 +83,7 @@ export const Project: React.FunctionComponent<IProjectProps> = ({
             username={sandbox.git.username}
             repo={sandbox.git.repo}
             branch={sandbox.git.branch}
+            commitSha={sandbox.git.commitSha}
           />
         </Item>
       )}

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/items/GitHub/Git/Git.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/items/GitHub/Git/Git.tsx
@@ -68,6 +68,7 @@ export const Git: FunctionComponent = () => {
           repo={originalGit.repo}
           url={githubRepoUrl(originalGit)}
           username={originalGit.username}
+          commitSha={originalGit.commitSha}
         />
       </Margin>
 

--- a/packages/common/src/components/GithubBadge/index.stories.tsx
+++ b/packages/common/src/components/GithubBadge/index.stories.tsx
@@ -10,6 +10,7 @@ stories
       username="CompuIves"
       repo="codesandbox-client"
       branch="master"
+      commitSha="9823ru9238ru8u998ur2398ru"
     />
   ))
   .add('Other Branch', () => (
@@ -17,5 +18,14 @@ stories
       username="CompuIves"
       repo="codesandbox-client"
       branch="storybook"
+      commitSha="9823ru9238ru8u998ur2398ru"
+    />
+  ))
+  .add('CommitSha', () => (
+    <GithubBadge
+      username="CompuIves"
+      repo="codesandbox-client"
+      branch="9823ru9238ru8u998ur2398ru"
+      commitSha="9823ru9238ru8u998ur2398ru"
     />
   ));

--- a/packages/common/src/components/GithubBadge/index.tsx
+++ b/packages/common/src/components/GithubBadge/index.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from 'react';
+import React, { FunctionComponent, useCallback } from 'react';
 import GithubIcon from 'react-icons/lib/go/mark-github';
 import { BorderRadius, Text, Icon, StyledA } from './elements';
 
@@ -7,6 +7,7 @@ type BadgeProps = {
   repo: string;
   url?: string;
   branch: string;
+  commitSha: string;
 };
 
 type DivOrAProps = {
@@ -26,19 +27,36 @@ const GithubBadge: FunctionComponent<BadgeProps> = ({
   repo,
   url,
   branch,
+  commitSha,
   ...props
-}) => (
-  <DivOrA {...props} href={url}>
-    <BorderRadius hasUrl={Boolean(url)}>
-      <Icon>
-        <GithubIcon />
-      </Icon>
-      <Text>
-        {username}/{repo}
-        {branch && branch !== 'master' ? `@${branch}` : ''}
-      </Text>
-    </BorderRadius>
-  </DivOrA>
-);
+}) => {
+  const getBadgeName = useCallback(() => {
+    if (branch === commitSha) {
+      return branch.substr(0, 7);
+    }
+
+    if (branch === 'master') {
+      return undefined;
+    }
+
+    return branch;
+  }, [branch, commitSha]);
+
+  const displayBranch = getBadgeName();
+
+  return (
+    <DivOrA {...props} href={url}>
+      <BorderRadius hasUrl={Boolean(url)}>
+        <Icon>
+          <GithubIcon />
+        </Icon>
+        <Text>
+          {username}/{repo}
+          {displayBranch ? `@${displayBranch}` : ''}
+        </Text>
+      </BorderRadius>
+    </DivOrA>
+  );
+};
 
 export default GithubBadge;

--- a/packages/homepage/src/screens/explore/SandboxModal.js
+++ b/packages/homepage/src/screens/explore/SandboxModal.js
@@ -249,6 +249,7 @@ export default class SandboxModal extends React.PureComponent {
                         username={sandbox.git.username}
                         repo={sandbox.git.repo}
                         branch={sandbox.git.branch}
+                        commitSha={sandbox.git.commitSha}
                         url={githubRepoUrl(sandbox.git)}
                       />
                     )}


### PR DESCRIPTION
For imported direct commits we will show the first 7 characters of the `commitSha`, so the short `commitSha`.

Makes this:

![image](https://user-images.githubusercontent.com/587016/67511388-15569080-f697-11e9-8112-1ccf6ce7ddd0.png)

Show as this:

![image](https://user-images.githubusercontent.com/587016/67511531-5fd80d00-f697-11e9-8a64-e9bc5e9cf14a.png)

