### PR TITLE
Optimize resolving of sass files

### DIFF
--- a/packages/app/src/sandbox/eval/transpilers/sass/index.ts
+++ b/packages/app/src/sandbox/eval/transpilers/sass/index.ts
@@ -9,7 +9,7 @@ class SassTranspiler extends WorkerTranspiler {
   worker: Worker;
 
   constructor() {
-    super('sass-loader', SassWorker, 2, { hasFS: true });
+    super('sass-loader', SassWorker, 1, { hasFS: true });
 
     this.cacheable = false;
   }

--- a/packages/app/src/sandbox/eval/transpilers/sass/worker/utils/imports.ts
+++ b/packages/app/src/sandbox/eval/transpilers/sass/worker/utils/imports.ts
@@ -1,0 +1,14 @@
+const lineRegex = /@import\s*['|"|`]([^"|'|`]*)['|"|`]/;
+
+export function getImports(code: string): string[] {
+  const lines = code.split('\n');
+  const result = new Set();
+  lines.forEach(line => {
+    const match = line.match(lineRegex);
+    if (match && match[1]) {
+      result.add(match[1]);
+    }
+  });
+
+  return Array.from(result) as string[];
+}


### PR DESCRIPTION
Related to #1543.

Our sass-loader requires a round-trip from the worker thread to the main thread to check if a file exists, because the file should live on the main thread. Because of this it can take long to resolve a single file, since we need to use the node resolver (which checks ~20 paths) before finding the right result. Because 99% of the time, the file is relative to the requester, we now check that first before using the node resolver. This results in 99% of the cases that we only need to do 1 roundtrip, instead of 20, and thus in faster Sass compiling.