### PR TITLE
Add back user feedback survey behaviour

### DIFF
--- a/packages/app/src/app/overmind/actions.ts
+++ b/packages/app/src/app/overmind/actions.ts
@@ -76,7 +76,8 @@ type ModalName =
   | 'preferences'
   | 'share'
   | 'searchDependencies'
-  | 'signInForTemplates';
+  | 'signInForTemplates'
+  | 'userSurvey';
 export const modalOpened: Action<{ modal: ModalName; message?: string }> = (
   { state, effects },
   { modal, message }

--- a/packages/app/src/app/overmind/effects/api/index.ts
+++ b/packages/app/src/app/overmind/effects/api/index.ts
@@ -68,6 +68,9 @@ export default {
   getCurrentUser(): Promise<CurrentUser> {
     return api.get('/users/current');
   },
+  markSurveySeen(): Promise<void> {
+    return api.post('/users/survey-seen', {});
+  },
   getDependency(name: string): Promise<Dependency> {
     return api.get(`/dependencies/${name}@latest`);
   },

--- a/packages/app/src/app/overmind/factories.ts
+++ b/packages/app/src/app/overmind/factories.ts
@@ -30,6 +30,7 @@ export const withLoadApp = <T>(
       state.user = await effects.api.getCurrentUser();
       actions.internal.setPatronPrice();
       actions.internal.setSignedInCookie();
+      actions.internal.showUserSurveyIfNeeded();
       effects.live.connect();
       actions.userNotifications.internal.initialize();
       effects.api.preloadTemplates();
@@ -112,7 +113,7 @@ export const createModals = <
   state?: {
     current: keyof T;
   } & {
-    [K in keyof T]: T[K]['state'] & { isCurrent: IDerive<any, any, boolean> }
+    [K in keyof T]: T[K]['state'] & { isCurrent: IDerive<any, any, boolean> };
   };
   actions?: {
     [K in keyof T]: {
@@ -121,7 +122,7 @@ export const createModals = <
         T[K]['result']
       >;
       close: AsyncAction<T[K]['result']>;
-    }
+    };
   };
 } => {
   function createModal(name, modal) {

--- a/packages/app/src/app/overmind/internalActions.ts
+++ b/packages/app/src/app/overmind/internalActions.ts
@@ -9,6 +9,8 @@ import {
 } from '@codesandbox/common/lib/types';
 import { identify, setUserId } from '@codesandbox/common/lib/utils/analytics';
 
+import { notificationState } from '@codesandbox/common/lib/utils/notifications';
+import { NotificationStatus } from '@codesandbox/notifications';
 import { createOptimisticModule } from './utils/common';
 import getItems from './utils/items';
 import { defaultOpenedModule, mainModule } from './utils/main-module';
@@ -66,6 +68,33 @@ export const setSignedInCookie: Action = ({ state }) => {
   document.cookie = 'signedIn=true; Path=/;';
   identify('signed_in', true);
   setUserId(state.user.id);
+};
+
+export const showUserSurveyIfNeeded: Action = ({ state, effects, actions }) => {
+  if (state.user.sendSurvey) {
+    // Let the server know that we've seen the survey
+    effects.api.markSurveySeen();
+
+    notificationState.addNotification({
+      title: 'Help improve CodeSandbox',
+      message:
+        "We'd love to hear your thoughts, it's 7 questions and will only take 2 minutes.",
+      status: NotificationStatus.NOTICE,
+      sticky: true,
+      actions: {
+        primary: [
+          {
+            label: 'Open Survey',
+            run: () => {
+              actions.modalOpened({
+                modal: 'userSurvey',
+              });
+            },
+          },
+        ],
+      },
+    });
+  }
 };
 
 export const addNotification: Action<{

--- a/packages/app/src/app/overmind/internalActions.ts
+++ b/packages/app/src/app/overmind/internalActions.ts
@@ -9,7 +9,6 @@ import {
 } from '@codesandbox/common/lib/types';
 import { identify, setUserId } from '@codesandbox/common/lib/utils/analytics';
 
-import { notificationState } from '@codesandbox/common/lib/utils/notifications';
 import { NotificationStatus } from '@codesandbox/notifications';
 import { createOptimisticModule } from './utils/common';
 import getItems from './utils/items';
@@ -75,7 +74,7 @@ export const showUserSurveyIfNeeded: Action = ({ state, effects, actions }) => {
     // Let the server know that we've seen the survey
     effects.api.markSurveySeen();
 
-    notificationState.addNotification({
+    effects.notificationToast.add({
       title: 'Help improve CodeSandbox',
       message:
         "We'd love to hear your thoughts, it's 7 questions and will only take 2 minutes.",

--- a/packages/common/src/types/index.ts
+++ b/packages/common/src/types/index.ts
@@ -125,6 +125,7 @@ export type CurrentUser = {
       email: string;
     };
   };
+  sendSurvey: boolean;
 };
 
 export type CustomTemplate = {


### PR DESCRIPTION
With the move to Overmind we forgot to port over our userFeedbackSurvey behaviour from Cerebral. This puts it back in.

Tested the flow by removing the `if` check and confirming that the notification asking about the survey would pop up. Then verified that the modal opened with the typeform.