### PR TITLE
Add xr-spatial-tracking support to preview

### DIFF
--- a/packages/app/src/app/pages/common/Modals/ShareModal/getCode.ts
+++ b/packages/app/src/app/pages/common/Modals/ShareModal/getCode.ts
@@ -72,7 +72,7 @@ export const getIframeScript = (sandbox, mainModule, state) =>
      src="${getEmbedUrl(sandbox, mainModule, state)}"
      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
      title="${escapeHtml(getSandboxName(sandbox))}"
-     allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr"
+     allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
      sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
    ></iframe>`;
 

--- a/packages/common/src/components/Preview/index.tsx
+++ b/packages/common/src/components/Preview/index.tsx
@@ -608,7 +608,7 @@ class BasePreview extends React.Component<Props, State> {
           {(style: { opacity: number }) => (
             <>
               <StyledFrame
-                allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr"
+                allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
                 sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
                 src={this.state.url}
                 ref={this.setIframeElement}

--- a/packages/homepage/src/screens/home/explore/index.js
+++ b/packages/homepage/src/screens/home/explore/index.js
@@ -96,7 +96,7 @@ const Sandbox = ({
           big={big}
           title={id}
           src={`https://codesandbox.io/embed/${id}?fontsize=14&hidenavigation=1&view=preview&hidedevtools=1`}
-          allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr"
+          allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
           sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
         />
       ) : (

--- a/standalone-packages/react-sandpack/src/components/SandpackProvider/SandpackProvider.tsx
+++ b/standalone-packages/react-sandpack/src/components/SandpackProvider/SandpackProvider.tsx
@@ -273,7 +273,7 @@ export default class SandpackProvider extends React.PureComponent<
               position: 'absolute',
               visibility: 'hidden',
             }}
-            allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr"
+            allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
             sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
             src={this.props.bundlerURL}
           />


### PR DESCRIPTION
## What kind of change does this PR introduce?
Adds 'xr-spatial-tracking' to allowed attributes in preview iframe

## What is the current behavior?
Can't use webxr in preview

## What is the new behavior?
Can use webxr in preview

- [x] Testing - viewed share modal, tried preview, and tried embedding app
- [x] Ready to be merged