### PR TITLE
remove live notification

### DIFF
--- a/packages/app/src/app/overmind/namespaces/live/liveMessageOperators.ts
+++ b/packages/app/src/app/overmind/namespaces/live/liveMessageOperators.ts
@@ -52,11 +52,6 @@ export const onJoin: Operator<LiveMessage<{
 }>> = mutate(({ effects, actions, state }, { data }) => {
   state.live.liveUserId = data.live_user_id;
 
-  // Show message to confirm that you've joined a live session if you're not the owner
-  if (!state.live.isCurrentEditor) {
-    effects.notificationToast.success('Connected to Live!');
-  }
-
   if (state.live.reconnecting) {
     // We reconnected!
     effects.live.getAllClients().forEach(client => {


### PR DESCRIPTION
Codesandbox is live by default, so this message is just confusing, as noted from a user showing us git flow issues. We also have an indication at the top showing who else is in the session now. 