### PR TITLE
Components: Textarea optional autosize

### DIFF
--- a/packages/components/src/components/Textarea/index.tsx
+++ b/packages/components/src/components/Textarea/index.tsx
@@ -80,17 +80,29 @@ export const Textarea: React.FC<ITextareaProps> = ({
   return (
     <>
       <Wrapper>
-        <Autosize value={innerValue} style={props.style}>
-          {(height: number) => (
-            <TextareaComponent
-              value={innerValue}
-              onChange={internalOnChange}
-              maxLength={maxLength}
-              {...props}
-              style={{ ...(props.style || {}), height }}
-            />
-          )}
-        </Autosize>
+        {autosize ? (
+          <Autosize value={innerValue} style={props.style}>
+            {(height: number) => (
+              <TextareaComponent
+                value={innerValue}
+                onChange={internalOnChange}
+                maxLength={maxLength}
+                {...props}
+                style={{
+                  ...(props.style || {}),
+                  height,
+                }}
+              />
+            )}
+          </Autosize>
+        ) : (
+          <TextareaComponent
+            value={innerValue}
+            onChange={internalOnChange}
+            maxLength={maxLength}
+            {...props}
+          />
+        )}
 
         {maxLength ? (
           <Count limit={maxLength <= innerValue.length}>


### PR DESCRIPTION
Even thought autosize is an optional prop, it was always autosizing. Removed that bug.