### PR TITLE
Disable visual tests for the month

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -214,13 +214,13 @@ commands:
             JEST_JUNIT_OUTPUT: '/tmp/test-results/js-test-results.xml'
       - store_test_results: *store_test_results
       - store_artifacts: *store_artifacts
-  test_visual_regressions:
-    description: "Test Chromatic with 'yarn chromatic'"
-    steps:
-      - restore_cache: *restore_deps_cache
-      - attach_workspace: *attach_deps_workspace
-      - run:
-          command: yarn chromatic
+  # test_visual_regressions:
+  #   description: "Test Chromatic with 'yarn chromatic'"
+  #   steps:
+  #     - restore_cache: *restore_deps_cache
+  #     - attach_workspace: *attach_deps_workspace
+  #     - run:
+  #         command: yarn chromatic
   test_jest:
     description: 'Test with `yarn test`'
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -298,11 +298,11 @@ jobs:
     steps:
       - checkout_with_cache
       - test_integrations
-  test-visual-regressions:
-    executor: node
-    steps:
-      - checkout_with_cache
-      - test_visual_regressions
+  # test-visual-regressions:
+  #   executor: node
+  #   steps:
+  #     - checkout_with_cache
+  #     - test_visual_regressions
   test-jest:
     executor: node
     steps:
@@ -363,9 +363,9 @@ workflows:
       - test-integrations:
           requires:
             - build-deps
-      - test-visual-regressions:
-          requires:
-            - build-deps
+      # - test-visual-regressions:
+      #     requires:
+      #       - build-deps
       - typecheck:
           requires:
             - build-deps
@@ -389,7 +389,7 @@ workflows:
             - typecheck
             - test-integrations
             - test-jest
-            - test-visual-regressions
+            # - test-visual-regressions
           filters:
             branches:
               only:


### PR DESCRIPTION
We crossed our open source limit of 35,000 snapshots per month

Short term fix: Commenting out the test from circleCI so that we can uncomment it back at the start of new billing cycle in 9 days

Suggestion for long term fix: We should only run visual tests after checking if there are changes to packages/components. Right now, we're running them for every change in the app which running out of our quota faster