### PR TITLE
Fix spacing in homepage text

### DIFF
--- a/packages/homepage/src/screens/home/NPMFeature/index.js
+++ b/packages/homepage/src/screens/home/NPMFeature/index.js
@@ -121,7 +121,7 @@ export default () => {
           <Heading id="share-one-click">Share in a single click</Heading>
           <SubHeading>
             Say goodbye to the days where you had to create a zip file just to
-            share your code.Now you can copy the link and share away!
+            share your code. Now you can copy the link and share away!
           </SubHeading>
         </Centered>
 
@@ -137,7 +137,7 @@ export default () => {
               <ExtraSpacing>
                 <Feature Icon={NPMIcon} iconSize={42} title="NPM Support">
                   Think of any npm dependency you want to use, we probably
-                  support it!You can install a new dependency within seconds.
+                  support it! You can install a new dependency within seconds.
                   <br />
                   <Link
                     href="https://hackernoon.com/how-we-make-npm-packages-work-in-the-browser-announcing-the-new-packager-6ce16aa4cee6"
@@ -155,7 +155,7 @@ export default () => {
                   <Link href="https://codesandbox.io/search" target="_blank">
                     <SandboxCount />+ created sandboxes
                   </Link>{' '}
-                  on CodeSandbox.We want this to be a platform where everyone
+                  on CodeSandbox. We want this to be a platform where everyone
                   can easily learn and share.
                 </Feature>
               </ExtraSpacing>
@@ -169,10 +169,10 @@ export default () => {
               <ExtraSpacing>
                 <Feature right Icon={EmbedIcon} iconSize={42} title="Embedding">
                   We built a lightweight version of CodeSandbox for embeds, this
-                  allows you to embed your sandbox anywhere.Viewers can even
-                  play ith the code in the embed, without leaving the website.We
-                  fer many customization options to make sure you can show the
-                  embed exactly the way you want.
+                  allows you to embed your sandbox anywhere. Viewers can even
+                  play with the code in the embed, without leaving the website.
+                  We offer many customization options to make sure you can show
+                  the embed exactly the way you want.
                 </Feature>
               </ExtraSpacing>
             </Column>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Minor text update

## What is the current behavior?

The current text has missing spaces between words and has absent letters in some words

## What is the new behavior?

Add spacing between words. Add missing letters in words.

## Checklist

- [ ] Documentation N/A
- [x] Testing
- [x] Ready to be merged
- [ ] Added myself to contributors table N/A