### PR TITLE
Update user type, increase API perf

### DIFF
--- a/packages/common/src/types/index.ts
+++ b/packages/common/src/types/index.ts
@@ -188,15 +188,13 @@ export type User = {
   sandboxCount: number;
   givenLikeCount: number;
   receivedLikeCount: number;
-  currentModuleShortid: string;
   viewCount: number;
   forkedCount: number;
   sandboxes: PaginatedSandboxes;
   likedSandboxes: PaginatedSandboxes;
   badges: Badge[];
   topSandboxes: SmallSandbox[];
-  subscriptionSince: string;
-  selection: Selection | null;
+  subscriptionSince: string | null;
 };
 
 export type LiveUser = {
@@ -291,6 +289,15 @@ export type PickedSandboxDetails = {
   title: string;
 };
 
+export type SandboxAuthor = {
+  id: string;
+  username: string;
+  name: string;
+  avatarUrl: string;
+  badges: Badge[];
+  subscriptionSince: string | null;
+};
+
 export type Sandbox = {
   id: string;
   alias: string | null;
@@ -325,7 +332,7 @@ export type Sandbox = {
   } | null;
   roomId: string | null;
   privacy: 0 | 1 | 2;
-  author: User | null;
+  author: SandboxAuthor | null;
   forkedFromSandbox: ForkedSandbox | null;
   git: GitInfo | null;
   tags: string[];


### PR DESCRIPTION
After doing some profiling on our API calls (especially forking and showing sandboxes) I found out that the majority of the time is spent on rendering the author of a sandbox. This is because for the author we do some expensive computations, like counting the total fork count and like count, but also rendering up to 5 sandboxes for the top sandboxes.

I think this is unnecessary for the `author` field, so I propose with this PR to remove a bunch of fields from `sandbox.author` so that we can have much faster API calls. I think we will really shave ~50% response time when doing this change.