### PR TITLE
Comments: Reset replies when comment changes

### DIFF
--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Comments/Dialog/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Comments/Dialog/index.tsx
@@ -466,7 +466,6 @@ const Replies = ({ replies, replyCount, repliesRenderedCallback }) => {
     if (!replyCount) {
       // If the dialog is already open without any replies,
       // just skip all of the animations for opening transitions
-      skeletonController.set({ height: 0, opacity: 0 });
       repliesController.set({ opacity: 1, height: 'auto' });
       setStepInTimeline(2);
     } else if (!repliesAlreadyLoadedOnFirstRender.current && T === -1) {

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Comments/Dialog/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Comments/Dialog/index.tsx
@@ -466,6 +466,7 @@ const Replies = ({ replies, replyCount, repliesRenderedCallback }) => {
     if (!replyCount) {
       // If the dialog is already open without any replies,
       // just skip all of the animations for opening transitions
+      skeletonController.set({ height: 0, opacity: 0 });
       repliesController.set({ opacity: 1, height: 'auto' });
       setStepInTimeline(2);
     } else if (!repliesAlreadyLoadedOnFirstRender.current && T === -1) {

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Comments/Dialog/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Comments/Dialog/index.tsx
@@ -152,6 +152,7 @@ export const Dialog: React.FC = () => {
                 />
 
                 <Replies
+                  key={comment.id}
                   replies={replies}
                   replyCount={comment.replyCount}
                   repliesRenderedCallback={() => setRepliesRendered(true)}


### PR DESCRIPTION
The timeline in replies should start from -1 when currentComment changes

We do this by using the key prop to re-render the replies section (as it should :))