### PR TITLE
fix: version copied from editor status bar

### DIFF
--- a/packages/app/src/app/pages/Sandbox/Editor/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/index.tsx
@@ -213,7 +213,7 @@ const Editor = () => {
               })}
             >
               <FakeStatusBarText>
-                Version: {VERSION.split('-').pop()}
+                {`Version: ${VERSION.split('-').pop()}`}
               </FakeStatusBarText>
               <StatusBar
                 className="monaco-workbench mac nopanel"

--- a/packages/app/src/app/pages/Sandbox/Editor/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/index.tsx
@@ -212,9 +212,7 @@ const Editor = () => {
                 height: STATUS_BAR_SIZE,
               })}
             >
-              <FakeStatusBarText>
-                {`Version: ${VERSION.split('-').pop()}`}
-              </FakeStatusBarText>
+              <FakeStatusBarText>{VERSION.split('-').pop()}</FakeStatusBarText>
               <StatusBar
                 className="monaco-workbench mac nopanel"
                 ref={statusbarEl}


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?
Enhancement
<!-- Is it a Bug fix, feature, docs update, ... -->

## What is the current behavior?
When we copy the text from the status bar present in Editor we also get a comma in between version and commitSha. Like this 
`Version: ,ac5b1e45c`
<!-- You can also link to an open issue here -->

## What is the new behavior?
Avoid Comma
<!-- if this is a feature change -->

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Locally copied version
2. Tested the react behavior here: https://codesandbox.io/s/goofy-solomon-nq9bm?file=/src/App.js

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->

`Question` Can anyone explain to me how this is happening. Is React tracking explicitly if a string is passed it keeps as a string ( this is expected ) but when we declare a variable it tracks as an array ( Not able to understand this :/ )
