### PR TITLE
Fix refresh for hash based URL in Preview

### DIFF
--- a/packages/common/src/components/Preview/index.tsx
+++ b/packages/common/src/components/Preview/index.tsx
@@ -487,6 +487,8 @@ class BasePreview extends React.Component<Props, State> {
         back: false,
         forward: false,
       });
+
+      this.handleHashedURL(urlInAddressBar);
     }
   };
 
@@ -497,7 +499,10 @@ class BasePreview extends React.Component<Props, State> {
     const urlToSet = urlInAddressBar || url;
 
     if (this.element) {
-      this.element.src = urlToSet || this.currentUrl();
+      const iframeSRC = urlToSet || this.currentUrl();
+      this.element.src = iframeSRC;
+
+      this.handleHashedURL(iframeSRC);
     }
 
     this.setState({
@@ -505,6 +510,14 @@ class BasePreview extends React.Component<Props, State> {
       back: false,
       forward: false,
     });
+  };
+
+  handleHashedURL = url => {
+    if (url.includes('#')) {
+      dispatch({
+        type: 'refresh',
+      });
+    }
   };
 
   handleBack = () => {

--- a/packages/common/src/components/Preview/index.tsx
+++ b/packages/common/src/components/Preview/index.tsx
@@ -488,7 +488,7 @@ class BasePreview extends React.Component<Props, State> {
         forward: false,
       });
 
-      this.handleHashedURL(urlInAddressBar);
+      this.refreshHashedUrl(urlInAddressBar);
     }
   };
 
@@ -502,7 +502,7 @@ class BasePreview extends React.Component<Props, State> {
       const iframeSRC = urlToSet || this.currentUrl();
       this.element.src = iframeSRC;
 
-      this.handleHashedURL(iframeSRC);
+      this.refreshHashedUrl(iframeSRC);
     }
 
     this.setState({
@@ -512,7 +512,7 @@ class BasePreview extends React.Component<Props, State> {
     });
   };
 
-  handleHashedURL = url => {
+  refreshHashedUrl = url => {
     if (url.includes('#')) {
       dispatch({
         type: 'refresh',

--- a/packages/common/src/components/Preview/index.tsx
+++ b/packages/common/src/components/Preview/index.tsx
@@ -513,11 +513,11 @@ class BasePreview extends React.Component<Props, State> {
   };
 
   refreshHashedUrl = url => {
-    if (url.includes('#')) {
-      dispatch({
-        type: 'refresh',
-      });
+    if (!url.includes('#')) {
+      return;
     }
+
+    dispatch({ type: 'refresh' });
   };
 
   handleBack = () => {


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?

<!-- Is it a Bug fix, feature, docs update, ... -->
Fix #3757 


## What is the current behavior?

<!-- You can also link to an open issue here -->
`hash` change in the `url` doesn't trigger a page reload in the Iframe

## What is the new behavior?

<!-- if this is a feature change -->
dispatch `refresh` to manually to trigger `reload` in Iframe

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Fork -> https://codesandbox.io/s/sinuous-router-g2eud
2. Click on any route Eg: `Bob's Profile` which changes the url in the address bar to `/#users/bob`
3. Then click on `Reload` icon in the `Browser` Tab.
4. It should reload the Iframe.

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
