### PR TITLE
Fix access to constructor on xorigin object

### DIFF
--- a/packages/codesandbox-api/src/protocol/protocol.ts
+++ b/packages/codesandbox-api/src/protocol/protocol.ts
@@ -2,9 +2,18 @@ const generateId = () =>
   // Such a random ID
   Math.floor(Math.random() * 1000000 + Math.random() * 1000000);
 
+const getConstructorName = (x: any) => {
+  try {
+    return x.constructor.name;
+  } catch(e) {
+    return '';
+  }
+};
+
 export default class Protocol {
   private outgoingMessages: Set<number> = new Set();
   private internalId: number;
+  private isWorker: boolean;
 
   constructor(
     private type: string,
@@ -13,6 +22,7 @@ export default class Protocol {
   ) {
     this.createConnection();
     this.internalId = generateId();
+    this.isWorker = getConstructorName(target) === 'Worker';
   }
 
   getTypeId() {
@@ -91,11 +101,11 @@ export default class Protocol {
 
   private _postMessage(m: any) {
     if (
-      this.target.constructor.name === 'Worker' ||
+      this.isWorker ||
       // @ts-ignore Unknown to TS
       (typeof DedicatedWorkerGlobalScope !== 'undefined' &&
         // @ts-ignore Unknown to TS
-        target instanceof DedicatedWorkerGlobalScope)
+        this.target instanceof DedicatedWorkerGlobalScope)
     ) {
       // @ts-ignore
       this.target.postMessage(m);


### PR DESCRIPTION
**How?**
It looks like in `protocol.ts` we need to send
different params to `postMessage` if the `target`
is a `Worker`...

There's probably a more polymorphic way to handle
all of this, but this commit implements a quick
and dirty function which returns a default value
if an error is thrown (i.e. a "SecurityError" in this case)

**References:**

- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Property_access_denied
- https://gitlab.com/gitlab-org/gitlab/issues/27144#note_258460537

<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?

Fixes https://github.com/codesandbox/codesandbox-client/issues/3173

## What is the current behavior?

It doesn't work in a xorigin iframe 😞 

![Screen Shot 2019-12-10 at 5 10 06 PM](https://user-images.githubusercontent.com/4908127/70582363-e9786700-1b7f-11ea-92d1-263ba5c04dac.png)

## What is the new behavior?

It works now 😄 

![Screen Shot 2019-12-10 at 5 11 16 PM](https://user-images.githubusercontent.com/4908127/70582367-eda48480-1b7f-11ea-84d9-d32c6ac4b784.png)

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Make the change
2. Rebuild the assets necessary for self-hosted code sandbox
3. Start a simple web server with built assets

## Checklist

- [ ] Documentation
- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
