### PR TITLE
Don't use list.hover for file tree

### DIFF
--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Explorer/Files/DirectoryEntry/Entry/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Explorer/Files/DirectoryEntry/Entry/index.tsx
@@ -189,7 +189,7 @@ const Entry: React.FC<IEntryProps> = ({
             borderRight: '2px solid',
             minHeight: 28,
             borderColor: rightColors[0] || 'transparent',
-            ':hover': {
+            ':hover:not([aria-selected="true"])': {
               // override ListAction to keep background same as before
               // we do this to diffrentiate between hover and selected
               backgroundColor: 'inherit',

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Explorer/Files/DirectoryEntry/Entry/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Explorer/Files/DirectoryEntry/Entry/index.tsx
@@ -189,6 +189,11 @@ const Entry: React.FC<IEntryProps> = ({
             borderRight: '2px solid',
             minHeight: 28,
             borderColor: rightColors[0] || 'transparent',
+            ':hover': {
+              // override ListAction to keep background same as before
+              // we do this to diffrentiate between hover and selected
+              backgroundColor: 'inherit',
+            },
           }}
         >
           <Stack gap={2} align="center">


### PR DESCRIPTION
To differentiate between hover and selected state in file tree - we only change foreground color to signal hover