### PR TITLE
fix preview reload on history changes

### DIFF
--- a/packages/common/src/components/Preview/index.tsx
+++ b/packages/common/src/components/Preview/index.tsx
@@ -515,7 +515,6 @@ class BasePreview extends React.Component<Props, State> {
   commitUrl = (url: string, back: boolean, forward: boolean) => {
     this.setState({
       urlInAddressBar: url,
-      url,
       back,
       forward,
     });


### PR DESCRIPTION
When changing urls with "pushState" / "history" it does a refresh now. This PR fixes that. Tested using history and location. Location does full refresh, as it should, while history just changes the url.

This issue might have been introduced realted to `vscodeeffects` as some changes was necessary related to "smooth" forking. 