### PR TITLE
feat(devTools): open dev tools panel on error

### DIFF
--- a/packages/app/src/app/components/Preview/DevTools/Console/index.tsx
+++ b/packages/app/src/app/components/Preview/DevTools/Console/index.tsx
@@ -158,6 +158,10 @@ class ConsoleComponent extends React.Component<StyledProps> {
         },
       })
     );
+
+    if (method === 'error') {
+      this.props.openDevTools();
+    }
   }
 
   list;

--- a/packages/app/src/app/components/Preview/DevTools/index.tsx
+++ b/packages/app/src/app/components/Preview/DevTools/index.tsx
@@ -505,7 +505,6 @@ export class DevTools extends React.PureComponent<Props, State> {
         <ContentContainer>
           {panes.map((view, i) => {
             const { Content } = this.getViews()[view.id];
-
             return (
               <Content
                 key={view.id + JSON.stringify(view.options)}


### PR DESCRIPTION
Ref https://github.com/codesandbox/codesandbox-client/issues/3493

This PR opens the DevTools panel on error, this is to prevent the users from missing these errors. 

Todo: 

- [ ] Close the devtools when the errors are fixed.