### PR TITLE
upgrade template-icons to 1.1.0 for tailwind

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -74,7 +74,7 @@
     "@babel/plugin-transform-destructuring": "^7.5.0",
     "@babel/preset-env": "^7.5.5",
     "@codesandbox/executors": "^0.1.0",
-    "@codesandbox/template-icons": "^1.0.2",
+    "@codesandbox/template-icons": "^1.1.0",
     "@emmetio/codemirror-plugin": "^0.3.5",
     "@sentry/webpack-plugin": "^1.8.0",
     "@styled-system/css": "^5.0.23",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -46,7 +46,7 @@
     "@babel/plugin-transform-flow-strip-types": "^7.0.0",
     "@babel/polyfill": "^7.4.4",
     "@codesandbox/notifications": "^1.0.6",
-    "@codesandbox/template-icons": "^1.0.2",
+    "@codesandbox/template-icons": "^1.1.0",
     "@sentry/browser": "^5.9.0",
     "@styled-system/css": "^5.0.23",
     "@tippy.js/react": "^3.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1187,11 +1187,6 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@codesandbox/template-icons@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@codesandbox/template-icons/-/template-icons-1.0.2.tgz#9471002b5d05b3782f893138e0fc6ee5469dd879"
-  integrity sha512-pYN5g2U6QygS168qDrgKbCFPa9ITBUACt1zpdmTZHktJi14o+pLqy1CJct41UQP6ovdL1XFL00hpPpp0qfJ0gw==
-
 "@codesandbox/template-icons@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@codesandbox/template-icons/-/template-icons-1.1.0.tgz#ef37b97dc6057b63a500c6710fbca5f9c7a9730d"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1192,6 +1192,11 @@
   resolved "https://registry.yarnpkg.com/@codesandbox/template-icons/-/template-icons-1.0.2.tgz#9471002b5d05b3782f893138e0fc6ee5469dd879"
   integrity sha512-pYN5g2U6QygS168qDrgKbCFPa9ITBUACt1zpdmTZHktJi14o+pLqy1CJct41UQP6ovdL1XFL00hpPpp0qfJ0gw==
 
+"@codesandbox/template-icons@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@codesandbox/template-icons/-/template-icons-1.1.0.tgz#ef37b97dc6057b63a500c6710fbca5f9c7a9730d"
+  integrity sha512-p14rcYOSfI1A6UkFO/aS+H/cuJvlVT4bLpjCEt7kv+KCFaRjd70FDEzfyKLHH/s57k0W2MWrhB25fqPZm89OXg==
+
 "@csstools/convert-colors@^1.4.0":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@csstools/convert-colors/-/convert-colors-1.4.0.tgz#ad495dc41b12e75d588c6db8b9834f08fa131eb7"


### PR DESCRIPTION
Part of the work to add an official tailwind template: https://codesandbox.io/s/tailwind-css-playground-kkkzc