### PR TITLE
Cleanup GitHub screen

### DIFF
--- a/packages/app/src/app/overmind/namespaces/git/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/git/actions.ts
@@ -4,9 +4,7 @@ import * as internalActions from './internalActions';
 
 export const internal = internalActions;
 
-export const repoTitleChanged: Action<{
-  title: string;
-}> = ({ state }, { title }) => {
+export const repoTitleChanged: Action<string> = ({ state }, title) => {
   state.git.repoTitle = title;
   state.git.error = null;
 };
@@ -96,15 +94,11 @@ export const createCommitClicked: AsyncAction = async ({ state, effects }) => {
   state.git.originalGitChanges = null;
 };
 
-export const subjectChanged: Action<{
-  subject: string;
-}> = ({ state }, { subject }) => {
+export const subjectChanged: Action<string> = ({ state }, subject) => {
   state.git.subject = subject;
 };
 
-export const descriptionChanged: Action<{
-  description: string;
-}> = ({ state }, { description }) => {
+export const descriptionChanged: Action<string> = ({ state }, description) => {
   state.git.description = description;
 };
 

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/items/GitHub/CreateRepo/CreateRepo.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/items/GitHub/CreateRepo/CreateRepo.tsx
@@ -26,7 +26,7 @@ export const CreateRepo: FunctionComponent<Props> = ({ style }) => {
 
   const updateRepoTitle = ({
     target: { value: title },
-  }: ChangeEvent<HTMLInputElement>) => repoTitleChanged({ title });
+  }: ChangeEvent<HTMLInputElement>) => repoTitleChanged(title);
   const createRepo = () => {
     track('Export to GitHub Clicked');
     createRepoClicked();

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/items/GitHub/Git/Git.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/items/GitHub/Git/Git.tsx
@@ -43,11 +43,10 @@ export const Git: FunctionComponent = () => {
   const createPR = () => createPrClicked();
   const changeSubject = ({
     target: { value },
-  }: ChangeEvent<HTMLInputElement>) => subjectChanged({ subject: value });
+  }: ChangeEvent<HTMLInputElement>) => subjectChanged(value);
   const changeDescription = ({
     target: { value },
-  }: ChangeEvent<HTMLTextAreaElement>) =>
-    descriptionChanged({ description: value });
+  }: ChangeEvent<HTMLTextAreaElement>) => descriptionChanged(value);
 
   const modulesNotSaved = !isAllModulesSynced;
   const changeCount = gitChanges

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/GitHub/Changes.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/GitHub/Changes.tsx
@@ -1,25 +1,46 @@
-import React from 'react';
-import { Text, List, ListItem } from '@codesandbox/components';
+import { List, ListItem, Text } from '@codesandbox/components';
+import React, { FunctionComponent } from 'react';
+
+import { useOvermind } from 'app/overmind';
+
 import { AddedIcon, DeletedIcon, ChangedIcon } from './Icons';
 
 const getChanges = changes => changes.slice().sort();
 
-export const Changes = ({ added, modified, deleted }) => (
-  <List paddingBottom={6}>
-    {getChanges(added).map(change => (
-      <ListItem gap={2}>
-        <AddedIcon /> <Text variant="muted">{change}</Text>
-      </ListItem>
-    ))}
-    {getChanges(modified).map(change => (
-      <ListItem gap={2}>
-        <ChangedIcon /> <Text variant="muted">{change}</Text>
-      </ListItem>
-    ))}
-    {getChanges(deleted).map(change => (
-      <ListItem gap={2}>
-        <DeletedIcon /> <Text variant="muted">{change}</Text>
-      </ListItem>
-    ))}
-  </List>
-);
+export const Changes: FunctionComponent = () => {
+  const {
+    state: {
+      git: {
+        originalGitChanges: { added, modified, deleted },
+      },
+    },
+  } = useOvermind();
+
+  return (
+    <List paddingBottom={6}>
+      {getChanges(added).map(change => (
+        <ListItem gap={2}>
+          <AddedIcon />
+
+          <Text variant="muted">{change}</Text>
+        </ListItem>
+      ))}
+
+      {getChanges(modified).map(change => (
+        <ListItem gap={2}>
+          <ChangedIcon />
+
+          <Text variant="muted">{change}</Text>
+        </ListItem>
+      ))}
+
+      {getChanges(deleted).map(change => (
+        <ListItem gap={2}>
+          <DeletedIcon />
+
+          <Text variant="muted">{change}</Text>
+        </ListItem>
+      ))}
+    </List>
+  );
+};

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/GitHub/CommitForm.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/GitHub/CommitForm.tsx
@@ -1,15 +1,17 @@
-import React, { ChangeEvent } from 'react';
-import css from '@styled-system/css';
 import {
-  FormField,
-  Stack,
-  Input,
-  Textarea,
   Button,
+  FormField,
+  Input,
+  Stack,
+  Textarea,
 } from '@codesandbox/components';
