### PR TITLE
Improve login and logout

### DIFF
--- a/packages/app/src/app/overmind/actions.ts
+++ b/packages/app/src/app/overmind/actions.ts
@@ -3,6 +3,7 @@ import {
   convertTypeToStatus,
 } from '@codesandbox/common/lib/utils/notifications';
 
+import { Page } from '@codesandbox/common/lib/types';
 import { withLoadApp } from './factories';
 import * as internalActions from './internalActions';
 import { Action, AsyncAction } from '.';
@@ -13,15 +14,16 @@ export const appUnmounted: AsyncAction = async ({ effects, actions }) => {
   effects.connection.removeListener(actions.connectionChanged);
 };
 
-export const sandboxPageMounted: AsyncAction = withLoadApp();
+export const sandboxPageMounted: AsyncAction = withLoadApp(Page.NEW_SANDBOX);
 
-export const searchMounted: AsyncAction = withLoadApp();
+export const searchMounted: AsyncAction = withLoadApp(Page.SEARCH);
 
-export const codesadboxMounted: AsyncAction = withLoadApp();
+export const codesadboxMounted: AsyncAction = withLoadApp(Page.SADBOX);
 
-export const genericPageMounted: AsyncAction = withLoadApp();
+export const genericPageMounted: AsyncAction = withLoadApp(Page.GENERIC_PAGE);
 
 export const cliMounted: AsyncAction = withLoadApp(
+  Page.CLI,
   async ({ state, actions }) => {
     if (state.user) {
       await actions.internal.authorize();
@@ -52,9 +54,11 @@ export const notificationRemoved: Action<{
   state.notifications.splice(notificationToRemoveIndex, 1);
 };
 
-export const cliInstructionsMounted: AsyncAction = withLoadApp();
+export const cliInstructionsMounted: AsyncAction = withLoadApp(
+  Page.CLI_INSTRUCTIONS
+);
 
-export const githubPageMounted: AsyncAction = withLoadApp();
+export const githubPageMounted: AsyncAction = withLoadApp(Page.GITHUB);
 
 export const connectionChanged: Action<boolean> = ({ state }, connected) => {
   state.connected = connected;
@@ -179,19 +183,10 @@ export const signInGithubClicked: AsyncAction = async ({ state, actions }) => {
   state.isLoadingGithub = false;
 };
 
-export const signOutClicked: AsyncAction = async ({
-  state,
-  effects,
-  actions,
-}) => {
+export const signOutClicked: AsyncAction = async ({ effects }) => {
   effects.analytics.track('Sign Out', {});
-  state.workspace.openedWorkspaceItem = 'files';
-  if (state.live.isLive) {
-    actions.live.internal.disconnect();
-  }
   await effects.api.signout();
   effects.jwt.reset();
-  state.user = null;
   effects.browser.reload();
 };
 

--- a/packages/app/src/app/overmind/effects/router.ts
+++ b/packages/app/src/app/overmind/effects/router.ts
@@ -66,8 +66,21 @@ export default new (class RouterEffect {
     history.replace(url.replace(origin, ''));
   }
 
+  reload() {
+    const current = new URL(location.href);
+    history.replace(
+      `${current.pathname}${
+        current.search ? `?${current.search}&login` : '?login'
+      }`
+    );
+  }
+
   getParameter(key: string): string | null {
     const currentUrl = new URL(location.href);
     return currentUrl.searchParams.get(key);
+  }
+
+  getPathParts() {
+    return new URL(location.href).pathname.split('/');
   }
 })();

--- a/packages/app/src/app/overmind/factories.ts
+++ b/packages/app/src/app/overmind/factories.ts
@@ -1,4 +1,8 @@
-import { Contributor, PermissionType } from '@codesandbox/common/lib/types';
+import {
+  Contributor,
+  PermissionType,
+  Page,
+} from '@codesandbox/common/lib/types';
 import { hasPermission } from '@codesandbox/common/lib/utils/permission';
 import { IDerive, IState } from 'overmind';
 
@@ -9,10 +13,11 @@ import { AsyncAction } from '.';
   and settings
 */
 export const withLoadApp = <T>(
+  page: Page,
   continueAction?: AsyncAction<T>
 ): AsyncAction<T> => async (context, value) => {
   const { effects, state, actions } = context;
-
+  state.currentPage = page;
   if (state.hasLoadedApp && continueAction) {
     await continueAction(context, value);
     return;

--- a/packages/app/src/app/overmind/namespaces/dashboard/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/dashboard/actions.ts
@@ -1,8 +1,9 @@
 import { Action, AsyncAction } from 'app/overmind';
 import { withLoadApp } from 'app/overmind/factories';
+import { Page } from '@codesandbox/common/lib/types';
 import { OrderBy } from './state';
 
-export const dashboardMounted: AsyncAction = withLoadApp();
+export const dashboardMounted: AsyncAction = withLoadApp(Page.DASHBOARD);
 
 export const sandboxesSelected: Action<{
   sandboxIds: string[];

--- a/packages/app/src/app/overmind/namespaces/editor/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/editor/actions.ts
@@ -9,6 +9,7 @@ import {
   WindowOrientation,
   Module,
   UserSelection,
+  Page,
 } from '@codesandbox/common/lib/types';
 import { logBreadcrumb } from '@codesandbox/common/lib/utils/analytics/sentry';
 import { getTextOperation } from '@codesandbox/common/lib/utils/diff';
@@ -91,9 +92,11 @@ export const loadCursorFromUrl: AsyncAction = async ({
 
   await actions.editor.moduleSelected({ id: module.id });
 
-  const [parsedHead, parsedAnchor] = selection.split('-').map(Number);
-  if (!isNaN(parsedHead) && !isNaN(parsedAnchor)) {
-    effects.vscode.setSelection(parsedHead, parsedAnchor);
+  if (selection) {
+    const [parsedHead, parsedAnchor] = selection.split('-').map(Number);
+    if (!isNaN(parsedHead) && !isNaN(parsedAnchor)) {
+      effects.vscode.setSelection(parsedHead, parsedAnchor);
+    }
   }
 };
 
@@ -134,7 +137,7 @@ export const npmDependencyRemoved: AsyncAction<string> = withOwnedSandbox(
 
 export const sandboxChanged: AsyncAction<{ id: string }> = withLoadApp<{
   id: string;
-}>(async ({ state, actions, effects }, { id }) => {
+}>(Page.SANDBOX, async ({ state, actions, effects }, { id }) => {
   // This happens when we fork. This can be avoided with state first routing
   if (state.editor.isForkingSandbox && state.editor.currentSandbox) {
     effects.vscode.openModule(state.editor.currentModule);

--- a/packages/app/src/app/overmind/namespaces/explore/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/explore/actions.ts
@@ -1,8 +1,9 @@
-import { PickedSandboxDetails } from '@codesandbox/common/lib/types';
+import { PickedSandboxDetails, Page } from '@codesandbox/common/lib/types';
 import { Action, AsyncAction } from 'app/overmind';
 import { withLoadApp } from 'app/overmind/factories';
 
 export const popularSandboxesMounted: AsyncAction<string> = withLoadApp(
+  Page.CURATOR,
   async ({ state, actions, effects }, date) => {
     try {
       state.explore.popularSandboxes = await effects.api.getPopularSandboxes(

--- a/packages/app/src/app/overmind/namespaces/live/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/live/actions.ts
@@ -3,6 +3,7 @@ import {
   LiveMessageEvent,
   UserViewRange,
   UserSelection,
+  Page,
 } from '@codesandbox/common/lib/types';
 import { Action, AsyncAction, Operator } from 'app/overmind';
 import { withLoadApp } from 'app/overmind/factories';
@@ -17,7 +18,7 @@ export const internal = internalActions;
 
 export const signInToRoom: AsyncAction<{
   roomId: string;
-}> = withLoadApp(async ({ state, effects, actions }, { roomId }) => {
+}> = withLoadApp(Page.LIVE, async ({ state, effects, actions }, { roomId }) => {
   await actions.internal.signIn({});
 
   if (state.isLoggedIn) {
@@ -57,7 +58,7 @@ export const onOperationError: Action<{
 
 export const roomJoined: AsyncAction<{
   roomId: string;
-}> = withLoadApp(async ({ state, effects, actions }, { roomId }) => {
+}> = withLoadApp(Page.LIVE, async ({ state, effects, actions }, { roomId }) => {
   if (!state.isLoggedIn) {
     return;
   }

--- a/packages/app/src/app/overmind/namespaces/patron/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/patron/actions.ts
@@ -1,8 +1,8 @@
 import { AsyncAction, Action } from 'app/overmind';
 import { withLoadApp } from 'app/overmind/factories';
-import { StripeErrorCode } from '@codesandbox/common/lib/types';
+import { StripeErrorCode, Page } from '@codesandbox/common/lib/types';
 
-export const patronMounted: AsyncAction = withLoadApp();
+export const patronMounted: AsyncAction = withLoadApp(Page.PATRON);
 
 export const priceChanged: Action<{ price: number }> = (
   { state },

--- a/packages/app/src/app/overmind/namespaces/profile/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/profile/actions.ts
@@ -1,8 +1,9 @@
-import { Sandbox } from '@codesandbox/common/lib/types';
+import { Sandbox, Page } from '@codesandbox/common/lib/types';
 import { Action, AsyncAction } from 'app/overmind';
 import { withLoadApp } from 'app/overmind/factories';
 
 export const profileMounted: AsyncAction<string> = withLoadApp(
+  Page.PROFILE,
   async ({ effects, state }, username) => {
     state.profile.isLoadingProfile = true;
     state.profile.notFound = false;

--- a/packages/app/src/app/overmind/state.ts
+++ b/packages/app/src/app/overmind/state.ts
@@ -3,12 +3,14 @@ import {
   Notification,
   Sandbox,
   UploadFile,
+  Page,
 } from '@codesandbox/common/lib/types';
 import store from 'store/dist/store.modern';
 
 import { Derive } from '.';
 
 type State = {
+  currentPage: Page | null;
   isPatron: Derive<State, boolean>;
   isFirstVisit: boolean;
   isLoggedIn: Derive<State, boolean>;
@@ -42,6 +44,7 @@ type State = {
 };
 
 export const state: State = {
+  currentPage: null,
   isFirstVisit: false,
   isPatron: ({ user }) =>
     Boolean(user && user.subscription && user.subscription.since),

--- a/packages/common/src/types/index.ts
+++ b/packages/common/src/types/index.ts
@@ -742,3 +742,21 @@ export type PatronTier = 1 | 2 | 3 | 4;
 export type SandboxFs = {
   [path: string]: Module | Directory;
 };
+
+export enum Page {
+  NEW_SANDBOX = 'NewSandbox',
+  GITHUB = 'Github',
+  CLI_INSTRUCTIONS = 'CliInstructions',
+  DASHBOARD = 'Dashboard',
+  SANDBOX = 'Sandbox',
+  CURATOR = 'Curator',
+  LIVE = 'Live',
+  SIGN_IN = 'SignIn',
+  PROFILE = 'Profile',
+  SEARCH = 'Search',
+  PATRON = 'Patron',
+  PRO = 'Pro',
+  CLI = 'Cli',
+  SADBOX = 'Sadbox',
+  GENERIC_PAGE = 'GenericPage',
+}


### PR DESCRIPTION
This improves the general login/logout flow:

- When you logout there are no state changes, causing this weird middle state... you log out and the browser refreshes
- Now we track what page you are on. When you log in on a page it will rerun the mounting action for that page

I think we might have had a few subtle bugs related to this as some pages did not rerun the "appLoad" logic. Meaning you might have had a user and jwt, but missing settings etc.

I have tested logging in and out on all pages affected.