### PR TITLE
feat(dashboard): add option to delete template

### DIFF
--- a/packages/app/src/app/overmind/namespaces/dashboard/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/dashboard/actions.ts
@@ -75,7 +75,7 @@ export const deleteTemplate: AsyncAction<{
   templateId: string;
 }> = async ({ actions, effects }, { sandboxId, templateId }) => {
   try {
-    effects.analytics.track('Template - Removed', { source: 'editor' });
+    effects.analytics.track('Template - Removed', { source: 'Context Menu' });
     await effects.api.deleteTemplate(sandboxId, templateId);
     actions.modalClosed();
     effects.notificationToast.success('Template Deleted');

--- a/packages/app/src/app/overmind/namespaces/dashboard/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/dashboard/actions.ts
@@ -69,3 +69,17 @@ export const createSandboxClicked: AsyncAction<{
   sandboxId: string;
 }> = ({ actions }, { body, sandboxId }) =>
   actions.editor.forkExternalSandbox({ body, sandboxId });
+
+export const deleteTemplate: AsyncAction<{
+  sandboxId: string;
+  templateId: string;
+}> = async ({ actions, effects }, { sandboxId, templateId }) => {
+  try {
+    effects.analytics.track('Template - Removed', { source: 'editor' });
+    await effects.api.deleteTemplate(sandboxId, templateId);
+    actions.modalClosed();
+    effects.notificationToast.success('Template Deleted');
+  } catch (error) {
+    effects.notificationToast.error('Could not delete custom template');
+  }
+};

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Templates/Mine/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Templates/Mine/index.tsx
@@ -33,7 +33,7 @@ export const Templates = (props: TemplatesProps) => {
     },
   } = useOvermind();
   const { teamId } = props.match.params;
-  const { loading, error, data } = useQuery<
+  const { loading, error, data, refetch } = useQuery<
     ListTemplatesQuery,
     ListTemplatesQueryVariables
   >(LIST_OWNED_TEMPLATES, {
@@ -102,12 +102,12 @@ export const Templates = (props: TemplatesProps) => {
                 },
               ],
               {
-                title: `Delete template`,
+                title: `Delete Template`,
                 action: () => {
                   deleteTemplate({
                     sandboxId: template.sandbox.id,
                     templateId: template.id,
-                  });
+                  }).then(() => refetch());
                   return true;
                 },
                 color: theme.red.darken(0.2)(),

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Templates/Mine/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Templates/Mine/index.tsx
@@ -5,8 +5,10 @@ import { useQuery } from '@apollo/react-hooks';
 
 import { DelayedAnimation } from 'app/components/DelayedAnimation';
 import { ContextMenu } from 'app/components/ContextMenu';
+import { useOvermind } from 'app/overmind';
 import history from 'app/utils/history';
 import track from '@codesandbox/common/lib/utils/analytics';
+import theme from '@codesandbox/common/lib/theme';
 import { sandboxUrl } from '@codesandbox/common/lib/utils/url-generator';
 import CustomTemplate from '@codesandbox/common/lib/components/CustomTemplate';
 import { getSandboxName } from '@codesandbox/common/lib/utils/get-sandbox-name';
@@ -25,6 +27,11 @@ import { Navigation } from '../Navigation';
 type TemplatesProps = RouteComponentProps<{ teamId: string }> & {};
 
 export const Templates = (props: TemplatesProps) => {
+  const {
+    actions: {
+      dashboard: { deleteTemplate },
+    },
+  } = useOvermind();
   const { teamId } = props.match.params;
   const { loading, error, data } = useQuery<
     ListTemplatesQuery,
@@ -84,13 +91,26 @@ export const Templates = (props: TemplatesProps) => {
         {sortedTemplates.map((template, i) => (
           <ContextMenu
             items={[
+              [
+                {
+                  title: 'Convert to Sandbox',
+                  action: () => {
+                    track('Template - Removed', { source: 'Context Menu' });
+                    unmakeTemplates([template.sandbox.id], teamId);
+                    return true;
+                  },
+                },
+              ],
               {
-                title: 'Convert to Sandbox',
+                title: `Delete template`,
                 action: () => {
-                  track('Template - Removed', { source: 'Context Menu' });
-                  unmakeTemplates([template.sandbox.id], teamId);
+                  deleteTemplate({
+                    sandboxId: template.sandbox.id,
+                    templateId: template.id,
+                  });
                   return true;
                 },
+                color: theme.red.darken(0.2)(),
               },
             ]}
             key={template.id}


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?
Feature.
<!-- Is it a Bug fix, feature, docs update, ... -->

## What is the current behavior?
To delete a template, the user needs to open it first.
<!-- You can also link to an open issue here -->

## What is the new behavior?
There is a new option to delete a template from the dashboard.
<!-- if this is a feature change -->

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Create a template if you don't have any;
2. To go Dashboard > My templates;
3. Right-click a template and select `Delete Template`;
4. Verify that the template is removed and the dashboard is updated.

## Notes

The new action is very similar to `workspace.deleteTemplate` but without pulling data from the `state` and without updating the (opened) sandbox. Should I refactor and reuse that? I wouldn't like to but it's up to you.