### PR TITLE
Improve React DevTools Implementation

### DIFF
--- a/packages/app/src/app/components/Preview/DevTools/React-Devtools/elements.ts
+++ b/packages/app/src/app/components/Preview/DevTools/React-Devtools/elements.ts
@@ -8,6 +8,12 @@ export const Container = styled.div`
   color: ${props =>
     props.theme['editor.foreground'] || 'rgba(255, 255, 255, 0.8)'};
 
+  /* do not show button because it doesn't work */
+  button[class^='ToggleOff___'],
+  button[class^='ToggleOff___'] + div {
+    display: none;
+  }
+
   * {
     box-sizing: border-box;
     -webkit-font-smoothing: var(--font-smoothing);

--- a/packages/app/src/app/components/Preview/DevTools/React-Devtools/elements.ts
+++ b/packages/app/src/app/components/Preview/DevTools/React-Devtools/elements.ts
@@ -8,12 +8,6 @@ export const Container = styled.div`
   color: ${props =>
     props.theme['editor.foreground'] || 'rgba(255, 255, 255, 0.8)'};
 
-  /* do not show button because it doesn't work */
-  button[class^='ToggleOff___'],
-  button[class^='ToggleOff___'] + div {
-    display: none;
-  }
-
   * {
     box-sizing: border-box;
     -webkit-font-smoothing: var(--font-smoothing);

--- a/packages/common/src/templates/helpers/react-template.ts
+++ b/packages/common/src/templates/helpers/react-template.ts
@@ -1,0 +1,21 @@
+import Template, { ViewConfig } from '../template';
+
+export class ReactTemplate extends Template {
+  getViews(): ViewConfig[] {
+    const REACT_VIEWS: ViewConfig[] = [
+      {
+        views: [{ id: 'codesandbox.browser' }, { id: 'codesandbox.tests' }],
+      },
+      {
+        open: true,
+        views: [
+          { id: 'codesandbox.console' },
+          { id: 'codesandbox.problems' },
+          { id: 'codesandbox.react-devtools' },
+        ],
+      },
+    ];
+
+    return REACT_VIEWS;
+  }
+}

--- a/packages/common/src/templates/react-ts.ts
+++ b/packages/common/src/templates/react-ts.ts
@@ -1,9 +1,9 @@
+import { decorateSelector } from '../utils/decorate-selector';
+import { ReactTemplate } from './helpers/react-template';
+
 import configurations from './configuration';
 
-import Template from './template';
-import { decorateSelector } from '../utils/decorate-selector';
-
-export default new Template(
+export default new ReactTemplate(
   'create-react-app-typescript',
   'React + TS',
   'https://github.com/wmonk/create-react-app-typescript',

--- a/packages/common/src/templates/react.ts
+++ b/packages/common/src/templates/react.ts
@@ -1,9 +1,9 @@
-import Template from './template';
 import { decorateSelector } from '../utils/decorate-selector';
 
 import configurations from './configuration';
+import { ReactTemplate } from './helpers/react-template';
 
-export default new Template(
+export default new ReactTemplate(
   'create-react-app',
   'React',
   'https://github.com/facebookincubator/create-react-app',

--- a/packages/common/src/templates/template.ts
+++ b/packages/common/src/templates/template.ts
@@ -69,12 +69,6 @@ const CLIENT_VIEWS: ViewConfig[] = [
   },
 ];
 
-// React sandboxes have an additional devtool on top of CLIENT_VIEWS
-const REACT_CLIENT_VIEWS: ViewConfig[] = JSON.parse(
-  JSON.stringify(CLIENT_VIEWS)
-);
-REACT_CLIENT_VIEWS[1].views.push({ id: 'codesandbox.react-devtools' });
-
 const SERVER_VIEWS: ViewConfig[] = [
   {
     views: [{ id: 'codesandbox.browser' }],
@@ -206,16 +200,6 @@ export default class Template {
     if (this.isServer) {
       return SERVER_VIEWS;
     }
-
-    const dependencies =
-      configurationFiles.package &&
-      configurationFiles.package.parsed &&
-      configurationFiles.package.parsed.dependencies;
-
-    if (dependencies && dependencies.react) {
-      return REACT_CLIENT_VIEWS;
-    }
-
     return CLIENT_VIEWS;
   }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Code Improvment

## What is the current behavior?

The devtools will open in anything that has react with some pretty shady code even though it doesn't work in server sandboxes

## What is the new behavior?

Create a React Template where I extend from to add to react and react-ts
Also remove inpespect button with css as it does not work as mentioned in the beggining

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Opened React Template
2. Open React + TS
3. Open several others to make sure it wasn't there

