### PR TITLE
🔨 Switch Preview to use useOvermind

### DIFF
--- a/packages/app/src/app/overmind/namespaces/editor/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/editor/actions.ts
@@ -571,9 +571,10 @@ export const toggleEditorPreviewLayout: Action = ({ state, effects }) => {
   effects.vscode.resetLayout();
 };
 
-export const previewActionReceived: Action<{
-  action: any;
-}> = ({ state, effects, actions }, { action }) => {
+export const previewActionReceived: Action<any> = (
+  { actions, effects, state },
+  action
+) => {
   switch (action.action) {
     case 'notification':
       effects.notificationToast.add({


### PR DESCRIPTION
Follow-up of #2638

Things I did extra:
- Change `previewActionReceived`'s signature to accept `any ` instead of `{ action: any }`, because it only has 1 argument
- Use `FunctionComponent` instead of `React.FC`, since [it's the same](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/f13238a5d2086cd87f3209704f8897f7f701d957/types/react/index.d.ts#L513), but `FunctionComponent` is a bit clearer I think
- use `ServerContainerStatus` enum instead of string values