### PR TITLE
Fix printing a double UnaryExpression

### DIFF
--- a/packages/app/src/sandbox/eval/transpilers/babel/convert-esmodule/__snapshots__/index.test.ts.snap
+++ b/packages/app/src/sandbox/eval/transpilers/babel/convert-esmodule/__snapshots__/index.test.ts.snap
@@ -1,5 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`convert-esmodule can convert + + 1`] = `
+"\\"use strict\\";
+c = (10, + +15);
+"
+`;
+
 exports[`convert-esmodule can convert class default exports 1`] = `
 "\\"use strict\\";
 Object.defineProperty(exports, \\"__esModule\\", {

--- a/packages/app/src/sandbox/eval/transpilers/babel/convert-esmodule/generator.ts
+++ b/packages/app/src/sandbox/eval/transpilers/babel/convert-esmodule/generator.ts
@@ -2,6 +2,39 @@ import * as astring from 'astring';
 import * as meriyah from 'meriyah';
 import { Identifier } from 'meriyah/dist/estree';
 
+// Enables parenthesis regardless of precedence
+const NEEDS_PARENTHESES = 17;
+const EXPRESSIONS_PRECEDENCE = {
+  // Definitions
+  ArrayExpression: 20,
+  TaggedTemplateExpression: 20,
+  ThisExpression: 20,
+  Identifier: 20,
+  Literal: 18,
+  TemplateLiteral: 20,
+  Super: 20,
+  SequenceExpression: 20,
+  // Operations
+  MemberExpression: 19,
+  CallExpression: 19,
+  NewExpression: 19,
+  // Other definitions
+  ArrowFunctionExpression: NEEDS_PARENTHESES,
+  ClassExpression: NEEDS_PARENTHESES,
+  FunctionExpression: NEEDS_PARENTHESES,
+  ObjectExpression: NEEDS_PARENTHESES,
+  // Other operations
+  UpdateExpression: 16,
+  UnaryExpression: 15,
+  BinaryExpression: 14,
+  LogicalExpression: 13,
+  ConditionalExpression: 4,
+  AssignmentExpression: 3,
+  AwaitExpression: 2,
+  YieldExpression: 2,
+  RestElement: 1,
+};
+
 /**
  * Add support for next syntax
  */
@@ -29,5 +62,33 @@ export const customGenerator = {
     state.write('$csbImport(');
     this[node.source.type](node.source, state);
     state.write(')');
+  },
+  UnaryExpression(
+    node: meriyah.ESTree.UnaryExpression,
+    state: { write(s: string): void }
+  ) {
+    if (node.prefix) {
+      state.write(node.operator);
+      if (
+        node.operator.length > 1 ||
+        node.argument.type === 'UnaryExpression'
+      ) {
+        state.write(' ');
+      }
+      if (
+        EXPRESSIONS_PRECEDENCE[node.argument.type] <
+        EXPRESSIONS_PRECEDENCE.UnaryExpression
+      ) {
+        state.write('(');
+        this[node.argument.type](node.argument, state);
+        state.write(')');
+      } else {
+        this[node.argument.type](node.argument, state);
+      }
+    } else {
+      // FIXME: This case never occurs
+      this[node.argument.type](node.argument, state);
+      state.write(node.operator);
+    }
   },
 };

--- a/packages/app/src/sandbox/eval/transpilers/babel/convert-esmodule/index.test.ts
+++ b/packages/app/src/sandbox/eval/transpilers/babel/convert-esmodule/index.test.ts
@@ -423,4 +423,12 @@ describe('convert-esmodule', () => {
 
     expect(convertEsModule(code)).toMatchSnapshot();
   });
+
+  it('can convert + +', () => {
+    const code = `
+    c = (10.0, + +(15))
+    `;
+
+    expect(convertEsModule(code)).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
Our esmodule converter printed an ast of:
```
c = (10.0, + +(15))
```
to
```
c = (10.0, ++(15))
```
which is wrong, this fixes it.

Fixes #4476

Also opened a PR here to fix upstream: https://github.com/davidbonnet/astring/pull/315.