### PR TITLE
fix: show like button on showcase title when the user is logged in

### DIFF
--- a/packages/app/src/app/pages/Profile/Showcase/SandboxInfo/index.js
+++ b/packages/app/src/app/pages/Profile/Showcase/SandboxInfo/index.js
@@ -13,12 +13,13 @@ import {
   PlayButtonContainer,
 } from './elements';
 
-function SandboxInfo({ sandbox }) {
+function SandboxInfo({ sandbox, isLoggedIn }) {
   return (
     <Container>
       <Row alignItems="center">
         <Title>
-          {getSandboxName(sandbox)} <Like sandbox={sandbox} />
+          {getSandboxName(sandbox)}{' '}
+          {isLoggedIn ? <Like sandbox={sandbox} /> : null}
         </Title>
       </Row>
       <Row alignItems="flex-start">

--- a/packages/app/src/app/pages/Profile/Showcase/index.js
+++ b/packages/app/src/app/pages/Profile/Showcase/index.js
@@ -62,7 +62,7 @@ class Showcase extends React.Component {
               />
             </div>
             <div style={{ flex: 1 }}>
-              <SandboxInfo sandbox={sandbox} />
+              <SandboxInfo sandbox={sandbox} isLoggedIn={store.isLoggedIn} />
             </div>
           </Column>
         </Margin>


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?

<!-- Is it a Bug fix, feature, docs update, ... -->
Improvement. Not sure if this was intentional as the like button doesn't work but I guess its better to not show like in Editor at the top.

## What is the current behavior?
Like button visible in showcase even when the user is logged out.
<!-- You can also link to an open issue here -->

## What is the new behavior?
Show like button only when logged in, like in editor.

<!-- if this is a feature change -->

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

- Tested this page locally

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation- N/A
- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
