### PR TITLE
fix: add theme provider to get all the custom vakues

### DIFF
--- a/packages/app/src/app/pages/Sandbox/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/index.tsx
@@ -10,6 +10,7 @@ import { Navigation } from 'app/pages/common/Navigation';
 import React, { useEffect } from 'react';
 import { Helmet } from 'react-helmet';
 import { Link } from 'react-router-dom';
+import { ThemeProvider } from '@codesandbox/components';
 
 import Editor from './Editor';
 
@@ -61,7 +62,7 @@ export const Sandbox = React.memo<Props>(
         const isGithub = match.params.id.includes('github');
 
         return (
-          <>
+          <ThemeProvider>
             <div
               style={{
                 fontWeight: 300,
@@ -126,7 +127,7 @@ export const Sandbox = React.memo<Props>(
                 </div>
               </div>
             )}
-          </>
+          </ThemeProvider>
         );
       }
 


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?
Maybe a fix for #3934 

<!-- Is it a Bug fix, feature, docs update, ... -->
## What is the current behavior?
Seeing a different error than the one reported in Crash. I suspect this is because the component are accessing values from the theme which isn't present and we are having those values in Custom ThemeProvider present in components.

Error: 
https://www.loom.com/share/ac0a8f907a3d469d9209127aaf1b3995
<!-- You can also link to an open issue here -->

## What is the new behavior?
Fix:
https://www.loom.com/share/04b8adf59daf4d1196d07353c5ad790e
<!-- if this is a feature change -->

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Tested the same URL reported in crash and seems to work properly.

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
