### PR TITLE
Fix typo on search page

### DIFF
--- a/packages/app/src/app/pages/Search/Filters/index.js
+++ b/packages/app/src/app/pages/Search/Filters/index.js
@@ -23,7 +23,7 @@ const Filters = () => (
     <Filter
       attributeName="template"
       operator="or"
-      title="Enviroment"
+      title="Environment"
       transformItems={items =>
         items.map(({ label, ...item }) => {
           const { name, niceName } = getTemplate(label);


### PR DESCRIPTION
Fixes typo in the environment sub-header on the search page
