### PR TITLE
fix(CI): Only use resource-class:xlarge on master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -283,6 +283,11 @@ commands:
 
 jobs:
   build-deps:
+    executor: node
+    steps:
+      - checkout_with_cache
+      - build_deps
+  build-deps-master:
     executor: node-xlarge
     steps:
       - checkout_with_cache
@@ -359,25 +364,39 @@ workflows:
   version: 2
   build-and-test:
     jobs:
-      - build-deps
+      - build-deps:
+          filters:
+            branches:
+              ignore:
+                - master
+      - build-deps-master:
+          filters:
+            branches:
+              only:
+                - master
       - test-integrations:
           requires:
             - build-deps
       # - test-visual-regressions:
       #     requires:
       #       - build-deps
+      #       - build-deps-master
       - typecheck:
           requires:
             - build-deps
+            - build-deps-master
       - test-jest:
           requires:
             - build-deps
+            - build-deps-master
       - lint:
           requires:
             - build-deps
+            - build-deps-master
       - build-prod:
           requires:
             - build-deps
+            - build-deps-master
       - create-docker-image:
           requires:
             - build-prod

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -293,6 +293,11 @@ jobs:
       - checkout_with_cache
       - build_deps
   build-prod:
+    executor: node
+    steps:
+      - checkout_with_cache
+      - build_prod
+  build-prod-master:
     executor: node-xlarge
     steps:
       - checkout_with_cache
@@ -396,14 +401,25 @@ workflows:
       - build-prod:
           requires:
             - build-deps
+          filters:
+            branches:
+              ignore:
+                - master
+      - build-prod-master:
+          requires:
             - build-deps-master
+          filters:
+            branches:
+              only:
+                - master
       - create-docker-image:
           requires:
             - build-prod
+            - build-prod-master
       - deploy-to-production:
           requires:
             - create-docker-image
-            - build-prod
+            - build-prod-master
             - lint
             - typecheck
             - test-integrations

--- a/testpr-script.js
+++ b/testpr-script.js
@@ -1,4 +1,3 @@
-// Just lock out a CI build
 const { spawn } = require('child_process');
 const { argv } = require('yargs');
 const username = require('username');

--- a/testpr-script.js
+++ b/testpr-script.js
@@ -1,3 +1,4 @@
+// Just lock out a CI build
 const { spawn } = require('child_process');
 const { argv } = require('yargs');
 const username = require('username');


### PR DESCRIPTION
After upgrading containers in 4d3ef6e, a73c2b3 & 5af1e63, CI keeps failing

https://app.circleci.com/pipelines/github/MichaelDeBoey/codesandbox-client/1321/workflows/1069edcc-f24d-463b-9a71-520112f3f5c5/jobs/9259

![Schermafbeelding 2020-04-15 om 17 12 46](https://user-images.githubusercontent.com/6643991/79354191-6061aa00-7f3c-11ea-9e1a-c44e2914b248.png)
