### PR TITLE
drop smooth forking on containers

### DIFF
--- a/packages/app/src/app/overmind/effects/vscode/ModelsHandler.ts
+++ b/packages/app/src/app/overmind/effects/vscode/ModelsHandler.ts
@@ -206,11 +206,12 @@ export class ModelsHandler {
 
     moduleModel.selections = userSelections;
 
-    if (!moduleModel.model) {
+    const model = await moduleModel.model;
+
+    if (!model) {
       return;
     }
 
-    const model = await moduleModel.model;
     const lines = model.getLinesContent() || [];
     const activeEditor = this.editorApi.getActiveCodeEditor();
 


### PR DESCRIPTION
Containers used smooth forking, though they would start up on first codechange. This was not ideal user experience and due to passing websocket messages to wrong instance until code change was made, it was decided to drop smooth forking on containers.