### PR TITLE
Remove sandbox service worker

### DIFF
--- a/packages/app/config/webpack.prod.js
+++ b/packages/app/config/webpack.prod.js
@@ -12,6 +12,7 @@ const ManifestPlugin = require('webpack-manifest-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const VERSION = require('@codesandbox/common/lib/version').default;
 // const childProcess = require('child_process');
+const RemoveServiceWorkerPlugin = require('webpack-remove-serviceworker-plugin');
 const commonConfig = require('./webpack.common');
 
 const publicPath = '/';
@@ -201,143 +202,6 @@ module.exports = merge(commonConfig, {
         },
       ],
     }),
-    // Generate a service worker script that will precache, and keep up to date,
-    // the HTML & assets that are part of the Webpack build.
-    new SWPrecacheWebpackPlugin({
-      // By default, a cache-busting query parameter is appended to requests
-      // used to populate the caches, to ensure the responses are fresh.
-      // If a URL is already hashed by Webpack, then there is no concern
-      // about it being stale, and the cache-busting can be skipped.
-      dontCacheBustUrlsMatching: /\.\w{8}\./,
-      filename: 'sandbox-service-worker.js',
-      cacheId: 'code-sandbox-sandbox',
-      logger(message) {
-        if (message.indexOf('Total precache size is') === 0) {
-          // This message occurs for every build and is a bit too noisy.
-          return;
-        }
-        if (message.indexOf('Skipping static resource') === 0) {
-          // This message obscures real errors so we ignore it.
-          // https://github.com/facebookincubator/create-react-app/issues/2612
-          return;
-        }
-        // eslint-disable-next-line no-console
-        console.log(message);
-      },
-      minify: true,
-      // For unknown URLs, fallback to the index page
-      navigateFallback: 'https://new.codesandbox.io/frame.html',
-      staticFileGlobs: process.env.SANDBOX_ONLY
-        ? ['www/index.html']
-        : ['www/frame.html'],
-      stripPrefix: 'www/',
-      // Ignores URLs starting from /__ (useful for Firebase):
-      // https://github.com/facebookincubator/create-react-app/issues/2237#issuecomment-302693219
-      navigateFallbackWhitelist: [/^(?!\/__).*/],
-      // Don't precache sourcemaps (they're large) and build asset manifest:
-      staticFileGlobsIgnorePatterns: [/\.map$/, /asset-manifest\.json$/],
-      maximumFileSizeToCacheInBytes: 1024 * 1024 * 20, // 20mb
-      runtimeCaching: [
-        {
-          urlPattern: /api\/v1\/sandboxes/,
-          handler: 'networkFirst',
-          options: {
-            cache: {
-              maxEntries: 50,
-              name: 'sandboxes-cache',
-            },
-          },
-        },
-        {
-          urlPattern: /api\/v1\/dependencies/,
-          handler: 'fastest',
-          options: {
-            cache: {
-              maxAgeSeconds: 60 * 60 * 24,
-              name: 'dependency-version-cache',
-            },
-          },
-        },
-        {
-          // These should be dynamic, since it's not loaded from this domain
-          // But from the root domain
-          urlPattern: /codesandbox\.io\/static\/js\//,
-          handler: 'fastest',
-          options: {
-            cache: {
-              // A day
-              maxAgeSeconds: 60 * 60 * 24,
-              name: 'static-root-cache',
-            },
-          },
-        },
-        {
-          urlPattern: /\.amazonaws\.com\/prod\/package/,
-          handler: 'fastest',
-          options: {
-            cache: {
-              // a week
-              maxAgeSeconds: 60 * 60 * 24 * 7,
-              name: 'dependency-url-generator-cache',
-            },
-          },
-        },
-        {
-          urlPattern: /prod-packager-packages\.csb\.dev/,
-          handler: 'fastest',
-          options: {
-            cache: {
-              maxAgeSeconds: 60 * 60 * 24 * 7,
-              name: 'dependency-files-cache',
-            },
-          },
-        },
-        {
-          urlPattern: /^https:\/\/unpkg\.com/,
-          handler: 'cacheFirst',
-          options: {
-            cache: {
-              maxEntries: 300,
-              name: 'unpkg-dep-cache',
-              maxAgeSeconds: 60 * 60 * 24 * 7,
-            },
-          },
-        },
-        {
-          urlPattern: /^https:\/\/cdn\.rawgit\.com/,
-          handler: 'cacheFirst',
-          options: {
-            cache: {
-              maxEntries: 300,
-              name: 'rawgit-cache',
-              maxAgeSeconds: 60 * 60 * 24 * 7,
-            },
-          },
-        },
-        {
-          urlPattern: /jsdelivr\.(com|net)/,
-          handler: 'cacheFirst',
-          options: {
-            cache: {
-              maxEntries: 300,
-              name: 'jsdelivr-dep-cache',
-              maxAgeSeconds: 60 * 60 * 24 * 7,
-            },
-          },
-        },
-        {
-          urlPattern: /cloudflare\.com/,
-          handler: 'cacheFirst',
-          options: {
-            cache: {
-              maxEntries: 50,
-              name: 'cloudflare-cache',
-              maxAgeSeconds: 60 * 60 * 24 * 7,
-            },
-          },
-        },
-      ],
-    }),
     // Moment.js is an extremely popular library that bundles large locale files
     // by default due to how Webpack interprets its code. This is a practical
     // solution that requires the user to opt into importing specific locales.
