### PR TITLE
🔨 Switch AliasDeploymentButton to use useOvermind

### DIFF
--- a/packages/app/src/app/overmind/namespaces/deployment/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/deployment/actions.ts
@@ -163,9 +163,10 @@ export const deleteDeployment: AsyncAction = async ({
   );
 };
 
-export const aliasDeployment: AsyncAction<{
-  id: string;
-}> = async ({ state, effects, actions }, { id }) => {
+export const aliasDeployment: AsyncAction<string> = async (
+  { state, effects, actions },
+  id
+) => {
   const zeitConfig = effects.zeit.getConfig(state.editor.currentSandbox);
 
   try {

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/items/Deployment/Zeit/Deploys/Actions/AliasDeploymentButton/AliasDeploymentButton.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/items/Deployment/Zeit/Deploys/Actions/AliasDeploymentButton/AliasDeploymentButton.tsx
@@ -1,13 +1,14 @@
-import React from 'react';
-import { useOvermind } from 'app/overmind';
 import { ZeitDeployment } from '@codesandbox/common/lib/types';
+import React, { FunctionComponent } from 'react';
+
+import { useOvermind } from 'app/overmind';
+
 import { Action } from '../../../../elements';
 
 type Props = {
   deploy: ZeitDeployment;
 };
-
-export const AliasDeploymentButton: React.FC<Props> = ({
+export const AliasDeploymentButton: FunctionComponent<Props> = ({
   deploy: { alias: aliases, uid: id },
 }) => {
   const {
@@ -15,11 +16,9 @@ export const AliasDeploymentButton: React.FC<Props> = ({
       deployment: { aliasDeployment },
     },
   } = useOvermind();
+
   return (
-    <Action
-      disabled={aliases.length > 0}
-      onClick={() => aliasDeployment({ id })}
-    >
+    <Action disabled={aliases.length > 0} onClick={() => aliasDeployment(id)}>
       {aliases.length > 0 ? 'Aliased' : 'Alias'}
     </Action>
   );


### PR DESCRIPTION
Resubmission of #2844

Follow-up of #2742

Things I did extra:
- Change `aliasDeployment`'s signature to accept a `string` instead of `{ id: string }`, because it only has 1 argument
- Use `FunctionComponent` instead of `React.FC`, since [it's the same](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/f13238a5d2086cd87f3209704f8897f7f701d957/types/react/index.d.ts#L513), but `FunctionComponent` is a bit clearer I think