### PR TITLE
Dashboard - only show counter for multiple items

### DIFF
--- a/packages/app/src/app/pages/NewDashboard/Components/Selection/DragPreview.tsx
+++ b/packages/app/src/app/pages/NewDashboard/Components/Selection/DragPreview.tsx
@@ -151,24 +151,26 @@ export const DragPreview: React.FC<DragPreviewProps> = React.memo(
               stiffness: 1000,
             }}
           >
-            <div
-              css={css({
-                position: 'fixed',
-                top: '-1rem',
-                right: '-1rem',
-                zIndex: 20,
-                borderRadius: '50%',
-                width: 32,
-                height: 32,
-                backgroundColor: 'blues.600',
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                fontWeight: 500,
-              })}
-            >
-              {selectedIds.length}
-            </div>
+            {selectedIds.length > 1 ? (
+              <div
+                css={css({
+                  position: 'fixed',
+                  top: '-1rem',
+                  right: '-1rem',
+                  zIndex: 20,
+                  borderRadius: '50%',
+                  width: 32,
+                  height: 32,
+                  backgroundColor: 'blues.600',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  fontWeight: 500,
+                })}
+              >
+                {selectedIds.length}
+              </div>
+            ) : null}
             {selectedItems.map((item, index) => (
               <Stack gap={2} align="center" key={item.id || item.path}>
                 <Stack


### PR DESCRIPTION
showing a counter of 1 doesn't convey any information. We should remove it to keep it minimal

<img width="280" alt="Screenshot 2020-07-21 at 11 30 10 AM" src="https://user-images.githubusercontent.com/1863771/88037756-9c149d00-cb45-11ea-8f58-8f86d0f6cb9d.png">

on the flip side, it does give a hint that you can select multiple. Leaving this for @DannyRuchtie and @CompuIves's input

