### PR TITLE
embed: show alias instead of id as fallback title

### DIFF
--- a/packages/app/src/embed/components/Sidebar/SandboxInfo/index.js
+++ b/packages/app/src/embed/components/Sidebar/SandboxInfo/index.js
@@ -3,7 +3,7 @@ import { Container, Title, Description, Stats } from './elements';
 import AvatarBlock from '../AvatarBlock';
 
 const SandboxInfo = ({ sandbox }) => {
-  const title = sandbox.title || sandbox.id;
+  const title = sandbox.title || sandbox.alias || sandbox.id;
 
   return (
     <Container>


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?
Improvment
<!-- Is it a Bug fix, feature, docs update, ... -->

## What is the current behavior?
In embed, we show `id` as a fallback if the title is not defined
<!-- You can also link to an open issue here -->

## What is the new behavior?
Show `alias` as a fallback. Not sure if this makes sense but for consistency between app and embed it will make sense. As on app, the title is set to alias by default.
<!-- if this is a feature change -->

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Local testing

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
