### PR TITLE
🔨 Switch CreateNewSandbox to use useOvermind

### DIFF
--- a/packages/app/src/app/overmind/namespaces/dashboard/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/dashboard/actions.ts
@@ -65,7 +65,7 @@ export const searchChanged: Action<{ search: string }> = (
 };
 
 export const createSandboxClicked: AsyncAction<{
+  body: { collectionId: string };
   sandboxId: string;
-  body: { collectionId: string | undefined };
-}> = ({ actions }, { sandboxId, body }) =>
-  actions.editor.internal.forkSandbox({ sandboxId, body });
+}> = ({ actions }, { body, sandboxId }) =>
+  actions.editor.internal.forkSandbox({ body, sandboxId });

--- a/packages/app/src/app/pages/Dashboard/Content/CreateNewSandbox/elements.ts
+++ b/packages/app/src/app/pages/Dashboard/Content/CreateNewSandbox/elements.ts
@@ -1,6 +1,6 @@
-import styled, { css, keyframes } from 'styled-components';
 import { Link } from 'react-router-dom';
 import { animated } from 'react-spring/renderprops';
+import styled, { css, keyframes } from 'styled-components';
 
 const fadeIn = keyframes`
   0%   { opacity: 0; }
@@ -17,6 +17,7 @@ export const DarkBG = styled.div<{ closing: boolean }>`
     background-color: black;
     opacity: 0;
     transition: 0.3s ease opacity;
