### PR TITLE
Components: add default line height of normal to Text

### DIFF
--- a/packages/components/src/components/Text/index.tsx
+++ b/packages/components/src/components/Text/index.tsx
@@ -43,6 +43,7 @@ export const Text = styled(Element).attrs(p => ({
       fontSize: size || 'inherit', // from theme.fontSizes
       textAlign: align || 'left',
       fontWeight: weight || null, // from theme.fontWeights
+      lineHeight: 'normal',
       fontStyle: fontStyle || null, // from theme.fontWeights
       display: block || maxWidth ? 'block' : 'inline',
       color: variants[variant],

--- a/packages/components/src/components/Text/text.stories.tsx
+++ b/packages/components/src/components/Text/text.stories.tsx
@@ -67,3 +67,7 @@ export const Align = () => (
     sometimes, just sometimes you need to align right
   </Text>
 );
+
+export const MaxWidth = () => (
+  <Text maxWidth={200}>this text will get cropped after 200px</Text>
+);

--- a/packages/components/src/components/Text/text.stories.tsx
+++ b/packages/components/src/components/Text/text.stories.tsx
@@ -69,5 +69,5 @@ export const Align = () => (
 );
 
 export const MaxWidth = () => (
-  <Text maxWidth={200}>this text will get cropped after 200px</Text>
+  <Text maxWidth={200}>this text will get cropped beyond 200px</Text>
 );


### PR DESCRIPTION
Text inherits line height from the parent, this means it can pick up smaller line heights all the way up from html/body which isn't meant for this component.

Adding a default line height which can be overwritten on demand

Fixes CSB-267
Fixes CSB-268


This went way better than expected!

2 places need work, creating a issue for that

before and after:
<img width="247" alt="Screenshot 2020-06-17 at 12 16 41 PM" src="https://user-images.githubusercontent.com/1863771/84886325-92a29b80-b094-11ea-9bac-7ebbf79a212a.png"> <img width="272" alt="Screenshot 2020-06-17 at 12 17 20 PM" src="https://user-images.githubusercontent.com/1863771/84886331-946c5f00-b094-11ea-8671-916d26e55273.png">

in the share modal: before and after:
<img width="247" alt="Screenshot 2020-06-17 at 12 17 39 PM" src="https://user-images.githubusercontent.com/1863771/84886522-d695a080-b094-11ea-9571-9803cfe9e773.png"> <img width="247" alt="Screenshot 2020-06-17 at 12 17 04 PM" src="https://user-images.githubusercontent.com/1863771/84886529-d7c6cd80-b094-11ea-9859-610c3831d93f.png">
