### PR TITLE
Fix renaming forked sandboxes

### DIFF
--- a/packages/app/src/app/overmind/namespaces/editor/internalActions.ts
+++ b/packages/app/src/app/overmind/namespaces/editor/internalActions.ts
@@ -351,6 +351,10 @@ export const forkSandbox: AsyncAction<{
       });
     }
 
+    state.workspace.project.title = forkedSandbox.title;
+    state.workspace.project.alias = forkedSandbox.alias;
+    state.workspace.project.description = forkedSandbox.description;
+
     Object.assign(
       state.editor.sandboxes[state.editor.currentId],
       forkedSandbox

--- a/packages/app/src/app/overmind/namespaces/editor/internalActions.ts
+++ b/packages/app/src/app/overmind/namespaces/editor/internalActions.ts
@@ -351,9 +351,9 @@ export const forkSandbox: AsyncAction<{
       });
     }
 
-    state.workspace.project.title = forkedSandbox.title;
-    state.workspace.project.alias = forkedSandbox.alias;
-    state.workspace.project.description = forkedSandbox.description;
+    state.workspace.project.title = forkedSandbox.title || '';
+    state.workspace.project.description = forkedSandbox.description || '';
+    state.workspace.project.alias = forkedSandbox.alias || '';
 
     Object.assign(
       state.editor.sandboxes[state.editor.currentId],

--- a/packages/app/src/app/overmind/namespaces/workspace/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/workspace/actions.ts
@@ -106,31 +106,15 @@ export const sandboxInfoUpdated: AsyncAction = withOwnedSandbox(
 
       effects.analytics.track(`Sandbox - Update ${event}`);
 
-      const payload: {
-        title?: string;
-        description?: string;
-        alias?: string;
-      } = {};
+      sandbox.title = project.title;
+      sandbox.description = project.description;
+      sandbox.alias = project.alias;
 
-      if (hasChangedTitle) {
-        payload.title = project.title;
-        sandbox.title = project.title;
-      }
-
-      if (hasChangedDescription) {
-        payload.description = project.description;
-        sandbox.description = project.description;
-      }
-
-      if (hasChangedAlias) {
-        payload.alias = project.alias;
-        sandbox.alias = project.alias;
-      }
-
-      const updatedSandbox = await effects.api.updateSandbox(
-        sandbox.id,
-        payload
-      );
+      const updatedSandbox = await effects.api.updateSandbox(sandbox.id, {
+        title: project.title,
+        description: project.description,
+        alias: project.alias,
+      });
 
       effects.router.replaceSandboxUrl(updatedSandbox);
 

--- a/packages/app/src/app/overmind/namespaces/workspace/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/workspace/actions.ts
@@ -106,15 +106,31 @@ export const sandboxInfoUpdated: AsyncAction = withOwnedSandbox(
 
       effects.analytics.track(`Sandbox - Update ${event}`);
 
-      sandbox.title = project.title;
-      sandbox.description = project.description;
-      sandbox.alias = project.alias;
+      const payload: {
+        title?: string;
+        description?: string;
+        alias?: string;
+      } = {};
 
-      const updatedSandbox = await effects.api.updateSandbox(sandbox.id, {
-        title: project.title,
-        description: project.description,
-        alias: project.alias,
-      });
+      if (hasChangedTitle) {
+        payload.title = project.title;
+        sandbox.title = project.title;
+      }
+
+      if (hasChangedDescription) {
+        payload.description = project.description;
+        sandbox.description = project.description;
+      }
+
+      if (hasChangedAlias) {
+        payload.alias = project.alias;
+        sandbox.alias = project.alias;
+      }
+
+      const updatedSandbox = await effects.api.updateSandbox(
+        sandbox.id,
+        payload
+      );
 
       effects.router.replaceSandboxUrl(updatedSandbox);
 


### PR DESCRIPTION
Fixes #3175

When renaming a sandbox users would get an error saying "alias has already been taken", which is thrown because we send an alias that has been taken in the payload.

I thought to resolve this by conditionally adding title, description and alias to the payload based on whether they were changed, but there was another issue that arose from this.

After a fork we don't set the `project` fields to the forked sandbox, so we always think that the alias changed when changing the name of a sandbox. I updated this too.