### PR TITLE
fix(deployments): display error messages from ZEIT Now

### DIFF
--- a/packages/app/src/app/overmind/namespaces/deployment/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/deployment/actions.ts
@@ -1,7 +1,16 @@
+import { AxiosError } from 'axios';
+import { get } from 'lodash-es';
 import { Action, AsyncAction } from 'app/overmind';
 import * as internalActions from './internalActions';
 
 export const internal = internalActions;
+
+const getZeitErrorMessage = (error: AxiosError) =>
+  get(
+    error,
+    'response.data.error.message',
+    'An unknown error occurred when connecting to ZEIT'
+  );
 
 export const deployWithNetlify: AsyncAction = async ({
   effects,
@@ -67,9 +76,7 @@ export const getDeploys: AsyncAction = async ({ state, effects }) => {
       zeitConfig.name
     );
   } catch (error) {
-    effects.notificationToast.error(
-      'An unknown error occurred when connecting to ZEIT'
-    );
+    effects.notificationToast.error(getZeitErrorMessage(error));
   }
 
   state.deployment.gettingDeploys = false;
@@ -80,19 +87,16 @@ export const deployClicked: AsyncAction = async ({
   effects,
   actions,
 }) => {
-  state.deployment.deploying = true;
-  const zip = await effects.zip.create(state.editor.currentSandbox);
-  const contents = await effects.jsZip.loadAsync(zip.file);
-
   try {
+    state.deployment.deploying = true;
+    const zip = await effects.zip.create(state.editor.currentSandbox);
+    const contents = await effects.jsZip.loadAsync(zip.file);
     state.deployment.url = await effects.zeit.deploy(
       contents,
       state.editor.currentSandbox
     );
   } catch (error) {
-    effects.notificationToast.error(
-      'An unknown error occurred when connecting to ZEIT'
-    );
+    effects.notificationToast.error(getZeitErrorMessage(error));
   }
 
   state.deployment.deploying = false;


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?
Bug fix. Closes #3019.
<!-- Is it a Bug fix, feature, docs update, ... -->

## What is the current behavior?
We are displaying a generic error message when a request to ZEIT Now fails.
<!-- You can also link to an open issue here -->

## What is the new behavior?
According to [ZEIT Now's API documentation](https://zeit.co/docs/api#errors), every error contains the same structure, always with a `message` property. We are now trying to access this property from the error but displaying the generic error as a fallback.
<!-- if this is a feature change -->

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Fork [this sandbox](https://codesandbox.io/s/share-server-xvwzh);
2. Try to deploy it to ZEIT Now;
3. Verify that the error from the API is displayed.

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
## Notes

There are other issues related to deployment regarding duplicate `package.json` files.
I'll try to solve them with another PR later.