### PR TITLE
add forked indication to name of sandbox

### DIFF
--- a/packages/app/src/app/overmind/namespaces/editor/internalActions.ts
+++ b/packages/app/src/app/overmind/namespaces/editor/internalActions.ts
@@ -428,7 +428,7 @@ export const forkSandbox: AsyncAction<{
 
     const forkedSandbox = await effects.api.forkSandbox(id, {
       ...(sandbox.title && !sandbox.title.includes('(Forked)')
-        ? { title: sandbox.title + ' (Forked)' }
+        ? { title: `${sandbox.title} (Forked)` }
         : {}),
       ...usedBody,
     });

--- a/packages/app/src/app/overmind/namespaces/editor/internalActions.ts
+++ b/packages/app/src/app/overmind/namespaces/editor/internalActions.ts
@@ -427,7 +427,7 @@ export const forkSandbox: AsyncAction<{
     }
 
     const forkedSandbox = await effects.api.forkSandbox(id, {
-      ...(sandbox.title && !sandbox.title.includes('(FORKED)')
+      ...(sandbox.title && !sandbox.title.includes('(Forked)')
         ? { title: sandbox.title + ' (Forked)' }
         : {}),
       ...usedBody,

--- a/packages/app/src/app/overmind/namespaces/editor/internalActions.ts
+++ b/packages/app/src/app/overmind/namespaces/editor/internalActions.ts
@@ -428,7 +428,7 @@ export const forkSandbox: AsyncAction<{
 
     const forkedSandbox = await effects.api.forkSandbox(id, {
       ...(sandbox.title && !sandbox.title.includes('(FORKED)')
-        ? { title: sandbox.title + ' (FORKED)' }
+        ? { title: sandbox.title + ' (Forked)' }
         : {}),
       ...usedBody,
     });

--- a/packages/app/src/app/overmind/namespaces/editor/internalActions.ts
+++ b/packages/app/src/app/overmind/namespaces/editor/internalActions.ts
@@ -8,6 +8,7 @@ import {
   ServerContainerStatus,
   TabType,
 } from '@codesandbox/common/lib/types';
+import { NEW_DASHBOARD } from '@codesandbox/common/lib/utils/feature-flags';
 import { hasPermission } from '@codesandbox/common/lib/utils/permission';
 import slugify from '@codesandbox/common/lib/utils/slugify';
 import {
@@ -18,7 +19,6 @@ import { Action, AsyncAction } from 'app/overmind';
 import { sortObjectByKeys } from 'app/overmind/utils/common';
 import { getTemplate as computeTemplate } from 'codesandbox-import-utils/lib/create-sandbox/templates';
 import { mapValues } from 'lodash-es';
-import { NEW_DASHBOARD } from '@codesandbox/common/lib/utils/feature-flags';
 
 export const ensureSandboxId: Action<string, string> = ({ state }, id) => {
   if (state.editor.sandboxes[id]) {
@@ -426,7 +426,12 @@ export const forkSandbox: AsyncAction<{
       }
     }
 
-    const forkedSandbox = await effects.api.forkSandbox(id, usedBody);
+    const forkedSandbox = await effects.api.forkSandbox(id, {
+      ...(sandbox.title && !sandbox.title.includes('(FORKED)')
+        ? { title: sandbox.title + ' (FORKED)' }
+        : {}),
+      ...usedBody,
+    });
 
     // Copy over any unsaved code
     Object.assign(forkedSandbox, {


### PR DESCRIPTION
During the stream I noticed I was working on a fork of my original project... but was really no indication. I asked on the stream and got immediate response from an other person having the same issue. With this fix we add `(FORKED)` to the title of the sandbox you fork. This has two benefits:

1. You know by looking at the name if it is a forked sandbox
2. When you now fork a template the name if your sandbox will be the name of the template + `(FORKED)`

For example when you now fork the React template you will see this, instead of a cryptic name:

![Screenshot 2020-07-27 at 11 20 02](https://user-images.githubusercontent.com/3956929/88525636-20aa6400-cffb-11ea-9078-ae7cc77abe28.png)
