### PR TITLE
Fixed miss alignment in Share Icon

### DIFF
--- a/packages/app/src/app/pages/Sandbox/Editor/Header/icons.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Header/icons.tsx
@@ -64,7 +64,8 @@ export const EmbedIcon = props => (
     <path
       fillRule="evenodd"
       clipRule="evenodd"
-      d=“M9.6 10.4125V13.6937L16 8.0875L9.6 2.5V5.6875C3.38 6.49375 0.9 10.4875 0 14.5C2.22 11.6875 5.16 10.4125 9.6 10.4125V10.4125Z”      fill="currentColor"
+      d="M9.6 10.4125V13.6937L16 8.0875L9.6 2.5V5.6875C3.38 6.49375 0.9 10.4875 0 14.5C2.22 11.6875 5.16 10.4125 9.6 10.4125V10.4125Z"
+      fill="currentColor"
     />
   </svg>
 );

--- a/packages/app/src/app/pages/Sandbox/Editor/Header/icons.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Header/icons.tsx
@@ -64,8 +64,7 @@ export const EmbedIcon = props => (
     <path
       fillRule="evenodd"
       clipRule="evenodd"
-      d="M9.6 9.9125V13.1937L16 7.5875L9.6 2V5.1875C3.38 5.99375 0.9 9.9875 0 14C2.22 11.1875 5.16 9.9125 9.6 9.9125Z"
-      fill="currentColor"
+      d=“M9.6 10.4125V13.6937L16 8.0875L9.6 2.5V5.6875C3.38 6.49375 0.9 10.4875 0 14.5C2.22 11.6875 5.16 10.4125 9.6 10.4125V10.4125Z”      fill="currentColor"
     />
   </svg>
 );


### PR DESCRIPTION


Fixed miss alignment in Share Icon.

<img width="868" alt="Screenshot 2020-03-23 at 10 29 33" src="https://user-images.githubusercontent.com/46239581/77303377-2b728680-6cf3-11ea-8e1d-f352fafcbfa0.png">

#UX #UI


