### PR TITLE
Components: Fix tooltip zindex

### DIFF
--- a/packages/components/src/components/Tooltip/index.tsx
+++ b/packages/components/src/components/Tooltip/index.tsx
@@ -70,7 +70,7 @@ const TooltipStyles = createGlobalStyle(
       paddingY: 1,
       fontSize: 3,
       lineHeight: 1,
-      zIndex: 20,
+      zIndex: 20, // TODO: we need to sort out our z indexes!
 
       // multiline
       maxWidth: 160,

--- a/packages/components/src/components/Tooltip/index.tsx
+++ b/packages/components/src/components/Tooltip/index.tsx
@@ -70,7 +70,7 @@ const TooltipStyles = createGlobalStyle(
       paddingY: 1,
       fontSize: 3,
       lineHeight: 1,
-      zIndex: 3,
+      zIndex: 20,
 
       // multiline
       maxWidth: 160,


### PR DESCRIPTION
Tooltips should be on a higher plane than overlays and menus