### PR TITLE
fix(svelte): add fallback toUrl method to generate sourcemaps

### DIFF
--- a/packages/app/src/sandbox/eval/transpilers/svelte/svelte-worker.js
+++ b/packages/app/src/sandbox/eval/transpilers/svelte/svelte-worker.js
@@ -36,6 +36,12 @@ function getV3Code(code, version, path) {
       });
     });
 
+    if (!js.map.toUrl) {
+      js.map.toUrl = () =>
+        'data:application/json;charset=utf-8;base64,' +
+        btoa(JSON.stringify(js.map));
+    }
+
     return js;
   } catch (e) {
     return self.postMessage({

--- a/packages/app/src/sandbox/eval/transpilers/svelte/svelte-worker.js
+++ b/packages/app/src/sandbox/eval/transpilers/svelte/svelte-worker.js
@@ -36,6 +36,8 @@ function getV3Code(code, version, path) {
       });
     });
 
+    // Fallback to generate sourcemaps on Svelte 3.13+
+    // See https://github.com/codesandbox/codesandbox-client/pull/3114
     if (!js.map.toUrl) {
       js.map.toUrl = () =>
         'data:application/json;charset=utf-8;base64,' +


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?
Fix. Closes #3094. 
<!-- Is it a Bug fix, feature, docs update, ... -->

## What is the current behavior?
Svelte replaced `magic-string` with `code-red` on version `3.13.0` and with this, CodeSandbox can't compile Svelte components anymore because it relies on `toUrl` to [generate inline sourcemaps](https://github.com/codesandbox/codesandbox-client/blob/master/packages/app/src/sandbox/eval/transpilers/svelte/svelte-worker.js#L143).
<!-- You can also link to an open issue here -->

## What is the new behavior?
I've added a fallback function to generate the source maps like [`magic-string` does](https://github.com/Rich-Harris/magic-string/blob/master/src/SourceMap.js#L27).

I've opened [a PR](https://github.com/Rich-Harris/code-red/pull/22) to add this method to `code-red` but I'm not sure if it's the right approach or will even get merged. However, if we want to output sourcemaps, we'd need this because since 3.13.0, Svelte is "broken" on this matter.
<!-- if this is a feature change -->

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Open [this sandbox](https://codesandbox.io/s/modest-wind-fpzv0);
2. Verify that it compiles without the fallback if you change `svelte`s version to 3.12.1;
3. Verify that it compiles with the fallback if you change `svelte`s version to 3.13.0 or more.

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Testing <!-- We can only merge the PR if this is checked -->
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->

## Notes
What are your thoughts on this approach?
Should we **not** generate inline sourcemaps?