### PR TITLE
Don't set sandbox HTML if there's an HTML module

### DIFF
--- a/packages/app/src/sandbox/compile.ts
+++ b/packages/app/src/sandbox/compile.ts
@@ -597,11 +597,7 @@ async function compile({
           manager.clearCompiledCache();
         }
 
-        if (
-          !manager.preset.htmlDisabled ||
-          !firstLoad ||
-          process.env.LOCAL_SERVER
-        ) {
+        if (!htmlModule || !firstLoad || process.env.LOCAL_SERVER) {
           // The HTML is loaded from the server as a static file, no need to set the innerHTML of the body
           // on the first run.
           document.body.innerHTML = body;


### PR DESCRIPTION
Whenever a CRA without React dependency requires an HTML file, which and that one requires a JS file, top-level event listeners don't catch on.

That's because the compiler sets `body.innerHTML` after the JS has been loaded. This PR is a quick fix, but I will investigate tomorrow if this is the best fix, and if it fixes all cases.

Refer: https://codesandbox.io/s/vibrant-herschel-puilg?file=/public/index.html