### PR TITLE
fix: new directory input validation

### DIFF
--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/Files/DirectoryEntry/Entry/EntryTitleInput/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/Files/DirectoryEntry/Entry/EntryTitleInput/index.tsx
@@ -63,6 +63,7 @@ export const EntryTitleInput: FunctionComponent<Props> = ({
         onBlur={() => onCommit(currentValue, true)}
         onKeyUp={handleKeyUp}
         ref={select}
+        autoComplete="new-directory"
         value={currentValue}
         id={`input-${id}`}
         aria-invalid={Boolean(error)}

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/Files/DirectoryEntry/validateTitle.js
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/Files/DirectoryEntry/validateTitle.js
@@ -1,8 +1,11 @@
 export default (id, title, siblings = []) => {
   if (title.length === 0) return 'Title cannot be empty';
-  if (/^[09azAZ_.]+$/.test(title)) {
+  if (title.includes(' ')) {
     // It has whitespaces
-    return 'Title cannot have whitespaces or special characters';
+    return 'Title cannot have whitespaces';
+  }
+  if (/[!@#$%^&*(),.?":{}|<>]/g.test(title)) {
+    return 'Title cannot have special characters';
   }
 
   if (title.length > 32) {


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?
Bug Fix
<!-- Is it a Bug fix, feature, docs update, ... -->

## What is the current behavior?
- Chrome autocomplete shows up
- Typing `a` or `A` gives an error
- Added more special characters ( Not sure if it is needed )
- On putting, whitespaces error is not shown

![Kapture 2019-12-21 at 12 21 37](https://user-images.githubusercontent.com/22376783/71304503-c0f93400-23ed-11ea-808c-5ad08bc9f12a.gif)


<!-- You can also link to an open issue here -->

## What is the new behavior?
- Disable chrome autocomplete
- Fixed regex for special characters
- Whitespace checks

![Kapture 2019-12-21 at 12 22 53](https://user-images.githubusercontent.com/22376783/71304507-c787ab80-23ed-11ea-848b-d7136bef27c1.gif)

<!-- if this is a feature change -->

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Tested locally by checking all condition

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
