### PR TITLE
fix(create): react to keyboard events when search input is focused

### DIFF
--- a/packages/app/src/app/components/CreateNewSandbox/CreateSandbox/SearchBox/SearchBox.tsx
+++ b/packages/app/src/app/components/CreateNewSandbox/CreateSandbox/SearchBox/SearchBox.tsx
@@ -42,6 +42,7 @@ export const SearchBox = ({
     >
       <InputWrapper>
         <SearchElement
+          id="filter-templates"
           placeholder={placeholder}
           ref={inputEl}
           value={value}

--- a/packages/app/src/app/components/CreateNewSandbox/CreateSandbox/TemplateList/TemplateList.tsx
+++ b/packages/app/src/app/components/CreateNewSandbox/CreateSandbox/TemplateList/TemplateList.tsx
@@ -154,6 +154,9 @@ export const TemplateList = ({
   useKey(
     'ArrowRight',
     evt => {
+      if ((evt.target as HTMLInputElement).id === 'filter-templates') {
+        return;
+      }
       evt.preventDefault();
       safeSetFocusedTemplate(i => i + 1);
     },
@@ -164,6 +167,9 @@ export const TemplateList = ({
   useKey(
     'ArrowLeft',
     evt => {
+      if ((evt.target as HTMLInputElement).id === 'filter-templates') {
+        return;
+      }
       evt.preventDefault();
       safeSetFocusedTemplate(i => i - 1);
     },
@@ -174,6 +180,9 @@ export const TemplateList = ({
   useKey(
     'ArrowDown',
     evt => {
+      if ((evt.target as HTMLInputElement).id === 'filter-templates') {
+        return;
+      }
       evt.preventDefault();
       const { templateInfo, offset } = getTemplateInfoByIndex(
         focusedTemplateIndex
@@ -238,6 +247,9 @@ export const TemplateList = ({
   useKey(
     'ArrowUp',
     evt => {
+      if ((evt.target as HTMLInputElement).id === 'filter-templates') {
+        return;
+      }
       evt.preventDefault();
       const { templateInfo, offset } = getTemplateInfoByIndex(
         focusedTemplateIndex


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?
Bug fix. Closes #4073.
<!-- Is it a Bug fix, feature, docs update, ... -->

## What is the current behavior?
Keyboard events when the search input is focused are "swallowed" by the `useKey` hooks.
<!-- You can also link to an open issue here -->

## What is the new behavior?
Keyboard events fired from the search input are not handled by the `useKey` hooks.
<!-- if this is a feature change -->

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Type something in the search input on the create modal;
2. Press the arrow keys and verify that the interaction is kept inside the input;
3. Press `Esc` to blur from the search input;
4. Press the arrow keys and verify that it navigates through the list.

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
