### PR TITLE
Cleanup Explorer screen

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -86,6 +86,7 @@
     "@types/socket.io-client": "^1.4.32",
     "@vue/babel-preset-app": "^3.2.0",
     "airtable": "^0.5.8",
+    "algoliasearch": "^3.35.1",
     "apollo-boost": "^0.4.4",
     "apollo-link-batch-http": "^1.2.12",
     "apollo-link-context": "^1.0.18",

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Explorer/Dependencies/Dependency/BundleSizes.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Explorer/Dependencies/Dependency/BundleSizes.tsx
@@ -1,9 +1,10 @@
-import React, { useEffect, useState } from 'react';
 import { Stack, Text } from '@codesandbox/components';
+import React, { FunctionComponent, useEffect, useState } from 'react';
 
 const formatSize = (value: number) => {
   let unit: string;
   let size: number;
+
   if (Math.log10(value) < 3) {
     unit = 'B';
     size = value;
@@ -18,42 +19,52 @@ const formatSize = (value: number) => {
   return `${size.toFixed(1)}${unit}`;
 };
 
+type Bundle = {
+  gzip: number;
+  size: number;
+};
 type Props = {
   dependency: string;
   version: string;
 };
-
-export const BundleSizes = ({ dependency, version = '' }: Props) => {
-  const [size, setSize] = useState(null);
+export const BundleSizes: FunctionComponent<Props> = ({
+  dependency,
+  version,
+}) => {
+  const [bundle, setBundle] = useState<Bundle | null>(null);
   const [error, setError] = useState(null);
 
+  const getSizeForPKG = (pkg: string) => {
+    fetch(`https://bundlephobia.com/api/size?package=${pkg}`)
+      .then(response => response.json())
+      .then(setBundle)
+      .catch(setError);
+  };
   useEffect(() => {
     const cleanVersion = version.split('^');
     getSizeForPKG(`${dependency}@${cleanVersion[cleanVersion.length - 1]}`);
   }, [dependency, version]);
 
-  const getSizeForPKG = (pkg: string) => {
-    fetch(`https://bundlephobia.com/api/size?package=${pkg}`)
-      .then(rsp => rsp.json())
-      .then(setSize)
-      .catch(setError);
-  };
-
   if (error) {
     return (
-      <Text variant="muted" marginBottom={2}>
+      <Text marginBottom={2} variant="muted">
         There was a problem getting the size for {dependency}
       </Text>
     );
   }
 
-  return size ? (
+  return bundle ? (
     <Stack justify="space-between" css={{ width: '100%' }}>
       <Text>
-        <Text variant="muted">Gzip:</Text> {formatSize(size.gzip)}
+        <Text variant="muted">Gzip:</Text>
+
+        {formatSize(bundle.gzip)}
       </Text>
+
       <Text>
-        <Text variant="muted">Size:</Text> {formatSize(size.size)}
+        <Text variant="muted">Size:</Text>
+
+        {formatSize(bundle.size)}
       </Text>
     </Stack>
   ) : null;

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Explorer/Dependencies/Dependency/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Explorer/Dependencies/Dependency/index.tsx
@@ -1,66 +1,66 @@
-import React, { useState, useEffect } from 'react';
-import CrossIcon from 'react-icons/lib/md/clear';
-import RefreshIcon from 'react-icons/lib/md/refresh';
-import ArrowDropDown from 'react-icons/lib/md/keyboard-arrow-down';
-import ArrowDropUp from 'react-icons/lib/md/keyboard-arrow-up';
-import algoliasearch from 'algoliasearch/lite';
-import compareVersions from 'compare-versions';
 import Tooltip, {
   SingletonTooltip,
 } from '@codesandbox/common/lib/components/Tooltip';
 import { formatVersion } from '@codesandbox/common/lib/utils/ci';
-
-import css from '@styled-system/css';
 import {
-  ListAction,
-  Stack,
-  SidebarRow,
-  Select,
-  Text,
-  Link,
   Button,
+  Link,
+  ListAction,
+  Select,
+  SidebarRow,
+  Stack,
+  Text,
 } from '@codesandbox/components';
+import css from '@styled-system/css';
+import algoliasearch from 'algoliasearch/lite';
+import compareVersions from 'compare-versions';
+import React, { FunctionComponent, useEffect, useState } from 'react';
+import CrossIcon from 'react-icons/lib/md/clear';
+import RefreshIcon from 'react-icons/lib/md/refresh';
+import ArrowDropDown from 'react-icons/lib/md/keyboard-arrow-down';
+import ArrowDropUp from 'react-icons/lib/md/keyboard-arrow-up';
+
+import { useOvermind } from 'app/overmind';
 
 import { BundleSizes } from './BundleSizes';
-
-interface Props {
-  dependencies: { [dep: string]: string };
-  dependency: string;
-  onRemove: (dep: string) => void;
-  onRefresh: (dep: string, version?: string) => void;
-}
 
 const client = algoliasearch('OFCNCOG2CU', '00383ecd8441ead30b1b0ff981c426f5');
 const index = client.initIndex('npm-search');
 
-export const Dependency = ({
+type Props = {
+  dependencies: { [dependency: string]: string };
+  dependency: string;
+};
+export const Dependency: FunctionComponent<Props> = ({
   dependencies,
   dependency,
-  onRemove,
-  onRefresh,
-}: Props) => {
-  const [version, setVersion] = useState(null);
+}) => {
+  const {
+    actions: {
+      editor: { addNpmDependency, npmDependencyRemoved },
+    },
+  } = useOvermind();
   const [open, setOpen] = useState(false);
+  const [version, setVersion] = useState(null);
   const [versions, setVersions] = useState([]);
 
   const setVersionsForLatestPkg = (pkg: string) => {
     fetch(`/api/v1/dependencies/${pkg}`)
       .then(response => response.json())
-      .then(data => setVersion(data.data.version))
+      .then(({ data }) => setVersion(data.version))
       .catch(err => {
         if (process.env.NODE_ENV === 'development') {
           console.error(err); // eslint-disable-line no-console
         }
       });
   };
-
   useEffect(() => {
     // @ts-ignore
     index.getObject(dependency, ['versions']).then(({ versions: results }) => {
       const orderedVersions = Object.keys(results).sort((a, b) => {
         try {
           return compareVersions(b, a);
-        } catch (e) {
+        } catch {
           return 0;
         }
       });
@@ -84,15 +84,16 @@ export const Dependency = ({
       e.preventDefault();
       e.stopPropagation();
     }
-    onRemove(dependency);
-  };
 
+    npmDependencyRemoved(dependency);
+  };
   const handleRefresh = e => {
     if (e) {
       e.preventDefault();
       e.stopPropagation();
     }
-    onRefresh(dependency);
+
+    addNpmDependency({ name: dependency });
   };
 
   if (typeof dependencies[dependency] !== 'string') {
@@ -102,31 +103,32 @@ export const Dependency = ({
   return (
     <>
       <ListAction
-        justify="space-between"
         align="center"
         css={css({
           position: 'relative',
+
           '.actions': {
             backgroundColor: 'sideBar.background',
             display: 'none',
           },
+
           ':hover .actions': {
             backgroundColor: 'list.hoverBackground',
             display: 'flex',
           },
         })}
+        justify="space-between"
       >
         <Link
+          css={{ position: 'absolute', zIndex: 2 }}
           href={`/examples/package/${dependency}`}
           target="_blank"
-          css={{ position: 'absolute', zIndex: 2 }}
         >
           {dependency}
         </Link>
 
         <Stack
           align="center"
-          justify="flex-end"
           css={css({
             position: 'absolute',
             right: 2,
@@ -134,17 +136,17 @@ export const Dependency = ({
             flexShrink: 1,
             width: '100%',
           })}
+          justify="flex-end"
         >
-          <Text variant="muted" maxWidth="30%">
-            {formatVersion(dependencies[dependency])}{' '}
-            {version && <span>({formatVersion(version)})</span>}
+          <Text maxWidth="30%" variant="muted">
+            {`${formatVersion(dependencies[dependency])} (${formatVersion(
+              version
+            )})`}
           </Text>
         </Stack>
 
         <Stack
-          className="actions"
           align="center"
-          justify="flex-end"
           css={css({
             position: 'absolute',
             right: 0,
@@ -152,11 +154,15 @@ export const Dependency = ({
             zIndex: 2, // overlay on dependency name
             paddingLeft: 1,
           })}
+          className="actions"
+          justify="flex-end"
         >
           <Select
             css={{ width: '80px' }}
+            onChange={({ target: { value } }) =>
+              addNpmDependency({ name: dependency, version: value })
+            }
             value={versions.find(v => v === dependencies[dependency])}
-            onChange={e => onRefresh(dependency, e.target.value)}
           >
             {versions.map(a => (
               <option key={a}>{a}</option>
@@ -168,39 +174,41 @@ export const Dependency = ({
               <>
                 <Tooltip
                   content={open ? 'Hide sizes' : 'Show sizes'}
-                  style={{ outline: 'none' }}
                   singleton={singleton}
+                  style={{ outline: 'none' }}
                 >
                   <Button
-                    variant="link"
-                    onClick={() => setOpen(!open)}
                     css={css({ minWidth: 5 })}
+                    onClick={() => setOpen(show => !show)}
+                    variant="link"
                   >
                     {open ? <ArrowDropUp /> : <ArrowDropDown />}
                   </Button>
                 </Tooltip>
+
                 <Tooltip
                   content="Update to latest"
-                  style={{ outline: 'none' }}
                   singleton={singleton}
+                  style={{ outline: 'none' }}
                 >
                   <Button
-                    variant="link"
-                    onClick={handleRefresh}
                     css={css({ minWidth: 5 })}
+                    onClick={handleRefresh}
+                    variant="link"
                   >
                     <RefreshIcon />
                   </Button>
                 </Tooltip>
+
                 <Tooltip
                   content="Remove"
                   style={{ outline: 'none' }}
                   singleton={singleton}
                 >
                   <Button
-                    variant="link"
-                    onClick={handleRemove}
                     css={css({ minWidth: 5 })}
+                    onClick={handleRemove}
+                    variant="link"
                   >
                     <CrossIcon />
                   </Button>
@@ -210,6 +218,7 @@ export const Dependency = ({
           </SingletonTooltip>
         </Stack>
       </ListAction>
+
       {open ? (
         <SidebarRow marginX={2}>
           <BundleSizes

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Explorer/Dependencies/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Explorer/Dependencies/index.tsx
@@ -12,10 +12,7 @@ import { Dependency } from './Dependency';
 
 export const Dependencies: FunctionComponent = () => {
   const {
-    actions: {
-      modalOpened,
-      editor: { addNpmDependency, npmDependencyRemoved },
-    },
+    actions: { modalOpened },
     state: {
       editor: { parsedConfigurations },
     },
@@ -30,7 +27,6 @@ export const Dependencies: FunctionComponent = () => {
   }
 
   const { error, parsed } = parsedConfigurations.package;
-
   if (error) {
     return (
       <SidebarRow marginX={2}>
@@ -40,9 +36,8 @@ export const Dependencies: FunctionComponent = () => {
   }
 
   const { dependencies = {} } = parsed;
-
   return (
-    <Collapsible title="Dependencies" defaultOpen>
+    <Collapsible defaultOpen title="Dependencies">
       <List marginBottom={2}>
         {Object.keys(dependencies)
           .sort()
@@ -51,11 +46,10 @@ export const Dependencies: FunctionComponent = () => {
               dependencies={dependencies}
               dependency={dependency}
               key={dependency}
-              onRefresh={(name, version) => addNpmDependency({ name, version })}
-              onRemove={npmDependencyRemoved}
             />
           ))}
       </List>
+
       <SidebarRow marginX={2}>
         <Button
           variant="secondary"

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Explorer/ExternalResources/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Explorer/ExternalResources/index.tsx
@@ -1,21 +1,21 @@
-import React, { FunctionComponent } from 'react';
-import { useOvermind } from 'app/overmind';
 import getTemplateDefinition from '@codesandbox/common/lib/templates';
-import CrossIcon from 'react-icons/lib/md/clear';
-
 import {
+  Button,
   Collapsible,
-  Link,
-  Stack,
-  Input,
-  Select,
   FormField,
+  Input,
+  Link,
   List,
   ListAction,
+  Select,
   SidebarRow,
-  Button,
+  Stack,
 } from '@codesandbox/components';
 import css from '@styled-system/css';
+import React, { FunctionComponent } from 'react';
+import CrossIcon from 'react-icons/lib/md/clear';
+
+import { useOvermind } from 'app/overmind';
 
 import { fonts as listOfFonts } from './google-fonts';
 
@@ -39,7 +39,9 @@ export const ExternalResources: FunctionComponent = () => {
   );
 
   const { externalResourcesEnabled } = getTemplateDefinition(template);
-  if (!externalResourcesEnabled) return null;
+  if (!externalResourcesEnabled) {
+    return null;
+  }
 
   return (
     <Collapsible title="External resources">
@@ -48,20 +50,21 @@ export const ExternalResources: FunctionComponent = () => {
           <List>
             {otherResources.map(resource => (
               <ListAction
-                key={resource}
-                justify="space-between"
                 css={{
                   button: { opacity: 0 },
                   ':hover, :focus-within': { button: { opacity: 1 } },
                 }}
+                justify="space-between"
+                key={resource}
               >
                 <Link href={resource} target="_blank">
                   {getName(resource)}
                 </Link>
+
                 <Button
-                  variant="link"
                   css={css({ width: 'auto' })}
                   onClick={() => externalResourceRemoved(resource)}
+                  variant="link"
                 >
                   <CrossIcon />
                 </Button>
@@ -70,20 +73,21 @@ export const ExternalResources: FunctionComponent = () => {
 
             {fonts.map(resource => (
               <ListAction
-                key={resource}
-                justify="space-between"
                 css={{
                   button: { opacity: 0 },
                   ':hover, :focus-within': { button: { opacity: 1 } },
                 }}
+                justify="space-between"
+                key={resource}
               >
                 <Link href={resource} target="_blank">
                   {getFontFamily(resource).name}
                 </Link>
+
                 <Button
-                  variant="link"
                   css={css({ width: 'auto' })}
                   onClick={() => externalResourceRemoved(resource)}
+                  variant="link"
                 >
                   <CrossIcon />
                 </Button>
@@ -101,12 +105,13 @@ export const ExternalResources: FunctionComponent = () => {
         >
           <FormField label="External URL" direction="vertical">
             <Input
-              type="text"
-              required
-              placeholder="https://cdn.com/bootstrap.css"
               key={otherResources.length}
+              placeholder="https://cdn.com/bootstrap.css"
+              required
+              type="text"
             />
           </FormField>
+
           <SidebarRow marginX={2}>
             <Button type="submit" variant="secondary">
               Add resource
@@ -124,15 +129,16 @@ export const ExternalResources: FunctionComponent = () => {
         >
           <FormField label="Google Fonts" direction="vertical">
             <Select
-              required
-              placeholder="Select a font family"
               key={fonts.length}
+              placeholder="Select a font family"
+              required
             >
               {listOfFonts.sort().map(name => (
                 <option key={name}>{name}</option>
               ))}
             </Select>
           </FormField>
+
           <SidebarRow marginX={2}>
             <Button type="submit" variant="secondary">
               Add font
@@ -145,7 +151,6 @@ export const ExternalResources: FunctionComponent = () => {
 };
 
 const getNormalizedUrl = (url: string) => `${url.replace(/\/$/g, '')}/`;
-
 const getName = (resource: string) => {
   if (resource.endsWith('.css') || resource.endsWith('.js')) {
     const match = resource.match(/.*\/(.*)/);

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Explorer/Files/icons.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Explorer/Files/icons.tsx
@@ -1,9 +1,12 @@
-import React from 'react';
-import DeleteIcon from 'react-icons/lib/go/trashcan';
-import UndoIcon from 'react-icons/lib/md/undo';
-import NotSyncedIcon from 'react-icons/lib/go/primitive-dot';
+import React, { FunctionComponent, SVGProps } from 'react';
 
-const CrossIcon = props => (
+export { default as NotSyncedIcon } from 'react-icons/lib/go/primitive-dot';
+export { default as DeleteIcon } from 'react-icons/lib/go/trashcan';
+export { default as UndoIcon } from 'react-icons/lib/md/undo';
+
+type IconProps = SVGProps<SVGSVGElement>;
+
+export const CrossIcon: FunctionComponent<IconProps> = props => (
   <svg width={16} height={16} fill="none" viewBox="0 0 16 16" {...props}>
     <path
       fill="currentColor"
@@ -12,7 +15,7 @@ const CrossIcon = props => (
   </svg>
 );
 
-const EditIcon = props => (
+export const EditIcon: FunctionComponent<IconProps> = props => (
   <svg width={16} height={16} fill="none" viewBox="0 0 16 16" {...props}>
     <path
       fill="currentColor"
@@ -21,7 +24,7 @@ const EditIcon = props => (
   </svg>
 );
 
-const AddDirectoryIcon = props => (
+export const AddDirectoryIcon: FunctionComponent<IconProps> = props => (
   <svg width={16} height={16} fill="none" viewBox="0 0 16 16" {...props}>
     <path
       fill="currentColor"
@@ -30,7 +33,7 @@ const AddDirectoryIcon = props => (
   </svg>
 );
 
-const AddFileIcon = props => (
+export const AddFileIcon: FunctionComponent<IconProps> = props => (
   <svg width={16} height={16} fill="none" viewBox="0 0 16 16" {...props}>
     <path
       fill="currentColor"
@@ -41,7 +44,7 @@ const AddFileIcon = props => (
   </svg>
 );
 
-const DownloadIcon = props => (
+export const DownloadIcon: FunctionComponent<IconProps> = props => (
   <svg width={16} height={16} fill="none" viewBox="0 0 16 16" {...props}>
     <g clipPath="url(#clip0)">
       <path
@@ -59,7 +62,7 @@ const DownloadIcon = props => (
   </svg>
 );
 
-const UploadFileIcon = props => (
+export const UploadFileIcon: FunctionComponent<IconProps> = props => (
   <svg width={16} height={16} fill="none" viewBox="0 0 16 16" {...props}>
     <g clipPath="url(#clip0)">
       <path
@@ -76,15 +79,3 @@ const UploadFileIcon = props => (
     </defs>
   </svg>
 );
-
-export {
-  EditIcon,
-  DeleteIcon,
-  AddDirectoryIcon,
-  AddFileIcon,
-  UndoIcon,
-  NotSyncedIcon,
-  CrossIcon,
-  DownloadIcon,
-  UploadFileIcon,
-};

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Explorer/Files/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Explorer/Files/index.tsx
@@ -1,86 +1,89 @@
 import { getModulePath } from '@codesandbox/common/lib/sandbox/modules';
 import { Collapsible, SidebarRow } from '@codesandbox/components';
 import css from '@styled-system/css';
+import React, { FunctionComponent, useCallback, useState } from 'react';
+
 import { useOvermind } from 'app/overmind';
-import React from 'react';
 
 import EditIcons from './DirectoryEntry/Entry/EditIcons';
 import DirectoryEntry from './DirectoryEntry/index';
 
-export const Files = () => {
+export const Files: FunctionComponent = () => {
   const {
-    state: { editor: editorState, isLoggedIn },
     actions: { editor, files },
+    state: {
+      editor: editorState,
+      editor: {
+        currentSandbox: { directories, modules, privacy, title },
+      },
+      isLoggedIn,
+    },
   } = useOvermind();
+  const [editActions, setEditActions] = useState(null);
 
-  const [editActions, setEditActions] = React.useState(null);
-
-  const { currentSandbox: sandbox } = editorState;
-
-  const _getModulePath = React.useCallback(
+  const _getModulePath = useCallback(
     moduleId => {
       try {
-        return getModulePath(sandbox.modules, sandbox.directories, moduleId);
-      } catch (e) {
+        return getModulePath(modules, directories, moduleId);
+      } catch {
         return '';
       }
     },
-    [sandbox.directories, sandbox.modules]
+    [directories, modules]
   );
 
   return (
-    <>
-      <Collapsible title="Files" defaultOpen css={{ position: 'relative' }}>
-        <SidebarRow
-          justify="flex-end"
-          css={css({
-            // these could have been inside the collapsible as "actions"
-            // but this is the only exception where we have actions in the
-            // collapsible header. Keeping them in the body, also lets us
-            // get the animation effect of open/close state on it's own
-            // If this UI pattern catches on, it would be a good refactor
-            // to add actions API to collapsible
-            position: 'absolute',
-            top: 0,
-            right: 2,
-          })}
-        >
-          {editActions}
-        </SidebarRow>
-        <DirectoryEntry
-          root
-          getModulePath={_getModulePath}
-          title={sandbox.title || 'Project'}
-          signals={{ files, editor }}
-          store={{ editor: editorState, isLoggedIn }}
-          initializeProperties={({
-            onCreateModuleClick,
-            onCreateDirectoryClick,
-            onUploadFileClick,
-          }) => {
-            if (setEditActions) {
-              setEditActions(
-                // @ts-ignore
-                <EditIcons
-                  hovering
-                  forceShow={window.__isTouch}
-                  onCreateFile={onCreateModuleClick}
-                  onCreateDirectory={onCreateDirectoryClick}
-                  onDownload={editor.createZipClicked}
-                  onUploadFile={
-                    isLoggedIn && sandbox.privacy === 0
-                      ? onUploadFileClick
-                      : undefined
-                  }
-                />
-              );
-            }
-          }}
-          depth={-1}
-          id={null}
-          shortid={null}
-        />
-      </Collapsible>
-    </>
+    <Collapsible css={{ position: 'relative' }} defaultOpen title="Files">
+      <SidebarRow
+        css={css({
+          // these could have been inside the collapsible as "actions"
+          // but this is the only exception where we have actions in the
+          // collapsible header. Keeping them in the body, also lets us
+          // get the animation effect of open/close state on it's own
+          // If this UI pattern catches on, it would be a good refactor
+          // to add actions API to collapsible
+          position: 'absolute',
+          top: 0,
+          right: 2,
+        })}
+        justify="flex-end"
+      >
+        {editActions}
+      </SidebarRow>
+
+      <DirectoryEntry
+        depth={-1}
+        getModulePath={_getModulePath}
+        id={null}
+        initializeProperties={({
+          onCreateDirectoryClick,
+          onUploadFileClick,
+          onCreateModuleClick,
+        }) => {
+          if (!setEditActions) {
+            return;
+          }
+
+          setEditActions(
+            // @ts-ignore
+            <EditIcons
+              forceShow={window.__isTouch}
+              hovering
+              onCreateDirectory={onCreateDirectoryClick}
+              onCreateFile={onCreateModuleClick}
+              onDownload={editor.createZipClicked}
+              onUploadFile={
+                isLoggedIn && privacy === 0 ? onUploadFileClick : undefined
+              }
+            />
+          );
+        }}
+        root
+        shortid={null}
+        signals={{ files, editor }}
+        store={{ editor: editorState, isLoggedIn }}
+        title={title || 'Project'}
+      />
+    </Collapsible>
   );
 };

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Explorer/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Explorer/index.tsx
@@ -1,22 +1,28 @@
-import React from 'react';
+import React, { FunctionComponent } from 'react';
+
 import { useOvermind } from 'app/overmind';
-import { Files } from './Files';
+
 import { Dependencies } from './Dependencies';
 import { ExternalResources } from './ExternalResources';
+import { Files } from './Files';
 
-export const Explorer = () => {
+export const Explorer: FunctionComponent = () => {
   const {
-    state: { editor },
+    state: {
+      editor: {
+        currentSandbox: { template },
+      },
+    },
   } = useOvermind();
-
-  const template = editor.currentSandbox.template;
 
   return (
     <>
       <Files />
+
       {template !== 'static' && (
         <>
           <Dependencies />
+
           <ExternalResources />
         </>
       )}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5924,6 +5924,27 @@ algoliasearch@^3.24.5, algoliasearch@^3.27.1:
     semver "^5.1.0"
     tunnel-agent "^0.6.0"
 
+algoliasearch@^3.35.1:
+  version "3.35.1"
+  resolved "https://registry.yarnpkg.com/algoliasearch/-/algoliasearch-3.35.1.tgz#297d15f534a3507cab2f5dfb996019cac7568f0c"
+  integrity sha512-K4yKVhaHkXfJ/xcUnil04xiSrB8B8yHZoFEhWNpXg23eiCnqvTZw1tn/SqvdsANlYHLJlKl0qi3I/Q2Sqo7LwQ==
+  dependencies:
+    agentkeepalive "^2.2.0"
+    debug "^2.6.9"
+    envify "^4.0.0"
+    es6-promise "^4.1.0"
+    events "^1.1.0"
+    foreach "^2.0.5"
+    global "^4.3.2"
+    inherits "^2.0.1"
+    isarray "^2.0.1"
+    load-script "^1.0.0"
+    object-keys "^1.0.11"
+    querystring-es3 "^0.2.1"
+    reduce "^1.0.1"
+    semver "^5.1.0"
+    tunnel-agent "^0.6.0"
+
 all-contributors-cli@^6.9.2:
   version "6.9.3"
   resolved "https://registry.yarnpkg.com/all-contributors-cli/-/all-contributors-cli-6.9.3.tgz#84995eac024402107f15e836364a9d5bf39b0d46"


### PR DESCRIPTION
Things I did:
- Add `algoliasearch` dependency
- Make `BundleSizes`, `Dependency`, `Explorer` & `Files` a `FunctionComponent`
- Move `overmind` subscriptions as close as possible to the components itself instead of passing it through
- Type the icons