### PR TITLE
make code font dm

### DIFF
--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Comments/Dialog/Code.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Comments/Dialog/Code.tsx
@@ -29,6 +29,7 @@ export const Code = withTheme(({ value, language, theme }) => (
               whiteSpace: 'pre-wrap',
               maxHeight: 400,
               overflow: 'scroll',
+              fontFamily: "'dm', menlo, monospace",
 
               '*': {
                 wordBreak: 'break-all',


### PR DESCRIPTION
- [x]  Markdown - Use one of the code fonts that we have on the page - dm/menlo? @Sara Vieira

Change the font to DM