### PR TITLE
[FIX] switch zeit now to Vercel Now for codesandbox deployment

### DIFF
--- a/packages/homepage/content/docs/3-deployment.md
+++ b/packages/homepage/content/docs/3-deployment.md
@@ -11,16 +11,16 @@ integrated services. To deploy your app, you need to own the sandbox.
 
 ![Deployment Sidebar](./images/deployment-sidebar.png)
 
-## ZEIT
+## Vercel
 
-To deploy to ZEIT's [Now](https://zeit.co/now), access the Preferences menu and
-select the Integrations tab, then log into your ZEIT account.
+To deploy to Vercel's [Now](https://vercel.com/now), access the Preferences menu and
+select the Integrations tab, then log into your Vercel account.
 
 ### Deploying
 
 Go to any of your sandboxes, click on the Deployment menu, which is the rocket
 icon in left-hand activity bar in the editor. Select "Now". You'll need to sign
-in to [Now](https://zeit.co/now) when you're deploying for the first time. After
+in to [Vercel Now](https://vercel.com/now) when you're deploying for the first time. After
 you've signed in, you will be able to click "Deploy Now". It will deploy the
 sandbox and give you a URL.
 

--- a/packages/homepage/content/docs/3-deployment.md
+++ b/packages/homepage/content/docs/3-deployment.md
@@ -20,7 +20,7 @@ select the Integrations tab, then log into your Vercel account.
 
 Go to any of your sandboxes, click on the Deployment menu, which is the rocket
 icon in left-hand activity bar in the editor. Select "Now". You'll need to sign
-in to [Vercel Now](https://vercel.com/now) when you're deploying for the first time. After
+in to [Vercel](https://vercel.com/) when you're deploying for the first time. After
 you've signed in, you will be able to click "Deploy Now". It will deploy the
 sandbox and give you a URL.
 

--- a/packages/homepage/content/docs/3-deployment.md
+++ b/packages/homepage/content/docs/3-deployment.md
@@ -20,9 +20,9 @@ select the Integrations tab, then log into your Vercel account.
 
 Go to any of your sandboxes, click on the Deployment menu, which is the rocket
 icon in left-hand activity bar in the editor. Select "Now". You'll need to sign
-in to [Vercel](https://vercel.com) when you're deploying for the first time. After
-you've signed in, you will be able to click "Deploy Now". It will deploy the
-sandbox and give you a URL.
+in to [Vercel](https://vercel.com) when you're deploying for the first time.
+After you've signed in, you will be able to click "Deploy Now". It will deploy
+the sandbox and give you a URL.
 
 ### More Features
 

--- a/packages/homepage/content/docs/3-deployment.md
+++ b/packages/homepage/content/docs/3-deployment.md
@@ -13,7 +13,7 @@ integrated services. To deploy your app, you need to own the sandbox.
 
 ## Vercel
 
-To deploy to Vercel (https://vercel.com), access the Preferences menu and
+To deploy to [Vercel](https://vercel.com), access the Preferences menu and
 select the Integrations tab, then log into your Vercel account.
 
 ### Deploying

--- a/packages/homepage/content/docs/3-deployment.md
+++ b/packages/homepage/content/docs/3-deployment.md
@@ -13,7 +13,7 @@ integrated services. To deploy your app, you need to own the sandbox.
 
 ## Vercel
 
-To deploy to Vercel's [Now](https://vercel.com/now), access the Preferences menu and
+To deploy to Vercel (https://vercel.com), access the Preferences menu and
 select the Integrations tab, then log into your Vercel account.
 
 ### Deploying

--- a/packages/homepage/content/docs/3-deployment.md
+++ b/packages/homepage/content/docs/3-deployment.md
@@ -20,7 +20,7 @@ select the Integrations tab, then log into your Vercel account.
 
 Go to any of your sandboxes, click on the Deployment menu, which is the rocket
 icon in left-hand activity bar in the editor. Select "Now". You'll need to sign
-in to [Vercel](https://vercel.com/) when you're deploying for the first time. After
+in to [Vercel](https://vercel.com) when you're deploying for the first time. After
 you've signed in, you will be able to click "Deploy Now". It will deploy the
 sandbox and give you a URL.
 


### PR DESCRIPTION
## Docs
- Zeit just rebranded to Vercel and this PR changes the deployment guidelines to deployment for gridsome

## What is the current behavior?

Old Product Name

## What is the new behavior?

New Product Name

## Checklist

- [x] Documentation
- [x] Testing
- [x] Ready to be merged
- [ ] Added myself to contributors table
