### PR TITLE
Embed: Change default of hideNavigation to true (with backward compatibility)

### DIFF
--- a/packages/app/src/app/pages/common/Modals/ShareModal/index.js
+++ b/packages/app/src/app/pages/common/Modals/ShareModal/index.js
@@ -35,7 +35,7 @@ class ShareView extends React.Component {
     testsView: false,
     defaultModule: null,
     autoResize: false,
-    hideNavigation: false,
+    hideNavigation: true,
     isCurrentModuleView: false,
     fontSize: 14,
     initialPath: '',


### PR DESCRIPTION
One line change = fun line change

Goes well with https://github.com/codesandbox/codesandbox-client/pull/2941

By default, we show navigation bar in the embed. It's useful for sandboxes with multiple routes

That default hasn't aged well, majority of sandboxes don't have routes.

Ideally, we'd like to keep the navigation hidden unless an explicit flag asks for it. Example: `showNavigation=true`.

But that would change the behavior of existing embeds aka 🚨 backward breaking change 🚨

We can however, set `hideNavigation=1` for every new embed in the share sheet. This adds some fluff to the url but maintains backward compatibility.