### PR TITLE
Send env vars to vercel as secrets

### DIFF
--- a/packages/app/src/app/overmind/effects/vercel.ts
+++ b/packages/app/src/app/overmind/effects/vercel.ts
@@ -72,6 +72,36 @@ export default (() => {
     initialize(options: Options) {
       _options = options;
     },
+    async checkEnvironmentVariables(
+      sandbox: Sandbox,
+      envVars: {
+        [key: string]: string;
+      }
+    ) {
+      const nowData = this.getConfig(sandbox);
+      if (!nowData.env) return null;
+      const all = Object.keys(nowData.env).map(async envVar => {
+        const name = nowData.env[envVar].split('@')[1];
+
+        if (envVars[envVar]) {
+          try {
+            await axios.post(
+              `https://api.vercel.com/v3/now/secrets/`,
+              {
+                name,
+                value: envVars[envVar],
+              },
+              { headers: getDefaultHeaders() }
+            );
+            // eslint-disable-next-line no-empty
+          } catch {}
+        }
+      });
+
+      await Promise.all(all);
+
+      return null;
+    },
     getConfig(sandbox: Sandbox): VercelConfig {
       const nowConfigs = sandbox.modules
         .filter(

--- a/packages/app/src/app/overmind/effects/vercel.ts
+++ b/packages/app/src/app/overmind/effects/vercel.ts
@@ -93,6 +93,9 @@ export default (() => {
               },
               { headers: getDefaultHeaders() }
             );
+            // We don't do anything with the error for two main reasons
+            // 1 - Vercel already shows an error if a ENV variable is missing and you try to deploy
+            // 2 - This will also fail if the user already has the secret in their account
             // eslint-disable-next-line no-empty
           } catch {}
         }

--- a/packages/app/src/app/overmind/effects/vercel.ts
+++ b/packages/app/src/app/overmind/effects/vercel.ts
@@ -79,7 +79,7 @@ export default (() => {
       }
     ) {
       const nowData = this.getConfig(sandbox);
-      if (!nowData.env) return null;
+      if (!nowData || !nowData.env) return null;
       const all = Object.keys(nowData.env).map(async envVar => {
         const name = nowData.env[envVar].split('@')[1];
 

--- a/packages/app/src/app/overmind/namespaces/deployment/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/deployment/actions.ts
@@ -116,6 +116,16 @@ export const deployClicked: AsyncAction = async ({
     state.deployment.deploying = true;
     const zip = await effects.zip.create(sandbox);
     const contents = await effects.jsZip.loadAsync(zip.file);
+
+    if (sandbox.isSse) {
+      const envs = await effects.api.getEnvironmentVariables(
+        state.editor.currentSandbox.id
+      );
+      if (envs) {
+        await effects.vercel.checkEnvironmentVariables(sandbox, envs);
+      }
+    }
+
     state.deployment.url = await effects.vercel.deploy(contents, sandbox);
   } catch (error) {
     actions.internal.handleError({

--- a/packages/app/src/app/overmind/namespaces/deployment/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/deployment/actions.ts
@@ -117,7 +117,7 @@ export const deployClicked: AsyncAction = async ({
     const zip = await effects.zip.create(sandbox);
     const contents = await effects.jsZip.loadAsync(zip.file);
 
-    if (sandbox.isSse) {
+    if (sandbox.isSse && state.editor.currentSandbox) {
       const envs = await effects.api.getEnvironmentVariables(
         state.editor.currentSandbox.id
       );

--- a/packages/common/src/types/index.ts
+++ b/packages/common/src/types/index.ts
@@ -360,6 +360,7 @@ export type Sandbox = {
   git: GitInfo | null;
   tags: string[];
   isFrozen: boolean;
+  isSse?: boolean;
   environmentVariables: {
     [key: string]: string;
   } | null;


### PR DESCRIPTION
**Problem**: 
When you tried to deploy a project to vercel, if you had env variables these were never actually sent to vercel so everything failed


**Now**:
If you have env vars in your now.json file and have the same in environment variables these will be sent to vercel so you can deploy and these secrets will be added to your account

Example sandbox id: https://pr4169.build.csb.dev/s/cool-northcutt-ud4wr

Add an env variable called: NEXT_HELLO_CSB with any value and then go to the deployed site at `api/people/test` and magic!