### PR TITLE
feat: add copy sandbox link option on Sandbox Card

### DIFF
--- a/packages/app/src/app/pages/Dashboard/Content/SandboxCard/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/SandboxCard/index.tsx
@@ -81,6 +81,18 @@ type State = {
 export const DELETE_SANDBOX_DROP_KEY = 'delete';
 export const MAKE_TEMPLATE_DROP_KEY = 'makeTemplate';
 
+const copyToClipboard = (str: string) => {
+  const el = document.createElement('textarea');
+  el.value = str;
+  el.setAttribute('readonly', '');
+  el.style.position = 'absolute';
+  el.style.left = '-9999px';
+  document.body.appendChild(el);
+  el.select();
+  document.execCommand('copy');
+  document.body.removeChild(el);
+};
+
 class SandboxItemComponent extends React.PureComponent<Props, State> {
   el: HTMLDivElement;
   screenshotTimeout: number;
@@ -291,6 +303,13 @@ class SandboxItemComponent extends React.PureComponent<Props, State> {
           },
         },
         {
+          title: 'Copy Sandbox Link',
+          action: () => {
+            this.copySandboxURL();
+            return true;
+          },
+        },
+        {
           title: 'Fork Sandbox',
           action: () => {
             this.props.forkSandbox(this.props.id);
@@ -379,6 +398,14 @@ class SandboxItemComponent extends React.PureComponent<Props, State> {
         history.push(url);
       }
     }
+
+    return true;
+  };
+
+  copySandboxURL = () => {
+    const url = sandboxUrl({ id: this.props.id, alias: this.props.alias });
+
+    copyToClipboard(`https://codesandbox.io${url}`);
 
     return true;
   };


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?
Enhancement
<!-- Is it a Bug fix, feature, docs update, ... -->

## What is the current behavior?
We cannot get/copy the sandbox link from the dashboard. Usecase: I wanted to share a link of old codesandbox so I searched on the dashboard and had to open the sandbox to get the link.

<!-- You can also link to an open issue here -->

## What is the new behavior?
Add an option to copy the link directly from Context Menu.

![image](https://user-images.githubusercontent.com/22376783/79096280-4c6e4a80-7d7a-11ea-856c-643113f02ef8.png)

<!-- if this is a feature change -->

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

Locally tested 4-5 sandboxes link by copying the link from the above option.

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
