### PR TITLE
Fix importing sandbox

### DIFF
--- a/packages/app/src/app/components/CreateNewSandbox/CreateSandbox/Import/Import.tsx
+++ b/packages/app/src/app/components/CreateNewSandbox/CreateSandbox/Import/Import.tsx
@@ -5,6 +5,7 @@ import {
   gitHubRepoPattern,
 } from '@codesandbox/common/lib/utils/url-generator';
 import { Button } from '@codesandbox/components';
+import { Link } from 'react-router-dom';
 import { useOvermind } from 'app/overmind';
 import { SignInButton } from 'app/pages/common/SignInButton';
 import track from '@codesandbox/common/lib/utils/analytics';
@@ -114,6 +115,7 @@ export const Import = () => {
                 autoWidth
                 style={{ fontSize: 11 }}
                 disabled={!transformedUrl}
+                as={Link}
                 to={gitHubToSandboxUrl(url)}
                 onClick={() => {
                   actions.modalClosed();

--- a/packages/app/src/app/pages/GitHub/index.tsx
+++ b/packages/app/src/app/pages/GitHub/index.tsx
@@ -1,5 +1,6 @@
 import css from '@styled-system/css';
 import { withTheme } from 'styled-components';
+import { Link } from 'react-router-dom';
 import MaxWidth from '@codesandbox/common/lib/components/flex/MaxWidth';
 import { Element, ThemeProvider, Button } from '@codesandbox/components';
 import {
@@ -116,6 +117,7 @@ export const GitHub: FunctionComponent = withTheme(({ theme }) => {
                   />
 
                   <Button
+                    as={Link}
                     disabled={!transformedUrl}
                     to={gitHubToSandboxUrl(url)}
                   >


### PR DESCRIPTION
A button with `to` isn't a Link. @SaraVieira could you check whether this happens on other places? I think it started happening after the cleanup