### PR TITLE
Comments: Now the reply skeleton is actually themed

### DIFF
--- a/packages/components/src/components/SkeletonText/index.tsx
+++ b/packages/components/src/components/SkeletonText/index.tsx
@@ -11,7 +11,7 @@ const pulse = keyframes`
 
 export const SkeletonText = styled(Element)(props => {
   const color = props.theme.colors.sideBar.border;
-  const themeType = props.theme.vscodeTheme.type;
+  const themeType = props.theme.type || props.theme.vscodeTheme.type;
 
   /**
    * This is fun,

--- a/packages/components/src/components/SkeletonText/index.tsx
+++ b/packages/components/src/components/SkeletonText/index.tsx
@@ -11,7 +11,7 @@ const pulse = keyframes`
 
 export const SkeletonText = styled(Element)(props => {
   const color = props.theme.colors.sideBar.border;
-  const themeType = props.theme.type;
+  const themeType = props.theme.vscodeTheme.type;
 
   /**
    * This is fun,


### PR DESCRIPTION
Oh boy, the replies skeleton wasn't actually themed until now. It was always black.

```diff
- const themeType = props.theme.type;
+ const themeType = props.theme.vscodeTheme.type;
```