### PR TITLE
fix(template-icon): close popup on selecting the icon

### DIFF
--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/ProjectInfo/TemplateConfig.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/ProjectInfo/TemplateConfig.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useState } from 'react';
+import React, { FunctionComponent, useState, useCallback } from 'react';
 
 import { useOvermind } from 'app/overmind';
 import { ListAction, Text, Element } from '@codesandbox/components';
@@ -57,8 +57,10 @@ export const TemplateConfig: FunctionComponent = () => {
       },
     },
   } = useOvermind();
+  const [popupVisible, setPopupVisible] = useState(false);
   const iconPopover = usePopoverState({
     placement: 'top',
+    visible: popupVisible,
   });
   const [selectedIcon, setSelectedIcon] = useState(
     customTemplate.iconUrl || ''
@@ -66,11 +68,15 @@ export const TemplateConfig: FunctionComponent = () => {
 
   const DefaultIcon = getIcon(template);
 
-  const setIcon = (key: string) => {
-    setSelectedIcon(key);
-    iconPopover.hide();
-    editTemplate({ ...customTemplate, iconUrl: key });
-  };
+  const setIcon = useCallback(
+    (key: string) => {
+      setSelectedIcon(key);
+      setPopupVisible(false);
+      editTemplate({ ...customTemplate, iconUrl: key });
+    },
+    [customTemplate, editTemplate, setSelectedIcon, setPopupVisible]
+  );
+
   const TemplateIcon = Icons[selectedIcon];
 
   return (
@@ -96,7 +102,12 @@ export const TemplateConfig: FunctionComponent = () => {
                 const TemplateIconMap = Icons[i];
                 return (
                   // eslint-disable-next-line
-                  <li onClick={() => setIcon(i)} role="button" tabIndex={0}>
+                  <li
+                    key={i}
+                    onClick={() => setIcon(i)}
+                    role="button"
+                    tabIndex={0}
+                  >
                     <IconButton>
                       <TemplateIconMap width={24} />
                     </IconButton>

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/ProjectInfo/TemplateConfig.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/ProjectInfo/TemplateConfig.tsx
@@ -101,14 +101,8 @@ export const TemplateConfig: FunctionComponent = () => {
               {Object.keys(Icons).map((i: string) => {
                 const TemplateIconMap = Icons[i];
                 return (
-                  // eslint-disable-next-line
-                  <li
-                    key={i}
-                    onClick={() => setIcon(i)}
-                    role="button"
-                    tabIndex={0}
-                  >
-                    <IconButton>
+                  <li key={i}>
+                    <IconButton onClick={() => setIcon(i)}>
                       <TemplateIconMap width={24} />
                     </IconButton>
                   </li>


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?

<!-- Is it a Bug fix, feature, docs update, ... -->
closes #3703

## What is the current behavior?

<!-- You can also link to an open issue here -->
On selecting an icon from template icon popup, the popup doesn't close.
Currently it can be closed with outside click.

## What is the new behavior?

<!-- if this is a feature change -->
Close template icon popup after selection the icon.

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.
The testing was done visually.

1. Go to `Template Info`
2. Click on `Template Icon` and select any icon.
3. It should close the popup.

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
