### PR TITLE
Download dependencies seperately and merge in bundler

### DIFF
--- a/packages/app/config/webpack.prod.js
+++ b/packages/app/config/webpack.prod.js
@@ -286,7 +286,7 @@ module.exports = merge(commonConfig, {
           },
         },
         {
-          urlPattern: /prod-packager-packages\.csb\.dev/,
+          urlPattern: /prod-packager-packages\.codesandbox\.io/,
           handler: 'fastest',
           options: {
             cache: {

--- a/packages/app/src/sandbox/eval/utils/get-dependency-name.test.ts
+++ b/packages/app/src/sandbox/eval/utils/get-dependency-name.test.ts
@@ -22,4 +22,10 @@ describe('getDependencyName', () => {
       '@angular/core/4.4.3'
     );
   });
+
+  it('can find a simple dependency name with beta tag', () => {
+    expect(getDependencyName('reakit/1.0.0-beta.16/lib/Component')).toBe(
+      'reakit/1.0.0-beta.16'
+    );
+  });
 });

--- a/packages/app/src/sandbox/eval/utils/get-dependency-name.ts
+++ b/packages/app/src/sandbox/eval/utils/get-dependency-name.ts
@@ -5,7 +5,7 @@ export default function getDependencyName(path: string) {
   if (path.startsWith('@')) {
     dependencyName += `/${dependencyParts.shift()}`;
   }
-  if (dependencyParts[0] && /^\d+\.\d+\.\d+$/.test(dependencyParts[0])) {
+  if (dependencyParts[0] && /^\d+\.\d+\.\d+.*$/.test(dependencyParts[0])) {
     // Make sure to include the aliased version if it's part of it
     dependencyName += `/${dependencyParts.shift()}`;
   }

--- a/packages/app/src/sandbox/npm/fetch-dependencies.ts
+++ b/packages/app/src/sandbox/npm/fetch-dependencies.ts
@@ -124,11 +124,10 @@ async function getDependencies(
 
       const dependencyUrl = dependenciesToQuery(dep);
       const bucketDependencyUrl = dependencyToPackagePath(name, version);
+      const fullUrl = `${BUCKET_URL}/${bucketDependencyUrl}`;
 
       try {
-        const bucketManifest = await callApi(
-          `${BUCKET_URL}/${bucketDependencyUrl}`
-        );
+        const bucketManifest = await callApi(fullUrl);
         return bucketManifest;
       } catch (e) {
         setScreen({
@@ -138,10 +137,7 @@ async function getDependencies(
         });
 
         // The dep has not been generated yet...
-        const { url } = await requestPackager(
-          `${PACKAGER_URL}/${dependencyUrl}`,
-          'POST'
-        );
+        await requestPackager(`${PACKAGER_URL}/${dependencyUrl}`, 'POST');
 
         setScreen({
           type: 'loading',
@@ -149,7 +145,7 @@ async function getDependencies(
           showFullScreen: showLoadingFullScreen,
         });
 
-        return requestPackager(`${BUCKET_URL}/${url}`);
+        return requestPackager(fullUrl);
       }
     })
   );


### PR DESCRIPTION
This sped up downloading dependencies 2-5x, even in some cases it takes 1s instead of 60s!

Fixes #3782
Fixes #3811