### PR TITLE
Add checks for patron redirect + remove badge from editor

### DIFF
--- a/packages/app/src/app/pages/Patron/index.tsx
+++ b/packages/app/src/app/pages/Patron/index.tsx
@@ -12,12 +12,21 @@ import { Content } from './elements';
 
 const Patron: React.FC = () => {
   const {
-    state: { user },
+    state: { hasLoadedApp, isLoggedIn, user },
     actions,
   } = useOvermind();
 
-  if (user && user.subscription && user.subscription.plan === 'pro') {
+  if (!isLoggedIn) {
     location.href = '/pro';
+  }
+  // don't send them away before authentication
+  if (hasLoadedApp && user) {
+    if (
+      !user.subscription || // if no subscription, get pro
+      user.subscription.plan !== 'patron' // if subscription but not patron, go to pro
+    ) {
+      location.href = '/pro';
+    }
   }
 
   useEffect(() => {

--- a/packages/app/src/app/pages/Sandbox/Editor/Header/Header.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Header/Header.tsx
@@ -7,7 +7,6 @@ import { UserMenu } from 'app/pages/common/UserMenu';
 import {
   SaveAllButton,
   RefreshButton,
-  PatronButton,
   PreferencesButton,
   NewSandboxButton,
   LikeButton,
@@ -37,7 +36,6 @@ export const Header: React.FC<IHeaderProps> = ({ zenMode }) => {
       preferences: {
         settings: { experimentVSCode: vscode },
       },
-      isPatron,
       updateStatus,
       hasLogIn,
       isLoggedIn,
@@ -65,7 +63,6 @@ export const Header: React.FC<IHeaderProps> = ({ zenMode }) => {
 
       <Right>
         {updateStatus === 'available' && <RefreshButton />}
-        {!isLoggedIn || (!isPatron && <PatronButton />)}
         {!isLoggedIn && <PreferencesButton />}
         <NewSandboxButton />
         {isLoggedIn && <LikeButton />}


### PR DESCRIPTION
Logic: 

```js
// not logged in, go to pro
if (!isLoggedIn) {
  location.href = '/pro';
}

// don't send them away before authentication
if (hasLoadedApp && user) {
  if (
    !user.subscription || // if no subscription, get pro
    user.subscription.plan !== 'patron' // if subscription but not patron, go to pro
  ) {
    location.href = '/pro';
  }
}
```