### PR TITLE
Fix Preference's types

### DIFF
--- a/packages/app/src/app/pages/common/Modals/PreferencesModal/Appearance/index.tsx
+++ b/packages/app/src/app/pages/common/Modals/PreferencesModal/Appearance/index.tsx
@@ -1,8 +1,9 @@
-import React from 'react';
-import { useOvermind } from 'app/overmind';
+import { PreferenceText } from '@codesandbox/common/lib/components/Preference/PreferenceText';
 import themes from '@codesandbox/common/lib/themes';
+import React from 'react';
 
-import PreferenceText from '@codesandbox/common/lib/components/Preference/PreferenceText';
+import { useOvermind } from 'app/overmind';
+
 import {
   Title,
   SubContainer,

--- a/packages/app/src/app/pages/common/Modals/PreferencesModal/elements.js
+++ b/packages/app/src/app/pages/common/Modals/PreferencesModal/elements.js
@@ -1,5 +1,5 @@
+import { Preference } from '@codesandbox/common/lib/components/Preference';
 import styled, { css } from 'styled-components';
-import Preference from '@codesandbox/common/lib/components/Preference';
 
 export const SubContainer = styled.div`
   color: ${props => props.theme.white};

--- a/packages/app/src/app/pages/common/Modals/ShareModal/elements.js
+++ b/packages/app/src/app/pages/common/Modals/ShareModal/elements.js
@@ -1,5 +1,5 @@
+import { Preference } from '@codesandbox/common/lib/components/Preference';
 import styled from 'styled-components';
-import Preference from '@codesandbox/common/lib/components/Preference';
 
 export const FilesContainer = styled.div`
   max-height: 300px;

--- a/packages/common/src/components/Preference/PreferenceDropdown.tsx
+++ b/packages/common/src/components/Preference/PreferenceDropdown.tsx
@@ -1,33 +1,31 @@
-import React from 'react';
+import React, { ChangeEvent, FunctionComponent } from 'react';
+
 import Select from '../Select';
 
-export type NameMapper = (param: string) => string;
-
-export type Props = {
+type Props = {
+  mapName?: (param: string) => string;
+  options: string[];
   setValue: (value: string) => void;
   value: string;
-  options: string[];
-  mapName?: NameMapper;
 };
 
-export default class PreferenceInput extends React.PureComponent<Props> {
-  handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    const { value } = e.target;
-
-    this.props.setValue(value);
+export const PreferenceDropdown: FunctionComponent<Props> = ({
+  mapName,
+  options,
+  setValue,
+  value,
+}) => {
+  const handleChange = ({ target }: ChangeEvent<HTMLSelectElement>) => {
+    setValue(target.value);
   };
 
-  render() {
-    const { value, options, mapName } = this.props;
-
-    return (
-      <Select onChange={this.handleChange} value={value}>
-        {options.map(op => (
-          <option key={op} value={op}>
-            {mapName ? mapName(op) : op}
-          </option>
-        ))}
-      </Select>
-    );
-  }
-}
+  return (
+    <Select onChange={handleChange} value={value}>
+      {options.map(option => (
+        <option key={option} value={option}>
+          {mapName ? mapName(option) : option}
+        </option>
+      ))}
+    </Select>
+  );
+};

--- a/packages/common/src/components/Preference/PreferenceKeybinding/index.tsx
+++ b/packages/common/src/components/Preference/PreferenceKeybinding/index.tsx
@@ -1,39 +1,42 @@
-import React from 'react';
+import React, { FunctionComponent } from 'react';
+
 import KeybindingInput from './KeybindingInput';
 
-export type Props = {
-  setValue: (value: Array<string[]>) => void;
-  value: Array<string[]>;
+type Props = {
+  setValue: (value: string[][]) => void;
+  value: string[][];
 };
 
-export default class PreferenceKeybinding extends React.PureComponent<Props> {
-  setValue = index => value => {
-    const result = [...this.props.value];
+export const PreferenceKeybinding: FunctionComponent<Props> = ({
+  setValue: setValueProp,
+  value: valueProp,
+  ...props
+}) => {
+  const setValue = (index: number) => (value: string[]) => {
+    const result = [...valueProp];
     result[index] = value;
 
-    this.props.setValue(result);
+    setValueProp(result);
   };
 
-  render() {
-    const { value } = this.props;
+  return (
+    <div>
+      <KeybindingInput
+        {...props}
+        placeholder="First"
+        setValue={setValue(0)}
+        value={valueProp[0]}
+      />
 
-    return (
-      <div>
-        <KeybindingInput
-          {...this.props}
-          placeholder="First"
-          value={value[0]}
-          setValue={this.setValue(0)}
-        />
-        {' - '}
-        <KeybindingInput
-          {...this.props}
-          placeholder="Second"
-          value={value.length === 2 && value[1]}
-          setValue={this.setValue(1)}
-          disabled={!value[0] || value[0].length === 0}
-        />
-      </div>
-    );
-  }
-}
+      {' - '}
+
+      <KeybindingInput
+        {...props}
+        disabled={!valueProp[0] || valueProp[0].length === 0}
+        placeholder="Second"
+        setValue={setValue(1)}
+        value={valueProp.length === 2 && valueProp[1]}
+      />
+    </div>
+  );
+};

--- a/packages/common/src/components/Preference/PreferenceNumber.tsx
+++ b/packages/common/src/components/Preference/PreferenceNumber.tsx
@@ -1,33 +1,32 @@
-import React from 'react';
-import { StyledInput } from './elements';
+import React, { ChangeEvent, ComponentProps, FunctionComponent } from 'react';
 
-export type Props = {
+import { Input } from './elements';
+
+type Props = {
   setValue: (value: number) => void;
-  value: number;
   step?: number;
-  style?: React.CSSProperties;
-};
+  value: number;
+} & Pick<ComponentProps<typeof Input>, 'style'>;
 
-export default class PreferenceInput extends React.PureComponent<Props> {
-  handleChange = e => {
-    const { value } = e.target;
-
-    if (!Number.isNaN(+value)) {
-      this.props.setValue(+value);
+export const PreferenceNumber: FunctionComponent<Props> = ({
+  setValue,
+  step,
+  style,
+  value,
+}) => {
+  const handleChange = ({ target }: ChangeEvent<HTMLInputElement>) => {
+    if (!Number.isNaN(+target.value)) {
+      setValue(+target.value);
     }
   };
 
-  render() {
-    const { value, style, step } = this.props;
-
-    return (
-      <StyledInput
-        step={step}
-        style={{ width: '3rem', ...style }}
-        type="number"
-        value={value}
-        onChange={this.handleChange}
-      />
-    );
-  }
-}
+  return (
+    <Input
+      onChange={handleChange}
+      step={step}
+      style={{ width: '3rem', ...style }}
+      type="number"
+      value={value}
+    />
+  );
+};

--- a/packages/common/src/components/Preference/PreferenceSwitch.tsx
+++ b/packages/common/src/components/Preference/PreferenceSwitch.tsx
@@ -1,27 +1,28 @@
-import React from 'react';
+import React, { FunctionComponent } from 'react';
+
 import Switch from '../Switch';
 
-export type Props = {
+type Props = {
+  setValue: (value: boolean) => void;
   value: boolean;
-  setValue: (val: boolean) => void;
 };
 
-export default class PreferenceSwitch extends React.Component<Props> {
-  handleClick = () => {
-    this.props.setValue(!this.props.value);
+export const PreferenceSwitch: FunctionComponent<Props> = ({
+  setValue,
+  value,
+}) => {
+  const handleClick = () => {
+    setValue(!value);
   };
 
-  render() {
-    const { value } = this.props;
-    return (
-      <Switch
-        onClick={this.handleClick}
-        small
-        style={{ width: '3rem' }}
-        offMode
-        secondary
-        right={value}
-      />
-    );
-  }
-}
+  return (
+    <Switch
+      offMode
+      onClick={handleClick}
+      right={value}
+      secondary
+      small
+      style={{ width: '3rem' }}
+    />
+  );
+};

--- a/packages/common/src/components/Preference/PreferenceText.tsx
+++ b/packages/common/src/components/Preference/PreferenceText.tsx
@@ -1,32 +1,37 @@
-import React from 'react';
+import {
+  ChangeEvent,
+  ComponentProps,
+  createElement,
+  FunctionComponent,
+} from 'react';
+
 import Input, { TextArea } from '../Input';
 
-export type Props = {
+type Props = {
+  block?: boolean;
+  isTextArea?: boolean;
+  placeholder?: string;
+  rows?: number;
   setValue: (value: string) => void;
   value: string;
-  placeholder?: string;
-  isTextArea?: boolean;
-  style?: React.CSSProperties;
-  block?: boolean;
-  rows?: number;
-};
+} & Pick<ComponentProps<typeof Input>, 'style'>;
 
-export default class PreferenceText extends React.PureComponent<Props> {
-  handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const { value } = e.target;
-
-    this.props.setValue(value);
+export const PreferenceText: FunctionComponent<Props> = ({
+  isTextArea,
+  placeholder,
+  setValue,
+  value,
+  ...props
+}) => {
+  const handleChange = ({ target }: ChangeEvent<HTMLInputElement>) => {
+    setValue(target.value);
   };
 
-  render() {
-    const { value, placeholder, isTextArea, ...props } = this.props;
-
-    return React.createElement(isTextArea ? TextArea : Input, {
-      style: { width: '9rem' },
-      value,
-      placeholder,
-      onChange: this.handleChange,
-      ...props,
-    });
-  }
-}
+  return createElement(isTextArea ? TextArea : Input, {
+    ...props,
+    style: { width: '9rem' },
+    value,
+    placeholder,
+    onChange: handleChange,
+  });
+};

--- a/packages/common/src/components/Preference/elements.ts
+++ b/packages/common/src/components/Preference/elements.ts
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
-import Input from '../Input';
+
+import InputBase from '../Input';
 
 export const Container = styled.div`
   display: flex;
@@ -7,6 +8,6 @@ export const Container = styled.div`
   align-items: center;
 `;
 
-export const StyledInput = styled(Input)`
+export const Input = styled(InputBase)`
   text-align: center;
 `;

--- a/packages/common/src/components/Preference/index.stories.tsx
+++ b/packages/common/src/components/Preference/index.stories.tsx
@@ -1,8 +1,10 @@
-import React from 'react';
 import { storiesOf } from '@storybook/react';
+import React from 'react';
+
 import { noop } from '../../test/mocks';
-import Preference from '.';
 import { KEYBINDINGS } from '../../utils/keybindings';
+
+import { Preference } from '.';
 
 const stories = storiesOf('components/Preference', module);
 const keyBindingKeys = Object.keys(KEYBINDINGS);

--- a/packages/common/src/components/Preference/index.test.tsx
+++ b/packages/common/src/components/Preference/index.test.tsx
@@ -1,9 +1,11 @@
 import 'jest-styled-components';
 import React from 'react';
+
 import { noop } from '../../test/mocks';
 import mountWithTheme from '../../test/themeMount';
-import Preference from '.';
 import { KEYBINDINGS } from '../../utils/keybindings';
+
+import { Preference } from '.';
 
 const keyBindingKeys = Object.keys(KEYBINDINGS);
 

--- a/packages/common/src/components/Preference/index.tsx
+++ b/packages/common/src/components/Preference/index.tsx
@@ -1,42 +1,43 @@
-import React from 'react';
+import React, { ComponentProps, FunctionComponent } from 'react';
+
 import Tooltip from '../../components/Tooltip';
 
-import PreferenceSwitch, { Props as SwitchProps } from './PreferenceSwitch';
-import PreferenceDropdown, {
-  Props as DropdownProps,
-} from './PreferenceDropdown';
-import PreferenceNumber, { Props as NumberProps } from './PreferenceNumber';
-import PreferenceText, { Props as TextProps } from './PreferenceText';
-import PreferenceKeybinding, {
-  Props as KeybindingProps,
-} from './PreferenceKeybinding';
 import { Container } from './elements';
+import { PreferenceDropdown } from './PreferenceDropdown';
+import { PreferenceKeybinding } from './PreferenceKeybinding';
+import { PreferenceNumber } from './PreferenceNumber';
+import { PreferenceSwitch } from './PreferenceSwitch';
+import { PreferenceText } from './PreferenceText';
 
 type PreferenceType =
   | 'boolean'
-  | 'string'
   | 'dropdown'
   | 'keybinding'
-  | 'number';
+  | 'number'
+  | 'string';
 
 type PreferenceProps<TString extends PreferenceType> = {
-  type: TString;
-  title: string;
-  style?: React.CSSProperties;
   className?: string;
+  style?: React.CSSProperties;
+  title: string;
   tooltip?: string;
+  type: TString;
 };
 
-export type BooleanPreference = PreferenceProps<'boolean'> & SwitchProps;
+export type BooleanPreference = PreferenceProps<'boolean'> &
+  ComponentProps<typeof PreferenceSwitch>;
 
-export type StringPreference = PreferenceProps<'string'> & TextProps;
+export type StringPreference = PreferenceProps<'string'> &
+  ComponentProps<typeof PreferenceText>;
 
-export type DropdownPreference = PreferenceProps<'dropdown'> & DropdownProps;
+export type DropdownPreference = PreferenceProps<'dropdown'> &
+  ComponentProps<typeof PreferenceDropdown>;
 
 export type KeybindingPreference = PreferenceProps<'keybinding'> &
-  KeybindingProps;
+  ComponentProps<typeof PreferenceKeybinding>;
 
-export type NumberPreference = PreferenceProps<'number'> & NumberProps;
+export type NumberPreference = PreferenceProps<'number'> &
+  ComponentProps<typeof PreferenceNumber>;
 
 export type Props =
   | BooleanPreference
@@ -45,31 +46,32 @@ export type Props =
   | KeybindingPreference
   | NumberPreference;
 
-const Preference = (props: Props) => {
-  const { title, style, className, tooltip, ...contentProps } = props;
-
-  let content: React.ReactNode;
-  switch (
-    contentProps.type // need 'type' as discriminant of union type
-  ) {
-    case 'boolean':
-      content = <PreferenceSwitch {...contentProps} />;
-      break;
-    case 'string':
-      content = <PreferenceText {...contentProps} />;
-      break;
-    case 'dropdown':
-      content = <PreferenceDropdown {...contentProps} />;
-      break;
-    case 'keybinding':
-      content = <PreferenceKeybinding {...contentProps} />;
-      break;
-    default:
-      content = <PreferenceNumber {...contentProps} />;
-  }
+export const Preference: FunctionComponent<Props> = ({
+  className,
+  style,
+  title,
+  tooltip,
+  ...contentProps
+}) => {
+  const getContent = () => {
+    switch (
+      contentProps.type // need 'type' as discriminant of union type
+    ) {
+      case 'boolean':
+        return <PreferenceSwitch {...contentProps} />;
+      case 'string':
+        return <PreferenceText {...contentProps} />;
+      case 'dropdown':
+        return <PreferenceDropdown {...contentProps} />;
+      case 'keybinding':
+        return <PreferenceKeybinding {...contentProps} />;
+      default:
+        return <PreferenceNumber {...contentProps} />;
+    }
+  };
 
   const Title = tooltip ? (
-    <Tooltip placement="right" content={tooltip}>
+    <Tooltip content={tooltip} placement="right">
       {title}
     </Tooltip>
   ) : (
@@ -77,11 +79,10 @@ const Preference = (props: Props) => {
   );
 
   return (
-    <Container style={style} className={className}>
+    <Container className={className} style={style}>
       {Title}
-      <div>{content}</div>
+
+      <div>{getContent()}</div>
     </Container>
   );
 };
-
-export default Preference;

--- a/packages/common/src/templates/configuration/elements.ts
+++ b/packages/common/src/templates/configuration/elements.ts
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
-import Preference from '../../components/Preference';
+
+import { Preference } from '../../components/Preference';
 
 export const PaddedPreference = (styled(Preference)`
   width: 100%;


### PR DESCRIPTION
## What kind of change does this PR introduce?
Updated the props of `Preference` and it's child components and also refactored the child components to `FunctionComponent`s.

Follow-up of #2861

## What is the current behavior?
- `Preference`'s child components are `ClassComponent`s
- `Preference`'s child components export their props separately so they can be used by `Preference`

## What is the new behavior?
- `Preference`'s child components are `FunctionComponent`s
- `Preference`'s child components don't export their props separately and `Preference` derives the props of his child components by using the [`ComponentProps` generic](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/8e0fa6fc55e715ccd9ee1656ba4ce2106067fbf9/types/react/index.d.ts#L777-L782)

## Checklist
- [N/A] Documentation
- [x] Testing
- [x] Ready to be merged
- [N/A] Added myself to contributors table