+
     ${!closing &&
       css`
         animation: ${fadeIn} 0.3s;
@@ -52,7 +53,11 @@ export const Container = styled.div<{ hide?: boolean }>`
     cursor: pointer;
     user-select: none;
     transition: 0.3s ease background-color;
-    ${hide && 'opacity: 0'};
+
+    ${hide &&
+      css`
+        opacity: 0;
+      `};
 
     &:first-child {
       border-bottom: 0;
@@ -79,24 +84,5 @@ export const AnimatedModalContainer = styled(animated.div)<{
     css`
       position: fixed;
       transition: 0.15s ease all;
-    `}
-`;
-
-export const FullsizeContainer = styled.div`
-  position: fixed;
-  top: 25vh;
-  left: 0;
-  bottom: 0;
-  right: 0;
-  opacity: 0;
-  z-index: 0;
-  width: 950px;
-  height: auto;
-  margin: 0 auto 15vh;
-  pointer-events: none;
-`;
-
-export const MeasureContainer = styled.div`
-  width: 100%;
-  height: 100%;
+    `};
 `;

--- a/packages/app/src/app/pages/Dashboard/Content/CreateNewSandbox/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/CreateNewSandbox/index.tsx
@@ -1,159 +1,150 @@
-import React, { useState, useEffect, useRef } from 'react';
+import Portal from '@codesandbox/common/lib/components/Portal';
+import theme from '@codesandbox/common/lib/theme';
+import { Template } from '@codesandbox/common/lib/types';
+import { ENTER, ESC } from '@codesandbox/common/lib/utils/keycodes';
+import { sandboxUrl } from '@codesandbox/common/lib/utils/url-generator';
+import React, {
+  FunctionComponent,
+  HTMLAttributes,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import { Spring } from 'react-spring/renderprops';
 import { ThemeProvider } from 'styled-components';
-import history from 'app/utils/history';
-import { ESC, ENTER } from '@codesandbox/common/lib/utils/keycodes';
-import theme from '@codesandbox/common/lib/theme';
-import { sandboxUrl } from '@codesandbox/common/lib/utils/url-generator';
-import Portal from '@codesandbox/common/lib/components/Portal';
+
 import { useOvermind } from 'app/overmind';
+import history from 'app/utils/history';
 
 import {
+  AnimatedModalContainer,
   ButtonsContainer,
   Container,
-  AnimatedModalContainer,
   ContainerLink,
   DarkBG,
 } from './elements';
-
 import { NewSandboxModal } from './NewSandboxModal';
 
-interface CreateNewSandboxProps {
-  style: React.CSSProperties;
-  collectionId?: string;
-  mostUsedSandboxTemplate: {
-    [key: string]: any;
-  };
-}
+const DEFAULT_RECT = { height: 0, width: 0, x: 0, y: 0 };
 
-const CreateNewSandbox: React.SFC<CreateNewSandboxProps> = ({
-  style,
+type Props = {
+  collectionId?: string;
+  mostUsedSandboxTemplate: Template;
+} & Pick<HTMLAttributes<HTMLDivElement>, 'style'>;
+export const CreateNewSandbox: FunctionComponent<Props> = ({
   collectionId,
   mostUsedSandboxTemplate,
+  style,
 }) => {
   const {
     actions: {
       dashboard: { createSandboxClicked },
     },
   } = useOvermind();
-
-  const [creating, setCreating] = useState(false);
   const [closingCreating, setClosingCreating] = useState(false);
+  const [creating, setCreating] = useState(false);
   const [forking, setForking] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+  const toRef = useRef<HTMLDivElement>(null);
 
-  const ref = useRef(null);
-  const toRef = useRef(null);
+  useEffect(() => {
+    const keydownListener = ({ keyCode }: KeyboardEvent) => {
+      if (keyCode === ESC) {
+        close();
+      }
+    };
+
+    document.addEventListener('keydown', keydownListener);
+
+    return () => document.removeEventListener('keydown', keydownListener);
+  }, []);
 
   const close = () => {
     setClosingCreating(true);
+
     setTimeout(() => {
       setClosingCreating(false);
       setCreating(false);
     }, 500);
   };
-
-  useEffect(() => {
-    const keydownListener = e => {
-      if (e.keyCode === ESC) {
-        close();
-      }
-    };
-    document.addEventListener('keydown', keydownListener);
-    return () => {
-      document.removeEventListener('keydown', keydownListener);
-    };
-  }, []);
-
-  const createSandbox = (template: { [key: string]: any }) => {
+  const createSandbox = ({ shortid }: Template) => {
     setForking(true);
-    if (!collectionId) {
-      setTimeout(() => {
-        history.push(sandboxUrl({ id: template.shortid }));
-      }, 300);
+
+    if (collectionId) {
+      createSandboxClicked({ body: { collectionId }, sandboxId: shortid });
     } else {
-      createSandboxClicked({
-        sandboxId: template.shortid,
-        body: {
-          collectionId,
-        },
-      });
+      setTimeout(() => {
+        history.push(sandboxUrl({ id: shortid }));
+      }, 300);
     }
   };
-
   const handleClick = () => {
     setCreating(true);
   };
 
-  const fromRects = ref.current ? ref.current.getBoundingClientRect() : {};
-  const toRects = toRef.current ? toRef.current.getBoundingClientRect() : {};
+  const buttonName = `Create ${mostUsedSandboxTemplate.niceName} Sandbox`;
+  const mostUsedSandboxComponent = collectionId ? (
+    <Container
+      color={mostUsedSandboxTemplate.color}
+      onClick={() => createSandbox(mostUsedSandboxTemplate)}
+      ref={ref}
+      role="button"
+      tabIndex={0}
+    >
+      {buttonName}
+    </Container>
+  ) : (
+    <ContainerLink
+      color={mostUsedSandboxTemplate.color}
+      to={sandboxUrl({ id: mostUsedSandboxTemplate.shortid })}
+    >
+      {buttonName}
+    </ContainerLink>
+  );
 
-  let usedRects = [
-    {
-      position: 'fixed',
-      top: toRects.y,
-      left: toRects.x,
-      height: toRects.height,
-      width: toRects.width,
-      overflow: 'hidden',
-    },
-    {
-      position: 'fixed',
-      left: fromRects.x,
-      top: fromRects.y,
-      width: fromRects.width + 32,
-      height: fromRects.height + 32,
-      overflow: 'hidden',
-    },
-  ];
-
-  if (!closingCreating) {
-    usedRects = usedRects.reverse();
-  }
-
-  let mostUsedSandboxComponent;
-  if (mostUsedSandboxTemplate) {
-    const buttonName = `Create ${mostUsedSandboxTemplate.niceName} Sandbox`;
-    if (collectionId) {
-      mostUsedSandboxComponent = (
-        <Container
-          ref={ref}
-          onClick={() => createSandbox(mostUsedSandboxTemplate)}
-          color={mostUsedSandboxTemplate.color}
-          tabIndex={0}
-          role="button"
-          hide={false}
-        >
-          {buttonName}
-        </Container>
-      );
-    } else {
-      mostUsedSandboxComponent = (
-        <ContainerLink
-          to={sandboxUrl({ id: mostUsedSandboxTemplate.shortid })}
-          color={mostUsedSandboxTemplate.color}
-        >
-          {buttonName}
-        </ContainerLink>
-      );
-    }
-  }
+  const fromRectDOM = ref.current
+    ? ref.current.getBoundingClientRect()
+    : DEFAULT_RECT;
+  const fromRect = {
+    position: 'fixed',
+    left: fromRectDOM.x,
+    top: fromRectDOM.y,
+    width: fromRectDOM.width + 32,
+    height: fromRectDOM.height + 32,
+    overflow: 'hidden',
+  };
+  const toRectDOM = toRef.current
+    ? toRef.current.getBoundingClientRect()
+    : DEFAULT_RECT;
+  const toRect = {
+    position: 'fixed',
+    top: toRectDOM.y,
+    left: toRectDOM.x,
+    height: toRectDOM.height,
+    width: toRectDOM.width,
+    overflow: 'hidden',
+  };
 
   return (
     <>
       {creating && (
         <>
           <Portal>
-            <DarkBG onClick={close} closing={closingCreating} />
+            <DarkBG closing={closingCreating} onClick={close} />
           </Portal>
+
           <Portal>
             <ThemeProvider theme={theme}>
-              <Spring native from={usedRects[0]} to={usedRects[1]}>
+              <Spring
+                from={closingCreating ? toRect : fromRect}
+                native
+                to={closingCreating ? fromRect : toRect}
+              >
                 {newStyle => (
                   <AnimatedModalContainer
-                    tabIndex={-1}
-                    aria-modal="true"
                     aria-labelledby="new-sandbox"
-                    forking={forking || undefined}
+                    aria-modal="true"
+                    forking={forking}
                     // @ts-ignore
                     style={
                       forking
@@ -166,12 +157,12 @@ const CreateNewSandbox: React.SFC<CreateNewSandboxProps> = ({
                           }
                         : newStyle
                     }
+                    tabIndex={-1}
                   >
                     <NewSandboxModal
-                      width={toRects.width}
-                      forking={forking}
                       closing={closingCreating}
                       createSandbox={createSandbox}
+                      forking={forking}
                     />
                   </AnimatedModalContainer>
                 )}
@@ -184,21 +175,23 @@ const CreateNewSandbox: React.SFC<CreateNewSandboxProps> = ({
       <div style={style}>
         <ButtonsContainer>
           <Container
-            ref={ref}
-            onClick={handleClick}
-            tabIndex={0}
-            role="button"
             hide={creating}
-            onKeyDown={e => {
-              if (e.keyCode === ENTER) {
+            onClick={handleClick}
+            onKeyDown={({ keyCode }: React.KeyboardEvent<HTMLDivElement>) => {
+              if (keyCode === ENTER) {
                 handleClick();
               }
             }}
+            ref={ref}
+            role="button"
+            tabIndex={0}
           >
             Create Sandbox
           </Container>
+
           {mostUsedSandboxComponent}
         </ButtonsContainer>
+
         <Portal>
           <div
             style={{
@@ -216,12 +209,10 @@ const CreateNewSandbox: React.SFC<CreateNewSandboxProps> = ({
               width: 950,
             }}
           >
-            <div ref={toRef} style={{ width: '100%', height: '100%' }} />
+            <div ref={toRef} style={{ height: '100%', width: '100%' }} />
           </div>
         </Portal>
       </div>
     </>
   );
 };
-
-export default CreateNewSandbox;

--- a/packages/app/src/app/pages/Dashboard/Content/routes/PathedSandboxes/index.js
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/PathedSandboxes/index.js
@@ -6,7 +6,7 @@ import { basename } from 'path';
 import { Content as Sandboxes } from '../../Sandboxes';
 import { Navigation } from './Navigation';
 // import Folders from './Folders';
-import CreateNewSandbox from '../../CreateNewSandbox';
+import { CreateNewSandbox } from '../../CreateNewSandbox';
 import getMostUsedTemplate from '../../../utils/get-most-used-template';
 
 import { PATHED_SANDBOXES_CONTENT_QUERY } from '../../../queries';

--- a/packages/app/src/app/pages/Dashboard/Content/routes/RecentSandboxes/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/RecentSandboxes/index.tsx
@@ -5,7 +5,7 @@ import { useQuery } from '@apollo/react-hooks';
 import { useOvermind } from 'app/overmind';
 import getMostUsedTemplate from '../../../utils/get-most-used-template';
 import { Content as Sandboxes } from '../../Sandboxes';
-import CreateNewSandbox from '../../CreateNewSandbox';
+import { CreateNewSandbox } from '../../CreateNewSandbox';
 import { RECENT_SANDBOXES_CONTENT_QUERY } from '../../../queries';
 
 export const RecentSandboxes = () => {


### PR DESCRIPTION
Follow-up of #2720

Things I did extra:
- Put all styles into the `elements.ts` file
- Make `CreateNewSandbox` a `FunctionComponent` (instead of `SFC`, since it's [deprecated](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/f13238a5d2086cd87f3209704f8897f7f701d957/types/react/index.d.ts#L497-L503)) and improve it's `Props` type
- Cleanup `CreateNewSandbox` a bit (`Spring`'s `from` & `to` prop + the way `mostUsedSandboxComponent` is created)
- Export `CreateNewSandbox` by a named export  instead of a `default export`