### PR TITLE
Fix esmodule conversion of files with reserved export keywords

### DIFF
--- a/packages/app/src/sandbox/eval/transpilers/babel/convert-esmodule/__snapshots__/index.test.ts.snap
+++ b/packages/app/src/sandbox/eval/transpilers/babel/convert-esmodule/__snapshots__/index.test.ts.snap
@@ -342,6 +342,7 @@ exports[`convert-esmodule works with variables that are named exports 1`] = `
   value: true
 });
 var __$csb_exports = [eventedState, eventedShowHideState];
+__$csb_exports.push(\\"test\\");
 var $csb__default = __$csb_exports;
 exports.default = $csb__default;
 "

--- a/packages/app/src/sandbox/eval/transpilers/babel/convert-esmodule/__snapshots__/index.test.ts.snap
+++ b/packages/app/src/sandbox/eval/transpilers/babel/convert-esmodule/__snapshots__/index.test.ts.snap
@@ -330,3 +330,13 @@ exports[`convert-esmodule parses and writes chars with linebreaks 1`] = `
 "var WS_CHARS = \\"u2000-     　﻿\\";
 "
 `;
+
+exports[`convert-esmodule works with variables that are named exports 1`] = `
+"Object.defineProperty(exports, \\"__esModule\\", {
+  value: true
+});
+var __$csb_exports = [eventedState, eventedShowHideState];
+var $csb__default = __$csb_exports;
+exports.default = $csb__default;
+"
+`;

--- a/packages/app/src/sandbox/eval/transpilers/babel/convert-esmodule/index.test.ts
+++ b/packages/app/src/sandbox/eval/transpilers/babel/convert-esmodule/index.test.ts
@@ -259,6 +259,14 @@ describe('convert-esmodule', () => {
     expect(convertEsModule(code)).toMatchSnapshot();
   });
 
+  it.only('works with variables that are named exports', () => {
+    const code = `
+    var exports = [eventedState, eventedShowHideState];
+    export default exports;
+    `;
+    expect(convertEsModule(code)).toMatchSnapshot();
+  });
+
   it('parses and writes chars with linebreaks', () => {
     const code =
       "var WS_CHARS = 'u2000-\\u200a\\u2028\\u2029\\u202f\\u205f\\u3000\\ufeff'";

--- a/packages/app/src/sandbox/eval/transpilers/babel/convert-esmodule/index.test.ts
+++ b/packages/app/src/sandbox/eval/transpilers/babel/convert-esmodule/index.test.ts
@@ -262,6 +262,7 @@ describe('convert-esmodule', () => {
   it('works with variables that are named exports', () => {
     const code = `
     var exports = [eventedState, eventedShowHideState];
+    exports.push('test');
     export default exports;
     `;
     expect(convertEsModule(code)).toMatchSnapshot();

--- a/packages/app/src/sandbox/eval/transpilers/babel/convert-esmodule/index.test.ts
+++ b/packages/app/src/sandbox/eval/transpilers/babel/convert-esmodule/index.test.ts
@@ -259,7 +259,7 @@ describe('convert-esmodule', () => {
     expect(convertEsModule(code)).toMatchSnapshot();
   });
 
-  it.only('works with variables that are named exports', () => {
+  it('works with variables that are named exports', () => {
     const code = `
     var exports = [eventedState, eventedShowHideState];
     export default exports;

--- a/packages/app/src/sandbox/eval/transpilers/babel/convert-esmodule/index.ts
+++ b/packages/app/src/sandbox/eval/transpilers/babel/convert-esmodule/index.ts
@@ -61,6 +61,30 @@ export function convertEsModule(code: string) {
     program.body.push(generateInteropRequire());
   }
 
+  // If there is a declaration of `exports` (`var exports = []`), we need to rename this
+  // variable as it's a reserved keyword
+  let exportsDefined = false;
+  // @ts-ignore
+  program = walk(program, {
+    enter(node) {
+      if (node.type === n.VariableDeclarator) {
+        const declNode = node as meriyah.ESTree.VariableDeclarator;
+        if (
+          declNode.id.type === n.Identifier &&
+          declNode.id.name === 'exports'
+        ) {
+          exportsDefined = true;
+        }
+      } else if (node.type === n.Identifier && exportsDefined) {
+        const idNode = node as meriyah.ESTree.Identifier;
+        if (idNode.name === 'exports') {
+          idNode.name = '__$csb_exports';
+          this.replace(idNode);
+        }
+      }
+    },
+  });
+
   for (; i < program.body.length; i++) {
     const statement = program.body[i];
 

--- a/packages/app/src/sandbox/eval/utils/is-es-module.test.ts
+++ b/packages/app/src/sandbox/eval/utils/is-es-module.test.ts
@@ -14,6 +14,6 @@ describe('is-es-module', () => {
     const start = performance.now();
     expect(isESModule(code)).toBe(true);
     const time = performance.now() - start;
-    expect(time).toBeLessThan(2);
+    expect(time).toBeLessThan(5);
   });
 });


### PR DESCRIPTION
If there's an esm file that defines `exports`, we first need to rename that variable as it's a reserved keyword in the world of commonjs.

Fixes https://github.com/codesandbox/codesandbox-client/discussions/4273.
Fixes #4292
