### PR TITLE
Add a collection id to creating a sandbox

### DIFF
--- a/packages/app/src/app/components/CreateNewSandbox/index.tsx
+++ b/packages/app/src/app/components/CreateNewSandbox/index.tsx
@@ -41,7 +41,7 @@ export const CreateNewSandboxButton: FunctionComponent<Props> = ({
   };
 
   const handleClick = () => {
-    modalOpened({ modal: 'newSandbox' });
+    modalOpened({ modal: 'newSandbox', props: { collectionId } });
   };
 
   return (


### PR DESCRIPTION
When you create a sandbox from a folder, it should appear in that folder after creation.

This did work before, but regressed with the new create modal. I want to bring it back in, but am not sure how to pass props into the modal.