### PR TITLE
Sandpack is ready to be used, fixes #2306

### DIFF
--- a/standalone-packages/sandpack/README.md
+++ b/standalone-packages/sandpack/README.md
@@ -1,7 +1,5 @@
 # Sandpack
 
-> DON'T USE THIS YET!
-
 A bundler that completely works in the browser and takes advantage of it.
 
 ## Why?


### PR DESCRIPTION
## What kind of change does this PR introduce?
Docs update that fixes #2306. Sandpack is used by Gitlab and CodeSanbox in production, so I think is stable enough.

## Checklist
- [x] Documentation
- [x] Ready to be merged
- [x] Added myself to contributors table
