### PR TITLE
fix: skeleton with color having opacity

### DIFF
--- a/packages/app/src/app/pages/Sandbox/Editor/Skeleton/elements.ts
+++ b/packages/app/src/app/pages/Sandbox/Editor/Skeleton/elements.ts
@@ -7,7 +7,7 @@ const pulse = keyframes`
 `;
 
 export const SkeletonTextBlock = styled.div(props => {
-  const color = props.theme.colors?.sideBar.border || '#242424';
+  let color = props.theme.colors?.sideBar.border || '#242424';
   const themeType = props.theme.vscodeTheme.type;
 
   /**
@@ -23,7 +23,16 @@ export const SkeletonTextBlock = styled.div(props => {
   const backgroundLuminosity = themeType === 'light' ? 86 : 14;
   const highlightLuminosity = themeType === 'light' ? 88 : 16;
 
+  // Color('#ff000033') throws error.
+  const colorWithOpacity = color.length === 9;
+
+  if (colorWithOpacity) {
+    // remove the opacity
+    color = color.slice(0, -2);
+  }
+
   const hsl = Color(color).hsl();
+
   const background = Color({ ...hsl, l: backgroundLuminosity }).hslString();
   const highlight = Color({ ...hsl, l: highlightLuminosity }).hslString();
 


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?
Bug Fix
<!-- Is it a Bug fix, feature, docs update, ... -->

## What is the current behavior?
When we select theme `red` and load the editor, the app breaks because skeleton is using `Color` package and `Color('#ff000033')` throws an error. 

<!-- You can also link to an open issue here -->

## What is the new behavior?
Fixes the color access with opacity.

Screen Recording: https://www.loom.com/share/c56684ce70834e91a8ec822b80061e8d 
<!-- if this is a feature change -->

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Locally tested with red theme

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
