### PR TITLE
Remove/replace Spectrum links with GitHub Discussions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 
 &nbsp;
 
-[![Join the community on Spectrum](https://withspectrum.github.io/badge/badge.svg)](https://spectrum.chat/codesandbox)
 [![All Contributors](https://img.shields.io/badge/all_contributors-153-orange.svg?style=flat-square)](#contributors-)
 [![CircleCI](https://circleci.com/gh/codesandbox/codesandbox-client.svg?style=svg)](https://circleci.com/gh/codesandbox/codesandbox-client)
 [![BrowserStack Status](https://www.browserstack.com/automate/badge.svg?badge_key=cVJuczlJWUtqWXhIbFN1ZjVQekF4NzNsd3phNEZRaGlWU0pHYVVkdGRFWT0tLXFtTVhaOWRySmN0ZG5QVDNDQ0g5Z0E9PQ==--79fe3eae4f149a400d396c9b12d3988f685785cf)](https://www.browserstack.com/automate/public-build/cVJuczlJWUtqWXhIbFN1ZjVQekF4NzNsd3phNEZRaGlWU0pHYVVkdGRFWT0tLXFtTVhaOWRySmN0ZG5QVDNDQ0g5Z0E9PQ==--79fe3eae4f149a400d396c9b12d3988f685785cf)

--- a/packages/app/src/app/components/SocialInfo/SocialInfo.tsx
+++ b/packages/app/src/app/components/SocialInfo/SocialInfo.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import TwitterIcon from 'react-icons/lib/fa/twitter';
 import GithubIcon from 'react-icons/lib/fa/github';
 import { Icon } from './elements';
-import { SpectrumLogo } from '../SpectrumLogo';
 
 export const SocialInfo: React.FC<React.HTMLAttributes<
   HTMLDivElement
@@ -13,9 +12,6 @@ export const SocialInfo: React.FC<React.HTMLAttributes<
     </Icon>
     <Icon href="https://github.com/codesandbox/codesandbox-client">
       <GithubIcon />
-    </Icon>
-    <Icon href="https://spectrum.chat/codesandbox">
-      <SpectrumLogo />
     </Icon>
   </div>
 );

--- a/packages/app/src/app/overmind/effects/vscode/Workbench.ts
+++ b/packages/app/src/app/overmind/effects/vscode/Workbench.ts
@@ -278,11 +278,6 @@ export class Workbench {
       'Follow Us on Twitter',
       'https://twitter.com/codesandbox'
     );
-    addBrowserNavigationCommand(
-      'codesandbox.help.spectrum',
-      'Join Us on Spectrum',
-      'https://spectrum.chat/codesandbox'
-    );
 
     this.addWorkbenchAction({
       id: 'codesandbox.help.feedback',
@@ -360,15 +355,6 @@ export class Workbench {
       command: {
         id: 'codesandbox.help.twitter',
         title: 'Follow Us on &&Twitter',
-      },
-    });
-
-    this.appendMenuItem(MenuId.MenubarHelpMenu, {
-      group: '3_social',
-      order: 3,
-      command: {
-        id: 'codesandbox.help.spectrum',
-        title: 'Join Us on S&&pectrum',
       },
     });
 

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/SSEDownNotice/SSEDownNotice.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/SSEDownNotice/SSEDownNotice.tsx
@@ -44,12 +44,12 @@ export const SSEDownNotice: FunctionComponent = () => {
         {"'"}t resolved with in a minute it would greatly help us if you could
         let us know on{' '}
         <a
-          href="https://spectrum.chat/codesandbox"
+          href="https://github.com/codesandbox/codesandbox-client/discussions"
           rel="noopener noreferrer"
           style={{ color: '#FFFFFF' }}
           target="_blank"
         >
-          Spectrum
+          GitHub
         </a>
         .
       </p>

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/ProjectInfo/Delete.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/ProjectInfo/Delete.tsx
@@ -2,7 +2,7 @@ import React, { MouseEvent } from 'react';
 import { useOvermind } from 'app/overmind';
 import css from '@styled-system/css';
 import { Button, Stack, Element, Link } from '@codesandbox/components';
-import { SpectrumLogo, GithubIcon, TwitterIcon } from './icons';
+import { GithubIcon, TwitterIcon } from './icons';
 
 const links = [
   { href: 'https://twitter.com/codesandbox', icon: <TwitterIcon /> },
@@ -10,7 +10,6 @@ const links = [
     href: 'https://github.com/codesandbox/codesandbox-client',
     icon: <GithubIcon />,
   },
-  { href: 'https://spectrum.chat/codesandbox', icon: <SpectrumLogo /> },
 ];
 
 export const Delete = () => {

--- a/packages/common/src/components/Footer.tsx
+++ b/packages/common/src/components/Footer.tsx
@@ -147,15 +147,6 @@ export default () => (
                   Twitter
                 </a>
               </li>
-              <li>
-                <a
-                  href="https://spectrum.chat/codesandbox"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  Spectrum
-                </a>
-              </li>
             </List>
           </Column>
         </Container>

--- a/packages/homepage/src/components/Footer/index.js
+++ b/packages/homepage/src/components/Footer/index.js
@@ -3,7 +3,6 @@ import { Link } from 'gatsby';
 import { P } from '../Typography';
 import Github from '../../assets/icons/github';
 import Twitter from '../../assets/icons/twitter';
-import Spectrum from '../../assets/icons/spectrum';
 import { FooterWrapper, Nav, Social } from './elements';
 
 const Footer = () => (
@@ -159,11 +158,6 @@ const Footer = () => (
       <li>
         <a title="Go to Twitter" href="https://twitter.com/codesandbox">
           <Twitter />
-        </a>
-      </li>
-      <li>
-        <a title="Go to Spectrum" href="https://spectrum.chat/codesandbox">
-          <Spectrum />
         </a>
       </li>
     </Social>


### PR DESCRIPTION
## What kind of change does this PR introduce?
We're moving discussions over to GitHub from Spectrum so we no longer want to direct folks to Spectrum. This PR removes links to Spectrum where there's currently already a link to GitHub, or replaces a link to Spectrum with one to GitHub Discussions where there isn't.

## Checklist
- [x] Testing
Checked all instances apart from see down notice (as I don't know how to force it to appear, and the SocialInfo component, as I couldn't work out where that's displayed - but the code looks ok.
- [x] Ready to be merged