### PR TITLE
Fix: Bring back create sandbox menu when All workspace exists

### DIFF
--- a/packages/app/src/app/overmind/namespaces/dashboard/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/dashboard/actions.ts
@@ -285,7 +285,8 @@ export const getAllFolders: AsyncAction = async ({ state, effects }) => {
     );
 
     state.dashboard.allCollections = collectionsByLevel.filter(
-      c => c.id && c.name
+      // c => c.id
+      c => c.id
     );
   } catch {
     effects.notificationToast.error(

--- a/packages/app/src/app/overmind/namespaces/dashboard/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/dashboard/actions.ts
@@ -284,10 +284,7 @@ export const getAllFolders: AsyncAction = async ({ state, effects }) => {
       getDecoratedCollection(collection)
     );
 
-    state.dashboard.allCollections = collectionsByLevel.filter(
-      // c => c.id
-      c => c.id
-    );
+    state.dashboard.allCollections = collectionsByLevel.filter(c => c.id);
   } catch {
     effects.notificationToast.error(
       'There was a problem getting your sandboxes'

--- a/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenu.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenu.tsx
@@ -35,7 +35,7 @@ interface IContextMenuProps extends IMenuProps {
   folders: Array<DashboardFolder>;
   repos?: Array<DashboardRepo>;
   setRenaming: null | ((value: boolean) => void);
-  createNewFolder: () => void;
+  createNewFolder: (() => void) | null;
   createNewSandbox: () => void;
   page: PageTypes;
 }

--- a/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenu.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenu.tsx
@@ -35,8 +35,8 @@ interface IContextMenuProps extends IMenuProps {
   folders: Array<DashboardFolder>;
   repos?: Array<DashboardRepo>;
   setRenaming: null | ((value: boolean) => void);
-  createNewFolder: (() => void) | null;
-  createNewSandbox: () => void;
+  createNewFolder: () => void;
+  createNewSandbox: (() => void) | null;
   page: PageTypes;
 }
 

--- a/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenus/ContainerMenu.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenus/ContainerMenu.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { useLocation } from 'react-router-dom';
 import { Menu } from '@codesandbox/components';
 import { Context, MenuItem } from '../ContextMenu';
 
@@ -13,7 +12,6 @@ export const ContainerMenu: React.FC<ContainerMenuProps> = ({
   createNewSandbox,
 }) => {
   const { visible, setVisibility, position } = React.useContext(Context);
-  const location = useLocation();
 
   return (
     <Menu.ContextMenu
@@ -22,8 +20,12 @@ export const ContainerMenu: React.FC<ContainerMenuProps> = ({
       position={position}
       style={{ width: 160 }}
     >
-      {location.pathname !== '/dashboard/all/' && (
-        <MenuItem onSelect={() => createNewSandbox()}>
+      {typeof createNewSandbox === 'function' && (
+        <MenuItem
+          onSelect={() => {
+            createNewSandbox();
+          }}
+        >
           Create new sandbox
         </MenuItem>
       )}

--- a/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenus/ContainerMenu.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenus/ContainerMenu.tsx
@@ -4,7 +4,7 @@ import { Context, MenuItem } from '../ContextMenu';
 
 interface ContainerMenuProps {
   createNewFolder: () => void;
-  createNewSandbox: () => void;
+  createNewSandbox: (() => void) | null;
 }
 
 export const ContainerMenu: React.FC<ContainerMenuProps> = ({

--- a/packages/app/src/app/pages/Dashboard/Content/routes/All/useFilteredItems.ts
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/All/useFilteredItems.ts
@@ -53,10 +53,12 @@ export const useFilteredItems = (
 
     const sortedFolders = orderBy(folderFolders, 'name').sort(a => 1);
 
-    const decoratedFolders = sortedFolders.map(folder => ({
-      type: 'folder' as 'folder',
-      ...folder,
-    }));
+    const decoratedFolders = sortedFolders
+      .filter(folder => folder.path !== '/')
+      .map(folder => ({
+        type: 'folder' as 'folder',
+        ...folder,
+      }));
 
     const decoratedSandboxes =
       typeof folderSandboxes === 'undefined'

--- a/packages/app/src/app/pages/Dashboard/Sidebar/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Sidebar/index.tsx
@@ -89,7 +89,8 @@ export const Sidebar: React.FC<SidebarProps> = ({
     }
   }, [state.activeTeam, state.activeTeamInfo, dashboard.teams, user]);
 
-  const folders = dashboard.allCollections || [];
+  const folders =
+    dashboard.allCollections.filter(folder => folder.path !== '/') || [];
 
   // context menu for folders
   const [menuVisible, setMenuVisibility] = React.useState(true);


### PR DESCRIPTION
1. Keep `/` path in collections when it is present (teams)

```diff
state.dashboard.allCollections = collectionsByLevel.filter(
-  c => c.id && c.name
+  c => c.id
);
```

2. Don't show `/` in explorer view or in show it twice in sidebar