### PR TITLE
Add noindex to search page

### DIFF
--- a/packages/app/src/app/pages/Search/index.tsx
+++ b/packages/app/src/app/pages/Search/index.tsx
@@ -83,7 +83,7 @@ export const Search: FunctionComponent<Props> = ({ history, location }) => {
     <Container>
       <Helmet>
         <title>Search - CodeSandbox</title>
-        <meta name="robots" content="noindex, nofollow">
+        <meta name="robots" content="noindex, nofollow" />
       </Helmet>
 
       <Styles />

--- a/packages/app/src/app/pages/Search/index.tsx
+++ b/packages/app/src/app/pages/Search/index.tsx
@@ -83,6 +83,7 @@ export const Search: FunctionComponent<Props> = ({ history, location }) => {
     <Container>
       <Helmet>
         <title>Search - CodeSandbox</title>
+        <meta name="robots" content="noindex, nofollow">
       </Helmet>
 
       <Styles />


### PR DESCRIPTION
Landing on search page results from a Google search is a poor experience, and Google is struggling to crawl the search pages properly resulting in some weird search results. This change prevents Google from indexing and crawling this page.

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.
https://pr3293.build.csb.dev/search lgtm!
