### PR TITLE
fix search

### DIFF
--- a/packages/app/src/app/components/CodeEditor/elements.ts
+++ b/packages/app/src/app/components/CodeEditor/elements.ts
@@ -2,7 +2,6 @@ import styled from 'styled-components';
 
 export const Icons = styled.div`
   background-color: rgba(0, 0, 0, 0.3);
-  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.3);
   border-radius: 2px;
   color: ${props =>
     props.theme.light ? 'rgba(0, 0, 0, 0.7)' : 'rgba(255, 255, 255, 0.7)'};

--- a/packages/app/src/app/pages/Sandbox/Editor/Content/EditorToast.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Content/EditorToast.tsx
@@ -1,14 +1,12 @@
-import * as React from 'react';
-import css from '@styled-system/css';
-
 import Tooltip from '@codesandbox/common/lib/components/Tooltip';
 import getTemplateDefinition from '@codesandbox/common/lib/templates';
-import { Icons } from 'app/components/CodeEditor/elements';
-import { useOvermind } from 'app/overmind';
-import QuestionIcon from 'react-icons/lib/go/question';
-
 import { LiveUser } from '@codesandbox/common/lib/types';
 import { Stack } from '@codesandbox/components';
+import css from '@styled-system/css';
+import { Icons } from 'app/components/CodeEditor/elements';
+import { useOvermind } from 'app/overmind';
+import * as React from 'react';
+import QuestionIcon from 'react-icons/lib/go/question';
 
 export const EditorToast = () => {
   const { state } = useOvermind();
@@ -32,9 +30,9 @@ export const EditorToast = () => {
     <Stack
       css={css({
         position: 'absolute',
-        top: 34,
+        bottom: 0,
         zIndex: 45,
-        right: 0,
+        right: 15,
       })}
       gap={1}
       direction="vertical"


### PR DESCRIPTION
The configuration indicator was overlaying the search. Since we can not put it underneath (as the search is inside VSCode) I decided to put it bottom right instead.

![Screenshot 2020-08-06 at 15 10 24](https://user-images.githubusercontent.com/3956929/89535785-2f60fa00-d7f7-11ea-9856-5b27934b5afe.png)
