### PR TITLE
Prevent clearing logs in development

### DIFF
--- a/packages/common/src/components/Preview/index.tsx
+++ b/packages/common/src/components/Preview/index.tsx
@@ -414,7 +414,11 @@ class BasePreview extends React.Component<Props, State> {
     const { settings } = this.props;
     const { sandbox } = this.props;
 
-    if (settings.clearConsoleEnabled && !this.serverPreview) {
+    if (
+      process.env.NODE_ENV !== 'development' &&
+      settings.clearConsoleEnabled &&
+      !this.serverPreview
+    ) {
       // @ts-ignore Chrome behaviour
       console.clear('__internal__'); // eslint-disable-line no-console
       dispatch({ type: 'clear-console' });


### PR DESCRIPTION
It is super annoying in development that clearing the console causes Chrome to loose its insight into objects that are logged out, even though "prevent clearing log" is set in the chrome devtools. This should fix it.