### PR TITLE
fix(tests): apply correct opacity to sync icon when watching tests

### DIFF
--- a/packages/app/src/app/components/Preview/DevTools/Tests/TestSummary/elements.ts
+++ b/packages/app/src/app/components/Preview/DevTools/Tests/TestSummary/elements.ts
@@ -1,4 +1,4 @@
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 import SyncIcon from 'react-icons/lib/go/sync';
 
 export const Container = styled.div`
@@ -49,13 +49,9 @@ export const TestData = styled.div`
 `;
 
 export const SyncIconStyled = styled(SyncIcon)<{ watching: boolean }>`
-  opacity: 0.7;
-  color: ${props => props.theme['button.hoverBackground']};
-  ${props =>
-    props.watching &&
-    css`
-      opacity: 1;
-    `}
+  && {
+    opacity: ${props => (props.watching ? 1 : undefined)};
+  }
 `;
 
 export const Actions = styled.div`
@@ -69,7 +65,6 @@ export const Actions = styled.div`
     cursor: pointer;
     opacity: 0.8;
     color: ${props => props.theme['button.hoverBackground']};
-
     margin-left: 0.5rem;
 
     &:hover {


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?
Bug fix. Closes #3002.
<!-- Is it a Bug fix, feature, docs update, ... -->

## What is the current behavior?
The sync's icon opacity doesn't change regardless of the `watching` state.
<!-- You can also link to an open issue here -->

## What is the new behavior?
It changes as expected. I used the [documented styled-components hack to override higher specificity](https://www.styled-components.com/docs/faqs#how-can-i-override-styles-with-higher-specificity) applied by the `Actions` component targeting `svg` tags.
<!-- if this is a feature change -->

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Visit [this sandbox](https://codesandbox.io/s/formation-javascript-avance-vnsp4);
2. Toggle file watching for tests;
3. Verify that the opacity changes as expected.

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
