### PR TITLE
chore: Only run Chromatic when files are changed

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -24,7 +24,7 @@
     "chromatic": "(if-env CIRCLE_BRANCH=master && yarn chromatic:master) || yarn chromatic:branch",
     "chromatic:base": "./node_modules/.bin/chromatic --build-script-name=build:storybook --exit-zero-on-changes --project-token=nffds42ndde",
     "chromatic:master": "yarn chromatic:base --auto-accept-changes",
-    "chromatic:branch": "(!(git diff master...HEAD --quiet ./src) && yarn chromatic:base) || echo 'Not running Chromatic...'",
+    "chromatic:branch": "(!(git diff master...HEAD --exit-code ./src) && echo 'RUN yarn chromatic:base') || echo 'Not running Chromatic...'",
     "prepublish": "yarn build"
   },
   "dependencies": {

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -24,7 +24,7 @@
     "chromatic": "(if-env CIRCLE_BRANCH=master && yarn chromatic:master) || yarn chromatic:branch",
     "chromatic:base": "./node_modules/.bin/chromatic --build-script-name=build:storybook --exit-zero-on-changes --project-token=nffds42ndde",
     "chromatic:master": "yarn chromatic:base --auto-accept-changes",
-    "chromatic:branch": "(!(git diff master...HEAD --exit-code ./src) && echo 'RUN yarn chromatic:base') || echo 'Not running Chromatic...'",
+    "chromatic:branch": "(!(git diff master...HEAD --quiet ./src) && yarn chromatic:base) || echo 'Not running Chromatic...'",
     "prepublish": "yarn build"
   },
   "dependencies": {

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -22,8 +22,9 @@
     "start:storybook": "start-storybook",
     "typecheck": "tsc --noEmit --pretty",
     "chromatic": "!(git diff --quiet ./src) && (if-env CIRCLE_BRANCH=master && yarn chromatic:master || yarn chromatic:branch)",
-    "chromatic:master": "./node_modules/.bin/chromatic --build-script-name=build:storybook --exit-zero-on-changes --auto-accept-changes --project-token=nffds42ndde",
-    "chromatic:branch": "./node_modules/.bin/chromatic --build-script-name=build:storybook --exit-zero-on-changes --project-token=nffds42ndde",
+    "chromatic:base": "./node_modules/.bin/chromatic --build-script-name=build:storybook --exit-zero-on-changes --project-token=nffds42ndde",
+    "chromatic:master": "yarn chromatic:base --auto-accept-changes",
+    "chromatic:branch": "yarn chromatic:base",
     "prepublish": "yarn build"
   },
   "dependencies": {

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -21,7 +21,7 @@
     "start": "yarn tsc --watch",
     "start:storybook": "start-storybook",
     "typecheck": "tsc --noEmit --pretty",
-    "chromatic": "if-env CIRCLE_BRANCH=master && yarn chromatic:master || yarn chromatic:branch",
+    "chromatic": "!(git diff --quiet ./src) && (if-env CIRCLE_BRANCH=master && yarn chromatic:master || yarn chromatic:branch)",
     "chromatic:master": "./node_modules/.bin/chromatic --build-script-name=build:storybook --exit-zero-on-changes --auto-accept-changes --project-token=nffds42ndde",
     "chromatic:branch": "./node_modules/.bin/chromatic --build-script-name=build:storybook --exit-zero-on-changes --project-token=nffds42ndde",
     "prepublish": "yarn build"

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -21,10 +21,10 @@
     "start": "yarn tsc --watch",
     "start:storybook": "start-storybook",
     "typecheck": "tsc --noEmit --pretty",
-    "chromatic": "!(git diff --quiet ./src) && (if-env CIRCLE_BRANCH=master && yarn chromatic:master || yarn chromatic:branch)",
+    "chromatic": "(if-env CIRCLE_BRANCH=master && yarn chromatic:master) || yarn chromatic:branch",
     "chromatic:base": "./node_modules/.bin/chromatic --build-script-name=build:storybook --exit-zero-on-changes --project-token=nffds42ndde",
     "chromatic:master": "yarn chromatic:base --auto-accept-changes",
-    "chromatic:branch": "yarn chromatic:base",
+    "chromatic:branch": "!(git diff --quiet ./src) && yarn chromatic:base",
     "prepublish": "yarn build"
   },
   "dependencies": {

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -24,7 +24,7 @@
     "chromatic": "(if-env CIRCLE_BRANCH=master && yarn chromatic:master) || yarn chromatic:branch",
     "chromatic:base": "./node_modules/.bin/chromatic --build-script-name=build:storybook --exit-zero-on-changes --project-token=nffds42ndde",
     "chromatic:master": "yarn chromatic:base --auto-accept-changes",
-    "chromatic:branch": "!(git diff master...HEAD --quiet ./src) && yarn chromatic:base",
+    "chromatic:branch": "(!(git diff master...HEAD --quiet ./src) && yarn chromatic:base) || echo 'Not running Chromatic...'",
     "prepublish": "yarn build"
   },
   "dependencies": {

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -24,7 +24,7 @@
     "chromatic": "(if-env CIRCLE_BRANCH=master && yarn chromatic:master) || yarn chromatic:branch",
     "chromatic:base": "./node_modules/.bin/chromatic --build-script-name=build:storybook --exit-zero-on-changes --project-token=nffds42ndde",
     "chromatic:master": "yarn chromatic:base --auto-accept-changes",
-    "chromatic:branch": "!(git diff --quiet ./src) && yarn chromatic:base",
+    "chromatic:branch": "!(git diff master...HEAD --quiet ./src) && yarn chromatic:base",
     "prepublish": "yarn build"
   },
   "dependencies": {


### PR DESCRIPTION
As suggested by @siddharthkp in #3955:
> Suggestion for long term fix: We should only run visual tests after checking if there are changes to `packages/components`. Right now, we're running them for every change in the app which running out of our quota faster