### PR TITLE
Add a fallback to commonjs if esmodule is not found

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -264,6 +264,7 @@
     "@types/gsap": "^1.20.1",
     "@types/jest": "24.0.13",
     "@types/lodash-es": "^4.17.2",
+    "@types/lru-cache": "^5.1.0",
     "@types/phoenix": "^1.4.0",
     "@types/prop-types": "^15.7.0",
     "@types/react": "^16.9.17",

--- a/packages/app/src/sandbox/eval/manager.ts
+++ b/packages/app/src/sandbox/eval/manager.ts
@@ -248,7 +248,7 @@ export default class Manager implements IEvaluator {
   }
 
   // Hoist these 2 functions to the top, since they get executed A LOT
-  isFile = (p: string, cb: Function | undefined, c: Function) => {
+  isFile = (p: string, cb?: Function | undefined, c?: Function) => {
     const callback = c || cb;
     const hasCallback = typeof callback === 'function';
 
@@ -645,7 +645,7 @@ export default class Manager implements IEvaluator {
           extensions: defaultExtensions.map(ext => '.' + ext),
           isFile: this.isFile,
           readFileSync: this.readFileSync,
-          packageFilter,
+          packageFilter: packageFilter(this.isFile),
           moduleDirectory: this.getModuleDirectories(),
         },
         (err, foundPath) => {
@@ -760,7 +760,7 @@ export default class Manager implements IEvaluator {
           extensions: defaultExtensions.map(ext => '.' + ext),
           isFile: this.isFile,
           readFileSync: this.readFileSync,
-          packageFilter,
+          packageFilter: packageFilter(this.isFile),
           moduleDirectory: this.getModuleDirectories(),
         });
         endMeasure(measureKey, { silent: true });

--- a/packages/app/src/sandbox/eval/npm/fetch-npm-module.ts
+++ b/packages/app/src/sandbox/eval/npm/fetch-npm-module.ts
@@ -276,10 +276,15 @@ function resolvePath(
 ): Promise<string> {
   const currentPath = currentTModule.module.path;
 
-  const isFile = (p, c, cb) => {
+  const isFile = (p: string, c?: any, cb?: any): any => {
     const callback = cb || c;
 
-    callback(null, Boolean(manager.transpiledModules[p]) || Boolean(meta[p]));
+    const result = Boolean(manager.transpiledModules[p]) || Boolean(meta[p]);
+    if (!callback) {
+      return result;
+    }
+
+    return callback(null, result);
   };
 
   return new Promise((res, reject) => {
@@ -288,7 +293,7 @@ function resolvePath(
       {
         filename: currentPath,
         extensions: defaultExtensions.map(ext => '.' + ext),
-        packageFilter,
+        packageFilter: packageFilter(isFile),
         moduleDirectory: [
           'node_modules',
           manager.envVariables.NODE_PATH,

--- a/packages/app/src/sandbox/eval/transpilers/babel/check.ts
+++ b/packages/app/src/sandbox/eval/transpilers/babel/check.ts
@@ -21,11 +21,7 @@ function checkComment(match: string[]) {
   return true;
 }
 
-export function shouldTranspile(code: string, path: string) {
-  if (isESModule(code)) {
-    return true;
-  }
-
+export function hasNewSyntax(code: string, path: string) {
   if (path.endsWith('.min.js')) {
     // This needs no transpiling and often fools our JSX check with <a etc...
     return false;
@@ -42,4 +38,12 @@ export function shouldTranspile(code: string, path: string) {
   }
 
   return false;
+}
+
+export function shouldTranspile(code: string, path: string) {
+  if (isESModule(code)) {
+    return true;
+  }
+
+  return hasNewSyntax(code, path);
 }

--- a/packages/app/src/sandbox/eval/transpilers/babel/worker/dynamic-download.ts
+++ b/packages/app/src/sandbox/eval/transpilers/babel/worker/dynamic-download.ts
@@ -113,7 +113,7 @@ function downloadRequires(currentPath: string, code: string) {
             filename: currentPath,
             extensions: ['.js', '.json'],
             moduleDirectory: ['node_modules'],
-            packageFilter,
+            packageFilter: packageFilter(this.isFile),
           });
         } catch (e) {
           await downloadFromError(e);

--- a/packages/app/src/sandbox/eval/utils/is-es-module.test.ts
+++ b/packages/app/src/sandbox/eval/utils/is-es-module.test.ts
@@ -1,6 +1,16 @@
 import isESModule from './is-es-module';
 
 describe('is-es-module', () => {
+  it('works with import', () => {
+    const code = `import a from 'a'`;
+    expect(isESModule(code)).toBe(true);
+  });
+
+  it('works with export', () => {
+    const code = `export a from 'a'`;
+    expect(isESModule(code)).toBe(true);
+  });
+
   it('handles exports that are not at the start of the line', () => {
     const code = `function r(r){var t=r&&r.pop?[]:{};for(var n in r)t[n]=r[n];return t}export default function(t,n,l){n.split&&(n=n.split("."));for(var o=r(t),a=o,e=0,f=n.length;e<f;e++)a=a[n[e]]=e===f-1?l&&l.call?l(a[n[e]]):l:r(a[n[e]]);return o}`;
     expect(isESModule(code)).toBe(true);

--- a/packages/app/src/sandbox/eval/utils/resolve-utils.ts
+++ b/packages/app/src/sandbox/eval/utils/resolve-utils.ts
@@ -1,10 +1,49 @@
+import { join } from 'path';
+import Cache from 'lru-cache';
 import { PackageJSON } from '@codesandbox/common/lib/types';
 
-export function packageFilter(p: PackageJSON) {
+const pkgCache = new Cache<string, PackageJSON>(10000);
+
+function replaceModuleField(
+  isFile: (p: string) => boolean,
+  p: PackageJSON,
+  pkgLocation: string
+): PackageJSON {
+  const checks = [
+    [pkgLocation, p.module],
+    [pkgLocation, p.module, 'index.js'],
+    [pkgLocation, p.module, 'index.mjs'],
+  ];
   if (p.module) {
-    // eslint-disable-next-line
-    p.main = p.module;
+    const foundFile = checks.find(pathSegments => {
+      const path = join(...pathSegments);
+      return isFile(path);
+    });
+
+    if (foundFile) {
+      // eslint-disable-next-line
+      p.main = p.module;
+    }
   }
 
   return p;
 }
+
+export const packageFilter = (isFile: (p: string) => boolean) => (
+  p: PackageJSON,
+  pkgLocation: string
+) => {
+  const id = p.name + p.version;
+  const cache = pkgCache.get(id);
+
+  if (cache) {
+    return cache;
+  }
+
+  // measure('replace-module-field');
+  const result = replaceModuleField(isFile, p, pkgLocation);
+  // endMeasure('replace-module-field');
+  pkgCache.set(id, result);
+
+  return result;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -4652,6 +4652,11 @@
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.149.tgz#1342d63d948c6062838fbf961012f74d4e638440"
   integrity sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ==
 
+"@types/lru-cache@^5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@types/lru-cache/-/lru-cache-5.1.0.tgz#57f228f2b80c046b4a1bd5cac031f81f207f4f03"
+  integrity sha512-RaE0B+14ToE4l6UqdarKPnXwVDuigfFv+5j9Dze/Nqr23yyuqdNvzcZi3xB+3Agvi5R4EOgAksfv3lXX4vBt9w==
+
 "@types/marked@0.0.28":
   version "0.0.28"
   resolved "https://registry.yarnpkg.com/@types/marked/-/marked-0.0.28.tgz#44ba754e9fa51432583e8eb30a7c4dd249b52faa"


### PR DESCRIPTION
Apparently some npm packages refer to a file using `"module":` field but the file doesn't exist. We recently changed to resolving `module` by default because of the exact reason, but on the `main` field (`main` field was referring to a file that doesn't exist).

This is tricky, and unfortunately it's allowed to refer to files that don't exist. The only solution for this is by introducing a separate check that verifies if the file exists, and if it doesn't fall back to `main`. It's a performance hit (as we have to do this during file resolving, which happens on the main thread), but I don't see another way.

Fixes #4276
Fixes #4275