### PR TITLE
Update Card component's height on User Settings

### DIFF
--- a/packages/app/src/app/pages/NewDashboard/Content/routes/Settings/components/index.tsx
+++ b/packages/app/src/app/pages/NewDashboard/Content/routes/Settings/components/index.tsx
@@ -6,7 +6,7 @@ export const Card = props => (
   <Element
     {...props}
     css={css({
-      height: 180,
+      height: 200,
       padding: 6,
       backgroundColor: 'grays.800',
       border: '1px solid',


### PR DESCRIPTION
## What kind of change does this PR introduce?
Make the card a bit larger.
This change will impact all cards' height.
I can change to only do this when on the Community Plan if necessary

## What is the current behavior?
<img width="1128" alt="Schermafbeelding 2020-07-10 om 02 41 36" src="https://user-images.githubusercontent.com/6643991/87103996-eac55b80-c256-11ea-9b4c-2d761b340361.png">

## What is the new behavior?
<img width="1142" alt="Schermafbeelding 2020-07-10 om 02 41 23" src="https://user-images.githubusercontent.com/6643991/87104006-f31d9680-c256-11ea-90fc-75ff052328b5.png">

## Checklist
- [N/A] Documentation
- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged
- [N/A] Added myself to contributors table