### PR TITLE
install specific version when using tags

### DIFF
--- a/packages/app/src/app/overmind/effects/api/index.ts
+++ b/packages/app/src/app/overmind/effects/api/index.ts
@@ -85,8 +85,8 @@ export default {
   revokeToken(token: string): Promise<void> {
     return api.delete(`/auth/revoke/${token}`);
   },
-  getDependency(name: string): Promise<Dependency> {
-    return api.get(`/dependencies/${name}@latest`);
+  getDependency(name: string, tag: string): Promise<Dependency> {
+    return api.get(`/dependencies/${name}@${tag}`);
   },
   async getSandbox(id: string): Promise<Sandbox> {
     const sandbox = await api.get<SandboxAPIResponse>(`/sandboxes/${id}`);

--- a/packages/app/src/app/overmind/namespaces/editor/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/editor/actions.ts
@@ -112,10 +112,10 @@ export const addNpmDependency: AsyncAction<{
   async ({ actions, effects, state }, { name, version, isDev }) => {
     effects.analytics.track('Add NPM Dependency');
     state.currentModal = null;
-    let newVersion = version;
-
-    if (!newVersion) {
-      const dependency = await effects.api.getDependency(name);
+    let newVersion = version || 'latest';
+    const isTag = !newVersion.includes('.');
+    if (isTag) {
+      const dependency = await effects.api.getDependency(name, newVersion);
       newVersion = dependency.version;
     }
 

--- a/packages/app/src/app/overmind/namespaces/editor/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/editor/actions.ts
@@ -10,6 +10,7 @@ import {
   WindowOrientation,
 } from '@codesandbox/common/lib/types';
 import { logBreadcrumb } from '@codesandbox/common/lib/utils/analytics/sentry';
+import { isAbsoluteVersion } from '@codesandbox/common/lib/utils/dependencies';
 import { getTextOperation } from '@codesandbox/common/lib/utils/diff';
 import { convertTypeToStatus } from '@codesandbox/common/lib/utils/notifications';
 import { hasPermission } from '@codesandbox/common/lib/utils/permission';
@@ -113,8 +114,8 @@ export const addNpmDependency: AsyncAction<{
     effects.analytics.track('Add NPM Dependency');
     state.currentModal = null;
     let newVersion = version || 'latest';
-    const isTag = !newVersion.includes('.');
-    if (isTag) {
+
+    if (!isAbsoluteVersion(newVersion)) {
       const dependency = await effects.api.getDependency(name, newVersion);
       newVersion = dependency.version;
     }


### PR DESCRIPTION
This handles two things:

1. When you use a TAG we add the actual version that tag represents (The same behaviour as when we do not add any specific version, we add the specific latest version)

2. A dependency can no longer override the types of the main package, if it is installed as an explicit package