### PR TITLE
🔨 Switch Live to use useOvermind

### DIFF
--- a/packages/app/src/app/overmind/namespaces/live/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/live/actions.ts
@@ -39,9 +39,10 @@ export const roomJoined: AsyncAction<{
   state.live.isLoading = false;
 });
 
-export const createLiveClicked: AsyncAction<{
-  sandboxId: string;
-}> = async ({ state, effects, actions }, { sandboxId }) => {
+export const createLiveClicked: AsyncAction<string> = async (
+  { actions, effects },
+  sandboxId
+) => {
   effects.analytics.track('Create Live Session');
 
   const roomId = await effects.api.createLiveRoom(sandboxId);
@@ -186,9 +187,9 @@ export const onSendChat: Action<{ message: string }> = (
   effects.live.sendChat(message);
 };
 
-export const onChatEnabledChange: Action<{ enabled: boolean }> = (
+export const onChatEnabledChange: Action<boolean> = (
   { effects, state },
-  { enabled }
+  enabled
 ) => {
   effects.analytics.track('Enable Live Chat');
 

--- a/packages/app/src/app/overmind/namespaces/live/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/live/actions.ts
@@ -40,7 +40,7 @@ export const roomJoined: AsyncAction<{
 });
 
 export const createLiveClicked: AsyncAction<string> = async (
-  { actions, effects },
+  { actions, effects, state },
   sandboxId
 ) => {
   effects.analytics.track('Create Live Session');

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/items/Live/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/items/Live/index.tsx
@@ -1,5 +1,6 @@
-import { useOvermind } from 'app/overmind';
 import React, { FunctionComponent } from 'react';
+
+import { useOvermind } from 'app/overmind';
 
 import {
   Description,
@@ -7,48 +8,47 @@ import {
   WorkspaceInputContainer,
   WorkspaceSubtitle,
 } from '../../elements';
+
 import { More } from '../More';
+
 import LiveButton from './LiveButton';
 import LiveInfo from './LiveInfo';
 
 export const Live: FunctionComponent = () => {
   const {
-    state: {
-      isLoggedIn,
-      live: {
-        isLive,
-        isOwner,
-        isTeam,
-        roomInfo,
-        liveUserId,
-        reconnecting,
-        notificationsHidden,
-        followingUserId,
-        isLoading,
-      },
-      editor: {
-        isAllModulesSynced,
-        currentSandbox: { owned, id },
-      },
-    },
     actions: {
       live: {
-        onModeChanged,
+        createLiveClicked,
         onAddEditorClicked,
+        onChatEnabledChange,
+        onFollow,
+        onModeChanged,
         onRemoveEditorClicked,
         onSessionCloseClicked,
         onToggleNotificationsHidden,
-        onChatEnabledChange,
-        onFollow,
-        createLiveClicked,
       },
     },
+    state: {
+      editor: {
+        currentSandbox: { id, owned },
+        isAllModulesSynced,
+      },
+      live: {
+        followingUserId,
+        isLive,
+        isLoading,
+        isOwner,
+        isTeam,
+        liveUserId,
+        notificationsHidden,
+        reconnecting,
+        roomInfo,
+      },
+      isLoggedIn,
+    },
   } = useOvermind();
-  const hasUnsyncedModules = !isAllModulesSynced;
 
-  const showPlaceHolder = (!isLive && !owned) || !isLoggedIn;
-
-  if (showPlaceHolder) {
+  if ((!isLive && !owned) || !isLoggedIn) {
     const message = isLoggedIn ? (
       <>
         You need to own this sandbox to open a live session to collaborate with
@@ -66,26 +66,22 @@ export const Live: FunctionComponent = () => {
     <div>
       {isLive ? (
         <LiveInfo
-          setMode={onModeChanged}
           addEditor={onAddEditorClicked}
-          removeEditor={onRemoveEditorClicked}
+          chatEnabled={roomInfo.chatEnabled}
+          currentUserId={liveUserId}
+          followingUserId={followingUserId}
           isOwner={isOwner}
           isTeam={isTeam}
-          roomInfo={roomInfo}
-          ownerIds={roomInfo.ownerIds}
-          currentUserId={liveUserId}
-          reconnecting={reconnecting}
-          onSessionCloseClicked={onSessionCloseClicked}
           notificationsHidden={notificationsHidden}
-          toggleNotificationsHidden={onToggleNotificationsHidden}
-          chatEnabled={roomInfo.chatEnabled}
-          toggleChatEnabled={() => {
-            onChatEnabledChange({
-              enabled: !roomInfo.chatEnabled,
-            });
-          }}
+          onSessionCloseClicked={onSessionCloseClicked}
+          ownerIds={roomInfo.ownerIds}
+          reconnecting={reconnecting}
+          removeEditor={onRemoveEditorClicked}
+          roomInfo={roomInfo}
           setFollowing={onFollow}
-          followingUserId={followingUserId}
+          setMode={onModeChanged}
+          toggleChatEnabled={() => onChatEnabledChange(!roomInfo.chatEnabled)}
+          toggleNotificationsHidden={onToggleNotificationsHidden}
         />
       ) : (
         <>
@@ -95,29 +91,25 @@ export const Live: FunctionComponent = () => {
             re doing it live!
           </Description>
 
-          <>
-            <WorkspaceSubtitle>Create live room</WorkspaceSubtitle>
-            <Description>
-              To invite others you need to generate a URL that others can join.
-            </Description>
+          <WorkspaceSubtitle>Create live room</WorkspaceSubtitle>
 
-            {hasUnsyncedModules && (
-              <ErrorDescription>
-                Save all your files before going live
-              </ErrorDescription>
-            )}
-            <WorkspaceInputContainer>
-              <LiveButton
-                onClick={() => {
-                  createLiveClicked({
-                    sandboxId: id,
-                  });
-                }}
-                isLoading={isLoading}
-                disable={hasUnsyncedModules}
-              />
-            </WorkspaceInputContainer>
-          </>
+          <Description>
+            To invite others you need to generate a URL that others can join.
+          </Description>
+
+          {!isAllModulesSynced && (
+            <ErrorDescription>
+              Save all your files before going live
+            </ErrorDescription>
+          )}
+
+          <WorkspaceInputContainer>
+            <LiveButton
+              disable={!isAllModulesSynced}
+              isLoading={isLoading}
+              onClick={() => createLiveClicked(id)}
+            />
+          </WorkspaceInputContainer>
         </>
       )}
     </div>

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/items/Live/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/items/Live/index.tsx
@@ -47,8 +47,9 @@ export const Live: FunctionComponent = () => {
       isLoggedIn,
     },
   } = useOvermind();
+  const showPlaceHolder = (!isLive && !owned) || !isLoggedIn;
 
-  if ((!isLive && !owned) || !isLoggedIn) {
+  if (showPlaceHolder) {
     const message = isLoggedIn ? (
       <>
         You need to own this sandbox to open a live session to collaborate with


### PR DESCRIPTION
Follow-up of #2663

Things I did extra:
- Change `createLiveClicked`'s signature to accept a `string` instead of `{ sandboxId: string }`, because it only has 1 argument
- Change `onChatEnabledChange`'s signature to accept a `boolean` instead of `{ enabled: boolean }`, because it only has 1 argument
- Remove unnecessary use of a `Fragment` (`<></>`)