### PR TITLE
Don't allow the sidebar to render if currentSandbox is not available

### DIFF
--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/index.tsx
@@ -53,7 +53,7 @@ export const WorkspaceComponent = ({ theme }) => {
               fontFamily: 'Inter, Roboto, sans-serif',
             }}
           >
-            <Component />
+            {state.editor.currentSandbox && <Component />}
           </div>
 
           {isLive && roomInfo.chatEnabled && <Chat />}


### PR DESCRIPTION
Fixes #3766
Fixes #3221
Fixes #3982
Fixes #3975
Fixes #3964
Fixes #4258
Fixes #4254
Fixes #4235
Fixes #4229
Fixes #4227
Fixes #4199
Fixes #4177
Fixes #4153
Fixes #4139
Fixes #4108
Fixes #3561
Fixes #3624

And probably some more. When someone clicks on the sidebar icon when loading a sandbox, or they navigate between sandboxes, it crashes because `currentSandbox` can now be null