### PR TITLE
fix(storage-management): fix behavior outside of a sandbox context

### DIFF
--- a/packages/app/src/app/overmind/factories.ts
+++ b/packages/app/src/app/overmind/factories.ts
@@ -77,29 +77,30 @@ export const withOwnedSandbox = <T>(
 ): AsyncAction<T> => async (context, payload) => {
   const { state, actions } = context;
 
-  if (state.editor.currentSandbox && !state.editor.currentSandbox.owned) {
-    if (state.editor.isForkingSandbox) {
-      return cancelAction(context, payload);
-    }
+  if (state.editor.currentSandbox) {
+    if (!state.editor.currentSandbox.owned) {
+      if (state.editor.isForkingSandbox) {
+        return cancelAction(context, payload);
+      }
 
-    await actions.editor.internal.forkSandbox({
-      sandboxId: state.editor.currentId,
-    });
-  } else if (
-    state.editor.currentSandbox &&
-    state.editor.currentSandbox.isFrozen &&
-    state.editor.sessionFrozen
-  ) {
-    const modalResponse = await actions.modals.forkFrozenModal.open();
-
-    if (modalResponse === 'fork') {
       await actions.editor.internal.forkSandbox({
         sandboxId: state.editor.currentId,
       });
-    } else if (modalResponse === 'unfreeze') {
-      state.editor.sessionFrozen = false;
-    } else if (modalResponse === 'cancel') {
-      return cancelAction(context, payload);
+    } else if (
+      state.editor.currentSandbox.isFrozen &&
+      state.editor.sessionFrozen
+    ) {
+      const modalResponse = await actions.modals.forkFrozenModal.open();
+
+      if (modalResponse === 'fork') {
+        await actions.editor.internal.forkSandbox({
+          sandboxId: state.editor.currentId,
+        });
+      } else if (modalResponse === 'unfreeze') {
+        state.editor.sessionFrozen = false;
+      } else if (modalResponse === 'cancel') {
+        return cancelAction(context, payload);
+      }
     }
   }
 

--- a/packages/app/src/app/overmind/factories.ts
+++ b/packages/app/src/app/overmind/factories.ts
@@ -77,7 +77,7 @@ export const withOwnedSandbox = <T>(
 ): AsyncAction<T> => async (context, payload) => {
   const { state, actions } = context;
 
-  if (!state.editor.currentSandbox.owned) {
+  if (state.editor.currentSandbox && !state.editor.currentSandbox.owned) {
     if (state.editor.isForkingSandbox) {
       return cancelAction(context, payload);
     }
@@ -86,6 +86,7 @@ export const withOwnedSandbox = <T>(
       sandboxId: state.editor.currentId,
     });
   } else if (
+    state.editor.currentSandbox &&
     state.editor.currentSandbox.isFrozen &&
     state.editor.sessionFrozen
   ) {

--- a/packages/app/src/app/pages/common/Modals/StorageManagementModal/AddFileToSandboxButton/elements.js
+++ b/packages/app/src/app/pages/common/Modals/StorageManagementModal/AddFileToSandboxButton/elements.js
@@ -4,7 +4,7 @@ import AddIcon from 'react-icons/lib/md/add';
 import Tooltip from '@codesandbox/common/lib/components/Tooltip';
 
 export const AddFileToSandboxButton = styled(props => (
-  <Tooltip content="Add file to sandbox">
+  <Tooltip content="Add file to sandbox" isEnabled={!props.disabled}>
     <button type="button" {...props}>
       <AddIcon />
     </button>

--- a/packages/app/src/app/pages/common/Modals/StorageManagementModal/AddFileToSandboxButton/index.js
+++ b/packages/app/src/app/pages/common/Modals/StorageManagementModal/AddFileToSandboxButton/index.js
@@ -8,6 +8,11 @@ export default class AddFileToSandboxButtonContainer extends React.PureComponent
   };
 
   render() {
-    return <AddFileToSandboxButton onClick={this.addFileToSandbox} />;
+    return (
+      <AddFileToSandboxButton
+        disabled={this.props.disabled}
+        onClick={this.addFileToSandbox}
+      />
+    );
   }
 }

--- a/packages/app/src/app/pages/common/Modals/StorageManagementModal/FilesList/index.js
+++ b/packages/app/src/app/pages/common/Modals/StorageManagementModal/FilesList/index.js
@@ -15,8 +15,8 @@ import {
   Table,
 } from './elements';
 
-const someSelected = obj =>
-  Object.keys(obj).filter(key => obj[key] === true).length;
+const getSelectedFiles = obj =>
+  Object.keys(obj).filter(key => obj[key] === true);
 
 class FilesList extends Component {
   state = {};
@@ -44,20 +44,22 @@ class FilesList extends Component {
       deleteFiles,
       addFilesToSandbox,
     } = this.props;
+    const filesToRemove = getSelectedFiles(this.state);
+
     return (
       <div css={{ margin: '0 2rem' }}>
         <Buttons>
           <Button
-            disabled={!someSelected(this.state)}
+            disabled={!filesToRemove.length}
             small
             onClick={() => addFilesToSandbox(this.getSelection())}
           >
             Add all selected to project
           </Button>
           <Button
-            disabled={!someSelected(this.state)}
+            disabled={!filesToRemove.length}
             small
-            onClick={() => deleteFiles(Object.keys(this.state))}
+            onClick={() => deleteFiles(filesToRemove)}
           >
             Delete all selected
           </Button>

--- a/packages/app/src/app/pages/common/Modals/StorageManagementModal/FilesList/index.js
+++ b/packages/app/src/app/pages/common/Modals/StorageManagementModal/FilesList/index.js
@@ -44,13 +44,14 @@ class FilesList extends Component {
       deleteFiles,
       addFilesToSandbox,
     } = this.props;
+    const canAddFile = Boolean(addFileToSandbox);
     const filesToRemove = getSelectedFiles(this.state);
 
     return (
       <div css={{ margin: '0 2rem' }}>
         <Buttons>
           <Button
-            disabled={!filesToRemove.length}
+            disabled={!filesToRemove.length || !canAddFile}
             small
             onClick={() => addFilesToSandbox(this.getSelection())}
           >
@@ -115,6 +116,7 @@ class FilesList extends Component {
                   `}
                 >
                   <AddFileToSandboxButton
+                    disabled={!canAddFile}
                     url={f.url}
                     name={f.name}
                     onAddFileToSandbox={addFileToSandbox}

--- a/packages/app/src/app/pages/common/Modals/StorageManagementModal/index.tsx
+++ b/packages/app/src/app/pages/common/Modals/StorageManagementModal/index.tsx
@@ -17,7 +17,12 @@ import FilesList from './FilesList';
 
 export const StorageManagementModal: FunctionComponent = () => {
   const {
-    state: { usedStorage, maxStorage, uploadedFiles },
+    state: {
+      editor: { currentSandbox },
+      usedStorage,
+      maxStorage,
+      uploadedFiles,
+    },
     actions: {
       files: { deletedUploadedFile, addedFileToSandbox },
     },
@@ -50,7 +55,7 @@ export const StorageManagementModal: FunctionComponent = () => {
           deleteFile={deletedUploadedFile}
           deleteFiles={files => files.map(id => deletedUploadedFile({ id }))}
           addFilesToSandbox={files => files.map(addedFileToSandbox)}
-          addFileToSandbox={addedFileToSandbox}
+          addFileToSandbox={currentSandbox ? addedFileToSandbox : undefined}
         />
       )}
 


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?
Bug fix. Closes #3077.
<!-- Is it a Bug fix, feature, docs update, ... -->

## What is the current behavior?
I noticed a few issues on the Storage Management modal:

1. If you select two files, unselect one of them and press to delete, we send the id for both files because we are not filtering which files have `{ [id]: true }`;
2. If you try to delete a file outside the editor, it fails because we try to access `state.editor.currentSandbox.owned` without checking for `currentSandbox` first;
3. If you open the modal outside the editor, the buttons to add files to the project are enabled.
<!-- You can also link to an open issue here -->

## What is the new behavior?
1. We are only sending the current selected files;
2. We are checking for `currentSandbox` before trying to read `currentSandbox.owned`;
3. We are disabling the button and tooltips for adding files to the project when the modal is opened outside the editor.
<!-- if this is a feature change -->

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

### Delete files flow

1. Open the modal outside the editor
2. Select files and press to delete them
3. Verify that the files are deleted.

### Add files flow

1. Open the modal outside the editor
2. Verify that the buttons for adding files are disabled.

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Testing <!-- We can only merge the PR if this is checked -->
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->

## Notes

I'd rather remove the buttons for adding files when the modal is opened outside the editor, but didn't took this route because it would required more changes and I'd like to get your feedback.