### PR TITLE
WIP work on making live joining while typing more smooth

### DIFF
--- a/packages/app/src/app/overmind/namespaces/live/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/live/actions.ts
@@ -90,11 +90,15 @@ export const liveMessageReceived: Operator<LiveMessage> = pipe(
   })
 );
 
-export const applyTransformation: Action<{
+export const applyTransformation: AsyncAction<{
   operation: any;
   moduleShortid: string;
-}> = ({ effects }, { operation, moduleShortid }) => {
-  effects.vscode.applyOperation(moduleShortid, operation);
+}> = async ({ effects }, { operation, moduleShortid }) => {
+  try {
+    await effects.vscode.applyOperation(moduleShortid, operation);
+  } catch (e) {
+    effects.live.send('live:module_state', {});
+  }
 };
 
 export const onSelectionChanged: Action<any> = (


### PR DESCRIPTION
Main problem:

When someone joins a live session while the other user is typing, the first few characters are not processed because VSCode hasn't initialized yet. 

My "fixes"

1. Introduce a queue for live messages and ensure that the queue is not processed in parallel (should this logic be in `live` instead maybe?
2. Make `live:module_state` more aggressive. This is our repair mechanism for when there is a state mismatch, it wasn't useful before, but now that we can call `vscode.setCode` it actually is more useful so I do more checks and make sure to call the module state when there is a mismatch. This works, but I had to add `this.applyingOperation = true`, which doesn't feel clean to do in a generic function that's called `setCode`, maybe you know what to do here? @christianalfoni 

So the interesting thing is, fix number 1 doesn't even work. I tried, but it seems to apply the operations on the saved code instead of module state code? My hunch is that the module state hasn't returned yet, and so the operations are applied on saved code instead of module state code. We maybe need to have an initialized state or something on live to fix that.

Fix number 2 fixes everything of course, but we should not resort to it that often.

This is WIP, just a couple of suggestions on fixes. But it's very quickly done, and ugly.