### PR TITLE
Reset live counters on sandbox change

### DIFF
--- a/packages/app/src/app/overmind/effects/live/index.ts
+++ b/packages/app/src/app/overmind/effects/live/index.ts
@@ -498,13 +498,9 @@ class Live {
   reset() {
     this.clients.clear();
 
-    if (this.awaitSendTimer) {
-      clearTimeout(this.awaitSendTimer);
-    }
+    clearTimeout(this.awaitSendTimer);
 
-    if (this.awaitSend) {
-      this.awaitSend = null;
-    }
+    this.awaitSend = null;
   }
 
   resetClient(moduleShortid: string, revision: number) {

--- a/packages/app/src/app/overmind/effects/live/index.ts
+++ b/packages/app/src/app/overmind/effects/live/index.ts
@@ -71,8 +71,8 @@ class Live {
     saved_code: string;
   }) => void;
 
-  private operationToElixir(ot) {
-    return ot.map(op => {
+  private operationToElixir(ot: (number | string)[]) {
+    return ot.map((op: number | string) => {
       if (typeof op === 'number') {
         if (op < 0) {
           return { d: -op };
@@ -495,6 +495,18 @@ class Live {
     });
   }
 
+  reset() {
+    this.clients.clear();
+
+    if (this.awaitSendTimer) {
+      clearTimeout(this.awaitSendTimer);
+    }
+
+    if (this.awaitSend) {
+      this.awaitSend = null;
+    }
+  }
+
   resetClient(moduleShortid: string, revision: number) {
     this.clients.reset(moduleShortid, revision);
   }
@@ -521,10 +533,6 @@ class Live {
 
   createClient(moduleShortid: string, revision: number) {
     return this.clients.create(moduleShortid, revision);
-  }
-
-  resetClients() {
-    this.clients.clear();
   }
 }
 

--- a/packages/app/src/app/overmind/namespaces/editor/internalActions.ts
+++ b/packages/app/src/app/overmind/namespaces/editor/internalActions.ts
@@ -72,7 +72,7 @@ export const initializeLiveSandbox: AsyncAction<Sandbox> = async (
       // to join
       state.live.joinSource === 'sandbox'
     ) {
-      await actions.live.internal.disconnect();
+      actions.live.internal.disconnect();
     }
   }
 

--- a/packages/app/src/app/overmind/namespaces/live/internalActions.ts
+++ b/packages/app/src/app/overmind/namespaces/live/internalActions.ts
@@ -44,7 +44,7 @@ export const reset: Action = ({ state, actions, effects }) => {
   state.live.isLoading = false;
   state.live.roomInfo = null;
   state.live.joinSource = 'sandbox';
-  effects.live.resetClients();
+  effects.live.reset();
 };
 
 export const disconnect: Action = ({ effects, actions }) => {


### PR DESCRIPTION
We had some side effects that were still running when we were forking a sandbox, this resets them.