### PR TITLE
Additional properties added to Preview Manager

### DIFF
--- a/standalone-packages/sandpack/src/manager/index.ts
+++ b/standalone-packages/sandpack/src/manager/index.ts
@@ -286,6 +286,19 @@ export default class PreviewManager {
       }));
   }
 
+  public getManagerTranspilerContext = (): Promise<{ [transpiler: string]: Object }> =>
+    new Promise(resolve => {
+      const listener = listen((message: any) => {
+        if (message.type === 'transpiler-context') {
+          resolve(message.data);
+
+          listener();
+        }
+      });
+
+        dispatch({ type: 'get-transpiler-context' });
+    });
+
   private getFiles() {
     const { sandboxInfo } = this;
 
@@ -313,17 +326,4 @@ export default class PreviewManager {
 
     this.element.parentNode.replaceChild(this.iframe, this.element);
   }
-
-  public getManagerTranspilerContext = (): Promise<{ [transpiler: string]: Object }> =>
-    new Promise(resolve => {
-      const listener = listen((message: any) => {
-        if (message.type === 'transpiler-context') {
-          resolve(message.data);
-
-          listener();
-        }
-      });
-
-        dispatch({ type: 'get-transpiler-context' });
-    });
 }

--- a/standalone-packages/sandpack/src/manager/index.ts
+++ b/standalone-packages/sandpack/src/manager/index.ts
@@ -99,6 +99,9 @@ export default class PreviewManager {
     this.options = options;
     this.sandboxInfo = sandboxInfo;
     this.bundlerURL = options.bundlerURL || BUNDLER_URL;
+    this.managerState = undefined;
+    this.errors = [];
+    this.status = 'initializing'
 
     if (typeof selector === 'string') {
       this.selector = selector;
@@ -145,6 +148,25 @@ export default class PreviewManager {
 
             this.updatePreview();
           }
+          break;
+        }
+        case 'start': {
+          this.errors = [];
+          break;
+        }
+        case 'status': {
+          this.status = message.status;
+          break;
+        }
+        case 'action': {
+          if (message.action === 'show-error') {
+            const { title, path, message, line, column } = message;
+            this.errors = [...this.errors, { title, path, message, line, column }];
+          }
+          break;
+        }
+        case 'state': {
+          this.managerState: message.state;
           break;
         }
         default: {

--- a/standalone-packages/sandpack/typings/types.d.ts
+++ b/standalone-packages/sandpack/typings/types.d.ts
@@ -1,0 +1,62 @@
+export interface IFile {
+  code: string;
+}
+
+export interface IFiles {
+  [path: string]: IFile;
+}
+
+export interface IModule {
+  code: string;
+  path: string;
+}
+
+export interface IModuleSource {
+  fileName: string;
+  compiledCode: string;
+  sourceMap: Object | undefined;
+}
+
+export interface IModuleError {
+  title: string;
+  message: string;
+  path: string;
+  line: number;
+  column: number;
+}
+
+export interface ITranspiledModule {
+  module: IModule;
+  query: string;
+  source: IModuleSource | undefined;
+  assets: {
+    [name: string]: IModuleSource;
+  };
+  isEntry: boolean;
+  isTestFile: boolean;
+  childModules: Array<string>;
+  /**
+   * All extra modules emitted by the loader
+   */
+  emittedAssets: Array<IModuleSource>;
+  initiators: Array<string>;
+  dependencies: Array<string>;
+  asyncDependencies: Array<string>;
+  transpilationDependencies: Array<string>;
+  transpilationInitiators: Array<string>;
+}
+
+export interface IManagerState {
+  entry: string;
+  transpiledModules: {
+    [id: string]: ITranspiledModule;
+  };
+}
+
+export type ManagerStatus =
+  | 'initializing'
+  | 'installing-dependencies'
+  | 'transpiling'
+  | 'evaluating'
+  | 'running-tests'
+  | 'idle';


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?

Added additional useful properties to Preview Manager such as managerState, status, getManagerTranspilerContext, errors. These things are available in react-sandpack, so it might be good to have these things here also.

## What is the current behavior?

Currently, the above mentioned properties are not available in the Preview Manager.

## What is the new behavior?

The above mentioned properties are added along with the existing properties. These changes have no conflict to the existing behavior

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. After the adding the above properties, taken build of the sandpack package and tested it in the local environment in a new test project.
2. Also, checked it in the local application where I have been already using the sandpack without changes.

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x ] Testing <!-- We can only merge the PR if this is checked -->
- [ x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
