### PR TITLE
fix caching of typings

### DIFF
--- a/packages/app/src/app/overmind/effects/vscode/SandboxFsSync/index.ts
+++ b/packages/app/src/app/overmind/effects/vscode/SandboxFsSync/index.ts
@@ -377,7 +377,12 @@ class SandboxFsSync {
       return this.typesInfo;
     }
 
-    this.typesInfo = fetch('https://unpkg.com/types-registry@latest/index.json')
+    this.typesInfo = fetch(
+      'https://unpkg.com/types-registry@latest/index.json',
+      // This falls back to etag caching, ensuring we always have latest version
+      // https://hacks.mozilla.org/2016/03/referrer-and-cache-control-apis-for-fetch/
+      { cache: 'no-cache' }
+    )
       .then(x => x.json())
       .then(x => x.entries);
 


### PR DESCRIPTION
This ensure we get the latest version looking at ETAG, instead of keeping it cached:

```ts
  // Download a resource with cache busting when dealing with a
  // properly configured server that will send the correct ETag
  // and Date headers and properly handle If-Modified-Since and
  // If-None-Match request headers, therefore we can rely on the
  // validation to guarantee a fresh response.
  fetch("some.json", {cache: "no-cache"})
    .then(function(response) { /* consume the response */ });
```