### PR TITLE
Fix upload error

### DIFF
--- a/packages/app/src/app/overmind/namespaces/files/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/files/actions.ts
@@ -427,12 +427,16 @@ export const filesUploaded: AsyncAction<{
       });
     } catch (error) {
       if (error.message.indexOf('413') !== -1) {
-        return;
+        actions.internal.handleError({
+          message: `The uploaded file is bigger than 7MB, contact hello@codesandbox.io if you want to raise this limit`,
+          error,
+        });
+      } else {
+        actions.internal.handleError({
+          message: 'Unable to upload files',
+          error,
+        });
       }
-      actions.internal.handleError({
-        message: 'Unable to upload files',
-        error,
-      });
     }
 
     actions.internal.closeModals(false);


### PR DESCRIPTION
We now show the right error for uploaded files if the file is larger than 7MB.