### PR TITLE
Fix a bug where forkedTemplateSandbox.git is undefined

### DIFF
--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/GitHub/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/GitHub/index.tsx
@@ -205,11 +205,10 @@ export const GitHub = () => {
         <Collapsible title="GitHub Repository" defaultOpen>
           <Element paddingX={2}>
             <Text variant="muted">
-              If you wish to contribute back to{' '}
-              {forkedTemplateSandbox.git.username}/
-              {forkedTemplateSandbox.git.repo}, you can link this sandbox to the
-              git repository. This will allow you to create commits and open
-              pull requests with this sandbox.
+              If you wish to contribute back to {upstreamSandbox.git.username}/
+              {upstreamSandbox.git.repo}, you can link this sandbox to the git
+              repository. This will allow you to create commits and open pull
+              requests with this sandbox.
             </Text>
             <Button
               marginTop={4}


### PR DESCRIPTION
We were checking for `git`, but not using the `git` property from that same object.

Fixes #4581