### PR TITLE
Increase test threshold

### DIFF
--- a/packages/app/src/sandbox/eval/utils/is-es-module.test.ts
+++ b/packages/app/src/sandbox/eval/utils/is-es-module.test.ts
@@ -29,6 +29,6 @@ describe('is-es-module', () => {
     const start = performance.now();
     expect(isESModule(code)).toBe(true);
     const time = performance.now() - start;
-    expect(time).toBeLessThan(5);
+    expect(time).toBeLessThan(10);
   });
 });


### PR DESCRIPTION
The test isn't consistent in the time it takes. So, sometimes it fails in unrelated PRs

Increasing the threshold from 5ms to 10ms so that we can still catch regressions but it has more room in CI