### PR TITLE
🔨 Switch SearchDependenciesModal to use useOvermind

### DIFF
--- a/packages/app/src/app/pages/common/Modals/SearchDependenciesModal.tsx
+++ b/packages/app/src/app/pages/common/Modals/SearchDependenciesModal.tsx
@@ -1,18 +1,18 @@
-import React from 'react';
+import React, { FunctionComponent } from 'react';
+
 import { useOvermind } from 'app/overmind';
 import SearchDependencies from 'app/pages/Sandbox/SearchDependencies';
 
-function SearchDependenciesModal() {
+export const SearchDependenciesModal: FunctionComponent = () => {
   const {
     actions: {
       editor: { addNpmDependency },
     },
   } = useOvermind();
+
   return (
     <SearchDependencies
       onConfirm={(name, version) => addNpmDependency({ name, version })}
     />
   );
-}
-
-export default SearchDependenciesModal;
+};

--- a/packages/app/src/app/pages/common/Modals/index.tsx
+++ b/packages/app/src/app/pages/common/Modals/index.tsx
@@ -27,7 +27,7 @@ import { NetlifyLogs } from './NetlifyLogs';
 import { PickSandboxModal } from './PickSandboxModal';
 import PreferencesModal from './PreferencesModal';
 import PRModal from './PRModal';
-import SearchDependenciesModal from './SearchDependenciesModal';
+import { SearchDependenciesModal } from './SearchDependenciesModal';
 import { SelectSandboxModal } from './SelectSandboxModal';
 import { ShareModal } from './ShareModal';
 import SignInForTemplates from './SignInForTemplates';


### PR DESCRIPTION
Follow-up of #2747

Things I did extra:
- Make `SearchDependenciesModal` a `FunctionComponent`
- Export `SearchDependenciesModal` by a named export  instead of a `default export`