### PR TITLE
Support tsconfig configuraton in Angular template

### DIFF
--- a/packages/app/src/sandbox/eval/presets/angular-cli/index.ts
+++ b/packages/app/src/sandbox/eval/presets/angular-cli/index.ts
@@ -1,5 +1,7 @@
 // @flow
 import { join, absolute } from '@codesandbox/common/lib/utils/path';
+import Manager from 'sandbox/eval/manager';
+import TranspiledModule from 'sandbox/eval/transpiled-module';
 import Preset from '..';
 
 import angular2Transpiler from '../../transpilers/angular2-template';
@@ -75,7 +77,7 @@ async function addAngularJSONResources(manager) {
       tModule.evaluate(manager);
     }
 
-    const scriptTModules = await Promise.all(
+    const scriptTModules: TranspiledModule[] = await Promise.all(
       scripts.map(async p => {
         const finalPath = absolute(join(project.root, p));
         const tModule = await manager.resolveTranspiledModuleAsync(
@@ -103,7 +105,7 @@ const getPathFromResource = (root, p) => {
   return absolute(join(root || 'src', p));
 };
 
-async function addAngularCLIResources(manager) {
+async function addAngularCLIResources(manager: Manager) {
   const { parsed } = manager.configurations['angular-cli'];
   if (parsed.apps && parsed.apps[0]) {
     const app = parsed.apps[0];
@@ -126,7 +128,7 @@ async function addAngularCLIResources(manager) {
     }
     /* eslint-enable no-await-in-loop */
 
-    const scriptTModules = await Promise.all(
+    const scriptTModules: TranspiledModule[] = await Promise.all(
       scripts.map(async p => {
         const finalPath = getPathFromResource(app.root, p);
         const tModule = await manager.resolveTranspiledModuleAsync(

--- a/packages/common/src/templates/angular.ts
+++ b/packages/common/src/templates/angular.ts
@@ -114,6 +114,7 @@ export default new AngularTemplate(
     extraConfigurations: {
       '/.angular-cli.json': configurations.angularCli,
       '/angular.json': configurations.angularJSON,
+      '/tsconfig.json': configurations.tsconfig,
     },
     netlify: false,
     isTypescript: true,

--- a/packages/common/src/templates/configuration/tsconfig/index.ts
+++ b/packages/common/src/templates/configuration/tsconfig/index.ts
@@ -1,4 +1,5 @@
 import { ConfigurationFile } from '../types';
+import { TemplateType } from '../..';
 
 const JSX_PRAGMA = {
   react: 'React.createElement',
@@ -12,7 +13,7 @@ const config: ConfigurationFile = {
   moreInfoUrl: 'http://www.typescriptlang.org/docs/handbook/tsconfig-json.html',
 
   getDefaultCode: (
-    template: string,
+    template: TemplateType,
     resolveModule: (path: string) => { code: string } | undefined
   ) => {
     if (template === 'create-react-app-typescript') {
@@ -143,6 +144,29 @@ const config: ConfigurationFile = {
           target: 'es5',
         },
       });
+    }
+
+    if (template === 'angular-cli') {
+      return JSON.stringify(
+        {
+          compileOnSave: false,
+          compilerOptions: {
+            baseUrl: './',
+            outDir: './dist/out-tsc',
+            sourceMap: true,
+            declaration: false,
+            downlevelIteration: true,
+            experimentalDecorators: true,
+            moduleResolution: 'node',
+            importHelpers: true,
+            target: 'es2015',
+            module: 'es2020',
+            lib: ['es2018', 'dom'],
+          },
+        },
+        null,
+        2
+      );
     }
 
     return JSON.stringify(


### PR DESCRIPTION
This adds custom `tsconfig.json` support for Angular, and changes the default config to output `es2015` by default.

Fixes #1543