### PR TITLE
fix(ux): disable button for already added fonts

### DIFF
--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/Dependencies/AddFont/index.js
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/Dependencies/AddFont/index.js
@@ -3,7 +3,7 @@ import { Button } from '@codesandbox/common/lib/components/Button';
 import { FontPicker } from './FontPicker/index';
 import { Container } from './elements';
 
-export const AddFont = ({ addResource }) => {
+export const AddFont = ({ addResource, addedResource }) => {
   const [activeFontFamily, setActiveFontFamily] = useState('Roboto');
 
   const addFont = async () => {
@@ -13,6 +13,10 @@ export const AddFont = ({ addResource }) => {
       await addResource(link);
     }
   };
+
+  const fontAlreadyExists = addedResource.filter(font =>
+    font.includes(activeFontFamily)
+  );
 
   return (
     <>
@@ -24,8 +28,15 @@ export const AddFont = ({ addResource }) => {
         />
       </Container>
       <Container>
-        <Button disabled={!activeFontFamily} block small onClick={addFont}>
-          Add Typeface
+        <Button
+          disabled={!activeFontFamily || fontAlreadyExists.length}
+          block
+          small
+          onClick={addFont}
+        >
+          {fontAlreadyExists.length > 0
+            ? 'Typeface already added'
+            : 'Add Typeface'}
         </Button>
       </Container>
     </>

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/Dependencies/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/Dependencies/index.tsx
@@ -115,6 +115,7 @@ export const Dependencies: FunctionComponent = () => {
                 resource,
               })
             }
+            addedResource={fonts}
           />
           {fonts.map(resource => (
             <ExternalFonts


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?
Enhancement
<!-- Is it a Bug fix, feature, docs update, ... -->

## What is the current behavior?
![FontExists](https://user-images.githubusercontent.com/22376783/68476935-20dab780-0252-11ea-83c8-a9539e63bc77.gif)

<!-- You can also link to an open issue here -->

## What is the new behavior?
Disable button and update the button message:
![image](https://user-images.githubusercontent.com/22376783/68476956-2cc67980-0252-11ea-96b3-ef4680c204e7.png)

<!-- if this is a feature change -->

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Visual test
2. The button is disabled so repeated fonts don't get added

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation - N/A
- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->

Also on another note. Sometimes the dropdown doesn't show up for typeface and when there is an advertisement it pops below and goes out of the screen. Any idea on this? I am happy to help on this issue as well :)