### PR TITLE
improves sourcemaps

### DIFF
--- a/packages/app/config/webpack.common.js
+++ b/packages/app/config/webpack.common.js
@@ -163,31 +163,6 @@ module.exports = {
 
   module: {
     rules: [
-      {
-        test: /\.(graphql|gql)$/,
-        exclude: /node_modules/,
-        loader: `graphql-tag/loader`,
-      },
-      {
-        test: /\.wasm$/,
-        loader: 'file-loader',
-        type: 'javascript/auto',
-      },
-      {
-        test: /\.scss$/,
-        use: getStyleLoaders(
-          {
-            importLoaders: 2,
-            sourceMap: true,
-          },
-          'sass-loader'
-        ),
-        // Don't consider CSS imports dead code even if the
-        // containing package claims to have no side effects.
-        // Remove this when webpack adds a warning or an error for this.
-        // See https://github.com/webpack/webpack/issues/6571
-        sideEffects: true,
-      },
       // Transpile node dependencies, node deps are often not transpiled for IE11
       {
         test: [
@@ -209,6 +184,8 @@ module.exports = {
         ],
         loader: 'babel-loader',
         query: {
+          retainLines: true,
+          cacheDirectory: true,
           presets: [
             '@babel/preset-flow',
             [
@@ -233,6 +210,31 @@ module.exports = {
             '@babel/plugin-transform-runtime',
           ],
         },
+      },
+      {
+        test: /\.(graphql|gql)$/,
+        exclude: /node_modules/,
+        loader: `graphql-tag/loader`,
+      },
+      {
+        test: /\.wasm$/,
+        loader: 'file-loader',
+        type: 'javascript/auto',
+      },
+      {
+        test: /\.scss$/,
+        use: getStyleLoaders(
+          {
+            importLoaders: 2,
+            sourceMap: true,
+          },
+          'sass-loader'
+        ),
+        // Don't consider CSS imports dead code even if the
+        // containing package claims to have no side effects.
+        // Remove this when webpack adds a warning or an error for this.
+        // See https://github.com/webpack/webpack/issues/6571
+        sideEffects: true,
       },
       {
         test: /\.(j|t)sx?$/,

--- a/packages/app/config/webpack.dev.js
+++ b/packages/app/config/webpack.dev.js
@@ -1,3 +1,4 @@
+const webpack = require('webpack');
 const merge = require('webpack-merge');
 // const webpack = require('webpack');
 const WebpackBar = require('webpackbar');
@@ -19,7 +20,7 @@ module.exports = merge(
   },
   commonConfig,
   {
-    devtool: 'eval',
+    devtool: false,
     mode: 'development',
     output: {
       filename: 'static/js/[name].js',
@@ -32,6 +33,9 @@ module.exports = merge(
     },
     plugins: [
       new WebpackBar(),
+      new webpack.EvalSourceMapDevToolPlugin({
+        include: /src\/app/,
+      }),
       // new webpack.HotModuleReplacementPlugin(),
     ],
   }


### PR DESCRIPTION
sourcemaps has been broken in dev. Now they work and is scoped to `src/app`, meaning it looks like this:

<img width="926" alt="Screenshot 2020-03-05 at 13 07 20" src="https://user-images.githubusercontent.com/3956929/75980258-634f9080-5ee2-11ea-8ae2-4389149fa6c5.png">

So all references that are **not** `app.js`, is actual references to the app. In this case `factories.ts` and `index.tsx`:

<img width="564" alt="Screenshot 2020-03-05 at 13 07 28" src="https://user-images.githubusercontent.com/3956929/75980292-74000680-5ee2-11ea-8378-00763e00c777.png">

The rest is just libraries and stuff where we do not really care about the sourcemaps. Which should also make the dev flow build faster.