### PR TITLE
fix: recover sandbox request body

### DIFF
--- a/packages/app/src/app/pages/Dashboard/queries.ts
+++ b/packages/app/src/app/pages/Dashboard/queries.ts
@@ -290,12 +290,12 @@ export function addSandboxesToFolder(
 export function undeleteSandboxes(selectedSandboxes) {
   client.mutate<AddToCollectionMutation, AddToCollectionMutationVariables>({
     mutation: ADD_SANDBOXES_TO_FOLDER_MUTATION,
+    // @ts-ignore
     variables: {
       sandboxIds: selectedSandboxes.toJS
         ? selectedSandboxes.toJS()
         : selectedSandboxes,
       collectionPath: '/',
-      teamId: null,
     },
     optimisticResponse: {
       __typename: 'RootMutationType',


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?
Bug - It looks more like a backend bug, but removing `teamId=null` from request body fixes it for the moment.

<!-- Is it a Bug fix, feature, docs update, ... -->

## What is the current behavior?
![RecoverError](https://user-images.githubusercontent.com/22376783/74610399-e7e79400-5118-11ea-8827-d5af4c6302b1.gif)

<!-- You can also link to an open issue here -->

## What is the new behavior?
![LocalRecoverSandbox](https://user-images.githubusercontent.com/22376783/74610400-ea49ee00-5118-11ea-97e5-3fe1a7305ecd.gif)

<!-- if this is a feature change -->

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Tested by recovering multiple sandboxes

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation - N/A
- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
