### PR TITLE
Black theme - change blue highlights to match editor

### DIFF
--- a/packages/common/src/themes/codesandbox-black.js
+++ b/packages/common/src/themes/codesandbox-black.js
@@ -172,7 +172,7 @@ const colors = {
   },
   peekViewEditor: {
     background: tokens.grays[600],
-    matchHighlightBackground: tokens.blues[300],
+    matchHighlightBackground: tokens.blues[500] + '33', // 20% opacity
   },
   peekViewEditorGutter: {
     background: null,
@@ -181,7 +181,7 @@ const colors = {
     background: tokens.grays[600],
     fileForeground: tokens.white,
     lineForeground: tokens.white,
-    matchHighlightBackground: tokens.blues[300],
+    matchHighlightBackground: tokens.blues[500] + '33', // 20% opacity,
     selectionBackground: tokens.grays[600],
     selectionForeground: tokens.white,
   },


### PR DESCRIPTION
Fixes peak view highlights :)

<img width="804" alt="Screenshot 2020-03-13 at 11 05 06 AM" src="https://user-images.githubusercontent.com/1863771/76611403-bcd74100-651a-11ea-9977-9a60de2c5d01.png">
