### PR TITLE
Fix live empty files

### DIFF
--- a/packages/app/src/app/components/CodeEditor/VSCode/index.tsx
+++ b/packages/app/src/app/components/CodeEditor/VSCode/index.tsx
@@ -965,9 +965,7 @@ export class VSCode extends React.Component<Props> implements Editor {
       ),
       options: {
         inlineClassName: classification.type
-          ? `${classification.kind} ${classification.type}-of-${
-              classification.parentKind
-            }`
+          ? `${classification.kind} ${classification.type}-of-${classification.parentKind}`
           : classification.kind,
       },
     }));

--- a/packages/app/src/app/overmind/namespaces/editor/internalActions.ts
+++ b/packages/app/src/app/overmind/namespaces/editor/internalActions.ts
@@ -15,6 +15,10 @@ import {
   sandboxUrl,
   editorUrl,
 } from '@codesandbox/common/lib/utils/url-generator';
+import {
+  captureException,
+  logBreadcrumb,
+} from '@codesandbox/common/lib/utils/analytics/sentry';
 
 export const ensureSandboxId: Action<string, string> = ({ state }, id) => {
   if (state.editor.sandboxes[id]) {
@@ -63,9 +67,15 @@ export const setModuleSavedCode: Action<{
   );
 
   if (moduleIndex > -1) {
-    state.editor.sandboxes[sandbox.id].modules[
-      moduleIndex
-    ].savedCode = savedCode;
+    const module = state.editor.sandboxes[sandbox.id].modules[moduleIndex];
+
+    logBreadcrumb({
+      type: 'error',
+      message: `SETTING UNDEFINED SAVEDCODE FOR CODE: ${module.code}`,
+    });
+    captureException(new Error('SETTING UNDEFINED SAVEDCODE'));
+
+    module.savedCode = savedCode;
   }
 };
 

--- a/packages/app/src/app/overmind/namespaces/live/liveMessageOperators.ts
+++ b/packages/app/src/app/overmind/namespaces/live/liveMessageOperators.ts
@@ -10,9 +10,10 @@ import { Operator } from 'app/overmind';
 import { camelizeKeys } from 'humps';
 import { NotificationStatus } from '@codesandbox/notifications/lib/state';
 
-export const onJoin: Operator<
-  LiveMessage<{ status: 'connected'; live_user_id: string }>
-> = mutate(({ effects, state }, { data }) => {
+export const onJoin: Operator<LiveMessage<{
+  status: 'connected';
+  live_user_id: string;
+}>> = mutate(({ effects, state }, { data }) => {
   state.live.liveUserId = data.live_user_id;
 
   effects.notificationToast.success(
@@ -28,11 +29,9 @@ export const onJoin: Operator<
   state.live.reconnecting = false;
 });
 
-export const onModuleState: Operator<
-  LiveMessage<{
-    module_state: any;
-  }>
-> = mutate(({ state, actions }, { data }) => {
+export const onModuleState: Operator<LiveMessage<{
+  module_state: any;
+}>> = mutate(({ state, actions }, { data }) => {
   // We get this when we notice that there is an out of sync
   // Really no reason to set this state as everything runs sync
   state.live.receivingCode = true;
@@ -40,14 +39,12 @@ export const onModuleState: Operator<
   state.live.receivingCode = false;
 });
 
-export const onUserEntered: Operator<
-  LiveMessage<{
-    users: any[];
-    editor_ids: string[];
-    owner_ids: string[];
-    joined_user_id: string;
-  }>
-> = mutate(({ state, effects }, { data }) => {
+export const onUserEntered: Operator<LiveMessage<{
+  users: any[];
+  editor_ids: string[];
+  owner_ids: string[];
+  joined_user_id: string;
+}>> = mutate(({ state, effects }, { data }) => {
   if (state.live.isLoading) {
     return;
   }
@@ -74,14 +71,12 @@ export const onUserEntered: Operator<
   }
 });
 
-export const onUserLeft: Operator<
-  LiveMessage<{
-    users: any[];
-    left_user_id: string;
-    editor_ids: string[];
-    owner_ids: string[];
-  }>
-> = mutate(({ state, actions, effects }, { data }) => {
+export const onUserLeft: Operator<LiveMessage<{
+  users: any[];
+  left_user_id: string;
+  editor_ids: string[];
+  owner_ids: string[];
+}>> = mutate(({ state, actions, effects }, { data }) => {
   if (!state.live.notificationsHidden) {
     const { users } = state.live.roomInfo;
     const user = users ? users.find(u => u.id === data.left_user_id) : null;
@@ -107,12 +102,10 @@ export const onUserLeft: Operator<
   state.live.roomInfo.editorIds = data.editor_ids;
 });
 
-export const onModuleSaved: Operator<
-  LiveMessage<{
-    moduleShortid: string;
-    savedCode: string;
-  }>
-> = mutate(({ state, actions }, { _isOwnMessage, data }) => {
+export const onModuleSaved: Operator<LiveMessage<{
+  moduleShortid: string;
+  module: Module;
+}>> = mutate(({ state, actions }, { _isOwnMessage, data }) => {
   if (_isOwnMessage) {
     return;
   }
@@ -128,27 +121,23 @@ export const onModuleSaved: Operator<
 
   actions.editor.internal.setModuleSavedCode({
     moduleShortid: data.moduleShortid,
-    savedCode: data.savedCode,
+    savedCode: data.module.savedCode,
   });
 });
 
-export const onModuleCreated: Operator<
-  LiveMessage<{
-    module: Module;
-  }>
-> = mutate(({ state }, { _isOwnMessage, data }) => {
+export const onModuleCreated: Operator<LiveMessage<{
+  module: Module;
+}>> = mutate(({ state }, { _isOwnMessage, data }) => {
   if (_isOwnMessage) {
     return;
   }
   state.editor.currentSandbox.modules.push(data.module);
 });
 
-export const onModuleMassCreated: Operator<
-  LiveMessage<{
-    modules: Module[];
-    directories: Directory[];
-  }>
-> = mutate(({ state }, { _isOwnMessage, data }) => {
+export const onModuleMassCreated: Operator<LiveMessage<{
+  modules: Module[];
+  directories: Directory[];
+}>> = mutate(({ state }, { _isOwnMessage, data }) => {
   if (_isOwnMessage) {
     return;
   }
@@ -160,12 +149,10 @@ export const onModuleMassCreated: Operator<
   );
 });
 
-export const onModuleUpdated: Operator<
-  LiveMessage<{
-    moduleShortid: string;
-    module: Module;
-  }>
-> = mutate(({ state }, { _isOwnMessage, data }) => {
+export const onModuleUpdated: Operator<LiveMessage<{
+  moduleShortid: string;
+  module: Module;
+}>> = mutate(({ state }, { _isOwnMessage, data }) => {
   if (_isOwnMessage) {
     return;
   }
@@ -180,11 +167,9 @@ export const onModuleUpdated: Operator<
   );
 });
 
-export const onModuleDeleted: Operator<
-  LiveMessage<{
-    moduleShortid: string;
-  }>
-> = mutate(({ actions }, { _isOwnMessage, data }) => {
+export const onModuleDeleted: Operator<LiveMessage<{
+  moduleShortid: string;
+}>> = mutate(({ actions }, { _isOwnMessage, data }) => {
   if (_isOwnMessage) {
     return;
   }
@@ -194,11 +179,9 @@ export const onModuleDeleted: Operator<
   });
 });
 
-export const onDirectoryCreated: Operator<
-  LiveMessage<{
-    module: Directory; // This is very weird?
-  }>
-> = mutate(({ state }, { _isOwnMessage, data }) => {
+export const onDirectoryCreated: Operator<LiveMessage<{
+  module: Directory; // This is very weird?
+}>> = mutate(({ state }, { _isOwnMessage, data }) => {
   if (_isOwnMessage) {
     return;
   }
@@ -206,12 +189,10 @@ export const onDirectoryCreated: Operator<
   state.editor.currentSandbox.directories.push(data.module);
 });
 
-export const onDirectoryUpdated: Operator<
-  LiveMessage<{
-    directoryShortid: string;
-    module: Directory; // Still very weird
-  }>
-> = mutate(({ state }, { _isOwnMessage, data }) => {
+export const onDirectoryUpdated: Operator<LiveMessage<{
+  directoryShortid: string;
+  module: Directory; // Still very weird
+}>> = mutate(({ state }, { _isOwnMessage, data }) => {
   if (_isOwnMessage) {
     return;
   }
@@ -223,11 +204,9 @@ export const onDirectoryUpdated: Operator<
   state.editor.sandboxes[sandbox.id].directories[directoryIndex] = data.module;
 });
 
-export const onDirectoryDeleted: Operator<
-  LiveMessage<{
-    directoryShortid: string;
-  }>
-> = mutate(({ state, actions }, { _isOwnMessage, data }) => {
+export const onDirectoryDeleted: Operator<LiveMessage<{
+  directoryShortid: string;
+}>> = mutate(({ state, actions }, { _isOwnMessage, data }) => {
   if (_isOwnMessage) {
     return;
   }
@@ -238,13 +217,11 @@ export const onDirectoryDeleted: Operator<
   });
 });
 
-export const onUserSelection: Operator<
-  LiveMessage<{
-    liveUserId: string;
-    moduleShortid: string;
-    selection: Selection;
-  }>
-> = mutate(({ state }, { _isOwnMessage, data }) => {
+export const onUserSelection: Operator<LiveMessage<{
+  liveUserId: string;
+  moduleShortid: string;
+  selection: Selection;
+}>> = mutate(({ state }, { _isOwnMessage, data }) => {
   if (_isOwnMessage) {
     return;
   }
@@ -278,12 +255,10 @@ export const onUserSelection: Operator<
   }
 });
 
-export const onUserCurrentModule: Operator<
-  LiveMessage<{
-    live_user_id: string;
-    moduleShortid: string;
-  }>
-> = mutate(({ state, actions }, { _isOwnMessage, data }) => {
+export const onUserCurrentModule: Operator<LiveMessage<{
+  live_user_id: string;
+  moduleShortid: string;
+}>> = mutate(({ state, actions }, { _isOwnMessage, data }) => {
   if (_isOwnMessage) {
     return;
   }
@@ -316,11 +291,9 @@ export const onUserCurrentModule: Operator<
   }
 });
 
-export const onLiveMode: Operator<
-  LiveMessage<{
-    mode: string;
-  }>
-> = mutate(({ state, actions }, { _isOwnMessage, data }) => {
+export const onLiveMode: Operator<LiveMessage<{
+  mode: string;
+}>> = mutate(({ state, actions }, { _isOwnMessage, data }) => {
   if (!_isOwnMessage) {
     state.live.roomInfo.mode = data.mode;
   }
@@ -330,32 +303,26 @@ export const onLiveMode: Operator<
   );
 });
 
-export const onLiveChatEnabled: Operator<
-  LiveMessage<{
-    enabled: boolean;
-  }>
-> = mutate(({ state }, { _isOwnMessage, data }) => {
+export const onLiveChatEnabled: Operator<LiveMessage<{
+  enabled: boolean;
+}>> = mutate(({ state }, { _isOwnMessage, data }) => {
   if (_isOwnMessage) {
     return;
   }
   state.live.roomInfo.chatEnabled = data.enabled;
 });
 
-export const onLiveAddEditor: Operator<
-  LiveMessage<{
-    editor_user_id: string;
-  }>
-> = mutate(({ state }, { _isOwnMessage, data }) => {
+export const onLiveAddEditor: Operator<LiveMessage<{
+  editor_user_id: string;
+}>> = mutate(({ state }, { _isOwnMessage, data }) => {
   if (!_isOwnMessage) {
     state.live.roomInfo.editorIds.push(data.editor_user_id);
   }
 });
 
-export const onLiveRemoveEditor: Operator<
-  LiveMessage<{
-    editor_user_id: string;
-  }>
-> = mutate(({ state }, { _isOwnMessage, data }) => {
+export const onLiveRemoveEditor: Operator<LiveMessage<{
+  editor_user_id: string;
+}>> = mutate(({ state }, { _isOwnMessage, data }) => {
   if (!_isOwnMessage) {
     const userId = data.editor_user_id;
 
@@ -366,12 +333,10 @@ export const onLiveRemoveEditor: Operator<
   }
 });
 
-export const onOperation: Operator<
-  LiveMessage<{
-    module_shortid: string;
-    operation: any;
-  }>
-> = mutate(({ state, effects }, { _isOwnMessage, data }) => {
+export const onOperation: Operator<LiveMessage<{
+  module_shortid: string;
+  operation: any;
+}>> = mutate(({ state, effects }, { _isOwnMessage, data }) => {
   if (state.live.isLoading) {
     return;
   }
@@ -400,9 +365,9 @@ export const onConnectionLoss: Operator<LiveMessage> = mutate(
   }
 );
 
-export const onDisconnect: Operator<
-  LiveMessage<{ reason: LiveDisconnectReason }>
-> = mutate(({ state, actions }, { data }) => {
+export const onDisconnect: Operator<LiveMessage<{
+  reason: LiveDisconnectReason;
+}>> = mutate(({ state, actions }, { data }) => {
   actions.live.internal.disconnect();
   state.editor.currentSandbox.owned = state.live.isOwner;
 
@@ -424,13 +389,11 @@ export const onOwnerLeft: Operator<LiveMessage> = mutate(({ actions }) => {
   });
 });
 
-export const onChat: Operator<
-  LiveMessage<{
-    live_user_id: string;
-    message: string;
-    date: number;
-  }>
-> = mutate(({ state }, { data }) => {
+export const onChat: Operator<LiveMessage<{
+  live_user_id: string;
+  message: string;
+  date: number;
+}>> = mutate(({ state }, { data }) => {
   let name = state.live.roomInfo.chat.users[data.live_user_id];
 
   if (!name) {
@@ -453,12 +416,10 @@ export const onChat: Operator<
   });
 });
 
-export const onNotification: Operator<
-  LiveMessage<{
-    message: string;
-    type: NotificationStatus;
-  }>
-> = mutate(({ effects }, { data }) => {
+export const onNotification: Operator<LiveMessage<{
+  message: string;
+  type: NotificationStatus;
+}>> = mutate(({ effects }, { data }) => {
   effects.notificationToast.add({
     message: data.message,
     status: data.type,

--- a/standalone-packages/codesandbox-browserfs/src/backend/CodeSandboxEditorFS.ts
+++ b/standalone-packages/codesandbox-browserfs/src/backend/CodeSandboxEditorFS.ts
@@ -64,11 +64,11 @@ export interface IManager {
 const warn = console.warn;
 
 function getCode(savedCode: string | null | undefined, code: string | undefined) {
-  if (savedCode !== null) {
-    return savedCode || '';
+  if (savedCode === null) {
+    return code || '';
   }
 
-  return code || '';
+  return savedCode || '';
 }
 
 class CodeSandboxFile extends PreloadFile<CodeSandboxEditorFS> implements File {


### PR DESCRIPTION
Upon saving a file it is automatically emptied by the other user. This is because the other user applies `savedCode = undefined` (because we read `data.savedCode` instead of `data.module.savedCode`), which in the `fs` then is seen as empty code. It sends that back as return.