### PR TITLE
Make GitHub import errors more descriptive

### DIFF
--- a/packages/app/src/app/overmind/namespaces/editor/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/editor/actions.ts
@@ -100,7 +100,11 @@ export const sandboxChanged: AsyncAction<{ id: string }> = withLoadApp<{
     actions.workspace.openDefaultItem();
   } catch (error) {
     state.editor.notFound = true;
-    state.editor.error = error.message;
+    let detail = error.response?.data?.errors?.detail;
+    if (Array.isArray(detail)) {
+      detail = detail[0];
+    }
+    state.editor.error = detail || error.message;
     state.editor.isLoading = false;
     return;
   }

--- a/packages/app/src/app/pages/Sandbox/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/index.tsx
@@ -77,7 +77,7 @@ export const Sandbox: React.FC<Props> = ({ match }) => {
             Something went wrong
           </div>
           <Title style={{ fontSize: '1.25rem', marginBottom: 0 }}>
-            {state.editor.error}
+            Error importing GitHub repository: {state.editor.error}
           </Title>
           <br />
           <div style={{ display: 'flex', maxWidth: 400, width: '100%' }}>

--- a/packages/app/src/app/pages/Sandbox/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/index.tsx
@@ -77,7 +77,8 @@ export const Sandbox: React.FC<Props> = ({ match }) => {
             Something went wrong
           </div>
           <Title style={{ fontSize: '1.25rem', marginBottom: 0 }}>
-            Error importing GitHub repository: {state.editor.error}
+            {isGithub ? 'Error importing GitHub repository: ' : ''}
+            {state.editor.error}
           </Title>
           <br />
           <div style={{ display: 'flex', maxWidth: 400, width: '100%' }}>


### PR DESCRIPTION
...and maybe other errors, as well?

This PR changes this GitHub import error message:

![image](https://user-images.githubusercontent.com/2083930/73526994-f3e60d00-441a-11ea-9914-fb39261e8bf2.png)

into this:

![image](https://user-images.githubusercontent.com/2083930/73526891-c4370500-441a-11ea-8a52-e341e177b2ba.png)
