### PR TITLE
Add a warning for unsupported functionality in move modal

### DIFF
--- a/packages/app/src/app/pages/common/Modals/MoveSandboxFolderModal/DirectoryPicker/SandboxesItem/FolderEntry/elements.ts
+++ b/packages/app/src/app/pages/common/Modals/MoveSandboxFolderModal/DirectoryPicker/SandboxesItem/FolderEntry/elements.ts
@@ -1,9 +1,10 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import { NavLink } from 'react-router-dom';
 import ChevronRight from 'react-icons/lib/md/chevron-right';
 
 export const Container = styled(NavLink)<{
   depth?: number;
+  disabled?: boolean;
 }>`
   transition: 0.25s ease all;
   display: flex;
@@ -18,17 +19,25 @@ export const Container = styled(NavLink)<{
 
   user-select: none;
 
-  cursor: pointer;
+  ${props =>
+    props.disabled
+      ? css`
+          opacity: 0.8;
+          outline: none;
+        `
+      : css`
+          cursor: pointer;
 
-  &:hover {
-    color: rgba(255, 255, 255, 0.8);
-  }
+          &:hover {
+            color: rgba(255, 255, 255, 0.8);
+          }
 
-  &:focus {
-    outline: none;
-    border-color: ${props => props.theme.secondary.clearer(0.5)};
-    color: rgba(255, 255, 255, 0.8);
-  }
+          &:focus {
+            outline: none;
+            border-color: ${() => props.theme.secondary.clearer(0.5)};
+            color: rgba(255, 255, 255, 0.8);
+          }
+        `}
 `;
 
 export const CreateDirectoryContainer = Container.withComponent('div');

--- a/packages/app/src/app/pages/common/Modals/MoveSandboxFolderModal/DirectoryPicker/SandboxesItem/index.tsx
+++ b/packages/app/src/app/pages/common/Modals/MoveSandboxFolderModal/DirectoryPicker/SandboxesItem/index.tsx
@@ -82,6 +82,11 @@ class SandboxesItemComponent extends React.Component<
               data.me.collections
             );
 
+            const disabledMessage =
+              teamId == null
+                ? "It's currently not possible to move sandboxes to 'All Sandboxes' in a personal workspace"
+                : undefined;
+
             return (
               <Container>
                 <FolderContainer
@@ -112,8 +117,13 @@ class SandboxesItemComponent extends React.Component<
                   folders={folders}
                   foldersByPath={foldersByPath}
                   name="All Sandboxes"
+                  disabled={disabledMessage}
                   open
-                  onSelect={onSelect}
+                  onSelect={args => {
+                    if (!disabledMessage) {
+                      onSelect(args);
+                    }
+                  }}
                   currentPath={currentPath}
                   currentTeamId={currentTeamId}
                 />


### PR DESCRIPTION
Because we're in a transition period to workspaces it's not possible to move sandboxes to "All Sandboxes" in personal workspaces due to technical limitations. This adds a message to the modal to let the user know.

Temporary fix for #4629

![image](https://user-images.githubusercontent.com/587016/89902308-95c68d80-dbe6-11ea-86c8-2191a00ea044.png)
