### PR TITLE
fix(tests): update error-polyfill to fix unexpected frame error

### DIFF
--- a/packages/app/src/sandbox/eval/tests/jest-lite.ts
+++ b/packages/app/src/sandbox/eval/tests/jest-lite.ts
@@ -421,9 +421,9 @@ export default class TestRunner {
 
         if (test.errors) {
           test.errors.forEach(err => {
-            if (err.mappedErrors) {
+            if (err.mappedErrors && err.mappedErrors.length) {
               const { mappedErrors } = err;
-              const mappedError = mappedErrors[0];
+              const [mappedError] = mappedErrors;
 
               dispatch(
                 actions.error.show(err.name || 'Jest Error', err.message, {

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -52,7 +52,7 @@
     "color": "0.11.4",
     "date-fns": "^2.0.0",
     "dot-object": "1.9.0",
-    "error-polyfill": "^0.1.1",
+    "error-polyfill": "^0.1.2",
     "humps": "CompuIves/humps",
     "image-extensions": "^1.1.0",
     "immer": "^3.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10262,9 +10262,10 @@ error-ex@^1.2.0, error-ex@^1.3.1:
   dependencies:
     is-arrayish "^0.2.1"
 
-error-polyfill@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/error-polyfill/-/error-polyfill-0.1.1.tgz#276654aad92ff2615582a323066173cc18da1eaf"
+error-polyfill@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/error-polyfill/-/error-polyfill-0.1.2.tgz#05b27de7d126cbc9d42a96f45faab28a98a0b28b"
+  integrity sha512-8uhnXlJuhFkmIfhw2tAHtWQGpXcw5rrc0dhuY3bhn8tBHvh6l0oL9VJvR2suqx9eltglKKhVPv8luPQy+UxLTA==
   dependencies:
     capability "^0.2.5"
     o3 "^1.0.3"


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?
Bug fix. Closes #502, closes #1744, closes #1997.
<!-- Is it a Bug fix, feature, docs update, ... -->

## What is the current behavior?
On Firefox and Safari, you can get an `Unexpected frame by generating stack` error. I believe this error was a false positive because it was removed on the version 1.1.2 of `error-polyfill`.
<!-- You can also link to an open issue here -->

## What is the new behavior?
The error is thrown and the expected behaviour on the three linked issues happen.
<!-- if this is a feature change -->

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Open the sandboxes on the linked issues;
2. Verify that the expected behaviour in all of them happen on Chrome, Firefox and Safari.

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
