### PR TITLE
🔨 Switch Curator to use useOvermind

### DIFF
--- a/packages/app/src/app/components/DelayedAnimation.ts
+++ b/packages/app/src/app/components/DelayedAnimation.ts
@@ -1,6 +1,6 @@
-import styled from 'styled-components';
 import delayEffect from '@codesandbox/common/lib/utils/animation/delay-effect';
+import styled from 'styled-components';
 
-export const DelayedAnimation = styled.div<{ delay: number }>`
-  ${({ delay }) => delayEffect(delay || 0)};
+export const DelayedAnimation = styled.div<{ delay?: number }>`
+  ${({ delay = 0 }) => delayEffect(delay)};
 `;

--- a/packages/app/src/app/overmind/namespaces/explore/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/explore/actions.ts
@@ -1,3 +1,4 @@
+import { PickedSandboxDetails } from '@codesandbox/common/lib/types';
 import { AsyncAction, Action } from 'app/overmind';
 import { withLoadApp } from 'app/overmind/factories';
 
@@ -43,11 +44,10 @@ export const pickSandbox: AsyncAction<{
   }
 };
 
-export const pickSandboxModal: Action<{
-  description: string;
-  id: string;
-  title: string;
-}> = ({ state }, details) => {
+export const pickSandboxModal: Action<PickedSandboxDetails> = (
+  { state },
+  details
+) => {
   state.explore.pickedSandboxDetails = details;
   state.currentModal = 'pickSandbox';
 };

--- a/packages/app/src/app/overmind/namespaces/explore/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/explore/actions.ts
@@ -1,19 +1,19 @@
 import { AsyncAction, Action } from 'app/overmind';
 import { withLoadApp } from 'app/overmind/factories';
 
-export const popularSandboxesMounted: AsyncAction<{
-  date: string;
-}> = withLoadApp(async ({ state, effects }, { date }) => {
-  try {
-    state.explore.popularSandboxes = await effects.api.getPopularSandboxes(
-      date
-    );
-  } catch (error) {
-    effects.notificationToast.error(
-      'There has been a problem getting the sandboxes'
-    );
+export const popularSandboxesMounted: AsyncAction<string> = withLoadApp(
+  async ({ state, effects }, date) => {
+    try {
+      state.explore.popularSandboxes = await effects.api.getPopularSandboxes(
+        date
+      );
+    } catch (error) {
+      effects.notificationToast.error(
+        'There has been a problem getting the sandboxes'
+      );
+    }
   }
-});
+);
 
 export const pickSandbox: AsyncAction<{
   id: string;
@@ -44,12 +44,10 @@ export const pickSandbox: AsyncAction<{
 };
 
 export const pickSandboxModal: Action<{
-  details: {
-    id: string;
-    title: string;
-    description: string;
-  };
-}> = ({ state }, { details }) => {
+  description: string;
+  id: string;
+  title: string;
+}> = ({ state }, details) => {
   state.explore.pickedSandboxDetails = details;
   state.currentModal = 'pickSandbox';
 };

--- a/packages/app/src/app/pages/Curator/elements.ts
+++ b/packages/app/src/app/pages/Curator/elements.ts
@@ -1,4 +1,6 @@
 import styled from 'styled-components';
+
+import { DelayedAnimation as DelayedAnimationBase } from 'app/components/DelayedAnimation';
 import { Title } from 'app/components/Title';
 
 export const Heading = styled(Title)`
@@ -38,4 +40,11 @@ export const PickerWrapper = styled.div`
   border-radius: 3px;
   top: 45px;
   right: 14px;
+`;
+
+export const DelayedAnimation = styled(DelayedAnimationBase)`
+  color: rgba(255, 255, 255, 0.5);
+  font-weight: 600;
+  margin-top: 2rem;
+  text-align: center;
 `;

