### PR TITLE
Make bracket matches more apparent in CSB Black

### DIFF
--- a/packages/components/src/themes/codesandbox-black.ts
+++ b/packages/components/src/themes/codesandbox-black.ts
@@ -47,7 +47,6 @@ const colors = {
   },
   editorBracketMatch: {
     background: tokens.grays[600],
-    border: tokens.grays[600],
   },
   editorCodeLens: {
     foreground: tokens.grays[600],


### PR DESCRIPTION
I always had trouble seeing the matching bracket borders in CSB Black, this changes it to make them more apparent by using the default border.

![image](https://user-images.githubusercontent.com/587016/86102858-57549380-babc-11ea-852e-947aa127d201.png)
