### PR TITLE
Persist selection and file in the url for loading later

### DIFF
--- a/packages/app/src/app/overmind/effects/router.ts
+++ b/packages/app/src/app/overmind/effects/router.ts
@@ -61,15 +61,9 @@ export default new (class RouterEffect {
     return `${window.location.origin}${window.location.pathname}?comment=${id}`;
   }
 
-  setParameter(key: string, value: string | null) {
-    const currentUrl = new URL(location.href);
-    if (value === null) {
-      currentUrl.searchParams.delete(key);
-    } else {
-      currentUrl.searchParams.set(key, value);
-    }
-
-    history.replace(currentUrl.toString().replace(currentUrl.origin, ''));
+  replace(url: string) {
+    const origin = new URL(url).origin;
+    history.replace(url.replace(origin, ''));
   }
 
   getParameter(key: string): string | null {

--- a/packages/app/src/app/overmind/effects/router.ts
+++ b/packages/app/src/app/overmind/effects/router.ts
@@ -3,7 +3,7 @@ import { getSandboxOptions } from '@codesandbox/common/lib/url';
 import { sandboxUrl } from '@codesandbox/common/lib/utils/url-generator';
 import history from '../../utils/history';
 
-export default {
+export default new (class RouterEffect {
   replaceSandboxUrl({
     id,
     alias,
@@ -14,7 +14,8 @@ export default {
     git?: GitInfo | null;
   }) {
     window.history.replaceState({}, '', sandboxUrl({ id, alias, git }));
-  },
+  }
+
   updateSandboxUrl(
     {
       id,
@@ -38,20 +39,41 @@ export default {
     } else {
       history.push(url);
     }
-  },
+  }
+
   redirectToNewSandbox() {
     history.push('/s/new');
-  },
+  }
+
   redirectToSandboxWizard() {
     history.replace('/s/');
-  },
+  }
+
   getSandboxOptions() {
     return getSandboxOptions(decodeURIComponent(document.location.href));
-  },
+  }
+
   getCommentId() {
-    return new URL(location.href).searchParams.get('comment');
-  },
+    return this.getParameter('comment');
+  }
+
   createCommentUrl(id: string) {
     return `${window.location.origin}${window.location.pathname}?comment=${id}`;
-  },
-};
+  }
+
+  setParameter(key: string, value: string | null) {
+    const currentUrl = new URL(location.href);
+    if (value === null) {
+      currentUrl.searchParams.delete(key);
+    } else {
+      currentUrl.searchParams.set(key, value);
+    }
+
+    history.replace(currentUrl.toString().replace(currentUrl.origin, ''));
+  }
+
+  getParameter(key: string): string | null {
+    const currentUrl = new URL(location.href);
+    return currentUrl.searchParams.get(key);
+  }
+})();

