### PR TITLE
Fix default opened files in parcel

### DIFF
--- a/packages/app/src/app/overmind/internalActions.ts
+++ b/packages/app/src/app/overmind/internalActions.ts
@@ -183,7 +183,8 @@ export const setCurrentSandbox: AsyncAction<Sandbox> = async (
   state.editor.mainModuleShortid = main.shortid;
 
   // Only change the module shortid if it doesn't exist in the new sandbox
-  // What is the scenario here?
+  // This can happen when a sandbox is opened that's different from the current
+  // sandbox, with completely different files
   if (
     !sandbox.modules.find(module => module.shortid === currentModuleShortid)
   ) {

--- a/packages/common/src/templates/parcel.ts
+++ b/packages/common/src/templates/parcel.ts
@@ -31,11 +31,13 @@ export class ParcelTemplate extends Template {
    * The file to open by the editor
    */
   getDefaultOpenedFiles(configFiles) {
-    const entries = [];
+    let entries = [];
 
     entries.push('/index.js');
     entries.push('/src/index.js');
-    entries.concat(this.getEntries(configFiles));
+    entries.push('/index.ts');
+    entries.push('/src/index.ts');
+    entries = entries.concat(this.getEntries(configFiles));
 
     return entries;
   }


### PR DESCRIPTION
Fixes #3262

Tested by opening that sandbox, and /s/vanilla to see if anything changed.

The problem was that we didn't reassign entries with the concat.