### PR TITLE
fix: show delete modal in collapsed state

### DIFF
--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/Files/DirectoryEntry/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/Files/DirectoryEntry/index.tsx
@@ -325,6 +325,12 @@ const DirectoryEntry: React.FunctionComponent<Props> = ({
           />
         </EntryContainer>
       )}
+
+      <DirectoryEntryModal
+        isOpen={Boolean(modalConfirm)}
+        onClose={closeModals}
+        {...modalConfirm}
+      />
       {open && (
         <Opener>
           {creating === 'directory' && (
@@ -349,11 +355,6 @@ const DirectoryEntry: React.FunctionComponent<Props> = ({
             markTabsNotDirty={markTabsNotDirty}
             discardModuleChanges={confirmDiscardChanges}
             getModulePath={getModulePath}
-          />
-          <DirectoryEntryModal
-            isOpen={Boolean(modalConfirm)}
-            onClose={closeModals}
-            {...modalConfirm}
           />
           {creating === 'module' && (
             <Entry


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?
Bug fix
<!-- Is it a Bug fix, feature, docs update, ... -->

## What is the current behavior?
Delete Modal only shows up when the directory is open. Closes: #3528 
<!-- You can also link to an open issue here -->

## What is the new behavior?
Modal is shown on the collapsed state as well.
<!-- if this is a feature change -->

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Tested Delete Directory & files using edit icons
2. Delete using context menu

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation - N/A
- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
