### PR TITLE
Match avatar and button size in header

### DIFF
--- a/packages/app/src/app/pages/Sandbox/Editor/Header/Actions.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Header/Actions.tsx
@@ -123,7 +123,9 @@ export const Actions = () => {
         <UserMenu>
           <Avatar
             user={{ ...user, subscriptionSince: null }}
-            css={css({ size: 6 })}
+            css={css({
+              size: '26px', // match button size next to it
+            })}
           />
         </UserMenu>
       ) : (


### PR DESCRIPTION
🎵He was a 26px
She was a 32px
Can I make it any more obvious?

🎸Added both to header
They didn't align properly
What more can I say?

```diff
  <Avatar
    user={user}
+   css={{ size: '26px' })
  />
```

side note: this is surfacing a need for avatar sizes in the future based on the context its used