### PR TITLE
Always favor 'module' over 'main'

### DIFF
--- a/packages/app/src/sandbox/eval/utils/resolve-utils.js
+++ b/packages/app/src/sandbox/eval/utils/resolve-utils.js
@@ -1,6 +1,5 @@
-export function packageFilter(p: Object) {
-  if (!p.main && p.module) {
-    // eslint-disable-next-line
+export function packageFilter(p) {
+  if (p.module) {
     p.main = p.module;
   }
 


### PR DESCRIPTION
This PR matches [`webpack` resolving behavior](https://webpack.js.org/configuration/resolve/#resolvemainfields), which always favors `module` over `main`.

Fixes #3305 .
