### PR TITLE
Reply animation refactor

### DIFF
--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Comments/Dialog/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Comments/Dialog/index.tsx
@@ -416,12 +416,12 @@ const Replies = ({ replies, repliesRenderedCallback }) => {
    * If replies are loaded, do nothing and wait for next animation
    * */
   React.useEffect(() => {
-    if (!replies.length || T > 0) {
+    if (!replies.length) {
       // If the dialog is already open without any replies,
       // just skip all of the animations for opening transitions
       repliesController.set({ opacity: 1, height: 'auto' });
       setStepInTimeline(2);
-    } else if (!repliesAlreadyLoadedOnFirstRender.current) {
+    } else if (!repliesAlreadyLoadedOnFirstRender.current && T === -1) {
       skeletonController.set({ height: SKELETON_HEIGHT, opacity: 1 });
       setStepInTimeline(0);
     }


### PR DESCRIPTION
motivation: animations are imperative, the reply animations has multiple steps in it. with our current implementations, there were multiple bugs that kept cropping up because of the declarative/imperative translation.

Rewrote the animations with a better (more explicit) transition for logic.

TODO: check for state changes in replies and decide animations for them
 - [x] new reply
 - [x] delete reply
 - [x] edit reply
 - [x] switch comments