### PR TITLE
Fix Bookmark button for non-signed in users by removing it

### DIFF
--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/items/NotOwnedSandboxInfo/NotOwnedSandboxInfo.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/items/NotOwnedSandboxInfo/NotOwnedSandboxInfo.tsx
@@ -10,7 +10,7 @@ import { WorkspaceItem } from '../../WorkspaceItem';
 export const NotOwnedSandboxInfo = () => {
   const [editActions, setEditActions] = useState(null);
   const {
-    state: { editor },
+    state: { editor, hasLogIn },
   } = useOvermind();
   const staticTemplate = editor.currentSandbox.template === 'static';
 
@@ -18,7 +18,9 @@ export const NotOwnedSandboxInfo = () => {
     <div style={{ marginTop: '1rem' }}>
       <Margin bottom={1.5}>
         <SandboxInfo sandbox={editor.currentSandbox} />
-        {editor.currentSandbox.customTemplate && <BookmarkTemplateButton />}
+        {editor.currentSandbox.customTemplate && hasLogIn && (
+          <BookmarkTemplateButton />
+        )}
       </Margin>
 
       <WorkspaceItem actions={editActions} defaultOpen title="Files">


### PR DESCRIPTION
In the future we'd have a modal saying you need to sign in to bookmark templates.