### PR TITLE
Center text inside Input, Select, Textarea

### DIFF
--- a/packages/components/src/components/Input/index.tsx
+++ b/packages/components/src/components/Input/index.tsx
@@ -26,6 +26,7 @@ export const Input = styled(Element).attrs({ as: 'input' })<{
     width: '100%',
     paddingX: 2,
     fontSize: 3,
+    lineHeight: 1, // trust the height
     fontFamily: 'Inter, sans-serif',
     borderRadius: 'small',
     backgroundColor: 'input.background',


### PR DESCRIPTION
These elements have a fixed height and are centered with flex. `line-height: 1` makes the font not have any additional height beyond its baseline