### PR TITLE
Fix removeChild error in Explorer

### DIFF
--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Explorer/Files/DirectoryEntry/Entry/EditIcons/index.js
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Explorer/Files/DirectoryEntry/Entry/EditIcons/index.js
@@ -43,65 +43,63 @@ function EditIcons({
 
   return (
     <div className={className}>
-      {(hovering || (window.__isTouch && active) || forceShow) && (
-        <Container>
-          <SingletonTooltip>
-            {singleton => (
-              <>
-                {onDownload && (
-                  <Tooltip content="Export to ZIP" singleton={singleton}>
-                    <Icon onClick={handleClick(onDownload)}>
-                      <DownloadIcon />
-                    </Icon>
-                  </Tooltip>
-                )}
-                {onUploadFile && (
-                  <Tooltip content="Upload Files" singleton={singleton}>
-                    <Icon onClick={handleClick(onUploadFile)}>
-                      <UploadFileIcon />
-                    </Icon>
-                  </Tooltip>
-                )}
-                {onDiscardChanges && (
-                  <Tooltip content="Discard Changes">
-                    <Icon onClick={handleClick(onDiscardChanges)}>
-                      <UndoIcon />
-                    </Icon>
-                  </Tooltip>
-                )}
-                {onEdit && (
-                  <Tooltip content="Rename" singleton={singleton}>
-                    <Icon onClick={handleClick(onEdit)}>
-                      <EditIcon />
-                    </Icon>
-                  </Tooltip>
-                )}
-                {onCreateFile && (
-                  <Tooltip content="New File" singleton={singleton}>
-                    <Icon onClick={handleClick(onCreateFile)}>
-                      <AddFileIcon />
-                    </Icon>
-                  </Tooltip>
-                )}
-                {onCreateDirectory && (
-                  <Tooltip content="New Directory" singleton={singleton}>
-                    <Icon onClick={handleClick(onCreateDirectory)}>
-                      <AddDirectoryIcon />
-                    </Icon>
-                  </Tooltip>
-                )}
-                {onDelete && (
-                  <Tooltip content="Delete" singleton={singleton}>
-                    <Icon onClick={handleClick(onDelete)}>
-                      <CrossIcon />
-                    </Icon>
-                  </Tooltip>
-                )}
-              </>
-            )}
-          </SingletonTooltip>
-        </Container>
-      )}
+      {hovering || (window.__isTouch && active) || forceShow ? (
+        <SingletonTooltip>
+          {singleton => (
+            <Container>
+              {onDownload && (
+                <Tooltip content="Export to ZIP" singleton={singleton}>
+                  <Icon onClick={handleClick(onDownload)}>
+                    <DownloadIcon />
+                  </Icon>
+                </Tooltip>
+              )}
+              {onUploadFile && (
+                <Tooltip content="Upload Files" singleton={singleton}>
+                  <Icon onClick={handleClick(onUploadFile)}>
+                    <UploadFileIcon />
+                  </Icon>
+                </Tooltip>
+              )}
+              {onDiscardChanges && (
+                <Tooltip content="Discard Changes">
+                  <Icon onClick={handleClick(onDiscardChanges)}>
+                    <UndoIcon />
+                  </Icon>
+                </Tooltip>
+              )}
+              {onEdit && (
+                <Tooltip content="Rename" singleton={singleton}>
+                  <Icon onClick={handleClick(onEdit)}>
+                    <EditIcon />
+                  </Icon>
+                </Tooltip>
+              )}
+              {onCreateFile && (
+                <Tooltip content="New File" singleton={singleton}>
+                  <Icon onClick={handleClick(onCreateFile)}>
+                    <AddFileIcon />
+                  </Icon>
+                </Tooltip>
+              )}
+              {onCreateDirectory && (
+                <Tooltip content="New Directory" singleton={singleton}>
+                  <Icon onClick={handleClick(onCreateDirectory)}>
+                    <AddDirectoryIcon />
+                  </Icon>
+                </Tooltip>
+              )}
+              {onDelete && (
+                <Tooltip content="Delete" singleton={singleton}>
+                  <Icon onClick={handleClick(onDelete)}>
+                    <CrossIcon />
+                  </Icon>
+                </Tooltip>
+              )}
+            </Container>
+          )}
+        </SingletonTooltip>
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
React throws a removeChild error when this is rendered:

```
<>
{false && <div />
</>
```

because the contents are empty, as I understood from here: https://stackoverflow.com/questions/54880669/react-domexception-failed-to-execute-removechild-on-node-the-node-to-be-re.

This seems to happen sometimes in the explorer, and this change fixes that.