@@ -359,6 +223,7 @@ module.exports = merge(commonConfig, {
         quality: '95-100',
       },
     }),
+    new RemoveServiceWorkerPlugin({ filename: 'sandbox-service-worker.js' }),
     // isMaster &&
     //   new SentryWebpackPlugin({
     //     include: 'src',

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -334,6 +334,7 @@
     "webpack-dev-server": "^3.7.2",
     "webpack-manifest-plugin": "^2.0.3",
     "webpack-merge": "^4.1.0",
+    "webpack-remove-serviceworker-plugin": "^1.0.0",
     "webpackbar": "^3.2.0",
     "whatwg-fetch": "^2.0.3",
     "workbox-webpack-plugin": "^3.6.3",

--- a/packages/app/src/sandbox/index.js
+++ b/packages/app/src/sandbox/index.js
@@ -3,7 +3,6 @@ import { isStandalone, listen, dispatch } from 'codesandbox-api';
 import { activate, initialize } from 'react-devtools-inline/backend';
 import _debug from '@codesandbox/common/lib/utils/debug';
 
-import registerServiceWorker from '@codesandbox/common/lib/registerServiceWorker';
 import requirePolyfills from '@codesandbox/common/lib/load-dynamic-polyfills';
 import { getModulePath } from '@codesandbox/common/lib/sandbox/modules';
 import { generateFileFromSandbox } from '@codesandbox/common/lib/templates/configuration/package-json';
@@ -30,8 +29,6 @@ export const SCRIPT_VERSION =
 debug('Booting sandbox');
 
 requirePolyfills().then(() => {
-  registerServiceWorker('/sandbox-service-worker.js', {});
-
   function sendReady() {
     dispatch({ type: 'initialized' });
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -29064,6 +29064,11 @@ webpack-merge@^4.1.0:
   dependencies:
     lodash "^4.17.5"
 
+webpack-remove-serviceworker-plugin@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/webpack-remove-serviceworker-plugin/-/webpack-remove-serviceworker-plugin-1.0.0.tgz#63a7604da9a7fd9bae8f9eef87d274a2470dcaa7"
+  integrity sha1-Y6dgTamn/Zuuj57vh9J0okcNyqc=
+
 webpack-sources@1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.3.0.tgz#2a28dcb9f1f45fe960d8f1493252b5ee6530fa85"


### PR DESCRIPTION
After handling a bug report in sandboxes that was related to another service worker that didn't update I decided that it would be worth looking into removing the service worker, for sandboxes in this case.

I don't think that we need service workers in a sandbox because:

1. They often don't need to be offline available
2. The performance improvements are not there, because:
  a. Every request (unpkg) is cached to disk anyway
  b. The cache of the sandbox is on the html, which is not loaded because of the service worker if it's cached. We could argue that the sandbox would speed up without service worker

This will also be less obnoxious for developers, when they look in their App tab, they will see a massive amount of service workers registered for sandboxes, since every sandbox registers its own service worker.

The advantage is that:

1. Sandboxes might speed up
2. Less bugs because of version differences/no cache availability
3. Sandboxes take less cache storage

Disadvantages:

1. You can't install a sandbox as an app (but people can add this in user code)
2. When there's no network connection the sandbox won't load

Still want to do a bit of testing on this, see if the performance gets affected.