### PR TITLE
Fix dependency picker hidden behind text

### DIFF
--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Explorer/Dependencies/Dependency/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Explorer/Dependencies/Dependency/index.tsx
@@ -148,7 +148,9 @@ export const Dependency = ({
           css={css({
             position: 'absolute',
             right: 0,
-            width: '150px', // overlay on text
+            width: 'auto',
+            zIndex: 2, // overlay on dependency name
+            paddingLeft: 1,
           })}
         >
           <Select


### PR DESCRIPTION
this bug was introduced last week in a different bug fix :)

![Screenshot 2020-03-09 at 2 55 07 PM](https://user-images.githubusercontent.com/1863771/76219981-fe17da00-6216-11ea-869d-2af41da22158.png)![Screenshot 2020-03-09 at 2 54 25 PM](https://user-images.githubusercontent.com/1863771/76219986-ffe19d80-6216-11ea-9c53-160f3d761f3d.png)
