### PR TITLE
(fix) Allow to enable vimmode for Chrome on iOS.

### DIFF
--- a/packages/app/src/app/pages/common/Modals/PreferencesModal/EditorPageSettings/EditorSettings/index.tsx
+++ b/packages/app/src/app/pages/common/Modals/PreferencesModal/EditorPageSettings/EditorSettings/index.tsx
@@ -12,7 +12,7 @@ import {
 } from '../../elements';
 import { VSCodePlaceholder } from '../../VSCodePlaceholder';
 
-const isSafari: boolean = /^((?!chrome|android).)*safari/i.test(
+const isSafari: boolean = /^((?!chrome|android|crios).)*safari/i.test(
   navigator.userAgent
 );
 const isFF: boolean = navigator.userAgent.toLowerCase().includes('firefox');

--- a/packages/app/src/app/pages/common/Modals/PreferencesModal/EditorPageSettings/EditorSettings/index.tsx
+++ b/packages/app/src/app/pages/common/Modals/PreferencesModal/EditorPageSettings/EditorSettings/index.tsx
@@ -12,7 +12,7 @@ import {
 } from '../../elements';
 import { VSCodePlaceholder } from '../../VSCodePlaceholder';
 
-const isSafari: boolean = /^((?!chrome|android|crios).)*safari/i.test(
+const isSafari: boolean = /^((?!chrome|android|crios|edgios|opt).)*safari/i.test(
   navigator.userAgent
 );
 const isFF: boolean = navigator.userAgent.toLowerCase().includes('firefox');


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix for #3699.

## What is the current behavior?

See #3699.

## What is the new behavior?

Enables vimmode settings option for Chrome on iPadOS.

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Open codesandbox.io on Chrome on iPadOS.
2. Open CodeSandbox Settings > Editor
3. Enable "Enable VIM extension"
4. Open a sandbox and see VIM-mode enabled in the editor view.

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
