### PR TITLE
Fix scoped packages rendering in version entry view

### DIFF
--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/Dependencies/VersionEntry/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/Dependencies/VersionEntry/index.tsx
@@ -29,7 +29,7 @@ interface State {
 
 function formatVersion(version: string) {
   if (CSB_PKG_PROTOCOL.test(version)) {
-    const commitSha = version.match(/commit\/(.*)\//);
+    const commitSha = version.match(/commit\/([\w\d]*)\//);
     if (commitSha && commitSha[1]) {
       return `csb:${commitSha[1]}`;
     }


### PR DESCRIPTION
Make this:

![image](https://user-images.githubusercontent.com/587016/68192180-3f6e5380-ffb1-11e9-90b3-b79ea0c899c0.png)

Turn into this:

![image](https://user-images.githubusercontent.com/587016/68192229-52812380-ffb1-11e9-8dc7-37eb38b183fc.png)
