### PR TITLE
Fix dependency name overflow

### DIFF
--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Explorer/Dependencies/Dependency/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Explorer/Dependencies/Dependency/index.tsx
@@ -119,7 +119,15 @@ export const Dependency = ({
         <Link
           href={`/examples/package/${dependency}`}
           target="_blank"
-          css={{ position: 'absolute', zIndex: 2 }}
+          title={dependency}
+          css={{
+            position: 'absolute',
+            zIndex: 2,
+            maxWidth: '60%',
+            whiteSpace: 'nowrap',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+          }}
         >
           {dependency}
         </Link>

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Explorer/Dependencies/Dependency/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Explorer/Dependencies/Dependency/index.tsx
@@ -120,13 +120,11 @@ export const Dependency = ({
           href={`/examples/package/${dependency}`}
           target="_blank"
           title={dependency}
+          maxWidth="60%"
           css={{
             position: 'absolute',
             zIndex: 2,
             maxWidth: '60%',
-            whiteSpace: 'nowrap',
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
           }}
         >
           {dependency}


### PR DESCRIPTION
Problem:

<img width="490" alt="CleanShot 2020-06-02 at 15 00 30@2x" src="https://user-images.githubusercontent.com/1051509/83523152-0021ca00-a4e2-11ea-8df9-bf71086c32b2.png">

Now:

<img width="471" alt="CleanShot 2020-06-02 at 15 00 19@2x" src="https://user-images.githubusercontent.com/1051509/83523160-031cba80-a4e2-11ea-9c28-1c5cbce97a45.png">
