### PR TITLE
Prepare imgbot and ignore image_snapshots

### DIFF
--- a/.imgbotconfig
+++ b/.imgbotconfig
@@ -1,0 +1,5 @@
+{
+  "ignoredFiles": [
+    "**/__image_snapshots__/**"
+  ]
+}


### PR DESCRIPTION
This PR is in preparation of adding [`imgbot`](https://imgbot.net).

Like @SaraVieira [suggested](https://github.com/codesandbox/codesandbox-client/pull/3137#issuecomment-562973518), I ignored the `test_snapshots` like described in https://imgbot.net/docs/#ignoring-files

@CompuIves After merging in this PR, you only need to add the bot to this repo (or just the whole organization) and the bot will automatically create PRs like #3137