### PR TITLE
Greatly improve file switching performance

### DIFF
--- a/packages/app/src/app/components/CodeEditor/VSCode/index.tsx
+++ b/packages/app/src/app/components/CodeEditor/VSCode/index.tsx
@@ -17,9 +17,10 @@ export const VSCode: React.FunctionComponent = () => {
   const { state, actions, effects } = useOvermind();
   const containerEl = useRef(null);
 
-  const getCurrentModule = React.useCallback(() => state.editor.currentModule, [
-    state,
-  ]);
+  const getCurrentModule = React.useCallback(
+    () => state.editor.currentModule,
+    [] // eslint-disable-line
+  );
 
   useEffect(() => {
     const rootEl = containerEl.current;

--- a/packages/app/src/app/components/CodeEditor/VSCode/index.tsx
+++ b/packages/app/src/app/components/CodeEditor/VSCode/index.tsx
@@ -17,6 +17,10 @@ export const VSCode: React.FunctionComponent = () => {
   const { state, actions, effects } = useOvermind();
   const containerEl = useRef(null);
 
+  const getCurrentModule = React.useCallback(() => state.editor.currentModule, [
+    state,
+  ]);
+
   useEffect(() => {
     const rootEl = containerEl.current;
     const mainContainer = effects.vscode.getEditorElement(
@@ -36,7 +40,7 @@ export const VSCode: React.FunctionComponent = () => {
                     actions.editor.codeChanged({ code, moduleShortid })
                   }
                   // Copy the object, we don't want mutations in the component
-                  currentModule={json(state.editor.currentModule)}
+                  currentModule={json(getCurrentModule())}
                   config={config}
                   sandbox={state.editor.currentSandbox}
                   {...(extraProps as any)}
@@ -60,9 +64,9 @@ export const VSCode: React.FunctionComponent = () => {
   }, [
     actions.editor,
     effects.vscode,
-    state.editor.currentModule,
     state.editor.currentSandbox,
     state.editor.currentSandbox.template,
+    getCurrentModule,
   ]);
 
   return (


### PR DESCRIPTION
Switching files was noticably slow, with this change it's almost instant. The reason for this was a `React.useEffect` that would execute for every time we switch a file, and this would cause VSCode to do a layout update. With this change file switching is instant.

![image](https://user-images.githubusercontent.com/587016/80975696-b8484e00-8e22-11ea-9f3c-8d18eeeadb61.png)