--- a/packages/app/src/app/pages/Curator/index.tsx
+++ b/packages/app/src/app/pages/Curator/index.tsx
@@ -76,8 +76,7 @@ export const Curator: FunctionComponent = () => {
         </SubTitle>
 
         <Buttons>
-          <span>Most popular sandboxes in the:</span>
-
+          Most popular sandboxes in the:
           <Button
             onClick={() =>
               fetchPopularSandboxes(getTime(subWeeks(new Date(), 1)))
@@ -86,7 +85,6 @@ export const Curator: FunctionComponent = () => {
           >
             Last Week
           </Button>
-
           <Button
             onClick={() =>
               fetchPopularSandboxes(getTime(subMonths(new Date(), 1)))
@@ -95,7 +93,6 @@ export const Curator: FunctionComponent = () => {
           >
             Last Month
           </Button>
-
           <Button
             onClick={() =>
               fetchPopularSandboxes(getTime(subMonths(new Date(), 6)))
@@ -104,13 +101,11 @@ export const Curator: FunctionComponent = () => {
           >
             Last 6 Months
           </Button>
-
           <Button onClick={() => setShowPicker(show => !show)} small>
             {selectedDate
               ? format(new Date(selectedDate), 'dd/MM/yyyy')
               : 'Custom'}
           </Button>
-
           {showPicker ? (
             <PickerWrapper>
               <DayPicker

--- a/packages/app/src/app/pages/Curator/index.tsx
+++ b/packages/app/src/app/pages/Curator/index.tsx
@@ -1,33 +1,44 @@
-import React, { useCallback, useEffect, useState } from 'react';
-import { getTime, subMonths, subWeeks, format } from 'date-fns';
-import DayPicker from 'react-day-picker';
 import { Button } from '@codesandbox/common/lib/components/Button';
-import Margin from '@codesandbox/common/lib/components/spacing/Margin';
 import MaxWidth from '@codesandbox/common/lib/components/flex/MaxWidth';
+import Margin from '@codesandbox/common/lib/components/spacing/Margin';
+import { format, getTime, subMonths, subWeeks } from 'date-fns';
+import React, {
+  FunctionComponent,
+  useCallback,
+  useEffect,
+  useState,
+} from 'react';
+import DayPicker from 'react-day-picker';
+import 'react-day-picker/lib/style.css';
+
 import { useOvermind } from 'app/overmind';
 import { SubTitle } from 'app/components/SubTitle';
-import { DelayedAnimation } from 'app/components/DelayedAnimation';
 import { Navigation } from 'app/pages/common/Navigation';
-import 'react-day-picker/lib/style.css';
-import { Container, Buttons, Heading, PickerWrapper } from './elements';
+
+import {
+  Container,
+  Buttons,
+  DelayedAnimation,
+  Heading,
+  PickerWrapper,
+} from './elements';
 import SandboxCard from './SandboxCard';
 
-const Curator: React.FC = () => {
+export const Curator: FunctionComponent = () => {
   const {
-    state: {
-      explore: { popularSandboxes },
-    },
     actions: {
       explore: { pickSandboxModal, popularSandboxesMounted },
     },
+    state: {
+      explore: { popularSandboxes },
+    },
   } = useOvermind();
-
   const [selectedDate, setSelectedDate] = useState(null);
   const [showPicker, setShowPicker] = useState(false);
 
   const fetchPopularSandboxes = useCallback(
     date => {
-      popularSandboxesMounted({ date });
+      popularSandboxesMounted(date);
     },
     [popularSandboxesMounted]
   );
@@ -38,7 +49,7 @@ const Curator: React.FC = () => {
 
   const pickSandbox = useCallback(
     (id, title, description) => {
-      pickSandboxModal({ details: { description, id, title } });
+      pickSandboxModal({ description, id, title });
     },
     [pickSandboxModal]
   );
@@ -65,7 +76,8 @@ const Curator: React.FC = () => {
         </SubTitle>
 
         <Buttons>
-          Most popular sandboxes in the:
+          <span>Most popular sandboxes in the:</span>
+
           <Button
             onClick={() =>
               fetchPopularSandboxes(getTime(subWeeks(new Date(), 1)))
@@ -74,6 +86,7 @@ const Curator: React.FC = () => {
           >
             Last Week
           </Button>
+
           <Button
             onClick={() =>
               fetchPopularSandboxes(getTime(subMonths(new Date(), 1)))
@@ -82,6 +95,7 @@ const Curator: React.FC = () => {
           >
             Last Month
           </Button>
+
           <Button
             onClick={() =>
               fetchPopularSandboxes(getTime(subMonths(new Date(), 6)))
@@ -90,11 +104,13 @@ const Curator: React.FC = () => {
           >
             Last 6 Months
           </Button>
+
           <Button onClick={() => setShowPicker(show => !show)} small>
             {selectedDate
               ? format(new Date(selectedDate), 'dd/MM/yyyy')
               : 'Custom'}
           </Button>
+
           {showPicker ? (
             <PickerWrapper>
               <DayPicker
@@ -116,21 +132,9 @@ const Curator: React.FC = () => {
             ))}
           </Container>
         ) : (
-          <DelayedAnimation
-            style={{
-              color: 'rgba(255, 255, 255, 0.5)',
-              fontWeight: 600,
-              marginTop: '2rem',
-              textAlign: 'center',
-            }}
-            delay={0}
-          >
-            Fetching Sandboxes...
-          </DelayedAnimation>
+          <DelayedAnimation>Fetching Sandboxes...</DelayedAnimation>
         )}
       </Margin>
     </MaxWidth>
   );
 };
-
-export default Curator;

--- a/packages/app/src/app/pages/Sandbox/Editor/Header/Buttons/PickButton/PickButton.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Header/Buttons/PickButton/PickButton.tsx
@@ -17,19 +17,13 @@ export const PickButton: FunctionComponent = () => {
   } = useOvermind();
 
   const details = {
+    description,
     id,
     title,
-    description,
   };
 
   return (
-    <Button
-      onClick={() => {
-        pickSandboxModal({ details });
-      }}
-      secondary={owned}
-      small
-    >
+    <Button onClick={() => pickSandboxModal(details)} secondary={owned} small>
       Pick
     </Button>
   );

--- a/packages/app/src/app/pages/index.tsx
+++ b/packages/app/src/app/pages/index.tsx
@@ -64,7 +64,9 @@ const Patron = Loadable(() =>
 );
 const Pro = Loadable(() => import(/* webpackChunkName: 'page-pro' */ './Pro'));
 const Curator = Loadable(() =>
-  import(/* webpackChunkName: 'page-curator' */ './Curator')
+  import(/* webpackChunkName: 'page-curator' */ './Curator').then(module => ({
+    default: module.Curator,
+  }))
 );
 const CodeSadbox = () => this[`💥`].kaboom();
 

--- a/packages/common/src/types/index.ts
+++ b/packages/common/src/types/index.ts
@@ -273,9 +273,9 @@ export type PickedSandboxes = {
 };
 
 export type PickedSandboxDetails = {
-  title: string;
-  id: string;
   description: string;
+  id: string;
+  title: string;
 };
 
 export type Sandbox = {


### PR DESCRIPTION
Follow-up of #2864

Things I did extra:
- Make `DelayedAnimation`'s `delay` prop really optional
- Change `popularSandboxesMounted`'s signature to accept a `string` instead of `{ date: string }`, because it only has 1 argument
- Change `pickSandboxModal`'s signature to get its argument types directly from `PickedSandboxDetails` instead of hardcoding them
- Put all styles into the `elements.ts` file
- Use `FunctionComponent` instead of `React.FC`, since [it's the same](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/f13238a5d2086cd87f3209704f8897f7f701d957/types/react/index.d.ts#L513), but `FunctionComponent` is a bit clearer I think
- Export `Curator` by a named export  instead of a `default export`