### PR TITLE
feat(download): export lock files when downloading sandbox

### DIFF
--- a/packages/app/src/app/overmind/effects/zip/create-zip/index.ts
+++ b/packages/app/src/app/overmind/effects/zip/create-zip/index.ts
@@ -196,8 +196,6 @@ export async function createDirectoryWithFiles(
   );
 }
 
-const DEFAULT_IGNORE = ['yarn.lock', 'package-lock.json'];
-
 export async function createZip(
   sandbox: Sandbox,
   modules: Array<Module>,
@@ -206,7 +204,7 @@ export async function createZip(
   useGitIgnore: boolean = false
 ) {
   const zip = new JSZip();
-  const ignorer = ignore().add(DEFAULT_IGNORE);
+  const ignorer = ignore();
 
   if (useGitIgnore) {
     const gitIgnore = modules.find(


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?
Feature. Closes #488.
<!-- Is it a Bug fix, feature, docs update, ... -->

## What is the current behavior?
Lock files are ignored. (Is there any reason for this behavior?)
<!-- You can also link to an open issue here -->

## What is the new behavior?
They are included in the zip file.
<!-- if this is a feature change -->

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Open any sandbox;
2. Click to export it.
3. Verify that the lock file is included on the zip file.

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->

## Notes
If there is a reason to ignore these files, please close the issue.