### PR TITLE
Use title from props to render directory

### DIFF
--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Explorer/Files/DirectoryEntry/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Explorer/Files/DirectoryEntry/index.tsx
@@ -62,7 +62,7 @@ interface Props {
   isOver?: boolean;
   canDrop?: boolean;
   signals?: any;
-  title?: string;
+  title: string;
   sandboxId?: string;
   sandboxTemplate?: any;
   mainModuleId?: string;
@@ -89,6 +89,7 @@ const DirectoryEntry: React.FunctionComponent<Props> = ({
   depth = 0,
   getModulePath,
   canDrop,
+  title: directoryTitle,
 }) => {
   const {
     state: {
@@ -336,8 +337,6 @@ const DirectoryEntry: React.FunctionComponent<Props> = ({
     moduleDoubleClicked();
   }, [moduleDoubleClicked]);
 
-  const title = root ? 'Project' : directories.find(m => m.id === id).title;
-
   return connectDropTarget(
     <div style={{ position: 'relative' }}>
       <Overlay isOver={isOver && canDrop} />
@@ -346,7 +345,7 @@ const DirectoryEntry: React.FunctionComponent<Props> = ({
           <Entry
             id={id}
             shortid={shortid}
-            title={title}
+            title={directoryTitle}
             depth={depth}
             type={open ? 'directory-open' : 'directory'}
             root={root}


### PR DESCRIPTION
Fixes #4366, but not the root problem. Should also benefit in performance, `find` can be very expensive.