### PR TITLE
Commentsfix

### DIFF
--- a/packages/app/src/app/overmind/actions.ts
+++ b/packages/app/src/app/overmind/actions.ts
@@ -259,6 +259,7 @@ export const refetchSandboxInfo: AsyncAction = async ({
   sandbox.roomId = updatedSandbox.roomId;
   sandbox.authorization = updatedSandbox.authorization;
   sandbox.privacy = updatedSandbox.privacy;
+  sandbox.featureFlags = updatedSandbox.featureFlags;
 
   await actions.editor.internal.initializeSandbox(sandbox);
 };

--- a/packages/app/src/app/overmind/namespaces/comments/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/comments/actions.ts
@@ -558,6 +558,17 @@ export const getSandboxComments: AsyncAction<string> = async (
       `There was a problem getting the sandbox comments`
     );
   }
+
+  // When we load the comments there might be changes already, lets make sure we transpose
+  // any comments on these changes. This does not fix it if you already managed to save, but
+  // that is considered an extreme edge case
+  state.editor.changedModuleShortids.forEach(moduleShortid => {
+    const module = state.editor.currentSandbox.modules.find(
+      moduleItem => moduleItem.shortid === moduleShortid
+    );
+    const operation = getTextOperation(module.savedCode, module.code);
+    actions.comments.transposeComments({ module, operation });
+  });
 };
 
 export const onCommentAdded: Action<CommentAddedSubscription> = (

--- a/packages/app/src/app/overmind/namespaces/comments/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/comments/actions.ts
@@ -563,10 +563,15 @@ export const getSandboxComments: AsyncAction<string> = async (
   // any comments on these changes. This does not fix it if you already managed to save, but
   // that is considered an extreme edge case
   state.editor.changedModuleShortids.forEach(moduleShortid => {
-    const module = state.editor.currentSandbox.modules.find(
+    const module = state.editor.currentSandbox!.modules.find(
       moduleItem => moduleItem.shortid === moduleShortid
     );
-    const operation = getTextOperation(module.savedCode, module.code);
+
+    if (!module) {
+      return;
+    }
+
+    const operation = getTextOperation(module.savedCode || '', module.code);
     actions.comments.transposeComments({ module, operation });
   });
 };

--- a/packages/app/src/app/overmind/namespaces/live/internalActions.ts
+++ b/packages/app/src/app/overmind/namespaces/live/internalActions.ts
@@ -105,7 +105,7 @@ export const initialize: AsyncAction<string, Sandbox | null> = async (
 export const initializeModuleFromState: Action<{
   moduleShortid: string;
   moduleInfo: IModuleStateModule;
-}> = ({ state, effects }, { moduleShortid, moduleInfo }) => {
+}> = ({ state, effects, actions }, { moduleShortid, moduleInfo }) => {
   const sandbox = state.editor.currentSandbox;
   if (!sandbox) {
     return;


### PR DESCRIPTION
This fixes issue with comments not being transposed when refreshing and changes has been made before comments are fetched.

I also fixed an issue where moving a sandbox to teams did not show the comments indicator. The reason was because we do not copy feature flags when refetching sandbox info. We do now 😄 