### PR TITLE
Enable run on click by default for Android and IOS

### DIFF
--- a/packages/app/src/embed/components/App/index.js
+++ b/packages/app/src/embed/components/App/index.js
@@ -10,6 +10,7 @@ import {
   findCurrentModule,
   findMainModule,
 } from '@codesandbox/common/lib/sandbox/modules';
+import { isIOS, isAndroid } from '@codesandbox/common/lib/utils/platform';
 import { Title } from 'app/components/Title';
 import { SubTitle } from 'app/components/SubTitle';
 import Content from '../Content';
@@ -106,7 +107,7 @@ export default class App extends React.PureComponent<
       hideDevTools,
       tabs,
       theme,
-      runOnClick,
+      runOnClick: runOnClick === undefined ? isAndroid || isIOS : runOnClick,
       verticalMode,
       highlightedLines: highlightedLines || [],
     };

--- a/packages/common/src/utils/platform.ts
+++ b/packages/common/src/utils/platform.ts
@@ -1,3 +1,6 @@
+export const isAndroid =
+  typeof navigator !== 'undefined' &&
+  Boolean(/(android)/i.test(navigator.userAgent));
 export const isIOS =
   typeof navigator !== 'undefined' &&
   Boolean(navigator.platform.match(/(iPhone|iPod|iPad)/i));


### PR DESCRIPTION
Sometimes Safari on iPhone would crash if there were multiple embeds on the same page. I think the same could happen on Android. With this we add a default, which prevents crashes if multiple embeds are on the same page.