### PR TITLE
Fix module being undefined

### DIFF
--- a/packages/app/src/app/overmind/internalActions.ts
+++ b/packages/app/src/app/overmind/internalActions.ts
@@ -210,7 +210,7 @@ export const setCurrentSandbox: AsyncAction<Sandbox> = async (
   const parsedConfigs = parseConfigurations(sandbox);
   const main = mainModule(sandbox, parsedConfigs);
 
-  state.editor.mainModuleShortid = main.shortid;
+  state.editor.mainModuleShortid = main?.shortid;
 
   // Only change the module shortid if it doesn't exist in the new sandbox
   // This can happen when a sandbox is opened that's different from the current


### PR DESCRIPTION
Fixes #4661

Real edge case; happens when `sandbox.modules == []`
