### PR TITLE
fix: cross-origin error

### DIFF
--- a/packages/app/src/app/index.html
+++ b/packages/app/src/app/index.html
@@ -4,6 +4,8 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
+  <!-- fix cross-origin error, by allowing to run JavaScript from eval or Function constructor source -->
+  <meta http-equiv="Content-Security-Policy" content="script-src 'self' 'unsafe-eval'">
 	<meta property="og:type" content="website">
 	<meta property="og:author" content='https://ivesvh.com'>
 	<meta property="og:title" content="CodeSandbox">

--- a/packages/app/src/app/index.html
+++ b/packages/app/src/app/index.html
@@ -5,7 +5,7 @@
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
   <!-- fix cross-origin error, by allowing to run JavaScript from eval or Function constructor source -->
-  <meta http-equiv="Content-Security-Policy" content="script-src 'self' 'unsafe-eval'">
+  <meta http-equiv="Content-Security-Policy" content="script-src 'self' 'unsafe-eval' 'unsafe-inline' https://*.googleapis.com">
 	<meta property="og:type" content="website">
 	<meta property="og:author" content='https://ivesvh.com'>
 	<meta property="og:title" content="CodeSandbox">

--- a/packages/app/src/app/index.html
+++ b/packages/app/src/app/index.html
@@ -5,7 +5,7 @@
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
   <!-- fix cross-origin error, by allowing to run JavaScript from eval or Function constructor source -->
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self' * data: mediastream: blob: filesystem:; script-src 'self' 'unsafe-eval' 'unsafe-inline' * data: mediastream: blob: filesystem:; style-src 'self' 'unsafe-eval' 'unsafe-inline' * data: mediastream: blob: filesystem:">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self' 'unsafe-eval' 'unsafe-inline' * data: mediastream: blob: filesystem:">
 	<meta property="og:type" content="website">
 	<meta property="og:author" content='https://ivesvh.com'>
 	<meta property="og:title" content="CodeSandbox">

--- a/packages/app/src/app/index.html
+++ b/packages/app/src/app/index.html
@@ -5,7 +5,7 @@
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
   <!-- fix cross-origin error, by allowing to run JavaScript from eval or Function constructor source -->
-  <meta http-equiv="Content-Security-Policy" content="script-src 'self' 'unsafe-eval' 'unsafe-inline' https://*.googleapis.com">
+  <meta http-equiv="Content-Security-Policy" content="default-src: 'self' data: mediastream: blob: filesystem: *; script-src 'self' 'unsafe-eval' 'unsafe-inline' *">
 	<meta property="og:type" content="website">
 	<meta property="og:author" content='https://ivesvh.com'>
 	<meta property="og:title" content="CodeSandbox">

--- a/packages/app/src/app/index.html
+++ b/packages/app/src/app/index.html
@@ -5,7 +5,7 @@
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
   <!-- fix cross-origin error, by allowing to run JavaScript from eval or Function constructor source -->
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self' * data: mediastream: blob: filesystem:; script-src 'self' 'unsafe-eval' 'unsafe-inline' *">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self' * data: mediastream: blob: filesystem:; script-src 'self' 'unsafe-eval' 'unsafe-inline' * data: mediastream: blob: filesystem:; style-src 'self' 'unsafe-eval' 'unsafe-inline' * data: mediastream: blob: filesystem:">
 	<meta property="og:type" content="website">
 	<meta property="og:author" content='https://ivesvh.com'>
 	<meta property="og:title" content="CodeSandbox">

--- a/packages/app/src/app/index.html
+++ b/packages/app/src/app/index.html
@@ -5,7 +5,7 @@
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
   <!-- fix cross-origin error, by allowing to run JavaScript from eval or Function constructor source -->
-  <meta http-equiv="Content-Security-Policy" content="default-src: 'self' * data mediastream blob filesystem; script-src 'self' 'unsafe-eval' 'unsafe-inline' *">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self' * data: mediastream: blob: filesystem:; script-src 'self' 'unsafe-eval' 'unsafe-inline' *">
 	<meta property="og:type" content="website">
 	<meta property="og:author" content='https://ivesvh.com'>
 	<meta property="og:title" content="CodeSandbox">

--- a/packages/app/src/app/index.html
+++ b/packages/app/src/app/index.html
@@ -5,7 +5,7 @@
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
   <!-- fix cross-origin error, by allowing to run JavaScript from eval or Function constructor source -->
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self' 'unsafe-eval' 'unsafe-inline' * data: mediastream: blob: filesystem:">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self' 'unsafe-eval' 'unsafe-inline' * data: mediastream: blob: filesystem:; frame-ancestors 'self' * data: mediastream: blob: filesystem:">
 	<meta property="og:type" content="website">
 	<meta property="og:author" content='https://ivesvh.com'>
 	<meta property="og:title" content="CodeSandbox">

--- a/packages/app/src/app/index.html
+++ b/packages/app/src/app/index.html
@@ -5,7 +5,7 @@
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
   <!-- fix cross-origin error, by allowing to run JavaScript from eval or Function constructor source -->
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self' 'unsafe-eval' 'unsafe-inline' * data: mediastream: blob: filesystem:; frame-ancestors 'self' * data: mediastream: blob: filesystem:">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self' 'unsafe-eval' 'unsafe-inline' * data: mediastream: blob: filesystem:">
 	<meta property="og:type" content="website">
 	<meta property="og:author" content='https://ivesvh.com'>
 	<meta property="og:title" content="CodeSandbox">

