### PR TITLE
Make description an h2

### DIFF
--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/items/NotOwnedSandboxInfo/elements.ts
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/items/NotOwnedSandboxInfo/elements.ts
@@ -3,7 +3,7 @@ import BaseQuestion from 'react-icons/lib/go/question';
 import { Link } from 'react-router-dom';
 
 export const Container = styled.div`
-  font-family: Inter;
+  font-family: 'Inter', sans-serif;
   margin: 0 1rem;
   margin-bottom: 1rem;
 `;
@@ -30,7 +30,7 @@ export const Environment = styled.a`
   }
 `;
 
-export const Description = styled.p`
+export const Description = styled.h2`
   font-weight: 300;
   font-size: 13px;
   color: ${props => props.theme['editor.foreground']};


### PR DESCRIPTION
Better for SEO, now shows like this (the same):

![image](https://user-images.githubusercontent.com/587016/71016052-dff97c80-20f4-11ea-8cd3-f22727d52578.png)
