### PR TITLE
add back 'bluetooth' to iframe allowed features

### DIFF
--- a/packages/common/src/components/Preview/index.tsx
+++ b/packages/common/src/components/Preview/index.tsx
@@ -608,7 +608,7 @@ class BasePreview extends React.Component<Props, State> {
           {(style: { opacity: number }) => (
             <>
               <StyledFrame
-                allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
+                allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking; bluetooth"
                 sandbox="allow-autoplay allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
                 src={this.state.url}
                 ref={this.setIframeElement}


### PR DESCRIPTION
## What kind of change does this PR introduce?
Allow to use the [Web Bluetooth](https://webbluetoothcg.github.io/web-bluetooth/)

As per this [commit](https://chromium-review.googlesource.com/c/chromium/src/+/657572) on chromium it is mandatory to add `bluetooth` to the allowed list for cross origin iframes to use bluetooth. 

## What is the current behavior?
Currently the Web Bluetooth API can't be used anymore it isn't in the allowed list of on the iframe. 

## What is the new behavior?
The Web Bluetooth API would work inside a sandbox.