--- a/packages/app/src/app/overmind/effects/vscode/index.ts
+++ b/packages/app/src/app/overmind/effects/vscode/index.ts
@@ -662,31 +662,32 @@ export class VSCodeEffect {
    */
   setSelection(head: number, anchor: number) {
     const activeEditor = this.editorApi.getActiveCodeEditor();
-
-    if (activeEditor) {
-      const model = activeEditor.getModel();
-
-      if (model) {
-        const headPos = indexToLineAndColumn(
-          model.getLinesContent() || [],
-          head
-        );
-        const anchorPos = indexToLineAndColumn(
-          model.getLinesContent() || [],
-          anchor
-        );
-
-        const range = new this.monaco.Range(
-          headPos.lineNumber,
-          headPos.column,
-          anchorPos.lineNumber,
-          anchorPos.column
-        );
-
-        this.revealRange(range);
-        activeEditor.setSelection(range);
-      }
+    if (!activeEditor) {
+      return;
     }
+    
+    const model = activeEditor.getModel();
+    if (!model) {
+      return;
+    }
+    
+    const headPos = indexToLineAndColumn(
+      model.getLinesContent() || [],
+      head
+    );
+    const anchorPos = indexToLineAndColumn(
+      model.getLinesContent() || [],
+      anchor
+    );
+    const range = new this.monaco.Range(
+      headPos.lineNumber,
+      headPos.column,
+      anchorPos.lineNumber,
+      anchorPos.column
+    );
+
+    this.revealRange(range);
+    activeEditor.setSelection(range);
   }
 
   // Communicates the endpoint for the WebsocketLSP

--- a/packages/app/src/app/overmind/effects/vscode/index.ts
+++ b/packages/app/src/app/overmind/effects/vscode/index.ts
@@ -655,6 +655,40 @@ export class VSCodeEffect {
     }
   }
 
+  /**
+   * Set the selection inside the editor
+   * @param head Start of the selection
+   * @param anchor End of the selection
+   */
+  setSelection(head: number, anchor: number) {
+    const activeEditor = this.editorApi.getActiveCodeEditor();
+
+    if (activeEditor) {
+      const model = activeEditor.getModel();
+
+      if (model) {
+        const headPos = indexToLineAndColumn(
+          model.getLinesContent() || [],
+          head
+        );
+        const anchorPos = indexToLineAndColumn(
+          model.getLinesContent() || [],
+          anchor
+        );
+
+        const range = new this.monaco.Range(
+          headPos.lineNumber,
+          headPos.column,
+          anchorPos.lineNumber,
+          anchorPos.column
+        );
+
+        this.revealRange(range);
+        activeEditor.setSelection(range);
+      }
+    }
+  }
+
   // Communicates the endpoint for the WebsocketLSP
   private createContainerForkHandler() {
     return () => {

--- a/packages/app/src/app/overmind/namespaces/editor/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/editor/actions.ts
@@ -845,12 +845,14 @@ export const onSelectionChanged: Action<UserSelection> = (
   { actions, state },
   selection
 ) => {
-  if (state.editor.currentModule) {
-    actions.editor.persistCursorToUrl({
-      module: state.editor.currentModule,
-      selection,
-    });
-  }
+  if (!state.editor.currentModule) {
+    return;
+  };
+  
+  actions.editor.persistCursorToUrl({
+    module: state.editor.currentModule,
+    selection,
+  });
 };
 
 export const toggleEditorPreviewLayout: Action = ({ state, effects }) => {

--- a/packages/app/src/app/overmind/namespaces/editor/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/editor/actions.ts
@@ -576,6 +576,8 @@ export const moduleSelected: AsyncAction<
 
     await actions.editor.internal.setCurrentModule(module);
 
+    actions.editor.persistCursorToUrl({ module });
+
     if (state.live.isLive && state.live.liveUser && state.live.roomInfo) {
       actions.editor.internal.updateSelectionsOfModule({ module });
       state.live.liveUser.currentModuleShortid = module.shortid;
@@ -595,8 +597,6 @@ export const moduleSelected: AsyncAction<
       }
 
       effects.live.sendUserCurrentModule(module.shortid);
-
-      actions.editor.persistCursorToUrl({ module });
 
       if (!state.editor.isInProjectView) {
         actions.editor.internal.updatePreviewCode();

--- a/packages/app/src/app/overmind/namespaces/editor/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/editor/actions.ts
@@ -63,6 +63,9 @@ export const loadCursorFromUrl: AsyncAction = async ({
   actions,
   state,
 }) => {
+  if (!state.editor.currentSandbox) {
+    return;
+  }
   try {
     const path = effects.router.getParameter('file');
     if (!path) {

--- a/packages/app/src/app/overmind/namespaces/editor/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/editor/actions.ts
@@ -56,7 +56,17 @@ export const persistCursorToUrl: Action<{
     parameter += `:${serializedSelection}`;
   }
 
-  effects.router.setParameter('file', parameter);
+  const newUrl = new URL(document.location.href);
+  newUrl.searchParams.set('file', parameter);
+
+  // Restore the URI encoded parts to their original values. Our server handles this well
+  // and all the browsers do too.
+  effects.router.replace(
+    newUrl
+      .toString()
+      .replace(/%2F/g, '/')
+      .replace('%3A', ':')
+  );
 }, 500);
 
 export const loadCursorFromUrl: AsyncAction = async ({

--- a/packages/app/src/app/overmind/namespaces/editor/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/editor/actions.ts
@@ -841,6 +841,18 @@ export const showEnvironmentVariablesNotification: AsyncAction = async ({
   }
 };
 
+export const onSelectionChanged: Action<UserSelection> = (
+  { actions, state },
+  selection
+) => {
+  if (state.editor.currentModule) {
+    actions.editor.persistCursorToUrl({
+      module: state.editor.currentModule,
+      selection,
+    });
+  }
+};
+
 export const toggleEditorPreviewLayout: Action = ({ state, effects }) => {
   const currentOrientation = state.editor.previewWindowOrientation;
 

--- a/packages/app/src/app/overmind/namespaces/editor/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/editor/actions.ts
@@ -86,7 +86,7 @@ export const loadCursorFromUrl: AsyncAction = async ({
       return;
     }
 
-    const [parsedHead, parsedAnchor] = selections.split(':').map(s => +s);
+    const [parsedHead, parsedAnchor] = selections.split(':').map(Number);
     if (!isNaN(parsedHead) && !isNaN(parsedAnchor)) {
       effects.vscode.setSelection(parsedHead, parsedAnchor);
     }

--- a/packages/app/src/app/overmind/namespaces/live/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/live/actions.ts
@@ -249,7 +249,7 @@ export const onViewRangeChanged: Action<UserViewRange> = (
 };
 
 export const onSelectionChanged: Action<UserSelection> = (
-  { state, effects, actions },
+  { state, effects },
   selection
 ) => {
   if (!state.live.roomInfo) {

--- a/packages/app/src/app/overmind/namespaces/live/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/live/actions.ts
@@ -249,11 +249,18 @@ export const onViewRangeChanged: Action<UserViewRange> = (
 };
 
 export const onSelectionChanged: Action<UserSelection> = (
-  { state, effects },
+  { state, effects, actions },
   selection
 ) => {
   if (!state.live.roomInfo) {
     return;
+  }
+
+  if (state.editor.currentModule) {
+    actions.editor.persistCursorToUrl({
+      module: state.editor.currentModule,
+      selection,
+    });
   }
 
   const { liveUserId } = state.live;
@@ -422,7 +429,7 @@ export const revealViewRange: Action<{ liveUserId: string }> = (
   }
 };
 
-export const revealCursorPosition: Action<{ liveUserId: string }> = (
+export const revealCursorPosition: AsyncAction<{ liveUserId: string }> = async (
   { state, effects, actions },
   { liveUserId }
 ) => {
@@ -438,7 +445,7 @@ export const revealCursorPosition: Action<{ liveUserId: string }> = (
       ({ shortid }) => shortid === user.currentModuleShortid
     )[0];
 
-    actions.editor.moduleSelected({ id: module.id });
+    await actions.editor.moduleSelected({ id: module.id });
 
     if (user.selection?.primary?.cursorPosition) {
       effects.vscode.revealPositionInCenterIfOutsideViewport(

--- a/packages/app/src/app/overmind/namespaces/live/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/live/actions.ts
@@ -256,13 +256,6 @@ export const onSelectionChanged: Action<UserSelection> = (
     return;
   }
 
-  if (state.editor.currentModule) {
-    actions.editor.persistCursorToUrl({
-      module: state.editor.currentModule,
-      selection,
-    });
-  }
-
   const { liveUserId } = state.live;
   const moduleShortid = state.editor.currentModuleShortid;
   if (!moduleShortid || !liveUserId) {

--- a/packages/app/src/app/overmind/onInitialize.ts
+++ b/packages/app/src/app/overmind/onInitialize.ts
@@ -83,7 +83,10 @@ export const onInitialize: OnInitialize = async (
     getCurrentUser: () => state.user,
     onOperationApplied: actions.editor.onOperationApplied,
     onCodeChange: actions.editor.codeChanged,
-    onSelectionChanged: actions.live.onSelectionChanged,
+    onSelectionChanged: selection => {
+      actions.editor.onSelectionChanged(selection);
+      actions.live.onSelectionChanged(selection);
+    },
     onViewRangeChanged: actions.live.onViewRangeChanged,
     onCommentClick: actions.comments.onCommentClick,
     reaction: overmindInstance.reaction,

--- a/packages/app/src/app/pages/Sandbox/Editor/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/index.tsx
@@ -29,7 +29,7 @@ const StatusBar = styled.div`
   }
 `;
 
-const ContentSplit = () => {
+const Editor = () => {
   const { state, actions, effects, reaction } = useOvermind();
   const statusbarEl = useRef(null);
   const [showSkeleton, setShowSkeleton] = useState(
@@ -211,4 +211,4 @@ const ContentSplit = () => {
   );
 };
 
-export default ContentSplit;
+export default Editor;

--- a/packages/app/src/app/pages/Sandbox/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/index.tsx
@@ -22,7 +22,7 @@ interface Props {
   };
 }
 
-export const Sandbox: React.FC<Props> = React.memo(
+export const Sandbox = React.memo<Props>(
   ({ match }) => {
     const { state, actions } = useOvermind();
 

--- a/packages/app/src/app/pages/Sandbox/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/index.tsx
@@ -22,152 +22,157 @@ interface Props {
   };
 }
 
-export const Sandbox: React.FC<Props> = ({ match }) => {
-  const { state, actions } = useOvermind();
+export const Sandbox: React.FC<Props> = React.memo(
+  ({ match }) => {
+    const { state, actions } = useOvermind();
 
-  useEffect(() => {
-    if (window.screen.availWidth < 800) {
-      if (!document.location.search.includes('from-embed')) {
-        const addedSign = document.location.search ? '&' : '?';
-        document.location.href =
-          document.location.href.replace('/s/', '/embed/') +
-          addedSign +
-          'codemirror=1';
-      } else {
-        actions.preferences.codeMirrorForced();
+    useEffect(() => {
+      if (window.screen.availWidth < 800) {
+        if (!document.location.search.includes('from-embed')) {
+          const addedSign = document.location.search ? '&' : '?';
+          document.location.href =
+            document.location.href.replace('/s/', '/embed/') +
+            addedSign +
+            'codemirror=1';
+        } else {
+          actions.preferences.codeMirrorForced();
+        }
       }
+
+      actions.live.onNavigateAway();
+
+      actions.editor.sandboxChanged({ id: match.params.id });
+    }, [actions.live, actions.editor, actions.preferences, match.params.id]);
+
+    useEffect(
+      () => () => {
+        actions.live.onNavigateAway();
+      },
+      [actions.live]
+    );
+
+    function getContent() {
+      const { hasLogIn, isLoggedIn } = state;
+
+      if (state.editor.error) {
+        const isGithub = match.params.id.includes('github');
+
+        return (
+          <>
+            <div
+              style={{
+                fontWeight: 300,
+                color: 'rgba(255, 255, 255, 0.5)',
+                marginBottom: '1rem',
+                fontSize: '1.5rem',
+              }}
+            >
+              Something went wrong
+            </div>
+            <Title style={{ fontSize: '1.25rem', marginBottom: 0 }}>
+              {state.editor.error}
+            </Title>
+            <br />
+            <div style={{ display: 'flex', maxWidth: 400, width: '100%' }}>
+              <Button block small style={{ margin: '.5rem' }} href="/s">
+                Create Sandbox
+              </Button>
+              <Button block small style={{ margin: '.5rem' }} href="/">
+                {hasLogIn ? 'Dashboard' : 'Homepage'}
+              </Button>
+            </div>
+            {isLoggedIn && isGithub && (
+              <div
+                style={{ maxWidth: 400, marginTop: '2.5rem', width: '100%' }}
+              >
+                <div
+                  style={{
+                    fontWeight: 300,
+                    color: 'rgba(255, 255, 255, 0.7)',
+                    marginBottom: '1rem',
+                    fontSize: '1rem',
+                    textAlign: 'center',
+                    lineHeight: 1.6,
+                  }}
+                >
+                  Did you try to open a private GitHub repository and are you a{' '}
+                  <Link to="/pro">pro</Link>? Then you might need to get private
+                  access:
+                </div>
+                <GithubIntegration small />
+                <div
+                  style={{
+                    fontWeight: 300,
+                    color: 'rgba(255, 255, 255, 0.7)',
+                    marginTop: '1rem',
+                    fontSize: '1rem',
+                    textAlign: 'center',
+                    lineHeight: 1.6,
+                  }}
+                >
+                  If you{"'"}re importing a sandbox from an organization, make
+                  sure to enable organization access{' '}
+                  <a
+                    href="https://github.com/settings/connections/applications/c07a89833b557afc7be2"
+                    target="_blank"
+                    rel="noreferrer noopener"
+                  >
+                    here
+                  </a>
+                  .
+                </div>
+              </div>
+            )}
+          </>
+        );
+      }
+
+      if (state.editor.notFound) {
+        return <NotFound />;
+      }
+
+      return null;
     }
 
-    actions.live.onNavigateAway();
+    const content = getContent();
 
-    actions.editor.sandboxChanged({ id: match.params.id });
-  }, [actions.live, actions.editor, actions.preferences, match.params.id]);
-
-  useEffect(
-    () => () => {
-      actions.live.onNavigateAway();
-    },
-    [actions.live]
-  );
-
-  function getContent() {
-    const { hasLogIn, isLoggedIn } = state;
-
-    if (state.editor.error) {
-      const isGithub = match.params.id.includes('github');
-
+    if (content) {
       return (
-        <>
-          <div
+        <Fullscreen>
+          <Padding
             style={{
-              fontWeight: 300,
-              color: 'rgba(255, 255, 255, 0.5)',
-              marginBottom: '1rem',
-              fontSize: '1.5rem',
+              display: 'flex',
+              flexDirection: 'column',
+              width: '100vw',
+              height: '100vh',
             }}
+            margin={1}
           >
-            Something went wrong
-          </div>
-          <Title style={{ fontSize: '1.25rem', marginBottom: 0 }}>
-            {state.editor.error}
-          </Title>
-          <br />
-          <div style={{ display: 'flex', maxWidth: 400, width: '100%' }}>
-            <Button block small style={{ margin: '.5rem' }} href="/s">
-              Create Sandbox
-            </Button>
-            <Button block small style={{ margin: '.5rem' }} href="/">
-              {hasLogIn ? 'Dashboard' : 'Homepage'}
-            </Button>
-          </div>
-          {isLoggedIn && isGithub && (
-            <div style={{ maxWidth: 400, marginTop: '2.5rem', width: '100%' }}>
-              <div
-                style={{
-                  fontWeight: 300,
-                  color: 'rgba(255, 255, 255, 0.7)',
-                  marginBottom: '1rem',
-                  fontSize: '1rem',
-                  textAlign: 'center',
-                  lineHeight: 1.6,
-                }}
-              >
-                Did you try to open a private GitHub repository and are you a{' '}
-                <Link to="/pro">pro</Link>? Then you might need to get private
-                access:
-              </div>
-              <GithubIntegration small />
-              <div
-                style={{
-                  fontWeight: 300,
-                  color: 'rgba(255, 255, 255, 0.7)',
-                  marginTop: '1rem',
-                  fontSize: '1rem',
-                  textAlign: 'center',
-                  lineHeight: 1.6,
-                }}
-              >
-                If you{"'"}re importing a sandbox from an organization, make
-                sure to enable organization access{' '}
-                <a
-                  href="https://github.com/settings/connections/applications/c07a89833b557afc7be2"
-                  target="_blank"
-                  rel="noreferrer noopener"
-                >
-                  here
-                </a>
-                .
-              </div>
-            </div>
-          )}
-        </>
+            <Navigation title="Sandbox Editor" />
+            <Centered
+              style={{ flex: 1, width: '100%', height: '100%' }}
+              horizontal
+              vertical
+            >
+              {content}
+            </Centered>
+          </Padding>
+        </Fullscreen>
       );
     }
 
-    if (state.editor.notFound) {
-      return <NotFound />;
-    }
+    const sandbox = state.editor.currentSandbox;
 
-    return null;
-  }
-
-  const content = getContent();
-
-  if (content) {
     return (
-      <Fullscreen>
-        <Padding
-          style={{
-            display: 'flex',
-            flexDirection: 'column',
-            width: '100vw',
-            height: '100vh',
-          }}
-          margin={1}
-        >
-          <Navigation title="Sandbox Editor" />
-          <Centered
-            style={{ flex: 1, width: '100%', height: '100%' }}
-            horizontal
-            vertical
-          >
-            {content}
-          </Centered>
-        </Padding>
-      </Fullscreen>
+      <>
+        <Helmet>
+          <title>
+            {sandbox ? getSandboxName(sandbox) : 'Loading...'} - CodeSandbox
+          </title>
+        </Helmet>
+        <Editor />
+      </>
     );
-  }
-
-  const sandbox = state.editor.currentSandbox;
-
-  return (
-    <>
-      <Helmet>
-        <title>
-          {sandbox ? getSandboxName(sandbox) : 'Loading...'} - CodeSandbox
-        </title>
-      </Helmet>
-      <Editor />
-    </>
-  );
-};
+  },
+  (prev, next) => prev.match.params.id === next.match.params.id
+);


### PR DESCRIPTION
With this change, we put the currently opened file and selection in the URL (`?file=...&selection=...`). When you share the link with others (or just refresh) you will directly go back to that file and select the same code. 

I tested it with several combinations of files and selections. Also made sure that you scroll to the location of the selection when you open it.