### PR TITLE
Change the focus of the navigationitem of the new sidebar

### DIFF
--- a/packages/app/src/app/pages/Sandbox/Editor/Navigation/elements.ts
+++ b/packages/app/src/app/pages/Sandbox/Editor/Navigation/elements.ts
@@ -44,6 +44,11 @@ export const IconContainer = styled(Stack)<{
       background: ${props.theme.colors.activityBar.hoverBackground};
     }
 
+    &:focus {
+      outline: none;
+      background: ${props.theme.colors.activityBar.hoverBackground};
+    }
+
     ${props.selected &&
       css`
         color: ${props.theme.colors.activityBar.selected};


### PR DESCRIPTION
This will make the focus of the navigation this background color instead of the outline. I think this looks a bit cleaner and will give an improvement in perceived speed.

![image](https://user-images.githubusercontent.com/587016/74470629-32f67280-4e9f-11ea-859c-fd186ac7c7ea.png)
