### PR TITLE
Simplify master build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -384,7 +384,6 @@ workflows:
       - deploy-to-production:
           requires:
             - create-docker-image
-            - build-prod
             - lint
             - typecheck
             - test-integrations


### PR DESCRIPTION
Since `create-docker-image` already requires `build-prod`, it's not necessary anymore that `deploy-to-production` requires it