### PR TITLE
Use new, faster oniguruma wasm library

### DIFF
--- a/packages/app/config/build.js
+++ b/packages/app/config/build.js
@@ -10,6 +10,10 @@ const staticAssets = [
     to: 'public/vscode-extensions/v13',
   },
   !SANDBOX_ONLY && {
+    from: 'node_modules/vscode-oniguruma/release/onig.wasm',
+    to: 'public/vscode-oniguruma/1.3.1/onig.wasm',
+  },
+  !SANDBOX_ONLY && {
     from: 'node_modules/onigasm/lib/onigasm.wasm',
     to: 'public/onigasm/2.2.1/onigasm.wasm',
   },

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -228,6 +228,7 @@
     "use-debounce": "^3.4.2",
     "use-interval": "^1.2.1",
     "util": "0.11.1",
+    "vscode-oniguruma": "^1.3.1",
     "vue": "^2.5.2",
     "vue-eslint-parser": "^2.0.3",
     "vue-hot-reload-api": "^2.3.3",

--- a/standalone-packages/vscode-textmate/package-lock.json
+++ b/standalone-packages/vscode-textmate/package-lock.json
@@ -3053,6 +3053,11 @@
         "replace-ext": "0.0.1"
       }
     },
+    "vscode-oniguruma": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.3.1.tgz",
+      "integrity": "sha512-gz6ZBofA7UXafVA+m2Yt2zHKgXC2qedArprIsHAPKByTkwq9l5y/izAGckqxYml7mSbYxTRTfdRwsFq3cwF4LQ=="
+    },
     "wcwidth": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",

--- a/standalone-packages/vscode-textmate/package.json
+++ b/standalone-packages/vscode-textmate/package.json
@@ -29,7 +29,8 @@
     "install-dependencies": "npm install --ignore-scripts"
   },
   "dependencies": {
-    "oniguruma": "^7.0.0"
+    "oniguruma": "^7.0.0",
+    "vscode-oniguruma": "^1.3.1"
   },
   "devDependencies": {
     "@types/mocha": "2.2.39",

--- a/standalone-packages/vscode-textmate/src/onigLibs.ts
+++ b/standalone-packages/vscode-textmate/src/onigLibs.ts
@@ -11,7 +11,8 @@ let onigurumaLib: Thenable<IOnigLib> = null;
 
 async function getWasm() {
 	const wasmPath = '/public/vscode-oniguruma/1.3.1/onig.wasm';
-	const response = await (window as any).fetch(wasmPath);
+
+	const response = await fetch(wasmPath);
 
 	return response.arrayBuffer();
 }

--- a/standalone-packages/vscode-textmate/src/onigLibs.ts
+++ b/standalone-packages/vscode-textmate/src/onigLibs.ts
@@ -11,12 +11,12 @@ let onigurumaLib: Thenable<IOnigLib> = null;
 
 async function getWasm() {
 	const wasmPath = '/public/vscode-oniguruma/1.3.1/onig.wasm';
-	const response = await window.fetch(wasmPath);
+	const response = await (window as any).fetch(wasmPath);
 
 	return response.arrayBuffer();
 }
 
-export async function getOnigasm(): Thenable<IOnigLib> {
+export async function getOnigasm(): Promise<IOnigLib> {
 	if (!onigasmLib) {
 		const onigasmModule = require('vscode-oniguruma');
 		const wasmBin = await getWasm()

--- a/standalone-packages/vscode-textmate/src/onigLibs.ts
+++ b/standalone-packages/vscode-textmate/src/onigLibs.ts
@@ -9,10 +9,17 @@ import { Thenable } from './main';
 let onigasmLib: Thenable<IOnigLib> = null;
 let onigurumaLib: Thenable<IOnigLib> = null;
 
-export function getOnigasm(): Thenable<IOnigLib> {
+async function getWasm() {
+	const wasmPath = '/public/vscode-oniguruma/1.3.1/onig.wasm';
+	const response = await fetch(wasmPath);
+
+	return response.arrayBuffer();
+}
+
+export async function getOnigasm(): Thenable<IOnigLib> {
 	if (!onigasmLib) {
-		let onigasmModule = require('onigasm');
-		const wasmBin = '/public/onigasm/2.2.1/onigasm.wasm';
+		const onigasmModule = require('vscode-oniguruma');
+		const wasmBin = await getWasm()
 		onigasmLib = onigasmModule.loadWASM(wasmBin).then((_: any) => {
 			return {
 				createOnigScanner(patterns: string[]) { return new onigasmModule.OnigScanner(patterns); },

--- a/standalone-packages/vscode-textmate/src/onigLibs.ts
+++ b/standalone-packages/vscode-textmate/src/onigLibs.ts
@@ -11,7 +11,7 @@ let onigurumaLib: Thenable<IOnigLib> = null;
 
 async function getWasm() {
 	const wasmPath = '/public/vscode-oniguruma/1.3.1/onig.wasm';
-	const response = await fetch(wasmPath);
+	const response = await window.fetch(wasmPath);
 
 	return response.arrayBuffer();
 }

--- a/standalone-packages/vscode-textmate/tsconfig.json
+++ b/standalone-packages/vscode-textmate/tsconfig.json
@@ -8,7 +8,8 @@
 		"declaration": true,
 		"lib": [
 			"es5",
-			"es2015.promise"
+			"es2015.promise",
+			"dom"
     ],
     "types": ["mocha", "node"]
 	},

--- a/yarn.lock
+++ b/yarn.lock
@@ -31286,6 +31286,11 @@ vscode-languageserver@^3.3.0:
     vscode-languageserver-protocol "3.5.1"
     vscode-uri "^1.0.1"
 
+vscode-oniguruma@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/vscode-oniguruma/-/vscode-oniguruma-1.3.1.tgz#e2383879c3485b19f533ec34efea9d7a2b14be8f"
+  integrity sha512-gz6ZBofA7UXafVA+m2Yt2zHKgXC2qedArprIsHAPKByTkwq9l5y/izAGckqxYml7mSbYxTRTfdRwsFq3cwF4LQ==
+
 vscode-uri@^1.0.1:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-1.0.8.tgz#9769aaececae4026fb6e22359cb38946580ded59"


### PR DESCRIPTION
Thanks to the work from https://github.com/microsoft/vscode/pull/95958, we can use a new oniguruma library that results in 2-3x faster syntax highlighting.