### PR TITLE
Disallow showing one live user under "More" button

### DIFF
--- a/packages/app/src/app/pages/Sandbox/Editor/Header/CollaboratorHeads/CollaboratorHeads.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Header/CollaboratorHeads/CollaboratorHeads.tsx
@@ -145,6 +145,12 @@ export const CollaboratorHeads: FunctionComponent = () => {
   const firstLiveUsers = orderedLiveUsers.slice(0, USER_OVERFLOW_LIMIT);
   const restLiveUsers = orderedLiveUsers.slice(USER_OVERFLOW_LIMIT);
 
+  // It doesn't make sense to show a "More" button for live users if there's
+  // only one in it.
+  if (restLiveUsers.length === 1) {
+    firstLiveUsers.push(restLiveUsers.pop());
+  }
+
   return (
     <Stack justify="center">
       <SingletonTooltip interactive>


### PR DESCRIPTION
Fixes this state:

![image](https://user-images.githubusercontent.com/587016/80114521-fb353680-8583-11ea-8537-b26bd4883561.png)

To only show that button if there are 2 or more extra users.