### PR TITLE
sign in button should width: auto

### DIFF
--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Deployment/Zeit.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Deployment/Zeit.tsx
@@ -98,7 +98,7 @@ export const Zeit = () => {
             <Button
               disabled={deploying}
               onClick={signInZeitClicked}
-              css={{ width: 50 }}
+              css={{ width: 'auto' }}
             >
               Sign in
             </Button>


### PR DESCRIPTION
bug:

![Screenshot 2020-02-27 at 10 18 35 AM](https://user-images.githubusercontent.com/1863771/75429859-bc4f7f80-594a-11ea-9d43-4ddc6c8c1083.png)

fix:

```
- <Button css={{ width: 50 }}>
+ <Button css={{ width: 'auto' }}>
```

hard coded widths are always trouble 🙃 