### PR TITLE
Remove unnecessary calculations for rendering files

### DIFF
--- a/packages/app/src/app/components/CodeEditor/VSCode/index.tsx
+++ b/packages/app/src/app/components/CodeEditor/VSCode/index.tsx
@@ -17,9 +17,10 @@ export const VSCode: React.FunctionComponent = () => {
   const { state, actions, effects } = useOvermind();
   const containerEl = useRef(null);
 
-  const getCurrentModule = React.useCallback(() => state.editor.currentModule, [
-    state,
-  ]);
+  const getCurrentModule = React.useCallback(
+    () => state.editor.currentModule,
+    [] // eslint-disable-line
+  );
 
   useEffect(() => {
     const rootEl = containerEl.current;

--- a/packages/app/src/app/components/CodeEditor/VSCode/index.tsx
+++ b/packages/app/src/app/components/CodeEditor/VSCode/index.tsx
@@ -17,6 +17,10 @@ export const VSCode: React.FunctionComponent = () => {
   const { state, actions, effects } = useOvermind();
   const containerEl = useRef(null);
 
+  const getCurrentModule = React.useCallback(() => state.editor.currentModule, [
+    state,
+  ]);
+
   useEffect(() => {
     const rootEl = containerEl.current;
     const mainContainer = effects.vscode.getEditorElement(
@@ -36,7 +40,7 @@ export const VSCode: React.FunctionComponent = () => {
                     actions.editor.codeChanged({ code, moduleShortid })
                   }
                   // Copy the object, we don't want mutations in the component
-                  currentModule={json(state.editor.currentModule)}
+                  currentModule={json(getCurrentModule())}
                   config={config}
                   sandbox={state.editor.currentSandbox}
                   {...(extraProps as any)}
@@ -60,9 +64,9 @@ export const VSCode: React.FunctionComponent = () => {
   }, [
     actions.editor,
     effects.vscode,
-    state.editor.currentModule,
     state.editor.currentSandbox,
     state.editor.currentSandbox.template,
+    getCurrentModule,
   ]);
 
   return (

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/Files/DirectoryEntry/DirectoryChildren/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/Files/DirectoryEntry/DirectoryChildren/index.tsx
@@ -62,7 +62,6 @@ const DirectoryChildren: React.FC<IDirectoryChildrenProps> = ({
         .map(dir => (
           <DirectoryEntry
             key={dir.id}
-            siblings={[...directories, ...modules]}
             depth={depth + 1}
             signals={{ files, editor }}
             store={{ editor: editorState, isLoggedIn }}

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/Files/DirectoryEntry/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/Files/DirectoryEntry/index.tsx
@@ -274,9 +274,7 @@ const DirectoryEntry: React.FunctionComponent<Props> = ({
     });
   };
 
-  const toggleOpen = () => {
-    setOpen(!open);
-  };
+  const toggleOpen = () => setOpen(!open);
 
   const closeTree = () => setOpen(false);
 

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/Files/DirectoryEntry/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/Files/DirectoryEntry/index.tsx
@@ -61,7 +61,6 @@ interface Props {
   connectDropTarget?: Function;
   isOver?: boolean;
   canDrop?: boolean;
-  siblings?: any;
   signals?: any;
   title?: string;
   sandboxId?: string;
@@ -275,7 +274,9 @@ const DirectoryEntry: React.FunctionComponent<Props> = ({
     });
   };
 
-  const toggleOpen = () => setOpen(!open);
+  const toggleOpen = () => {
+    setOpen(!open);
+  };
 
   const closeTree = () => setOpen(false);
 

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Explorer/Files/DirectoryEntry/DirectoryChildren/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Explorer/Files/DirectoryEntry/DirectoryChildren/index.tsx
@@ -62,7 +62,6 @@ const DirectoryChildren: React.FC<IDirectoryChildrenProps> = ({
         .map(dir => (
           <DirectoryEntry
             key={dir.id}
-            siblings={[...directories, ...modules]}
             depth={depth + 1}
             signals={{ files, editor }}
             store={{ editor: editorState, isLoggedIn }}

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Explorer/Files/DirectoryEntry/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Explorer/Files/DirectoryEntry/index.tsx
@@ -61,7 +61,6 @@ interface Props {
   connectDropTarget?: Function;
   isOver?: boolean;
   canDrop?: boolean;
-  siblings?: any;
   signals?: any;
   title?: string;
   sandboxId?: string;


### PR DESCRIPTION
Spreads are expensive, and it seems like we were doing it for all our folders. This removes the spreads.

It seems like we weren't using siblings at all anymore, even not in spreads and checks.

I tested this by opening and closing files/directories. 