### PR TITLE
remove redirect if user is trying to go to /s

### DIFF
--- a/packages/app/src/app/pages/Sandbox/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/index.tsx
@@ -31,15 +31,17 @@ export const Sandbox = React.memo<Props>(
     const { state, actions } = useOvermind();
 
     useEffect(() => {
-      if (window.screen.availWidth < 800) {
-        if (!document.location.search.includes('from-embed')) {
-          const addedSign = document.location.search ? '&' : '?';
-          document.location.href =
-            document.location.href.replace('/s/', '/embed/') +
-            addedSign +
-            'codemirror=1';
-        } else {
-          actions.preferences.codeMirrorForced();
+      if (!showNewSandboxModal) {
+        if (window.screen.availWidth < 800) {
+          if (!document.location.search.includes('from-embed')) {
+            const addedSign = document.location.search ? '&' : '?';
+            document.location.href =
+              document.location.href.replace('/s/', '/embed/') +
+              addedSign +
+              'codemirror=1';
+          } else {
+            actions.preferences.codeMirrorForced();
+          }
         }
       }
 
@@ -47,7 +49,13 @@ export const Sandbox = React.memo<Props>(
       if (match?.params) {
         actions.editor.sandboxChanged({ id: match.params.id });
       }
-    }, [actions.live, actions.editor, actions.preferences, match?.params]);
+    }, [
+      actions.live,
+      actions.editor,
+      actions.preferences,
+      match.params,
+      showNewSandboxModal,
+    ]);
 
     useEffect(
       () => () => {


### PR DESCRIPTION
We have a mobile redirect to send users from `s/new` to `embed/new` and this was also triggering when users were trying to go to `/s`