### PR TITLE
Add ownership to GitHub sandboxes

### DIFF
--- a/packages/app/src/app/overmind/effects/live/index.ts
+++ b/packages/app/src/app/overmind/effects/live/index.ts
@@ -120,7 +120,7 @@ export default new (class Live {
 
   joinChannel(roomId: string): Promise<JoinChannelTransformedResponse> {
     return new Promise((resolve, reject) => {
-      channel = this.getSocket().channel(`live:${roomId}`, {});
+      channel = this.getSocket().channel(`live:${roomId}`, { version: 2 });
 
       channel
         .join()

--- a/packages/app/src/app/overmind/factories.ts
+++ b/packages/app/src/app/overmind/factories.ts
@@ -77,12 +77,16 @@ export const withLoadApp = <T>(
 
 export const withOwnedSandbox = <T>(
   continueAction: AsyncAction<T>,
-  cancelAction: AsyncAction<T> = () => Promise.resolve()
+  cancelAction: AsyncAction<T> = () => Promise.resolve(),
+  changeType: 'unknown' | 'save' = 'unknown'
 ): AsyncAction<T> => async (context, payload) => {
   const { state, actions } = context;
 
   if (state.editor.currentSandbox) {
-    if (!state.editor.currentSandbox.owned) {
+    if (
+      !state.editor.currentSandbox.owned ||
+      (changeType === 'save' && !state.editor.canWriteCode)
+    ) {
       if (state.editor.isForkingSandbox) {
         return cancelAction(context, payload);
       }

--- a/packages/app/src/app/overmind/factories.ts
+++ b/packages/app/src/app/overmind/factories.ts
@@ -87,9 +87,7 @@ export const withOwnedSandbox = <T>(
   if (sandbox) {
     if (
       typeof requiredPermission !== 'undefined' &&
-      // TODO: remove the sandbox.owned check
-      (!sandbox.owned ||
-        !hasPermission(sandbox.authorization, requiredPermission))
+      !hasPermission(sandbox.authorization, requiredPermission)
     ) {
       if (state.editor.isForkingSandbox) {
         return cancelAction(context, payload);

--- a/packages/app/src/app/overmind/factories.ts
+++ b/packages/app/src/app/overmind/factories.ts
@@ -87,7 +87,9 @@ export const withOwnedSandbox = <T>(
   if (sandbox) {
     if (
       typeof requiredPermission !== 'undefined' &&
-      !hasPermission(sandbox.authorization, requiredPermission)
+      // TODO: remove the sandbox.owned check
+      (!sandbox.owned ||
+        !hasPermission(sandbox.authorization, requiredPermission))
     ) {
       if (state.editor.isForkingSandbox) {
         return cancelAction(context, payload);

--- a/packages/app/src/app/overmind/namespaces/editor/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/editor/actions.ts
@@ -156,7 +156,7 @@ export const resizingStopped: Action = ({ state }) => {
 export const codeSaved: AsyncAction<{
   code: string;
   moduleShortid: string;
-  cbID: string;
+  cbID: string | null;
 }> = withOwnedSandbox(
   async ({ actions }, { code, moduleShortid, cbID }) => {
     actions.editor.internal.saveCode({

--- a/packages/app/src/app/overmind/namespaces/editor/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/editor/actions.ts
@@ -166,7 +166,9 @@ export const codeSaved: AsyncAction<{
     });
   },
   async ({ effects }, { cbID }) => {
-    effects.vscode.callCallbackError(cbID);
+    if (cbID) {
+      effects.vscode.callCallbackError(cbID);
+    }
   },
   'write_project'
 );

--- a/packages/app/src/app/overmind/namespaces/editor/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/editor/actions.ts
@@ -168,7 +168,7 @@ export const codeSaved: AsyncAction<{
   async ({ effects }, { cbID }) => {
     effects.vscode.callCallbackError(cbID);
   },
-  'save'
+  'write_project'
 );
 
 export const onOperationApplied: Action<{

--- a/packages/app/src/app/overmind/namespaces/editor/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/editor/actions.ts
@@ -167,7 +167,8 @@ export const codeSaved: AsyncAction<{
   },
   async ({ effects }, { cbID }) => {
     effects.vscode.callCallbackError(cbID);
-  }
+  },
+  'save'
 );
 
 export const onOperationApplied: Action<{

--- a/packages/app/src/app/overmind/namespaces/editor/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/editor/actions.ts
@@ -18,6 +18,7 @@ import {
 import { clearCorrectionsFromAction } from 'app/utils/corrections';
 import { json } from 'overmind';
 
+import { hasPermission } from '@codesandbox/common/lib/utils/permission';
 import eventToTransform from '../../utils/event-to-transform';
 import * as internalActions from './internalActions';
 
@@ -118,7 +119,10 @@ export const sandboxChanged: AsyncAction<{ id: string }> = withLoadApp<{
 
   await actions.editor.internal.initializeLiveSandbox(sandbox);
 
-  if (sandbox.owned && !state.live.isLive) {
+  if (
+    hasPermission(sandbox.authorization, 'write_code') &&
+    !state.live.isLive
+  ) {
     actions.files.internal.recoverFiles();
   } else if (state.live.isLive) {
     effects.live.sendModuleStateSyncRequest();

--- a/packages/app/src/app/overmind/namespaces/editor/internalActions.ts
+++ b/packages/app/src/app/overmind/namespaces/editor/internalActions.ts
@@ -21,6 +21,7 @@ import { Action, AsyncAction } from 'app/overmind';
 import { sortObjectByKeys } from 'app/overmind/utils/common';
 import { getTemplate as computeTemplate } from 'codesandbox-import-utils/lib/create-sandbox/templates';
 import { mapValues } from 'lodash-es';
+import { hasPermission } from '@codesandbox/common/lib/utils/permission';
 
 export const ensureSandboxId: Action<string, string> = ({ state }, id) => {
   if (state.editor.sandboxes[id]) {
@@ -446,11 +447,13 @@ export const updateSandboxPackageJson: AsyncAction = async ({
 
   if (
     !sandbox ||
-    !state.editor.parsedConfigurations ||
-    !state.editor.parsedConfigurations.package ||
-    !state.editor.parsedConfigurations.package.parsed ||
+    !state.editor.parsedConfigurations?.package?.parsed ||
     !state.editor.currentPackageJSON
   ) {
+    return;
+  }
+
+  if (!hasPermission(sandbox.authorization, 'write_code')) {
     return;
   }
 

--- a/packages/app/src/app/overmind/namespaces/editor/internalActions.ts
+++ b/packages/app/src/app/overmind/namespaces/editor/internalActions.ts
@@ -254,7 +254,7 @@ export const removeNpmDependencyFromPackageJson: AsyncAction<string> = async (
 
   delete packageJson.dependencies[name];
 
-  await actions.editor.internal.saveCode({
+  await actions.editor.codeSaved({
     code: JSON.stringify(packageJson, null, 2),
     moduleShortid: state.editor.currentPackageJSON.shortid,
     cbID: null,
@@ -281,7 +281,7 @@ export const addNpmDependencyToPackageJson: AsyncAction<{
   packageJson[type][name] = version || 'latest';
   packageJson[type] = sortObjectByKeys(packageJson[type]);
 
-  await actions.editor.internal.saveCode({
+  await actions.editor.codeSaved({
     code: JSON.stringify(packageJson, null, 2),
     moduleShortid: state.editor.currentPackageJSON.shortid,
     cbID: null,
@@ -463,7 +463,7 @@ export const updateSandboxPackageJson: AsyncAction = async ({
   const code = JSON.stringify(parsed, null, 2);
   const moduleShortid = state.editor.currentPackageJSON.shortid;
 
-  await actions.editor.internal.saveCode({
+  await actions.editor.codeSaved({
     code,
     moduleShortid,
     cbID: null,
@@ -482,7 +482,7 @@ export const updateDevtools: AsyncAction<{
       state.editor.modulesByPath['/.codesandbox/workspace.json'];
 
     if (devtoolsModule) {
-      await actions.editor.internal.saveCode({
+      await actions.editor.codeSaved({
         code,
         moduleShortid: devtoolsModule.shortid,
         cbID: null,

--- a/packages/app/src/app/overmind/namespaces/editor/state.ts
+++ b/packages/app/src/app/overmind/namespaces/editor/state.ts
@@ -53,6 +53,7 @@ type State = {
   workspaceConfigCode: string;
   statusBar: boolean;
   previewWindowOrientation: WindowOrientation;
+  canWriteCode: Derive<State, boolean>;
   isAllModulesSynced: Derive<State, boolean>;
   currentSandbox: Derive<State, Sandbox | null>;
   currentModule: Derive<State, Module>;
@@ -119,6 +120,13 @@ export const state: State = {
   currentDevToolsPosition: {
     devToolIndex: 0,
     tabPosition: 0,
+  },
+  canWriteCode: ({ currentSandbox }) => {
+    if (currentSandbox?.git) {
+      return false;
+    }
+
+    return Boolean(currentSandbox?.owned);
   },
   currentSandbox: ({ sandboxes, currentId }) => {
     if (currentId && sandboxes[currentId]) {

--- a/packages/app/src/app/overmind/namespaces/editor/state.ts
+++ b/packages/app/src/app/overmind/namespaces/editor/state.ts
@@ -121,13 +121,8 @@ export const state: State = {
     devToolIndex: 0,
     tabPosition: 0,
   },
-  canWriteCode: ({ currentSandbox }) => {
-    if (currentSandbox?.git) {
-      return false;
-    }
-
-    return Boolean(currentSandbox?.owned);
-  },
+  canWriteCode: ({ currentSandbox }) =>
+    currentSandbox?.authorization === 'write_code',
   currentSandbox: ({ sandboxes, currentId }) => {
     if (currentId && sandboxes[currentId]) {
       return sandboxes[currentId];

--- a/packages/app/src/app/overmind/namespaces/files/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/files/actions.ts
@@ -79,7 +79,9 @@ export const moduleRenamed: AsyncAction<{
 
       actions.internal.handleError({ message: 'Could not rename file', error });
     }
-  }
+  },
+  async () => {},
+  'write_code'
 );
 
 export const directoryCreated: AsyncAction<{
@@ -151,7 +153,9 @@ export const directoryCreated: AsyncAction<{
         error,
       });
     }
-  }
+  },
+  async () => {},
+  'write_code'
 );
 
 export const moduleMovedToDirectory: AsyncAction<{
@@ -205,7 +209,9 @@ export const moduleMovedToDirectory: AsyncAction<{
         error,
       });
     }
-  }
+  },
+  async () => {},
+  'write_code'
 );
 
 export const directoryMovedToDirectory: AsyncAction<{
@@ -255,7 +261,9 @@ export const directoryMovedToDirectory: AsyncAction<{
         error,
       });
     }
-  }
+  },
+  async () => {},
+  'write_code'
 );
 
 export const directoryDeleted: AsyncAction<{
@@ -327,7 +335,9 @@ export const directoryDeleted: AsyncAction<{
         error,
       });
     }
-  }
+  },
+  async () => {},
+  'write_code'
 );
 
 export const directoryRenamed: AsyncAction<{
@@ -379,7 +389,9 @@ export const directoryRenamed: AsyncAction<{
         error,
       });
     }
-  }
+  },
+  async () => {},
+  'write_code'
 );
 
 export const gotUploadedFiles: AsyncAction<string> = async (
@@ -408,24 +420,28 @@ export const gotUploadedFiles: AsyncAction<string> = async (
 export const addedFileToSandbox: AsyncAction<{
   url: string;
   name: string;
-}> = withOwnedSandbox(async ({ actions, effects, state }, { name, url }) => {
-  if (!state.editor.currentSandbox) {
-    return;
-  }
-  actions.internal.closeModals(false);
-  await actions.files.moduleCreated({
-    title: name,
-    directoryShortid: null,
-    code: url,
-    isBinary: true,
-  });
+}> = withOwnedSandbox(
+  async ({ actions, effects, state }, { name, url }) => {
+    if (!state.editor.currentSandbox) {
+      return;
+    }
+    actions.internal.closeModals(false);
+    await actions.files.moduleCreated({
+      title: name,
+      directoryShortid: null,
+      code: url,
+      isBinary: true,
+    });
 
-  effects.executor.updateFiles(state.editor.currentSandbox);
-});
+    effects.executor.updateFiles(state.editor.currentSandbox);
+  },
+  async () => {},
+  'write_code'
+);
 
 export const deletedUploadedFile: AsyncAction<{
   id: string;
-}> = withOwnedSandbox(async ({ state, actions, effects }, { id }) => {
+}> = async ({ state, actions, effects }, { id }) => {
   if (!state.uploadedFiles) {
     return;
   }
@@ -441,7 +457,7 @@ export const deletedUploadedFile: AsyncAction<{
       error,
     });
   }
-});
+};
 
 export const filesUploaded: AsyncAction<{
   files: { [k: string]: { dataURI: string; type: string } };
@@ -489,7 +505,9 @@ export const filesUploaded: AsyncAction<{
     }
 
     actions.internal.closeModals(false);
-  }
+  },
+  async () => {},
+  'write_code'
 );
 
 export const massCreateModules: AsyncAction<{
@@ -550,7 +568,9 @@ export const massCreateModules: AsyncAction<{
         error,
       });
     }
-  }
+  },
+  async () => {},
+  'write_code'
 );
 
 export const moduleCreated: AsyncAction<{
@@ -650,7 +670,9 @@ export const moduleCreated: AsyncAction<{
         error,
       });
     }
-  }
+  },
+  async () => {},
+  'write_code'
 );
 
 export const moduleDeleted: AsyncAction<{
@@ -691,7 +713,9 @@ export const moduleDeleted: AsyncAction<{
       state.editor.modulesByPath = effects.vscode.sandboxFsSync.create(sandbox);
       actions.internal.handleError({ message: 'Could not delete file', error });
     }
-  }
+  },
+  async () => {},
+  'write_code'
 );
 
 export const createModulesByPath: AsyncAction<{

--- a/packages/app/src/app/overmind/namespaces/workspace/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/workspace/actions.ts
@@ -80,7 +80,7 @@ export const tagRemoved: AsyncAction<string> = withOwnedSandbox(
       const code = JSON.stringify(parsed, null, 2);
       const moduleShortid = state.editor.currentPackageJSON.shortid;
 
-      await actions.editor.internal.saveCode({
+      await actions.editor.codeSaved({
         code,
         moduleShortid,
         cbID: null,

--- a/packages/app/src/app/overmind/utils/items.ts
+++ b/packages/app/src/app/overmind/utils/items.ts
@@ -76,6 +76,7 @@ export function getDisabledItems(store: any): INavigationItem[] {
 export default function getItems(store: any): INavigationItem[] {
   if (
     store.live.isLive &&
+    !store.editor.currentSandbox.git &&
     !(
       store.live.isOwner ||
       (store.user &&

--- a/packages/common/src/types/index.ts
+++ b/packages/common/src/types/index.ts
@@ -13,6 +13,13 @@ export type SSEContainerStatus =
 
 export type SSEManagerStatus = 'connected' | 'disconnected' | 'initializing';
 
+export type PermissionType =
+  | 'write_code'
+  | 'write_project'
+  | 'comment'
+  | 'read'
+  | 'none';
+
 export type ModuleError = {
   message: string;
   line: number;
@@ -313,6 +320,7 @@ export type Sandbox = {
     path: string;
   };
   owned: boolean;
+  authorization: PermissionType;
   npmDependencies: {
     [dep: string]: string;
   };

--- a/packages/common/src/utils/permission.test.ts
+++ b/packages/common/src/utils/permission.test.ts
@@ -1,0 +1,14 @@
+import { hasPermission } from './permission';
+
+describe('permission', () => {
+  it('correctly accepts a lower permission', () => {
+    expect(hasPermission('write_code', 'read')).toBe(true);
+    expect(hasPermission('write_code', 'write_code')).toBe(true);
+    expect(hasPermission('write_project', 'comment')).toBe(true);
+  });
+
+  it('correctly rejects a a permission', () => {
+    expect(hasPermission('read', 'write_code')).toBe(false);
+    expect(hasPermission('read', 'comment')).toBe(false);
+  });
+});

--- a/packages/common/src/utils/permission.ts
+++ b/packages/common/src/utils/permission.ts
@@ -1,0 +1,26 @@
+import { PermissionType } from '../types';
+
+const permissions: PermissionType[] = [
+  'write_code',
+  'write_project',
+  'comment',
+  'read',
+  'none',
+];
+
+/**
+ * Whether the given permission is permitted compared to the required permission.
+ * We use a simple model for this, where if you have a top permission it will be considered
+ * that you have all other permissions. This same list is saved on the server, and this needs
+ * to keep in sync with that.
+ * @param permission Permission to test
+ * @param requiredPermission Required permission to pass the test
+ */
+export function hasPermission(
+  permission: PermissionType,
+  requiredPermission: PermissionType
+) {
+  return (
+    permissions.indexOf(permission) <= permissions.indexOf(requiredPermission)
+  );
+}


### PR DESCRIPTION
This allows users to change properties of a sandbox if they're the owner.
They can change the title, description, things like env variables. Everything
except the code, in which we'll autofork.

The goal of this is to answer to the multiple feature requests related to using
a git sandbox. While the best solution would be to invent a permission model,
we're not there yet and I'm not sure when we'll get it. So this seems like a good
intermediate solution instead.
