### PR TITLE
do smooth forking, but restart executor and refresh preview

### DIFF
--- a/packages/app/src/app/overmind/internalActions.ts
+++ b/packages/app/src/app/overmind/internalActions.ts
@@ -261,26 +261,7 @@ export const setCurrentSandbox: AsyncAction<Sandbox> = async (
   state.workspace.project.description = sandbox.description || '';
   state.workspace.project.alias = sandbox.alias || '';
 
-  await effects.executor.initializeExecutor(sandbox);
-
-  [
-    'connect',
-    'disconnect',
-    'sandbox:status',
-    'sandbox:start',
-    'sandbox:stop',
-    'sandbox:error',
-    'sandbox:log',
-    'sandbox:hibernate',
-    'sandbox:update',
-    'sandbox:port',
-    'shell:out',
-    'shell:exit',
-  ].forEach(message => {
-    effects.executor.listen(message, actions.server.onSSEMessage);
-  });
-
-  effects.executor.setupExecutor();
+  actions.server.startContainer(sandbox);
 };
 
 export const updateCurrentSandbox: AsyncAction<Sandbox> = async (

--- a/packages/app/src/app/overmind/namespaces/editor/internalActions.ts
+++ b/packages/app/src/app/overmind/namespaces/editor/internalActions.ts
@@ -360,6 +360,11 @@ export const forkSandbox: AsyncAction<{
     );
     effects.preview.updateAddressbarUrl();
 
+    if (templateDefinition.isServer) {
+      effects.preview.refresh();
+      actions.server.startContainer(forkedSandbox);
+    }
+
     if (state.workspace.openedWorkspaceItem === 'project-summary') {
       actions.workspace.openDefaultItem();
     }


### PR DESCRIPTION
Now we still do a smooth fork, but we fire up the executor on the forked sandbox and we refresh the preview so that we see the container fires up :)