### PR TITLE
Fix toggle full screen on safari

### DIFF
--- a/packages/app/src/app/overmind/effects/vscode/Workbench.ts
+++ b/packages/app/src/app/overmind/effects/vscode/Workbench.ts
@@ -150,7 +150,7 @@ export class Workbench {
             // @ts-ignore - safari has this under a webkit flag
           } else if (document.documentElement.webkitRequestFullscreen) {
             // @ts-ignore - safari has this under a webkit flag
-            document.documentElement.webkitRequestFullScreen();
+            document.documentElement.webkitRequestFullscreen();
           }
 
           this.addNotification({

--- a/packages/app/src/app/overmind/effects/vscode/Workbench.ts
+++ b/packages/app/src/app/overmind/effects/vscode/Workbench.ts
@@ -145,7 +145,13 @@ export class Workbench {
         if (document.fullscreenElement) {
           document.exitFullscreen();
         } else {
-          document.documentElement.requestFullscreen();
+          if (document.documentElement.requestFullscreen) {
+            document.documentElement.requestFullscreen();
+            // @ts-ignore - safari has this under a webkit flag
+          } else if (document.documentElement.webkitRequestFullscreen) {
+            // @ts-ignore - safari has this under a webkit flag
+            document.documentElement.webkitRequestFullScreen();
+          }
 
           this.addNotification({
             title: 'Fullscreen',


### PR DESCRIPTION
Fixes https://github.com/codesandbox/codesandbox-client/issues/4575

document.documentElement.requestFullscreen() doesn't work on safari, you have to use document.documentElement.webkitRequestFullscreen()