### PR TITLE
Fix: Icons cant be on scale

### DIFF
--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Comments/Comment.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Comments/Comment.tsx
@@ -70,7 +70,7 @@ export const Comment = React.memo(({ comment }: any) => {
             <Icon name="check" title="Resolved" color="green" />
           )}
           <Menu>
-            <Menu.IconButton name="more" title="Comment actions" size={3} />
+            <Menu.IconButton name="more" title="Comment actions" size={12} />
             <Menu.List>
               <Menu.Item
                 onSelect={() =>

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Comments/Dialog/Reply.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Comments/Dialog/Reply.tsx
@@ -57,7 +57,7 @@ export const Reply = ({
           {state.user.id === author.id && (
             <Stack align="center">
               <Menu>
-                <Menu.IconButton name="more" title="Reply actions" size={3} />
+                <Menu.IconButton name="more" title="Reply actions" size={12} />
                 <Menu.List>
                   <Menu.Item
                     onSelect={() =>

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Comments/Dialog/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Comments/Dialog/index.tsx
@@ -96,7 +96,7 @@ export const Dialog = props => {
                 })
               }
               name="check"
-              size={4}
+              size={14}
               title="Resolve Comment"
               css={css({
                 transition: 'color',
@@ -106,7 +106,7 @@ export const Dialog = props => {
             />
             <IconButton
               name="cross"
-              size={3}
+              size={10}
               title="Close comment dialog"
               onClick={closeDialog}
             />
@@ -146,7 +146,7 @@ export const Dialog = props => {
                     <Menu.IconButton
                       name="more"
                       title="Comment actions"
-                      size={3}
+                      size={12}
                     />
                     <Menu.List>
                       <Menu.Item

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Comments/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Comments/index.tsx
@@ -49,7 +49,7 @@ export const Comments: React.FC = () => {
     >
       <Icon
         name="comments"
-        size={20}
+        size={80}
         color="mutedForeground"
         css={{ opacity: 0.2 }}
       />
@@ -87,7 +87,7 @@ export const Comments: React.FC = () => {
               className="icon-button"
               name="filter"
               title="Filter comments"
-              size={3}
+              size={12}
             />
             <Menu.List>
               {options.map(option => (

--- a/packages/app/src/app/pages/Sandbox/Editor/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/index.tsx
@@ -197,18 +197,6 @@ const ContentSplit = () => {
             className="monaco-workbench mac nopanel"
             ref={statusbarEl}
           />
-          <div
-            style={{
-              position: 'fixed',
-              display: statusBar ? 'block' : 'none',
-              bottom: 0,
-              left: 0,
-              right: 0,
-              height: STATUS_BAR_SIZE,
-            }}
-          >
-            version
-          </div>
         </Fullscreen>
 
         <ForkFrozenSandboxModal />

--- a/packages/app/src/app/pages/Sandbox/Editor/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/index.tsx
@@ -197,6 +197,18 @@ const ContentSplit = () => {
             className="monaco-workbench mac nopanel"
             ref={statusbarEl}
           />
+          <div
+            style={{
+              position: 'fixed',
+              display: statusBar ? 'block' : 'none',
+              bottom: 0,
+              left: 0,
+              right: 0,
+              height: STATUS_BAR_SIZE,
+            }}
+          >
+            version
+          </div>
         </Fullscreen>
 
         <ForkFrozenSandboxModal />

--- a/packages/components/src/components/Icon/index.stories.tsx
+++ b/packages/components/src/components/Icon/index.stories.tsx
@@ -12,7 +12,7 @@ export const Simple = () => (
   <Stack gap={2}>
     <Icon name="github" />
     <Icon name="github" css={{ color: 'blues.500' }} />
-    <Icon name="github" size={6} />
+    <Icon name="github" size={24} />
   </Stack>
 );
 

--- a/packages/components/src/components/Icon/index.tsx
+++ b/packages/components/src/components/Icon/index.tsx
@@ -18,15 +18,11 @@ type IconProps = React.SVGAttributes<SVGElement> &
 
 export const Icon: React.FC<IconProps> = ({
   name = 'notFound',
-  size = 4,
+  size = 16,
   color = 'inherit',
   ...props
 }) => {
   const SVG = icons[name];
-  // we use a 4px scale for space and size
-  const scaledSize = size * 4;
 
-  return (
-    <SVG width={scaledSize} height={scaledSize} color={color} {...props} />
-  );
+  return <SVG width={size} height={size} color={color} {...props} />;
 };


### PR DESCRIPTION
Discussed this one with Danny and realised that our icons can't be on the 4pt scale

Example:

<img width="422" alt="Screenshot 2020-03-13 at 11 21 36 AM" src="https://user-images.githubusercontent.com/1863771/76612635-ff018200-651c-11ea-9833-a0bc1fe9b5d4.png">


The button that contains both these icons is the same size - 26x26, but the icons inside them have to be adjusted based how they look next to each other

Because of that, they can't always be 16. or even be on the 8/12/16 scale we have. We need more granular control of them

The ones in the image are 14x14 and 10x10 to look _optically aligned._ (both inside a 26x26 button)

- [x] Changed the icon component
- [x] updated all the components that use icon (backward compat lol)

Notes for future: It would be cool to optically align icons in the library so that there are less scenarios in which we need to optically align them. This can't be abstracted away fully because optical alignment depends on the context/neighbouring icons, so we'll always need this escape hatch 🙃 