### PR TITLE
Make TS errors english

### DIFF
--- a/packages/app/src/app/overmind/effects/vscode/initializers.ts
+++ b/packages/app/src/app/overmind/effects/vscode/initializers.ts
@@ -40,6 +40,7 @@ export function initializeSettings() {
           'editor.minimap.enabled': false,
           'workbench.editor.openSideBySideDirection': 'down',
           'svelte.plugin.typescript.diagnostics.enable': false,
+          'typescript.locale': 'en',
         },
         null,
         2
@@ -71,6 +72,7 @@ export function initializeSettings() {
     settingsChanged = changeIfNeeded('javascript.autoClosingTags', false);
     settingsChanged = changeIfNeeded('typescript.autoClosingTags', false);
     settingsChanged = changeIfNeeded('html.autoClosingTags', false);
+    settingsChanged = changeIfNeeded('typescript.locale', 'en');
     settingsChanged = changeIfNeeded(
       'typescript.tsserver.useSeparateSyntaxServer',
       false


### PR DESCRIPTION
Issue:

When you are abroad and/or your browser is configured in another language TS will go bananas and use another language to show errors even though all the rest of the errors are in English.

It's a weird experience that I could see on my wife's computer. All her computer is in English but the moment firefox was in Spanish you would get two different languages showing up in the errors.

All of the UI is in English and more commonly than not this is a mistake or a travel issue where people have some setting in the browser misconfigured.

Not to mention that Dank Mono does not support cyrlic so things get WEIRD

This sets all TS errors to be in English always so no more weird things like this happen

Closes #1870
Closes #3676
Closes #3923