--- a/packages/app/src/app/index.html
+++ b/packages/app/src/app/index.html
@@ -5,7 +5,7 @@
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
   <!-- fix cross-origin error, by allowing to run JavaScript from eval or Function constructor source -->
-  <meta http-equiv="Content-Security-Policy" content="default-src: 'self' data: mediastream: blob: filesystem: *; script-src 'self' 'unsafe-eval' 'unsafe-inline' *">
+  <meta http-equiv="Content-Security-Policy" content="default-src: 'self' * data mediastream blob filesystem; script-src 'self' 'unsafe-eval' 'unsafe-inline' *">
 	<meta property="og:type" content="website">
 	<meta property="og:author" content='https://ivesvh.com'>
 	<meta property="og:title" content="CodeSandbox">

--- a/packages/app/src/embed/index.html
+++ b/packages/app/src/embed/index.html
@@ -5,7 +5,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <!-- fix cross-origin error, by allowing to run JavaScript from eval or Function constructor source -->
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self' 'unsafe-eval' 'unsafe-inline' * data: mediastream: blob: filesystem:; frame-ancestors 'self' * data: mediastream: blob: filesystem:">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self' 'unsafe-eval' 'unsafe-inline' * data: mediastream: blob: filesystem:">
     <meta property="og:type" content="website">
     <meta property="og:author" content='https://ivesvh.com'>
     <meta property="og:title" content="CodeSandbox">

--- a/packages/app/src/embed/index.html
+++ b/packages/app/src/embed/index.html
@@ -4,6 +4,8 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <!-- fix cross-origin error, by allowing to run JavaScript from eval or Function constructor source -->
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self' 'unsafe-eval' 'unsafe-inline' * data: mediastream: blob: filesystem:; frame-ancestors 'self' * data: mediastream: blob: filesystem:">
     <meta property="og:type" content="website">
     <meta property="og:author" content='https://ivesvh.com'>
     <meta property="og:title" content="CodeSandbox">

--- a/packages/app/src/sandbox/index.html
+++ b/packages/app/src/sandbox/index.html
@@ -5,7 +5,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <!-- fix cross-origin error, by allowing to run JavaScript from eval or Function constructor source -->
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self' 'unsafe-eval' 'unsafe-inline' * data: mediastream: blob: filesystem:; frame-ancestors 'self' * data: mediastream: blob: filesystem:">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self' 'unsafe-eval' 'unsafe-inline' * data: mediastream: blob: filesystem:">
     <title>Sandbox - CodeSandbox</title>
     <link rel="manifest" href="/manifest.json">
     <link rel="shortcut icon" href="/favicon.ico">

--- a/packages/app/src/sandbox/index.html
+++ b/packages/app/src/sandbox/index.html
@@ -4,6 +4,8 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <!-- fix cross-origin error, by allowing to run JavaScript from eval or Function constructor source -->
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self' 'unsafe-eval' 'unsafe-inline' * data: mediastream: blob: filesystem:; frame-ancestors 'self' * data: mediastream: blob: filesystem:">
     <title>Sandbox - CodeSandbox</title>
     <link rel="manifest" href="/manifest.json">
     <link rel="shortcut icon" href="/favicon.ico">


### PR DESCRIPTION
Set [CSP header](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) for [`'script-src'`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/style-src) to allow to run JavaScript from `eval` or `Function` Constructor and access stacktrace beyond cross-origin boundary.

Another great article about CSP and `eval`:
https://developer.chrome.com/extensions/contentSecurityPolicy#JSEval

fixes #667 

<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?

Bugfix

<!-- Is it a Bug fix, feature, docs update, ... -->

## What is the current behavior?

JavaScript executed by `eval` or `Function` constructor is not allowed to access stuff like stacktraces beyond own origin according to default CSP rules. For more details see issue description at #667 

<!-- You can also link to an open issue here -->

## What is the new behavior?

CSP headers are reset, to allow JS within eval and Function constructor to access stuff like stacktraces cross-origin:

```html
<meta http-equiv="Content-Security-Policy" content="script-src 'self' 'unsafe-eval'">
```

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Testing <!-- We can only merge the PR if this is checked -->
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->

## Sample code to reproduce

Here is a reproduction script:
https://codesandbox.io/embed/ly0q02y9q9

```js
import React, { createElement, PureComponent } from "react";
import ReactDOM from "react-dom";
import val from "@skatejs/val";

import "./styles.css";

const h = val(createElement);

class CECrossOriginError extends HTMLElement {
  // properties getter
  static get observedAttributes() {
    return ["error"];
  }

  set error(value) {
    const error = Boolean(value);
    if (error) this.setAttribute("error", "");
    else this.removeAttribute("error");
  }

  get error() {
    return this.hasAttribute("error");
  }

  connectedCallback() {
    this.render();
  }

  attributeChangedCallback() {
    this.render();
  }

  render() {
    const { error } = this;

    this.className = error ? "has-error" : "";
  }
}

// Register the new element with the browser.
customElements.define("ce-cross-origin-error", CECrossOriginError);

class CrossOriginError extends PureComponent {
  render() {
    /** @jsx h */
    // can be fixed by extracting children, like:
    // const { children, ...props } = this
    // return <CECrossOriginError {...props}>{children}</CECrossOriginError>;
    const { props } = this;

    return <CECrossOriginError {...props} />;
  }
}

function App() {
  return (
    <div className="App">
      <h1>Hello CodeSandbox</h1>

      <CrossOriginError>foo bar</CrossOriginError>
    </div>
  );
}

const rootElement = document.getElementById("root");
ReactDOM.render(<App />, rootElement);
```