### PR TITLE
add hid feature policy to iframe

### DIFF
--- a/packages/common/src/components/Preview/index.tsx
+++ b/packages/common/src/components/Preview/index.tsx
@@ -596,7 +596,7 @@ class BasePreview extends React.Component<Props, State> {
             <>
               <StyledFrame
                 sandbox="allow-forms allow-scripts allow-same-origin allow-modals allow-popups allow-presentation"
-                allow="geolocation; microphone; camera;midi; vr; accelerometer; gyroscope; payment; ambient-light-sensor; encrypted-media; usb"
+                allow="geolocation; microphone; camera;midi; vr; accelerometer; gyroscope; payment; ambient-light-sensor; encrypted-media; usb; hid"
                 src={this.state.url}
                 ref={this.setIframeElement}
                 title={getSandboxName(sandbox)}


### PR DESCRIPTION
## What kind of change does this PR introduce?
Allow to use the [WebHID API](https://wicg.github.io/webhid/)

As per [Feature Policy](https://wicg.github.io/webhid/#feature-policy) to use the WebHID API (available behind a `chrome://flags` in Chrome) the sandbox iframe needs to allow `hid`. 

## What is the current behavior?
Currently the WebHID API can't be used anymore because it introduced a feature policy that isn't in the allowed list of the iframe. 

Currently broken sandboxes: 
* [Keyboard Backlight Control](https://codesandbox.io/s/webhid-demo-keyboard-backlight-qlq95)
* [Ambient Light Sensor](https://codesandbox.io/s/webhid-demo-ambient-light-sensor-ix382)

## What is the new behavior?
The WebHID API would work inside a sandbox 
