### PR TITLE
Handle long names in the sidebar

### DIFF
--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Explorer/Files/DirectoryEntry/Entry/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Explorer/Files/DirectoryEntry/Entry/index.tsx
@@ -191,7 +191,7 @@ const Entry: React.FC<IEntryProps> = ({
             borderColor: rightColors[0] || 'transparent',
           }}
         >
-          <Stack gap={2} align="center">
+          <Stack gap={2} align="center" css={{ width: '100%' }}>
             <EntryIcons type={type} error={moduleHasError} />
             {state === 'editing' ? (
               <FileInput
@@ -211,7 +211,7 @@ const Entry: React.FC<IEntryProps> = ({
                 })}
               />
             ) : (
-              <Text maxWidth={150}>{title}</Text>
+              <Text maxWidth="100%">{title}</Text>
             )}
             {isNotSynced && !state && (
               <NotSyncedIcon css={css({ color: 'blues.300' })} />

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/NotOwnedSandboxInfo/Summary.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/NotOwnedSandboxInfo/Summary.tsx
@@ -62,10 +62,10 @@ export const Summary = () => {
                     iconUrl={customTemplate.iconUrl}
                     environment={template}
                   />
-                  <Text maxWidth={190}>{getSandboxName(currentSandbox)}</Text>
+                  <Text maxWidth="100%">{getSandboxName(currentSandbox)}</Text>
                 </Stack>
               ) : (
-                <Text maxWidth={190}>{getSandboxName(currentSandbox)}</Text>
+                <Text maxWidth="100%">{getSandboxName(currentSandbox)}</Text>
               )}
             </Stack>
 
@@ -120,9 +120,14 @@ export const Summary = () => {
                 </Link>
               </ListItem>
             ) : null}
-            <ListItem justify="space-between">
+            <ListItem justify="space-between" gap={2}>
               <Text>Environment</Text>
-              <Link variant="muted" href={templateUrl} target="_blank">
+              <Link
+                variant="muted"
+                href={templateUrl}
+                target="_blank"
+                maxWidth="100%"
+              >
                 {template}
               </Link>
             </ListItem>

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/ProjectInfo/Summary.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/ProjectInfo/Summary.tsx
@@ -92,10 +92,12 @@ export const Summary = () => {
                       iconUrl={customTemplate.iconUrl}
                       environment={template}
                     />
-                    <Text maxWidth={190}>{getSandboxName(currentSandbox)}</Text>
+                    <Text maxWidth="100%">
+                      {getSandboxName(currentSandbox)}
+                    </Text>
                   </Stack>
                 ) : (
-                  <Text maxWidth={190}>{getSandboxName(currentSandbox)}</Text>
+                  <Text maxWidth="100%">{getSandboxName(currentSandbox)}</Text>
                 )}
                 <Button
                   variant="link"
@@ -129,7 +131,12 @@ export const Summary = () => {
                     {author.username}
                   </Text>
                   {team && (
-                    <Text size={2} marginTop={1} variant="muted">
+                    <Text
+                      size={2}
+                      marginTop={1}
+                      variant="muted"
+                      maxWidth="100%"
+                    >
                       {team.name}
                     </Text>
                   )}
@@ -165,9 +172,14 @@ export const Summary = () => {
               </Link>
             </ListItem>
           ) : null}
-          <ListItem justify="space-between">
+          <ListItem justify="space-between" gap={2}>
             <Text>Environment</Text>
-            <Link variant="muted" href={templateUrl} target="_blank">
+            <Link
+              variant="muted"
+              href={templateUrl}
+              target="_blank"
+              maxWidth="100%"
+            >
               {template}
             </Link>
           </ListItem>

--- a/packages/components/src/components/Avatar/index.tsx
+++ b/packages/components/src/components/Avatar/index.tsx
@@ -21,6 +21,7 @@ export const AvatarContainer = styled(Element).attrs({ as: 'span' })(
     height: 8,
     width: 8,
     position: 'relative',
+    flexShrink: 0, // avatars should never shrink inside flex
   })
 );
 

--- a/packages/components/src/components/Text/index.tsx
+++ b/packages/components/src/components/Text/index.tsx
@@ -29,9 +29,9 @@ export const Text = styled(Element).attrs({ as: 'span' })<ITextProps>(
       fontSize: size || 'inherit', // from theme.fontSizes
       textAlign: align || 'left',
       fontWeight: weight || null, // from theme.fontWeights
-      display: block ? 'block' : 'inline',
       color: variants[variant],
       maxWidth,
       ...(maxWidth ? overflowStyles : {}),
+      display: block || maxWidth ? 'block' : 'inline',
     })
 );


### PR DESCRIPTION
Use maxWidth liberally

- [x] long file names
- [x] long sandbox names
- [x] long environment names


Haven't solved dependencies yet, that needs a change in structure to work (different PR)