### PR TITLE
Fix how we transpile esmodule default

### DIFF
--- a/packages/app/src/sandbox/eval/transpilers/babel/convert-esmodule/__snapshots__/index.test.ts.snap
+++ b/packages/app/src/sandbox/eval/transpilers/babel/convert-esmodule/__snapshots__/index.test.ts.snap
@@ -20,7 +20,7 @@ exports.default = test;
 
 exports[`convert-esmodule can convert default imports 1`] = `
 "var $csb__b = require(\\"./b\\");
-var a = $_csb__interopRequireDefault($csb__b).default;
+var a = $_csb__interopRequireDefault($csb__b);
 function $_csb__interopRequireDefault(obj) {
   return obj && obj.__esModule ? obj : {
     default: obj
@@ -104,7 +104,7 @@ const func = $csb__b.a();
 
 exports[`convert-esmodule can handle async code 1`] = `
 "var $csb__test = require(\\"./test\\");
-var T = $_csb__interopRequireDefault($csb__test).default;
+var T = $_csb__interopRequireDefault($csb__test);
 (async () => {
   const test = await test2();
 });
@@ -118,7 +118,7 @@ function $_csb__interopRequireDefault(obj) {
 
 exports[`convert-esmodule can handle class properties 1`] = `
 "var $csb__test = require(\\"./test\\");
-var T = $_csb__interopRequireDefault($csb__test).default;
+var T = $_csb__interopRequireDefault($csb__test);
 class T2 {
   a = () => {
     return \\"test\\";
@@ -195,6 +195,18 @@ exports[`convert-esmodule handles default as exports 1`] = `
 });
 var $csb__Field = require(\\"./Field\\");
 exports.Field = $csb__Field.default;
+"
+`;
+
+exports[`convert-esmodule handles default function exports 1`] = `
+"var $csb__rgb = require(\\"./rgb\\");
+var rgb = $_csb__interopRequireDefault($csb__rgb);
+rgb.default.a;
+function $_csb__interopRequireDefault(obj) {
+  return obj && obj.__esModule ? obj : {
+    default: obj
+  };
+}
 "
 `;
 
@@ -336,8 +348,8 @@ const c = \\"test\\";
 
 exports[`convert-esmodule hoists imports at bottom 1`] = `
 "var $csb__proptypes = require(\\"prop-types\\");
-var PropTypes = $_csb__interopRequireDefault($csb__proptypes).default;
-const a = PropTypes.a;
+var PropTypes = $_csb__interopRequireDefault($csb__proptypes);
+const a = PropTypes.default.a;
 function $_csb__interopRequireDefault(obj) {
   return obj && obj.__esModule ? obj : {
     default: obj

--- a/packages/app/src/sandbox/eval/transpilers/babel/convert-esmodule/__snapshots__/index.test.ts.snap
+++ b/packages/app/src/sandbox/eval/transpilers/babel/convert-esmodule/__snapshots__/index.test.ts.snap
@@ -142,6 +142,18 @@ $csb__b.c();
 "
 `;
 
+exports[`convert-esmodule changes default imports inline 1`] = `
+"var $csb__rgb = require(\\"./rgb\\");
+var rgb = $_csb__interopRequireDefault($csb__rgb);
+rgb.default.a;
+function $_csb__interopRequireDefault(obj) {
+  return obj && obj.__esModule ? obj : {
+    default: obj
+  };
+}
+"
+`;
+
 exports[`convert-esmodule converts object shorthands 1`] = `
 "var $csb__templatefactory = require(\\"./template-factory.js\\");
 const short = {
@@ -195,18 +207,6 @@ exports[`convert-esmodule handles default as exports 1`] = `
 });
 var $csb__Field = require(\\"./Field\\");
 exports.Field = $csb__Field.default;
-"
-`;
-
-exports[`convert-esmodule handles default function exports 1`] = `
-"var $csb__rgb = require(\\"./rgb\\");
-var rgb = $_csb__interopRequireDefault($csb__rgb);
-rgb.default.a;
-function $_csb__interopRequireDefault(obj) {
-  return obj && obj.__esModule ? obj : {
-    default: obj
-  };
-}
 "
 `;
 

--- a/packages/app/src/sandbox/eval/transpilers/babel/convert-esmodule/index.test.ts
+++ b/packages/app/src/sandbox/eval/transpilers/babel/convert-esmodule/index.test.ts
@@ -296,7 +296,7 @@ describe('convert-esmodule', () => {
     expect(convertEsModule(code)).toMatchSnapshot();
   });
 
-  it('handles default function exports', () => {
+  it('changes default imports inline', () => {
     const code = `
     import rgb from './rgb';
 

--- a/packages/app/src/sandbox/eval/transpilers/babel/convert-esmodule/index.test.ts
+++ b/packages/app/src/sandbox/eval/transpilers/babel/convert-esmodule/index.test.ts
@@ -296,6 +296,16 @@ describe('convert-esmodule', () => {
     expect(convertEsModule(code)).toMatchSnapshot();
   });
 
+  it('handles default function exports', () => {
+    const code = `
+    import rgb from './rgb';
+
+    rgb.a;
+    `;
+
+    expect(convertEsModule(code)).toMatchSnapshot();
+  });
+
   it('keeps import order', () => {
     const code = `
     import '1';

--- a/packages/app/src/sandbox/eval/transpilers/babel/convert-esmodule/index.ts
+++ b/packages/app/src/sandbox/eval/transpilers/babel/convert-esmodule/index.ts
@@ -320,6 +320,8 @@ export function convertEsModule(code: string) {
             0,
             generateInteropRequireExpression(varName, localName)
           );
+
+          varsToRename[localName] = [localName, 'default'];
           importOffset++;
           return;
         }
@@ -405,7 +407,8 @@ export function convertEsModule(code: string) {
             varsToRename,
             ref.identifier.name
           ) &&
-          ref.resolved === null
+          ref.resolved === null &&
+          !ref.writeExpr
         ) {
           ref.identifier.name = varsToRename[ref.identifier.name].join('.');
         }

--- a/packages/app/src/sandbox/eval/transpilers/babel/convert-esmodule/utils.ts
+++ b/packages/app/src/sandbox/eval/transpilers/babel/convert-esmodule/utils.ts
@@ -469,25 +469,17 @@ export function generateInteropRequireExpression(
       {
         type: n.VariableDeclarator,
         init: {
-          type: n.MemberExpression,
-          object: {
-            type: n.CallExpression,
-            callee: {
-              type: n.Identifier,
-              name: '$_csb__interopRequireDefault',
-            },
-            arguments: [
-              {
-                type: n.Identifier,
-                name: varName,
-              },
-            ],
-          },
-          computed: false,
-          property: {
+          type: n.CallExpression,
+          callee: {
             type: n.Identifier,
-            name: 'default',
+            name: '$_csb__interopRequireDefault',
           },
+          arguments: [
+            {
+              type: n.Identifier,
+              name: varName,
+            },
+          ],
         },
         id: {
           type: n.Identifier,


### PR DESCRIPTION
We used to do

```
const a = interopRequireDefault(require('a')).default

a()
```

Now it will be

```
const $csb_a = require('a');
const a = interopRequireDefault($csb_a);

a.default()
```

In case `default` has been changed (often in case of cyclic dependencies).

