### PR TITLE
QOL improvements

### DIFF
--- a/packages/app/src/app/overmind/effects/live/index.ts
+++ b/packages/app/src/app/overmind/effects/live/index.ts
@@ -259,9 +259,6 @@ export default {
       message,
     });
   },
-  sendModuleState() {
-    return this.send('live:module_state', {});
-  },
   sendModuleSaved(module: Module) {
     return this.send('module:saved', {
       type: 'module',
@@ -272,7 +269,7 @@ export default {
   sendChatEnabled(enabled: boolean) {
     return this.send('live:chat_enabled', { enabled });
   },
-  sendModuleUpdateRequest() {
+  sendModuleStateSyncRequest() {
     return this.send('live:module_state', {});
   },
   sendUserSelection(moduleShortid: string, liveUserId: string, selection: any) {

--- a/packages/app/src/app/overmind/effects/vscode/SandboxFsSync/index.ts
+++ b/packages/app/src/app/overmind/effects/vscode/SandboxFsSync/index.ts
@@ -16,6 +16,7 @@ import { getGlobal } from '@codesandbox/common/lib/utils/global';
 import { protocolAndHost } from '@codesandbox/common/lib/utils/url-generator';
 import { json } from 'overmind';
 
+import { getSavedCode } from 'app/overmind/utils/sandbox';
 import { WAIT_INITIAL_TYPINGS_MS } from '../constants';
 import { appendFile, mkdir, rename, rmdir, unlink, writeFile } from './utils';
 
@@ -111,7 +112,9 @@ class SandboxFsSync {
 
     appendFile(fs, copy);
     this.send('append-file', copy);
-    browserFs.appendFile(join('/sandbox', module.path), module.code, () => {});
+
+    const savedCode = getSavedCode(module.code, module.savedCode);
+    browserFs.appendFile(join('/sandbox', module.path), savedCode, () => {});
   }
 
   public writeFile(fs: SandboxFs, module: Module) {
@@ -119,7 +122,9 @@ class SandboxFsSync {
 
     writeFile(fs, copy);
     this.send('write-file', copy);
-    browserFs.writeFile(join('/sandbox', module.path), module.code, () => {});
+
+    const savedCode = getSavedCode(module.code, module.savedCode);
+    browserFs.writeFile(join('/sandbox', module.path), savedCode, () => {});
 
     if (module.title === 'package.json') {
       this.syncDependencyTypings();

--- a/packages/app/src/app/overmind/namespaces/editor/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/editor/actions.ts
@@ -116,6 +116,8 @@ export const sandboxChanged: AsyncAction<{ id: string }> = withLoadApp<{
 
   if (sandbox.owned && !state.live.isLive) {
     actions.files.internal.recoverFiles();
+  } else if (state.live.isLive) {
+    effects.live.sendModuleStateSyncRequest();
   }
 
   effects.vscode.openModule(state.editor.currentModule);

--- a/packages/app/src/app/overmind/namespaces/editor/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/editor/actions.ts
@@ -506,14 +506,7 @@ export const discardModuleChanges: Action<{
     return;
   }
 
-  const code = module.savedCode === null ? module.code || '' : module.savedCode;
-  actions.editor.codeChanged({
-    code,
-    moduleShortid,
-  });
-
   module.updatedAt = new Date().toString();
-
   effects.vscode.revertModule(module);
 
   state.editor.changedModuleShortids.splice(

--- a/packages/app/src/app/overmind/namespaces/live/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/live/actions.ts
@@ -58,6 +58,8 @@ export const createLiveClicked: AsyncAction<{
 
   Object.assign(state.editor.sandboxes[state.editor.currentId], sandbox);
   state.editor.modulesByPath = effects.vscode.sandboxFsSync.create(sandbox);
+
+  effects.live.sendModuleStateSyncRequest();
 };
 
 export const liveMessageReceived: Operator<LiveMessage> = pipe(

--- a/packages/app/src/app/overmind/namespaces/live/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/live/actions.ts
@@ -33,8 +33,7 @@ export const roomJoined: AsyncAction<{
     state.editor.modulesByPath = fs;
   });
 
-  effects.live.sendModuleState();
-
+  effects.live.sendModuleStateSyncRequest();
   effects.vscode.openModule(state.editor.currentModule);
   effects.preview.executeCodeImmediately({ initialRender: true });
   state.live.isLoading = false;
@@ -59,8 +58,6 @@ export const createLiveClicked: AsyncAction<{
 
   Object.assign(state.editor.sandboxes[state.editor.currentId], sandbox);
   state.editor.modulesByPath = effects.vscode.sandboxFsSync.create(sandbox);
-
-  effects.live.sendModuleState();
 };
 
 export const liveMessageReceived: Operator<LiveMessage> = pipe(
@@ -104,7 +101,7 @@ export const applyTransformation: AsyncAction<{
   } catch (error) {
     // Do not care about the error, but something went wrong and we
     // need a full sync
-    effects.live.sendModuleState();
+    effects.live.sendModuleStateSyncRequest();
   }
 };
 
@@ -215,8 +212,4 @@ export const onFollow: Action<{
       id: module ? module.id : undefined,
     });
   }
-};
-
-export const onModuleStateMismatch: Action = ({ effects }) => {
-  effects.live.sendModuleUpdateRequest();
 };

--- a/packages/app/src/app/overmind/namespaces/live/internalActions.ts
+++ b/packages/app/src/app/overmind/namespaces/live/internalActions.ts
@@ -80,8 +80,6 @@ export const initialize: AsyncAction<string, Sandbox> = async (
     state.live.isLive = true;
     state.live.error = null;
 
-    effects.live.sendModuleStateSyncRequest();
-
     return sandbox;
   } catch (error) {
     state.live.error = error.reason;

--- a/packages/app/src/app/overmind/namespaces/live/liveMessageOperators.ts
+++ b/packages/app/src/app/overmind/namespaces/live/liveMessageOperators.ts
@@ -445,7 +445,7 @@ export const onOperation: Operator<LiveMessage<{
     } catch (e) {
       // Something went wrong, probably a sync mismatch. Request new version
       console.error('Something went wrong with applying OT operation');
-      effects.live.sendModuleUpdateRequest();
+      effects.live.sendModuleStateSyncRequest();
     }
   }
 });

--- a/packages/app/src/app/overmind/utils/sandbox.ts
+++ b/packages/app/src/app/overmind/utils/sandbox.ts
@@ -1,0 +1,14 @@
+/**
+ * We set savedCode to null if it's the same as code for memory/bandwidth reasons,
+ * this function returns the savedCode based on the two values.
+ */
+export const getSavedCode = (
+  code: string | undefined,
+  savedCode: string | undefined | null
+) => {
+  if (savedCode === null) {
+    return code || '';
+  }
+
+  return savedCode || '';
+};


### PR DESCRIPTION
Some extra fixes:

1. Change the syncing logic to only sync on change
2. We didn't sync if you join a sandbox with a live session as owner (`/s/:id`), I moved the syncing to live initialize to make sure that it always happens
3. We now debounce the selection updates when typing.