### PR TITLE
fix(deployments): use correct property to compare filename

### DIFF
--- a/packages/app/src/app/overmind/effects/zeit.ts
+++ b/packages/app/src/app/overmind/effects/zeit.ts
@@ -12,6 +12,31 @@ type Options = {
   getToken(): string;
 };
 
+interface Object {
+  [key: string]: string;
+}
+
+interface ApiData {
+  builds: Object[];
+  config?: Object;
+  deploymentType?: string;
+  env?: Object;
+  files: File[];
+  forceNew?: boolean;
+  name: string;
+  public: boolean;
+  regions: string[];
+  routes: Object[];
+  scope?: string;
+  version: number;
+}
+
+interface File {
+  data: string;
+  encoding?: string;
+  file: string;
+}
+
 export default (() => {
   let _options: Options;
 
@@ -133,7 +158,7 @@ export default (() => {
 async function getApiData(contents: any, sandbox: Sandbox) {
   const template = getTemplate(sandbox.template);
 
-  let apiData: any = {
+  let apiData: Partial<ApiData> = {
     files: [],
   };
   let packageJSON: any = {};
@@ -159,7 +184,7 @@ async function getApiData(contents: any, sandbox: Sandbox) {
     nowJSON = packageJSON.now;
   }
 
-  const nowDefaults: any = {
+  const nowDefaults: Pick<ApiData, 'name' | 'public'> = {
     name: `csb-${sandbox.id}`,
     public: true,
   };
@@ -174,7 +199,7 @@ async function getApiData(contents: any, sandbox: Sandbox) {
   packageJSON.name = nowJSON.name || nowDefaults.name;
 
   apiData.name = nowJSON.name || nowDefaults.name;
-  apiData.deploymentType = nowJSON.type || nowDefaults.type;
+  apiData.deploymentType = nowJSON.type;
   apiData.public = nowJSON.public || nowDefaults.public;
 
   // if now v2 we need to tell now the version, builds and routes

--- a/packages/app/src/app/overmind/effects/zeit.ts
+++ b/packages/app/src/app/overmind/effects/zeit.ts
@@ -217,7 +217,7 @@ async function getApiData(contents: any, sandbox: Sandbox) {
     // if person added some files but no package.json
     if (
       filePath === 'package.json' &&
-      !apiData.files.find(f => f.name === 'package.json')
+      !apiData.files.find(f => f.file === 'package.json')
     ) {
       apiData.files.push({
         file: 'package.json',


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?
Bug fix. Closes #2486, closes #2357.
<!-- Is it a Bug fix, feature, docs update, ... -->

## What is the current behavior?
In some ocasions, we are sending two `package.json` files.
<!-- You can also link to an open issue here -->

## What is the new behavior?
We are comparing the correct property (`file` instead of `name`) and adding some typings to reduce the change of bugs on ZEIT's effects file.
<!-- if this is a feature change -->

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Fork [this sandbox](https://codesandbox.io/s/nodenow-mdjn4);
2. Try to deploy it to ZEIT Now;
3. Verify that the deploy is successful.

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
## Notes

When I added the typings, I noticed that we were trying to access a default property (`type` from `nowDefaults`) that had no value. Should we add something there?