### PR TITLE
CSB Black - bump up the contrast for line numbers

### DIFF
--- a/packages/common/src/themes/codesandbox-black.js
+++ b/packages/common/src/themes/codesandbox-black.js
@@ -86,8 +86,8 @@ const colors = {
     activeForeground: tokens.grays[300],
   },
   editorLineNumber: {
-    foreground: tokens.grays[600],
-    activeForeground: tokens.grays[400],
+    foreground: tokens.grays[400],
+    activeForeground: tokens.grays[200],
   },
   editorRuler: {
     foreground: tokens.white,


### PR DESCRIPTION
Fixes https://github.com/codesandbox/codesandbox-client/issues/3824

left: production
middle: this PR
right: over correction?

![image](https://user-images.githubusercontent.com/1863771/78667305-024c1b80-78d9-11ea-8b87-69e8cf4622e9.png)
