### PR TITLE
fix hiding of remove resource button.

### DIFF
--- a/packages/app/src/embed/components/Sidebar/ExternalResources/index.js
+++ b/packages/app/src/embed/components/Sidebar/ExternalResources/index.js
@@ -38,7 +38,7 @@ function ExternalResources({ sandbox }) {
           {externalResources.map(dep => (
             <Row key={dep}>
               <span>{getName(dep)}</span>
-              <a href={dep} rel="nofollow noopener noreferrer" target="_blank">
+              <a href={dep} rel="nofollow noopener noreferrer" target="_blank" style={{overflow:"scroll"}}>
                 open
               </a>
             </Row>


### PR DESCRIPTION
Remove button is not showing if the resource length is **more**. So I have fixed it by adding 'overflow:scroll' to the anchor.

<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?
Bug fix

<!-- Is it a Bug fix, feature, docs update, ... -->

## What is the current behavior?
If accidentally client will add lengthy resource, Then he will not able to remove it.
<!-- You can also link to an open issue here -->

## What is the new behavior?
Now by scrolling the resource link he is able to remove the unwanted resources.
<!-- if this is a feature change -->

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Step A
2. Step B
3. Step C

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
