### PR TITLE
refactor(deployment): rename ZEIT Now to Vercel

### DIFF
--- a/packages/app/src/app/overmind/actions.ts
+++ b/packages/app/src/app/overmind/actions.ts
@@ -147,12 +147,12 @@ export const signInZeitClicked: AsyncAction = async ({
       await actions.deployment.internal.getZeitUserDetails();
     } catch (error) {
       actions.internal.handleError({
-        message: 'Could not authorize with ZEIT',
+        message: 'Could not authorize with Vercel',
         error,
       });
     }
   } else {
-    notificationToast.error('Could not authorize with ZEIT');
+    notificationToast.error('Could not authorize with Vercel');
   }
 
   state.isLoadingZeit = false;

--- a/packages/app/src/app/overmind/effects/git/export-to-github.ts
+++ b/packages/app/src/app/overmind/effects/git/export-to-github.ts
@@ -10,7 +10,7 @@ interface IAPIModule {
 
 export default async function deploy(sandbox: Sandbox) {
   // We first get the zip file, this is what we essentially need to have deployed.
-  // So we convert it to an API request that ZEIT will understand
+  // So we convert it to an API request that Vercel will understand
   const zipFile = await createZip(
     sandbox,
     sandbox.modules,

--- a/packages/app/src/app/overmind/effects/zeit.ts
+++ b/packages/app/src/app/overmind/effects/zeit.ts
@@ -44,7 +44,7 @@ export default (() => {
     const token = _options.getToken();
 
     if (!token) {
-      throw new Error('You have no Zeit token');
+      throw new Error('You have no Vercel token');
     }
 
     return {
@@ -196,7 +196,7 @@ async function getApiData(contents: any, sandbox: Sandbox) {
   // We'll omit the homepage-value from package.json as it creates wrong assumptions over the now deployment environment.
   packageJSON = omit(packageJSON, 'homepage');
 
-  // We force the sandbox id, so ZEIT will always group the deployments to a
+  // We force the sandbox id, so Vercel will always group the deployments to a
   // single sandbox
   packageJSON.name = nowJSON.name || nowDefaults.name;
 

--- a/packages/app/src/app/overmind/namespaces/deployment/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/deployment/actions.ts
@@ -10,7 +10,7 @@ const getZeitErrorMessage = (error: AxiosError) =>
   get(
     error,
     'response.data.error.message',
-    'An unknown error occurred when connecting to ZEIT'
+    'An unknown error occurred when connecting to Vercel'
   );
 
 export const deployWithNetlify: AsyncAction = async ({
@@ -140,7 +140,7 @@ export const deploySandboxClicked: AsyncAction = async ({
 
   if (!zeitIntegration || !zeitIntegration.token) {
     effects.notificationToast.error(
-      'You are not authorized with Zeit, please refresh and log in again'
+      'You are not authorized with Vercel, please refresh and log in again'
     );
     return;
   }
@@ -154,7 +154,7 @@ export const deploySandboxClicked: AsyncAction = async ({
       }
     } catch (error) {
       actions.internal.handleError({
-        message: 'Could not authorize with ZEIT',
+        message: 'Could not authorize with Vercel',
         error,
       });
     }

--- a/packages/app/src/app/overmind/namespaces/deployment/internalActions.ts
+++ b/packages/app/src/app/overmind/namespaces/deployment/internalActions.ts
@@ -17,7 +17,7 @@ export const getZeitUserDetails: AsyncAction = async ({
       state.user.integrations.zeit.email = zeitDetails.email;
     } catch (error) {
       actions.internal.handleError({
-        message: 'Could not authorize with ZEIT',
+        message: 'Could not authorize with Vercel',
         error,
       });
     }

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/items/Deployment/Deployment.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/items/Deployment/Deployment.tsx
@@ -30,11 +30,11 @@ export const Deployment: FunctionComponent = () => {
   if (showPlaceholder) {
     const message = isLoggedIn ? (
       <>
-        You need to own this sandbox to deploy this sandbox to Netlify or ZEIT.{' '}
-        <p>Fork this sandbox to make a deploy!</p>
+        You need to own this sandbox to deploy this sandbox to Netlify or
+        Vercel. <p>Fork this sandbox to make a deploy!</p>
       </>
     ) : (
-      <>You need to be signed in to deploy this sandbox to Netlify or ZEIT.</>
+      <>You need to be signed in to deploy this sandbox to Netlify or Vercel.</>
     );
 
     return <More message={message} id="github" />;

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/items/Deployment/Zeit/DeployButton/DeployButton.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/items/Deployment/Zeit/DeployButton/DeployButton.tsx
@@ -29,8 +29,12 @@ export const DeployButton: FunctionComponent<Props> = ({ isOpen, toggle }) => {
         onToggle={toggle}
       >
         Deploy your sandbox on{' '}
-        <a href="https://zeit.co/now" rel="noreferrer noopener" target="_blank">
-          <span>ZEIT Now</span>
+        <a
+          href="https://vercel.com/home"
+          rel="noreferrer noopener"
+          target="_blank"
+        >
+          <span>Vercel</span>
         </a>
       </DeploymentIntegration>
     </DeployButtonContainer>

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Deployment/NotLoggedIn.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Deployment/NotLoggedIn.tsx
@@ -20,7 +20,7 @@ export const NotLoggedIn = () => {
         <Stack direction="vertical" gap={2} marginBottom={6}>
           <Text size={2} variant="muted" block>
             You can deploy a production version of your sandbox using one of our
-            supported providers - Netlify or ZEIT.
+            supported providers - Netlify or Vercel.
           </Text>
           <Text size={2} variant="muted" block>
             You need to be signed in to deploy this sandbox.

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Deployment/NotOwner.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Deployment/NotOwner.tsx
@@ -25,7 +25,7 @@ export const NotOwner = () => {
         <Stack direction="vertical" gap={2} marginBottom={6}>
           <Text size={2} variant="muted" block>
             You can deploy a production version of your sandbox using one of our
-            supported providers - Netlify or ZEIT.
+            supported providers - Netlify or Vercel.
           </Text>
           <Text size={2} variant="muted" block>
             You need to own this sandbox to deploy.

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Deployment/Zeit.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Deployment/Zeit.tsx
@@ -26,18 +26,18 @@ export const Zeit = () => {
   const { deploySandboxClicked, setDeploymentToDelete } = deployment;
 
   return (
-    <Integration icon={ZeitIcon} title="ZEIT Now">
+    <Integration icon={ZeitIcon} title="Vercel">
       {integrations.zeit ? (
         <>
           <Element marginX={2} marginBottom={sandboxDeploys.length ? 6 : 0}>
             <Text variant="muted" block marginBottom={4}>
               Deploy your sandbox to{' '}
-              <Link href="https://zeit.co/now" target="_blank">
-                ZEIT Now
+              <Link href="https://vercel.com/home" target="_blank">
+                Vercel
               </Link>
             </Text>
             <Button disabled={deploying} onClick={deploySandboxClicked}>
-              Deploy to Zeit
+              Deploy to Vercel
             </Button>
           </Element>
 

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Deployment/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Deployment/index.tsx
@@ -34,7 +34,7 @@ export const Deployment: FunctionComponent = () => {
       <Element paddingX={2}>
         <Text variant="muted" block marginBottom={6}>
           You can deploy a production version of your sandbox using one of our
-          supported providers - Netlify or ZEIT.
+          supported providers - Netlify or Vercel.
         </Text>
         <Stack direction="vertical" gap={5}>
           <Zeit />

--- a/packages/app/src/app/pages/common/Modals/DeploymentModal/index.tsx
+++ b/packages/app/src/app/pages/common/Modals/DeploymentModal/index.tsx
@@ -30,7 +30,7 @@ export const DeploymentModal: FunctionComponent = () => {
   return (
     <Alert
       title="Deployment"
-      description="Deploy a production version of your Sandbox to ZEIT Now"
+      description="Deploy a production version of your Sandbox to Vercel"
     >
       {url ? (
         <Element marginBottom={4}>
@@ -44,7 +44,7 @@ export const DeploymentModal: FunctionComponent = () => {
             You can manage your deployments{' '}
             <Link
               variant="muted"
-              href="https://zeit.co/dashboard"
+              href="https://vercel.com/dashboard"
               target="_blank"
               rel="noreferrer noopener"
             >

--- a/packages/app/src/app/pages/common/ZeitIntegration/index.tsx
+++ b/packages/app/src/app/pages/common/ZeitIntegration/index.tsx
@@ -15,7 +15,7 @@ export const ZeitIntegration: FunctionComponent<Props> = ({ small }) => {
 
   return (
     <Integration
-      name="ZEIT"
+      name="Vercel"
       small={small}
       bgColor="black"
       description="Deployments"

--- a/packages/common/src/templates/configuration/now/index.ts
+++ b/packages/common/src/templates/configuration/now/index.ts
@@ -3,9 +3,9 @@ import { ConfigurationFile } from '../types';
 const config: ConfigurationFile = {
   title: 'now.json',
   type: 'now',
-  description: 'Configuration for your deployments on ZEIT Now.',
+  description: 'Configuration for your deployments on Vercel.',
   moreInfoUrl:
-    'https://zeit.co/docs/configuration#introduction/configuration-reference',
+    'https://vercel.com/docs/configuration#introduction/configuration-reference',
 
   getDefaultCode: () => JSON.stringify({}, null, 2),
 };

--- a/packages/common/src/templates/template.ts
+++ b/packages/common/src/templates/template.ts
@@ -206,7 +206,7 @@ export default class Template {
   }
 
   /**
-   * Alter the apiData to ZEIT for making deployment work
+   * Alter the apiData to Vercel for making deployment work
    */
   alterDeploymentData = (apiData: any) => {
     const packageJSONFile = apiData.files.find(x => x.file === 'package.json');

--- a/packages/components/src/components/Integration/index.stories.tsx
+++ b/packages/components/src/components/Integration/index.stories.tsx
@@ -37,7 +37,7 @@ const ZeitIcon = props => (
 
 export const IntegrationZeit = () => (
   <div style={{ width: 184 }}>
-    <Integration icon={ZeitIcon} title="ZEIT">
+    <Integration icon={ZeitIcon} title="Vercel">
       <Element marginX={2}>
         <Stack direction="vertical">
           <Text variant="muted">Enables</Text>

--- a/packages/homepage/src/pages/company/index.js
+++ b/packages/homepage/src/pages/company/index.js
@@ -142,7 +142,7 @@ export default () => (
         <div>
           <img
             src={Zeit}
-            alt="Zeit"
+            alt="Vercel"
             css={`
               height: 97px;
             `}

--- a/packages/homepage/src/pages/ide/index.js
+++ b/packages/homepage/src/pages/ide/index.js
@@ -141,10 +141,9 @@ export default () => (
           <IconWrapper>
             <Deploy />
           </IconWrapper>
-          <BigTitles>Deploy to ZEIT or Netlify</BigTitles>
+          <BigTitles>Deploy to Vercel or Netlify</BigTitles>
           <P muted center>
-            Deploy a production version of your sandbox with ZEIT Now or
-            Netlify.
+            Deploy a production version of your sandbox with Vercel or Netlify.
           </P>
         </div>
         <div>

--- a/packages/homepage/src/pages/pricing/index.js
+++ b/packages/homepage/src/pages/pricing/index.js
@@ -368,9 +368,9 @@ export default () => (
       </li>
       <li>
         <div>
-          <FeatureTitle>ZEIT Now Deploy</FeatureTitle>
+          <FeatureTitle>Vercel Deploy</FeatureTitle>
           <P muted small>
-            Deploy a production version of your sandbox to ZEIT Now.
+            Deploy a production version of your sandbox to Vercel.
           </P>
         </div>
         <span>✓</span>


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?
Refactor. ZEIT has rebranded to Vercel.
<!-- Is it a Bug fix, feature, docs update, ... -->

## What is the current behavior?
We're displaying deployment to ZEIT Now yet.
<!-- You can also link to an open issue here -->

## What is the new behavior?
We are displaying deployment to Vercel. Only texts in the app were changed, code still refers to it as `zeit`. Blog posts and announcements were not updated too.
<!-- if this is a feature change -->

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.
N/A

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
