### PR TITLE
dashboard: Make card clickable

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -269,7 +269,7 @@
     "@types/react-helmet": "^5.0.11",
     "@types/react-icons": "2.2.7",
     "@types/react-instantsearch": "^5.2.3",
-    "@types/react-router-dom": "^4.3.1",
+    "@types/react-router-dom": "^5.0.1",
     "@types/react-stripe-elements": "^1.3.2",
     "@types/resolve": "^0.0.8",
     "@types/semver": "6.2.0",

--- a/packages/app/src/app/pages/NewDashboard/Components/SandboxCard/Menu.tsx
+++ b/packages/app/src/app/pages/NewDashboard/Components/SandboxCard/Menu.tsx
@@ -4,7 +4,7 @@ import { Menu } from '@codesandbox/components';
 import { sandboxUrl } from '@codesandbox/common/lib/utils/url-generator';
 import { useHistory } from 'react-router-dom';
 
-export const MenuOptions = ({ sandbox, template, setEdit }) => {
+export const MenuOptions = ({ sandbox, isTemplate, setEdit }) => {
   const { effects, actions } = useOvermind();
   const history = useHistory();
   const url = sandboxUrl({
@@ -12,7 +12,7 @@ export const MenuOptions = ({ sandbox, template, setEdit }) => {
     alias: sandbox.alias,
   });
 
-  const getFolderUrl = (path, isTemplate) => {
+  const getFolderUrl = path => {
     if (isTemplate) return '/new-dashboard/templates';
     if (path === '/' || !path) return '/new-dashboard/all/drafts';
 
@@ -25,7 +25,7 @@ export const MenuOptions = ({ sandbox, template, setEdit }) => {
       <Menu.List>
         <Menu.Item
           onSelect={() => {
-            history.push(getFolderUrl(sandbox.collection.path, template));
+            history.push(getFolderUrl(sandbox.collection.path));
           }}
         >
           Show in Folder
@@ -66,10 +66,10 @@ export const MenuOptions = ({ sandbox, template, setEdit }) => {
             actions.dashboard.downloadSandboxes([sandbox.id]);
           }}
         >
-          Export {template ? 'template' : 'sandbox'}
+          Export {isTemplate ? 'template' : 'sandbox'}
         </Menu.Item>
         <Menu.Item onSelect={() => setEdit(true)}>Rename sandbox</Menu.Item>
-        {template ? (
+        {isTemplate ? (
           <Menu.Item
             onSelect={() => {
               actions.dashboard.unmakeTemplate([sandbox.id]);
@@ -86,7 +86,7 @@ export const MenuOptions = ({ sandbox, template, setEdit }) => {
             Make sandbox a template
           </Menu.Item>
         )}
-        {template ? (
+        {isTemplate ? (
           <Menu.Item onSelect={() => {}}>Delete template</Menu.Item>
         ) : (
           <Menu.Item

--- a/packages/app/src/app/pages/NewDashboard/Components/SandboxCard/Menu.tsx
+++ b/packages/app/src/app/pages/NewDashboard/Components/SandboxCard/Menu.tsx
@@ -2,15 +2,11 @@ import React from 'react';
 import { useOvermind } from 'app/overmind';
 import { Menu } from '@codesandbox/components';
 import { sandboxUrl } from '@codesandbox/common/lib/utils/url-generator';
-import { withRouter } from 'react-router-dom';
+import { useHistory } from 'react-router-dom';
 
-export const MenuOptionsComponent = ({
-  sandbox,
-  template,
-  setEdit,
-  history,
-}) => {
+export const MenuOptions = ({ sandbox, template, setEdit }) => {
   const { effects, actions } = useOvermind();
+  const history = useHistory();
   const url = sandboxUrl({
     id: sandbox.id,
     alias: sandbox.alias,
@@ -25,7 +21,7 @@ export const MenuOptionsComponent = ({
 
   return (
     <Menu>
-      <Menu.IconButton name="more" size={9} title="Sandbox options" />
+      <Menu.IconButton name="more" size={9} title="Sandbox actions" />
       <Menu.List>
         <Menu.Item
           onSelect={() => {
@@ -36,7 +32,7 @@ export const MenuOptionsComponent = ({
         </Menu.Item>
         <Menu.Item
           onSelect={() => {
-            window.open(`https://codesandbox.io${url}`);
+            history.push(url);
           }}
         >
           Open sandbox
@@ -105,6 +101,3 @@ export const MenuOptionsComponent = ({
     </Menu>
   );
 };
-
-// @ts-ignore
-export const MenuOptions = withRouter(MenuOptionsComponent);

--- a/packages/app/src/app/pages/NewDashboard/Components/SandboxCard/index.tsx
+++ b/packages/app/src/app/pages/NewDashboard/Components/SandboxCard/index.tsx
@@ -14,13 +14,7 @@ import {
 import css from '@styled-system/css';
 import { MenuOptions } from './Menu';
 
-type Props = {
-  sandbox: any;
-  template?: boolean;
-  style?: any;
-};
-
-export const SandboxCard = ({ sandbox, template, ...props }: Props) => {
+export const SandboxCard = ({ sandbox, template, ...props }) => {
   const sandboxTitle = sandbox.title || sandbox.alias || sandbox.id;
   const { actions } = useOvermind();
   const [edit, setEdit] = useState(false);

--- a/packages/app/src/app/pages/NewDashboard/Components/SandboxCard/index.tsx
+++ b/packages/app/src/app/pages/NewDashboard/Components/SandboxCard/index.tsx
@@ -14,7 +14,7 @@ import {
 import css from '@styled-system/css';
 import { MenuOptions } from './Menu';
 
-export const SandboxCard = ({ sandbox, template, ...props }) => {
+export const SandboxCard = ({ sandbox, isTemplate = false, ...props }) => {
   const sandboxTitle = sandbox.title || sandbox.alias || sandbox.id;
   const { actions } = useOvermind();
   const [edit, setEdit] = useState(false);
@@ -81,7 +81,11 @@ export const SandboxCard = ({ sandbox, template, ...props }) => {
             {sandboxTitle}
           </Text>
         )}
-        <MenuOptions sandbox={sandbox} template={template} setEdit={setEdit} />
+        <MenuOptions
+          sandbox={sandbox}
+          isTemplate={isTemplate}
+          setEdit={setEdit}
+        />
       </Stack>
       <Stack marginX={4}>
         <Stats

--- a/packages/app/src/app/pages/NewDashboard/Components/SandboxCard/index.tsx
+++ b/packages/app/src/app/pages/NewDashboard/Components/SandboxCard/index.tsx
@@ -1,4 +1,7 @@
 import React, { useState } from 'react';
+import { useHistory } from 'react-router-dom';
+import { useOvermind } from 'app/overmind';
+import { sandboxUrl } from '@codesandbox/common/lib/utils/url-generator';
 import {
   Stack,
   Element,
@@ -6,9 +9,9 @@ import {
   Stats,
   Input,
   SkeletonText,
+  isMenuClicked,
 } from '@codesandbox/components';
 import css from '@styled-system/css';
-import { useOvermind } from 'app/overmind';
 import { MenuOptions } from './Menu';
 
 type Props = {
@@ -22,6 +25,12 @@ export const SandboxCard = ({ sandbox, template, ...props }: Props) => {
   const { actions } = useOvermind();
   const [edit, setEdit] = useState(false);
   const [newName, setNewName] = useState(sandboxTitle);
+  const history = useHistory();
+
+  const url = sandboxUrl({
+    id: sandbox.id,
+    alias: sandbox.alias,
+  });
 
   const editSandboxTitle = async e => {
     e.preventDefault();
@@ -46,11 +55,16 @@ export const SandboxCard = ({ sandbox, template, ...props }: Props) => {
         overflow: 'hidden',
         transition: 'all ease-in-out',
         transitionDuration: theme => theme.speeds[4],
-        ':hover, :focus': {
+        ':hover, :focus, :focus-within': {
+          cursor: 'pointer',
           transform: 'scale(0.98)',
         },
       })}
       {...props}
+      onClick={event => {
+        if (isMenuClicked(event)) return;
+        history.push(url);
+      }}
     >
       <Element
         as="div"

--- a/packages/app/src/app/pages/NewDashboard/Components/SandboxItem/Menu.tsx
+++ b/packages/app/src/app/pages/NewDashboard/Components/SandboxItem/Menu.tsx
@@ -6,7 +6,7 @@ import { withRouter } from 'react-router-dom';
 
 export const MenuOptionsComponent = ({
   sandbox,
-  template,
+  isTemplate = false,
   setEdit,
   history,
 }) => {
@@ -16,7 +16,7 @@ export const MenuOptionsComponent = ({
     alias: sandbox.alias,
   });
 
-  const getFolderUrl = (path, isTemplate) => {
+  const getFolderUrl = path => {
     if (isTemplate) return '/new-dashboard/templates';
     if (path === '/' || !path) return '/new-dashboard/all/drafts';
 
@@ -53,7 +53,7 @@ export const MenuOptionsComponent = ({
       <Menu.List>
         <Menu.Item
           onSelect={() => {
-            history.push(getFolderUrl(sandbox.collection.path, template));
+            history.push(getFolderUrl(sandbox.collection.path));
           }}
         >
           Show in Folder
@@ -94,10 +94,10 @@ export const MenuOptionsComponent = ({
             actions.dashboard.downloadSandboxes([sandbox.id]);
           }}
         >
-          Export {template ? 'template' : 'sandbox'}
+          Export {isTemplate ? 'template' : 'sandbox'}
         </Menu.Item>
         <Menu.Item onSelect={() => setEdit(true)}>Rename sandbox</Menu.Item>
-        {template ? (
+        {isTemplate ? (
           <Menu.Item
             onSelect={() => {
               actions.dashboard.unmakeTemplate([sandbox.id]);
@@ -114,7 +114,7 @@ export const MenuOptionsComponent = ({
             Make sandbox a template
           </Menu.Item>
         )}
-        {template ? (
+        {isTemplate ? (
           <Menu.Item onSelect={() => {}}>Delete template</Menu.Item>
         ) : (
           <Menu.Item

--- a/packages/app/src/app/pages/NewDashboard/Components/SandboxItem/index.tsx
+++ b/packages/app/src/app/pages/NewDashboard/Components/SandboxItem/index.tsx
@@ -7,11 +7,15 @@ import { MenuOptions } from './Menu';
 
 type Props = {
   sandbox: any;
-  template?: boolean;
+  isTemplate?: boolean;
   style?: any;
 };
 
-export const SandboxItem = ({ sandbox, template, ...props }: Props) => {
+export const SandboxItem = ({
+  sandbox,
+  isTemplate = false,
+  ...props
+}: Props) => {
   const sandboxTitle = sandbox.title || sandbox.alias || sandbox.id;
   const { actions } = useOvermind();
   const [edit, setEdit] = useState(false);
@@ -79,7 +83,11 @@ export const SandboxItem = ({ sandbox, template, ...props }: Props) => {
           Updated {formatDistanceToNow(new Date(sandbox.updatedAt))} ago
         </Text>
       )}
-      <MenuOptions sandbox={sandbox} template={template} setEdit={setEdit} />
+      <MenuOptions
+        sandbox={sandbox}
+        isTemplate={isTemplate}
+        setEdit={setEdit}
+      />
     </Stack>
   );
 };

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Comments/Comment.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Comments/Comment.tsx
@@ -6,6 +6,7 @@ import {
   Menu,
   Stack,
   Text,
+  isMenuClicked,
 } from '@codesandbox/components';
 import VisuallyHidden from '@reach/visually-hidden';
 import { css } from '@styled-system/css';
@@ -50,10 +51,7 @@ export const Comment = React.memo<{
         // don't trigger comment if you click on the menu
         // we have to handle this because of an upstream
         // bug in reach/menu-button
-        const target = event.target as HTMLElement;
-        if (target.tagName === 'button' || target.tagName === 'svg') {
-          return;
-        }
+        if (isMenuClicked(event)) return;
 
         const currentTarget = event.currentTarget as HTMLElement;
         const boundingRect = currentTarget.getBoundingClientRect();

--- a/packages/common/src/components/Button/index.tsx
+++ b/packages/common/src/components/Button/index.tsx
@@ -21,6 +21,7 @@ type Props = {
 const Button: FunctionComponent<Props> = ({ style = {}, ...props }) => {
   // Link
   if (typeof props.to === 'string') {
+    // @ts-ignore
     return <LinkButton {...props} style={style} to={props.to} />;
   }
 

--- a/packages/components/src/components/Menu/index.tsx
+++ b/packages/components/src/components/Menu/index.tsx
@@ -131,4 +131,21 @@ Menu.IconButton = MenuIconButton;
 Menu.List = MenuList;
 Menu.Item = MenuItem;
 
+export const isMenuClicked = event => {
+  // don't trigger comment if you click on the menu
+  // we handle this because of an upstream
+  // bug in reach/menu-button
+  const target = event.target as HTMLElement;
+
+  if (
+    target.tagName === 'BUTTON' ||
+    target.tagName === 'svg' ||
+    target.tagName === 'path'
+  ) {
+    return true;
+  }
+
+  return false;
+};
+
 export { Menu };

--- a/yarn.lock
+++ b/yarn.lock
@@ -4727,10 +4727,10 @@
     "@types/prop-types" "*"
     "@types/react" "*"
 
-"@types/react-router-dom@^4.3.1":
-  version "4.3.5"
-  resolved "https://registry.yarnpkg.com/@types/react-router-dom/-/react-router-dom-4.3.5.tgz#72f229967690c890d00f96e6b85e9ee5780db31f"
-  integrity sha512-eFajSUASYbPHg2BDM1G8Btx+YqGgvROPIg6sBhl3O4kbDdYXdFdfrgQFf/pcBuQVObjfT9AL/dd15jilR5DIEA==
+"@types/react-router-dom@^5.0.1":
+  version "5.1.5"
+  resolved "https://registry.yarnpkg.com/@types/react-router-dom/-/react-router-dom-5.1.5.tgz#7c334a2ea785dbad2b2dcdd83d2cf3d9973da090"
+  integrity sha512-ArBM4B1g3BWLGbaGvwBGO75GNFbLDUthrDojV2vHLih/Tq8M+tgvY1DSwkuNrPSwdp/GUL93WSEpTZs8nVyJLw==
   dependencies:
     "@types/history" "*"
     "@types/react" "*"


### PR DESCRIPTION
Closes CSB-142

- updated @types/react-router-dom to match react-router-dom version
- Move isMenuClicked logic to components and use it in card and comments
- use useHistory api instead of withRouter
- rename `template` prop to `isTemplate` to convey intent
- ignore incorrect types for common/components/button


Notes for reviewer - 

updates router types which failed the check in [one place](https://github.com/codesandbox/codesandbox-client/pull/4020/files#r417830423) 