### PR TITLE
fixes several issues with github flow

### DIFF
--- a/packages/app/src/app/overmind/namespaces/git/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/git/actions.ts
@@ -535,8 +535,9 @@ export const resolveOutOfSync: AsyncAction = async ({
     );
     sandbox.originalGit!.commitSha = git.sourceCommitSha;
     sandbox.originalGitCommitSha = git.sourceCommitSha;
-    await actions.git._loadSourceSandbox();
   }
+
+  await actions.git._loadSourceSandbox();
 
   actions.git._setGitChanges();
   git.outOfSyncUpdates.added = [];

--- a/packages/app/src/app/overmind/namespaces/git/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/git/actions.ts
@@ -428,11 +428,13 @@ export const deleteConflictedFile: AsyncAction<GitFileCompare> = async (
   actions.git._tryResolveConflict();
 };
 
-export const diffConflictedFile: Action<GitFileCompare> = (
+export const diffConflictedFile: AsyncAction<GitFileCompare> = async (
   { state, actions },
   conflict
 ) => {
   const module = state.editor.modulesByPath['/' + conflict.filename] as Module;
+
+  await actions.editor.moduleSelected({ id: module.id });
 
   actions.editor.setCode({
     moduleShortid: module.shortid,
@@ -504,13 +506,13 @@ export const resolveOutOfSync: AsyncAction = async ({
   if (git.gitState === SandboxGitState.OUT_OF_SYNC_PR_BASE) {
     const changes: GitChanges = {
       added: added.map(change => ({
-        path: change.filename,
+        path: '/' + change.filename,
         content: change.content!,
         encoding: 'utf-8',
       })),
-      deleted: deleted.map(change => change.filename),
+      deleted: deleted.map(change => '/' + change.filename),
       modified: modified.map(change => ({
-        path: change.filename,
+        path: '/' + change.filename,
         content: change.content!,
         encoding: 'utf-8',
       })),
@@ -521,7 +523,6 @@ export const resolveOutOfSync: AsyncAction = async ({
       changes,
       [git.sourceCommitSha!]
     );
-    actions.git._setGitChanges();
     sandbox.originalGit!.commitSha = commit.sha;
     sandbox.originalGitCommitSha = commit.sha;
 
@@ -534,8 +535,10 @@ export const resolveOutOfSync: AsyncAction = async ({
     );
     sandbox.originalGit!.commitSha = git.sourceCommitSha;
     sandbox.originalGitCommitSha = git.sourceCommitSha;
+    await actions.git._loadSourceSandbox();
   }
 
+  actions.git._setGitChanges();
   git.outOfSyncUpdates.added = [];
   git.outOfSyncUpdates.deleted = [];
   git.outOfSyncUpdates.modified = [];
@@ -582,25 +585,25 @@ export const _evaluateGitChanges: AsyncAction<
   const conflicts = changes.reduce<GitFileCompare[]>((aggr, change) => {
     const path = '/' + change.filename;
 
-    // We are in conflict if a file has been removed and it is still present
-    // in the sandbox
-    if (change.status === 'removed' && state.editor.modulesByPath[path]) {
-      return aggr.concat(change);
-    }
-
-    // We are in conflict if a file has been deleted in the sandbox, but
-    // is still present in the source
+    // We are in conflict if a file has been removed in the source and the
+    // sandbox has made changes to it
     if (
-      (change.status === 'modified' || change.status === 'added') &&
-      !state.editor.modulesByPath[path]
+      change.status === 'removed' &&
+      state.editor.modulesByPath[path] &&
+      (state.editor.modulesByPath[path] as Module).code !== change.content
     ) {
       return aggr.concat(change);
     }
 
-    // We are in conflict if the file exists in the sandbox, but
-    // the contents is different than both the change and the
+    // We are in conflict if a file has been modified in the source, but removed
+    // from the sandbox
+    if (change.status === 'modified' && !state.editor.modulesByPath[path]) {
+      return aggr.concat(change);
+    }
+
+    // We are in conflict if the source changed the file and sandbox also changed the file
     if (
-      (change.status === 'added' || change.status === 'modified') &&
+      change.status === 'modified' &&
       (state.editor.modulesByPath[path] as Module).code !== change.content &&
       (state.editor.modulesByPath[path] as Module).code !==
         state.git.sourceModulesByPath[path]
@@ -635,7 +638,9 @@ export const _evaluateGitChanges: AsyncAction<
           (state.editor.modulesByPath['/' + change.filename] as Module).code !==
             change.content)
       ) {
-        aggr[change.status].push(change);
+        aggr[change.status === 'removed' ? 'deleted' : change.status].push(
+          change
+        );
       }
 
       return aggr;

--- a/packages/app/src/app/overmind/namespaces/git/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/git/actions.ts
@@ -361,7 +361,6 @@ export const resolveConflicts: AsyncAction<Module> = async (
   { state, actions, effects },
   module
 ) => {
-  effects.analytics.track('GitHub - Resolve Conflicts');
   const conflict = state.git.conflicts.find(
     conflictItem => module.path === '/' + conflictItem.filename
   );
@@ -375,6 +374,7 @@ export const resolveConflicts: AsyncAction<Module> = async (
       cbID: null,
     });
 
+    effects.analytics.track('GitHub - Resolve Conflicts');
     actions.git._tryResolveConflict();
   }
 };

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/GitHub/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/GitHub/index.tsx
@@ -1,6 +1,7 @@
 import { GitFileCompare, SandboxGitState } from '@codesandbox/common/lib/types';
 import { githubRepoUrl } from '@codesandbox/common/lib/utils/url-generator';
 import {
+  Button,
   Collapsible,
   Element,
   Link,
@@ -8,7 +9,6 @@ import {
   ListItem,
   Stack,
   Text,
-  Button,
 } from '@codesandbox/components';
 import { useOvermind } from 'app/overmind';
 import React from 'react';
@@ -162,6 +162,7 @@ export const GitHub = () => {
                   <ListItem
                     gap={2}
                     key={conflict.filename}
+                    marginBottom={4}
                     css={{ display: 'block' }}
                   >
                     <Stack gap={3} align="center" marginBottom={4}>

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/GitHub/utils/getConflictsText.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/GitHub/utils/getConflictsText.tsx
@@ -1,8 +1,9 @@
-import React from 'react';
-import { Text } from '@codesandbox/components';
 import { GitFileCompare } from '@codesandbox/common/lib/types';
-import { getConflictType } from './getConflictType';
+import { Text } from '@codesandbox/components';
+import React from 'react';
+
 import { ConflictType } from '../types';
+import { getConflictType } from './getConflictType';
 
 export function getConflictText(
   branch: string,
@@ -14,7 +15,8 @@ export function getConflictText(
   if (conflictType === ConflictType.SOURCE_ADDED_SANDBOX_DELETED) {
     return (
       <Text>
-        <Text weight="bold">{branch}</Text> added this file, but you deleted it
+        <Text weight="bold">{branch}</Text> added this file, but it does not
+        exist in this sandbox
       </Text>
     );
   }


### PR DESCRIPTION
The following issues has been adressed: 

- The Git Extractor has a new version. When dealing with sync of multiple commits we got the commit SHA of the oldest commit, causing your sandbox to be in sync... but still out of sync because of wrong commit SHA
- When dealing with syncing of `base` on a PR, we gave a filepath missing `/` on the commit... so it did not update correctly, causing a bit of havoc really
- Fixed updating git changes after doing a sync
- Fixed reloading the source sandbox after dealing with a sync
- Improved conflict resolution to also check content, also some comments to understand it better
- Fixed margin when having multiple conflicts
- Improved some text related to not necessarily being deleted by the user
- Moved the "conflict" event to trigger correctly

Please test this by:

- Create some repo on Github
- Make changes locally (two different commits) and push
- Refresh sandbox and try to sync, and refresh... all okay?
- Make changes locally (two different commits) and push
- Make changes to Sandbox, save and refresh
- Sync/conflict resolution and refresh... all okay?
- Now create a PR on this Sandbox and do the same above points again TWICE, both changing the `master` and changing the `pr branch` locally and try to sync up