### PR TITLE
fix(embed): likes counter on dislike shows inconsistent value

### DIFF
--- a/packages/app/src/embed/components/App/index.js
+++ b/packages/app/src/embed/components/App/index.js
@@ -1,4 +1,3 @@
-// @flow
 import * as React from 'react';
 import { ThemeProvider } from 'styled-components';
 import { camelizeKeys } from 'humps';

--- a/packages/app/src/embed/components/App/index.js
+++ b/packages/app/src/embed/components/App/index.js
@@ -268,12 +268,12 @@ export default class App extends React.PureComponent<
         }),
       })
         .then(x => x.json())
-        .then(() => {
+        .then(res => {
           this.setState(s => ({
             sandbox: {
               ...s.sandbox,
               userLiked: false,
-              likeCount: s.sandbox.likeCount - 1,
+              likeCount: res.count,
             },
           }));
         })


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?
Bug Fix
<!-- Is it a Bug fix, feature, docs update, ... -->

## What is the current behavior?
When in `Embed` you dislike ( removing the current like ) the like counter does `-2` i.e if number of likes were `1` it goes to `-1`.

Reason: 

For instant feedback, the like is updated when we click heart button and on receiving the response we do `-1` which causes inconsistency. I have used the response from Backend to reflect on state.

<!-- You can also link to an open issue here -->

## What is the new behavior?
Consistent behavior
<!-- if this is a feature change -->

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Tested Locally by replicating the bug

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation - N/A
- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
 Great work guys on the new embed design. Looks really awesome!!! 🔥 💯 
