### PR TITLE
Rename Explore Templates to Template Universe

### DIFF
--- a/packages/app/src/app/components/CreateNewSandbox/CreateSandbox/Explore/Explore.tsx
+++ b/packages/app/src/app/components/CreateNewSandbox/CreateSandbox/Explore/Explore.tsx
@@ -46,7 +46,7 @@ export const Explore = () => {
   return (
     <>
       <Header>
-        <span>Explore Templates</span>
+        <span>Template Universe</span>
         <div>
           <SearchBox
             onChange={evt => setSearch(evt.target.value)}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Text update.

## What is the current behavior?

Explore Templates was confusing to people, while we have been communicating Template Universe.

## What is the new behavior?

Communicate Template Universe in create sandbox modal.

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

Not tested and unsure if I edited the correct span. AMA and mea culpa.

## Checklist

Idem.