+import css from '@styled-system/css';
+
+import React, { ChangeEvent, FunctionComponent } from 'react';
+
 import { useOvermind } from 'app/overmind';
 
-export const CommitForm = () => {
+export const CommitForm: FunctionComponent = () => {
   const {
     actions: {
       git: {
@@ -28,16 +30,13 @@ export const CommitForm = () => {
   const hasWriteAccess = (rights: string = '') =>
     ['admin', 'write'].includes(rights);
 
-  const modulesNotSaved = !isAllModulesSynced;
-
   const changeSubject = ({
     target: { value },
-  }: ChangeEvent<HTMLInputElement>) => subjectChanged({ subject: value });
+  }: ChangeEvent<HTMLInputElement>) => subjectChanged(value);
 
   const changeDescription = ({
     target: { value },
-  }: ChangeEvent<HTMLTextAreaElement>) =>
-    descriptionChanged({ description: value });
+  }: ChangeEvent<HTMLTextAreaElement>) => descriptionChanged(value);
 
   return (
     <>
@@ -55,35 +54,35 @@ export const CommitForm = () => {
             value={subject}
           />
         </FormField>
-        <FormField direction="vertical" label="Commit description" hideLabel>
+
+        <FormField direction="vertical" hideLabel label="Commit description">
           <Textarea
             maxLength={280}
-            placeholder="Description"
             onChange={changeDescription}
+            placeholder="Description"
             value={description}
           />
         </FormField>
+
         <Stack
+          css={{ button: { width: '40%' } }}
           justify="space-between"
           marginX={2}
-          css={{
-            button: { width: '40%' },
-          }}
         >
-          {hasWriteAccess(originalGitChanges?.rights) && (
+          {hasWriteAccess(originalGitChanges?.rights) ? (
             <Button
+              disabled={!subject || !isAllModulesSynced}
+              onClick={createCommitClicked}
               variant="secondary"
-              disabled={!subject || modulesNotSaved}
-              onClick={() => createCommitClicked()}
             >
               Commit
             </Button>
-          )}
+          ) : null}
 
           <Button
+            disabled={!subject || !isAllModulesSynced}
+            onClick={createPrClicked}
             variant="secondary"
-            disabled={!subject || modulesNotSaved}
-            onClick={() => createPrClicked()}
           >
             Open PR
           </Button>

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/GitHub/CreateRepo.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/GitHub/CreateRepo.tsx
@@ -1,81 +1,86 @@
 import track from '@codesandbox/common/lib/utils/analytics';
-import React, { ChangeEvent } from 'react';
 import {
-  Collapsible,
-  Input,
-  Element,
-  Stack,
   Button,
-  Text,
+  Collapsible,
+  Element,
   FormField,
+  Input,
+  Stack,
+  Text,
 } from '@codesandbox/components';
+import React, { ChangeEvent, FunctionComponent } from 'react';
+
 import { useOvermind } from 'app/overmind';
 
-export const CreateRepo = () => {
+export const CreateRepo: FunctionComponent = () => {
   const {
     actions: {
       git: { createRepoClicked, repoTitleChanged },
     },
     state: {
       editor: {
-        isAllModulesSynced,
         currentSandbox: { originalGit },
+        isAllModulesSynced,
       },
       git: { error, repoTitle },
     },
   } = useOvermind();
 
   const updateRepoTitle = ({
-    target: { value: title },
-  }: ChangeEvent<HTMLInputElement>) => repoTitleChanged({ title });
+    target: { value },
+  }: ChangeEvent<HTMLInputElement>) => repoTitleChanged(value);
 
-  const createRepo = e => {
-    e.preventDefault();
+  const createRepo = event => {
+    event.preventDefault();
     track('Export to GitHub Clicked');
     createRepoClicked();
   };
 
-  const disabled = Boolean(error) || !repoTitle || !isAllModulesSynced;
-
   return (
     <Collapsible
-      title={originalGit ? 'Export to GitHub' : 'GitHub'}
       defaultOpen={!originalGit}
+      title={originalGit ? 'Export to GitHub' : 'GitHub'}
     >
       <Element paddingX={2}>
-        <Text variant="muted" marginBottom={4} block>
+        <Text block marginBottom={4} variant="muted">
           Create a GitHub repository to host your sandbox code and keep it in
           sync with CodeSandbox.
         </Text>
+
         {!isAllModulesSynced && (
-          <Text marginBottom={2} block variant="danger">
+          <Text block marginBottom={2} variant="danger">
             Save your files first before exporting.
           </Text>
         )}
 
         {error && (
-          <Text marginBottom={2} block variant="danger">
+          <Text block marginBottom={2} variant="danger">
             {error}
           </Text>
         )}
 
         <Stack
-          marginX={0}
           as="form"
           direction="vertical"
           gap={2}
+          marginX={0}
           onSubmit={createRepo}
         >
-          <FormField label="Repository name" hideLabel>
+          <FormField hideLabel label="Repository name">
             <Input
-              type="text"
               onChange={updateRepoTitle}
-              value={repoTitle}
               placeholder="Enter repository name"
+              type="text"
+              value={repoTitle}
             />
           </FormField>
+
           <Element paddingX={2}>
-            <Button type="submit" disabled={disabled} variant="secondary">
+            <Button
+              disabled={Boolean(error) || !repoTitle || !isAllModulesSynced}
+              type="submit"
+              variant="secondary"
+            >
               Create Repository
             </Button>
           </Element>

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/GitHub/GithubLogin.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/GitHub/GithubLogin.tsx
@@ -1,46 +1,48 @@
-import { useOvermind } from 'app/overmind';
-import css from '@styled-system/css';
-import React from 'react';
 import {
-  Integration,
-  Text,
-  Element,
-  Stack,
   Button,
   Collapsible,
+  Element,
+  Integration,
+  Stack,
+  Text,
 } from '@codesandbox/components';
+import css from '@styled-system/css';
+import React, { FunctionComponent } from 'react';
+
+import { useOvermind } from 'app/overmind';
+
 import { GitHubIcon } from './Icons';
 
-export const GithubLogin = () => {
+export const GithubLogin: FunctionComponent = () => {
   const {
     actions: { signInGithubClicked },
     state: { isLoadingGithub },
   } = useOvermind();
 
   return (
-    <Collapsible title="Github" defaultOpen>
+    <Collapsible defaultOpen title="Github">
       <Element paddingX={2}>
-        <Text variant="muted" marginBottom={4} block>
+        <Text block marginBottom={4} variant="muted">
           You can create commits and open pull requests if you add GitHub to
           your integrations.
         </Text>
+
         <Integration icon={GitHubIcon} title="GitHub">
           <Element
-            marginX={2}
             css={css({
               display: 'grid',
               gridTemplateColumns: '1fr auto',
               gridGap: 4,
             })}
+            marginX={2}
           >
             <Stack direction="vertical">
               <Text variant="muted">Enables</Text>
+
               <Text>Commits & PRs</Text>
             </Stack>
-            <Button
-              disabled={isLoadingGithub}
-              onClick={() => signInGithubClicked()}
-            >
+
+            <Button disabled={isLoadingGithub} onClick={signInGithubClicked}>
               Sign In
             </Button>
           </Element>

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/GitHub/Icons.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/GitHub/Icons.tsx
@@ -1,6 +1,8 @@
-import React from 'react';
+import React, { FunctionComponent, SVGProps } from 'react';
 
-export const GitHubIcon = props => (
+type IconProps = SVGProps<SVGSVGElement>;
+
+export const GitHubIcon: FunctionComponent<IconProps> = props => (
   <svg
     width="16"
     height="16"
@@ -16,7 +18,7 @@ export const GitHubIcon = props => (
   </svg>
 );
 
-export const AddedIcon = () => (
+export const AddedIcon: FunctionComponent = () => (
   <svg
     width="16"
     height="16"
@@ -33,7 +35,7 @@ export const AddedIcon = () => (
   </svg>
 );
 
-export const DeletedIcon = () => (
+export const DeletedIcon: FunctionComponent = () => (
   <svg
     width="16"
     height="16"
@@ -50,7 +52,7 @@ export const DeletedIcon = () => (
   </svg>
 );
 
-export const ChangedIcon = () => (
+export const ChangedIcon: FunctionComponent = () => (
   <svg
     width="16"
     height="16"

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/GitHub/NotLoggedIn.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/GitHub/NotLoggedIn.tsx
@@ -1,31 +1,32 @@
-import React from 'react';
-
 import {
-  Element,
+  Button,
   Collapsible,
+  Element,
   Stack,
   Text,
-  Button,
 } from '@codesandbox/components';
+import React, { FunctionComponent } from 'react';
+
 import { useOvermind } from 'app/overmind';
 
-export const NotLoggedIn = () => {
+export const NotLoggedIn: FunctionComponent = () => {
   const {
     actions: { signInClicked },
   } = useOvermind();
 
   return (
-    <Collapsible title="GitHub" defaultOpen>
+    <Collapsible defaultOpen title="GitHub">
       <Element paddingX={2}>
         <Stack direction="vertical" gap={2} marginBottom={6}>
-          <Text size={2} variant="muted" block>
+          <Text block size={2} variant="muted">
             You need to be signed in to export this sandbox to GitHub and make
             commits and pull requests to it.
           </Text>
         </Stack>
+
         <Button
-          variant="primary"
           onClick={() => signInClicked({ useExtraScopes: false })}
+          variant="primary"
         >
           Sign in with GitHub
         </Button>

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/GitHub/NotOwner.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/GitHub/NotOwner.tsx
@@ -1,15 +1,15 @@
-import React from 'react';
-
 import {
-  Element,
+  Button,
   Collapsible,
+  Element,
   Stack,
   Text,
-  Button,
 } from '@codesandbox/components';
+import React, { FunctionComponent } from 'react';
+
 import { useOvermind } from 'app/overmind';
 
-export const NotOwner = () => {
+export const NotOwner: FunctionComponent = () => {
   const {
     actions: {
       editor: { forkSandboxClicked },
@@ -20,21 +20,23 @@ export const NotOwner = () => {
   } = useOvermind();
 
   return (
-    <Collapsible title="Github" defaultOpen>
+    <Collapsible defaultOpen title="Github">
       <Element paddingX={2}>
         <Stack direction="vertical" gap={2} marginBottom={6}>
-          <Text size={2} variant="muted" block>
+          <Text block size={2} variant="muted">
             You need to own this sandbox to export this sandbox to GitHub and
             make commits and pull requests to it.
           </Text>
+
           <Text size={2} variant="muted" block>
             Make a fork to own the sandbox.
           </Text>
         </Stack>
+
         <Button
-          variant="primary"
           disabled={isForkingSandbox}
-          onClick={() => forkSandboxClicked()}
+          onClick={forkSandboxClicked}
+          variant="primary"
         >
           {isForkingSandbox ? 'Forking Sandbox...' : 'Fork Sandbox'}
         </Button>

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/GitHub/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/GitHub/index.tsx
@@ -1,31 +1,33 @@
-import React, { useEffect } from 'react';
+import { githubRepoUrl } from '@codesandbox/common/lib/utils/url-generator';
 import {
   Collapsible,
-  Text,
   Element,
-  Stack,
   Link,
+  Stack,
+  Text,
 } from '@codesandbox/components';
-import { githubRepoUrl } from '@codesandbox/common/lib/utils/url-generator';
-import { useOvermind } from 'app/overmind';
-import { GitHubIcon } from './Icons';
-import { CommitForm } from './CommitForm';
-import { Changes } from './Changes';
-import { CreateRepo } from './CreateRepo';
-import { GithubLogin } from './GithubLogin';
-import { NotOwner } from './NotOwner';
-import { NotLoggedIn } from './NotLoggedIn';
+import React, { FunctionComponent, useEffect } from 'react';
 
-export const GitHub = () => {
+import { useOvermind } from 'app/overmind';
+
+import { Changes } from './Changes';
+import { CommitForm } from './CommitForm';
+import { CreateRepo } from './CreateRepo';
+import { GitHubIcon } from './Icons';
+import { GithubLogin } from './GithubLogin';
+import { NotLoggedIn } from './NotLoggedIn';
+import { NotOwner } from './NotOwner';
+
+export const GitHub: FunctionComponent = () => {
   const {
     actions: {
       git: { gitMounted },
     },
     state: {
-      git: { isFetching, originalGitChanges: gitChanges },
       editor: {
         currentSandbox: { originalGit, owned },
       },
+      git: { isFetching, originalGitChanges },
       isLoggedIn,
       user,
     },
@@ -35,60 +37,76 @@ export const GitHub = () => {
     gitMounted();
   }, [gitMounted]);
 
-  const changeCount = gitChanges
-    ? gitChanges.added.length +
-      gitChanges.modified.length +
-      gitChanges.deleted.length
+  const changeCount = originalGitChanges
+    ? originalGitChanges.added.length +
+      originalGitChanges.modified.length +
+      originalGitChanges.deleted.length
     : 0;
 
-  if (!isLoggedIn) return <NotLoggedIn />;
-  if (!owned) return <NotOwner />;
-  if (!user.integrations.github) return <GithubLogin />;
+  if (!isLoggedIn) {
+    return <NotLoggedIn />;
+  }
+
+  if (!owned) {
+    return <NotOwner />;
+  }
+
+  if (!user.integrations.github) {
+    return <GithubLogin />;
+  }
 
   return (
     <>
       {originalGit ? (
-        <Collapsible title="Github" defaultOpen>
+        <Collapsible defaultOpen title="Github">
           <Element paddingX={2}>
             <Link
-              target="_blank"
-              rel="noopener noreferrer"
               href={githubRepoUrl(originalGit)}
+              rel="noopener noreferrer"
+              target="_blank"
             >
-              <Stack gap={2} marginBottom={6} align="center">
+              <Stack align="center" gap={2} marginBottom={6}>
                 <GitHubIcon />
+
                 <Text size={2}>
-                  {originalGit.username}/{originalGit.repo}
+                  {`${originalGit.username}/${originalGit.repo}`}
                 </Text>
               </Stack>
             </Link>
           </Element>
+
           <Element>
-            <Text size={3} block marginBottom={2} marginX={2}>
-              Changes ({isFetching ? '...' : changeCount})
+            <Text block marginBottom={2} marginX={2} size={3}>
+              {`Changes (${isFetching ? '...' : changeCount})`}
             </Text>
+
             {!isFetching ? (
-              gitChanges && <Changes {...gitChanges} />
+              originalGitChanges ? (
+                <Changes />
+              ) : null
             ) : (
               <Element paddingX={2}>
                 <Text variant="muted">Fetching changes...</Text>
               </Element>
             )}
+
             {!isFetching && (
               <>
-                {changeCount > 0 && <CommitForm />}
-                {changeCount === 0 && (
+                {changeCount > 0 ? <CommitForm /> : null}
+
+                {changeCount === 0 ? (
                   <Element paddingX={2}>
                     <Text variant="muted" weight="bold">
                       There are no changes
                     </Text>
                   </Element>
-                )}
+                ) : null}
               </>
             )}
           </Element>
         </Collapsible>
       ) : null}
+
       <CreateRepo />
     </>
   );

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/NotOwnedSandboxInfo/Summary.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/NotOwnedSandboxInfo/Summary.tsx
@@ -121,11 +121,7 @@ export const Summary = () => {
                     borderColor: 'avatar.border',
                   })}
                 >
-                  <GitHubIcon
-                    title="GitHub repository"
-                    width={20}
-                    height={20}
-                  />
+                  <GitHubIcon height={20} width={20} />
                 </Stack>
                 <Link variant="muted" maxWidth="100%">
                   {currentSandbox.git.username}/{currentSandbox.git.repo}

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/ProjectInfo/Summary.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/ProjectInfo/Summary.tsx
@@ -161,11 +161,7 @@ export const Summary = () => {
                     borderColor: 'avatar.border',
                   })}
                 >
-                  <GitHubIcon
-                    title="GitHub repository"
-                    width={20}
-                    height={20}
-                  />
+                  <GitHubIcon height={20} width={20} />
                 </Stack>
                 <Link variant="muted" maxWidth="100%">
                   {currentSandbox.git.username}/{currentSandbox.git.repo}


### PR DESCRIPTION
Things I did:
- Change `repoTitleChanged`'s signature to accept a `string` instead of `{ title: string }`, because it only has 1 argument
- Change `subjectChanged`'s signature to accept a `string` instead of `{ subject: string }`, because it only has 1 argument
- Change `descriptionChanged`'s signature to accept a `string` instead of `{ description: string }`, because it only has 1 argument
- Move `overmind` subscriptions as close as possible to the components itself instead of passing it through
- Make `Changes`, `CommitForm`, `CreateRepo`, `GitHub`, `GithubLogin`, `NotLoggedIn` & `NotOwner` a `FunctionComponent`
- Type the icons