### PR TITLE
Correct link in test documents

### DIFF
--- a/packages/homepage/content/docs/2-tests.md
+++ b/packages/homepage/content/docs/2-tests.md
@@ -16,7 +16,7 @@ files that end with `.test.js`, `.spec.js`, `.test.ts(x)` and `.spec.js(x)`. We
 will automatically detect these test files and show the results in the Tests
 tab.
 
-Note: In [Container sandboxes](<(/docs/environment)>) you can still use Jest (or
+Note: In [Container sandboxes](/docs/environment) you can still use Jest (or
 whichever test framework you want), but we don't auto-detect these and you'd
 need to set it up yourself as you would locally.
 


### PR DESCRIPTION
## What kind of change does this PR introduce?
docs

## What is the current behavior?
link address is incorrect
https://codesandbox.io/docs/(/docs/environment)

## What is the new behavior?
now the link is going to the correct destination
https://codesandbox.io/docs/environment

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Updated document

## Checklist

- [x] Documentation
- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged
- [x] Added myself to contributors table