### PR TITLE
Sidebar - fix dependencies overlap

### DIFF
--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Explorer/Dependencies/Dependency/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Explorer/Dependencies/Dependency/index.tsx
@@ -149,6 +149,7 @@ export class Dependency extends React.PureComponent<Props, State> {
             >
               <Text
                 variant="muted"
+                maxWidth={75}
                 css={{ display: hovering ? 'none' : 'block' }}
               >
                 {formatVersion(dependencies[dependency])}{' '}

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Explorer/Dependencies/Dependency/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Explorer/Dependencies/Dependency/index.tsx
@@ -165,7 +165,7 @@ export class Dependency extends React.PureComponent<Props, State> {
             css={css({
               position: 'absolute',
               right: 0,
-              width: '160px',
+              width: '150px', // overlay on text
             })}
           >
             {hovering && (
@@ -193,7 +193,11 @@ export class Dependency extends React.PureComponent<Props, State> {
                         style={{ outline: 'none' }}
                         singleton={singleton}
                       >
-                        <Button variant="link" onClick={this.handleOpen}>
+                        <Button
+                          variant="link"
+                          onClick={this.handleOpen}
+                          css={css({ minWidth: 5 })}
+                        >
                           {open ? <ArrowDropUp /> : <ArrowDropDown />}
                         </Button>
                       </Tooltip>
@@ -202,7 +206,11 @@ export class Dependency extends React.PureComponent<Props, State> {
                         style={{ outline: 'none' }}
                         singleton={singleton}
                       >
-                        <Button variant="link" onClick={this.handleRefresh}>
+                        <Button
+                          variant="link"
+                          onClick={this.handleRefresh}
+                          css={css({ minWidth: 5 })}
+                        >
                           <RefreshIcon />
                         </Button>
                       </Tooltip>
@@ -211,7 +219,11 @@ export class Dependency extends React.PureComponent<Props, State> {
                         style={{ outline: 'none' }}
                         singleton={singleton}
                       >
-                        <Button variant="link" onClick={this.handleRemove}>
+                        <Button
+                          variant="link"
+                          onClick={this.handleRemove}
+                          css={css({ minWidth: 5 })}
+                        >
                           <CrossIcon />
                         </Button>
                       </Tooltip>

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Explorer/Files/DirectoryEntry/Entry/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Explorer/Files/DirectoryEntry/Entry/index.tsx
@@ -202,16 +202,7 @@ const Entry: React.FC<IEntryProps> = ({
                 error={error}
               />
             ) : (
-              <Text
-                css={{
-                  maxWidth: 150,
-                  overflow: 'hidden',
-                  textOverflow: 'ellipsis',
-                  whiteSpace: 'nowrap',
-                }}
-              >
-                {title}
-              </Text>
+              <Text maxWidth={150}>{title}</Text>
             )}
             {isNotSynced && !state && (
               <NotSyncedIcon css={css({ color: 'blues.300' })} />

--- a/packages/components/src/components/Select/index.tsx
+++ b/packages/components/src/components/Select/index.tsx
@@ -19,6 +19,8 @@ const SelectComponent = styled(Input).attrs({ as: 'select' })(
     transition: 'all ease',
     transitionDuration: theme => theme.speeds[2],
 
+    paddingRight: 5, // select has a caret icon on the right
+
     backgroundImage: theme =>
       theme && `url(${svg(theme.colors.input.placeholderForeground)})`,
     backgroundPosition: 'calc(100% - 8px) center',

--- a/packages/components/src/components/Text/index.tsx
+++ b/packages/components/src/components/Text/index.tsx
@@ -8,18 +8,27 @@ const variants = {
   danger: 'errorForeground',
 };
 
+const overflowStyles = {
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+};
+
 export const Text = styled(Element).attrs({ as: 'span' })<{
   size?: number;
   align?: string;
   weight?: string;
   block?: boolean;
   variant?: 'body' | 'muted' | 'danger';
-}>(({ size, align, weight, block, variant = 'body', ...props }) =>
+  maxWidth?: number;
+}>(({ size, align, weight, block, variant = 'body', maxWidth, ...props }) =>
   css({
     fontSize: size || 'inherit', // from theme.fontSizes
     textAlign: align || 'left',
     fontWeight: weight || null, // from theme.fontWeights
     display: block ? 'block' : 'inline',
     color: variants[variant],
+    maxWidth,
+    ...(maxWidth ? overflowStyles : {}),
   })
 );


### PR DESCRIPTION

bad: 

1. buttons dont have enough click space
2. long version numbers overlap with name
3. select box doesnt have padding for caret

![Screenshot 2020-02-05 at 3 09 04 PM](https://user-images.githubusercontent.com/1863771/73849060-8a566c00-4829-11ea-9cf3-8871eeab106b.png)

good:

![Screenshot 2020-02-05 at 3 08 11 PM](https://user-images.githubusercontent.com/1863771/73849064-8b879900-4829-11ea-9a0f-9f5953fa1321.png)
