### PR TITLE
Components: Responsive syntax for Stack direction

### DIFF
--- a/packages/components/src/components/List/index.tsx
+++ b/packages/components/src/components/List/index.tsx
@@ -13,7 +13,7 @@ export const List = styled(Element).attrs(p => ({
   css({
     listStyle: 'none',
     paddingLeft: 0,
-    margin: 0,
+    marginX: 0,
   })
 );
 

--- a/packages/components/src/components/List/index.tsx
+++ b/packages/components/src/components/List/index.tsx
@@ -13,7 +13,7 @@ export const List = styled(Element).attrs(p => ({
   css({
     listStyle: 'none',
     paddingLeft: 0,
-    marginX: 0,
+    margin: 0,
   })
 );
 

--- a/packages/components/src/components/Stack/index.tsx
+++ b/packages/components/src/components/Stack/index.tsx
@@ -1,22 +1,56 @@
-import styled from 'styled-components';
-import css from '@styled-system/css';
+import React from 'react';
+import deepmerge from 'deepmerge';
 import { Element } from '../Element';
 
-export const Stack = styled(Element)<{
-  gap?: number; // theme.space token
+type StackProps = {
   direction?: 'horizontal' | 'vertical';
   justify?: React.CSSProperties['justifyContent'];
   align?: React.CSSProperties['alignItems'];
   inline?: boolean;
-}>(({ gap = 0, direction = 'horizontal', justify, align, inline }) =>
-  css({
+  gap?: number;
+};
+
+export const Stack: React.FC<StackProps> = React.forwardRef(function Stack(
+  {
+    direction = 'horizontal',
+    inline = false,
+    justify,
+    align,
+    gap,
+    css = {},
+    ...props
+  }: StackProps,
+  ref
+) {
+  const styles = {
     display: inline ? 'inline-flex' : 'flex',
-    flexDirection: direction === 'horizontal' ? 'row' : 'column',
     justifyContent: justify,
     alignItems: align,
+  };
 
-    '> *:not(:last-child)': {
-      [direction === 'horizontal' ? 'marginRight' : 'marginBottom']: gap,
-    },
-  })
-);
+  if (Array.isArray(direction)) {
+    styles.flexDirection = direction.map(d =>
+      d === 'vertical' ? 'column' : 'row'
+    );
+    styles['> * + *'] = direction.map(d => createGap(d, gap));
+  } else {
+    styles.flexDirection = direction === 'vertical' ? 'column' : 'row';
+    styles['> * + *'] = createGap(direction, gap);
+  }
+
+  return <Element ref={ref} css={deepmerge(styles, css)} {...props} />;
+});
+
+const createGap = (direction, gap) => {
+  if (direction === 'vertical') {
+    return {
+      marginTop: gap,
+      marginLeft: 0,
+    };
+  }
+
+  return {
+    marginTop: 0,
+    marginLeft: gap,
+  };
+};

--- a/packages/components/src/components/Stack/index.tsx
+++ b/packages/components/src/components/Stack/index.tsx
@@ -11,9 +11,7 @@ type StackProps = {
   gap?: number;
 };
 
-export const Stack = styled(Element).attrs(p => ({
-  as: ((p as unknown) as { as: string }).as || 'div',
-}))<StackProps>(
+export const Stack = styled(Element)<StackProps>(
   ({ direction = 'horizontal', justify, align, inline = false, gap }) => {
     const styles = {
       display: inline ? 'inline-flex' : 'flex',

--- a/packages/components/src/components/Stack/index.tsx
+++ b/packages/components/src/components/Stack/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import deepmerge from 'deepmerge';
-import { Element } from '../Element';
+import { Element, IElementProps } from '../Element';
 
 type StackProps = {
   direction?: 'horizontal' | 'vertical';
@@ -8,9 +8,13 @@ type StackProps = {
   align?: React.CSSProperties['alignItems'];
   inline?: boolean;
   gap?: number;
-};
+} & React.HTMLAttributes<HTMLDivElement> &
+  IElementProps;
 
-export const Stack: React.FC<StackProps> = React.forwardRef(function Stack(
+export const Stack: React.FC<StackProps> = React.forwardRef<
+  HTMLDivElement,
+  StackProps
+>(function Stack(
   {
     direction = 'horizontal',
     inline = false,
@@ -26,6 +30,7 @@ export const Stack: React.FC<StackProps> = React.forwardRef(function Stack(
     display: inline ? 'inline-flex' : 'flex',
     justifyContent: justify,
     alignItems: align,
+    flexDirection: 'row' as 'row' | 'column' | ('row' | 'column')[],
   };
 
   if (Array.isArray(direction)) {
@@ -38,7 +43,7 @@ export const Stack: React.FC<StackProps> = React.forwardRef(function Stack(
     styles['> * + *'] = createGap(direction, gap);
   }
 
-  return <Element ref={ref} css={deepmerge(styles, css)} {...props} />;
+  return <Element as="div" ref={ref} css={deepmerge(styles, css)} {...props} />;
 });
 
 const createGap = (direction, gap) => {

--- a/packages/components/src/components/Stack/index.tsx
+++ b/packages/components/src/components/Stack/index.tsx
@@ -24,10 +24,10 @@ export const Stack = styled(Element)<StackProps>(
       styles.flexDirection = direction.map(d =>
         d === 'vertical' ? 'column' : 'row'
       );
-      styles['> * + *'] = direction.map(d => createGap(d, gap));
+      styles['> *:not(:last-child)'] = direction.map(d => createGap(d, gap));
     } else {
       styles.flexDirection = direction === 'vertical' ? 'column' : 'row';
-      styles['> * + *'] = createGap(direction, gap);
+      styles['> *:not(:last-child)'] = createGap(direction, gap);
     }
 
     return css(styles);
@@ -37,13 +37,13 @@ export const Stack = styled(Element)<StackProps>(
 const createGap = (direction, gap) => {
   if (direction === 'vertical') {
     return {
-      marginTop: gap,
-      marginLeft: 0,
+      marginBottom: gap,
+      marginRight: 0,
     };
   }
 
   return {
-    marginTop: 0,
-    marginLeft: gap,
+    marginBottom: 0,
+    marginRight: gap,
   };
 };

--- a/packages/components/src/components/Stack/index.tsx
+++ b/packages/components/src/components/Stack/index.tsx
@@ -1,50 +1,40 @@
 import React from 'react';
-import deepmerge from 'deepmerge';
-import { Element, IElementProps } from '../Element';
+import styled from 'styled-components';
+import css from '@styled-system/css';
+import { Element } from '../Element';
 
 type StackProps = {
-  direction?: 'horizontal' | 'vertical';
+  direction?: 'horizontal' | 'vertical' | ('horizontal' | 'vertical')[];
   justify?: React.CSSProperties['justifyContent'];
   align?: React.CSSProperties['alignItems'];
   inline?: boolean;
   gap?: number;
-} & React.HTMLAttributes<HTMLDivElement> &
-  IElementProps;
+};
 
-export const Stack: React.FC<StackProps> = React.forwardRef<
-  HTMLDivElement,
-  StackProps
->(function Stack(
-  {
-    direction = 'horizontal',
-    inline = false,
-    justify,
-    align,
-    gap,
-    css = {},
-    ...props
-  }: StackProps,
-  ref
-) {
-  const styles = {
-    display: inline ? 'inline-flex' : 'flex',
-    justifyContent: justify,
-    alignItems: align,
-    flexDirection: 'row' as 'row' | 'column' | ('row' | 'column')[],
-  };
+export const Stack = styled(Element).attrs(p => ({
+  as: ((p as unknown) as { as: string }).as || 'div',
+}))<StackProps>(
+  ({ direction = 'horizontal', justify, align, inline = false, gap }) => {
+    const styles = {
+      display: inline ? 'inline-flex' : 'flex',
+      justifyContent: justify,
+      alignItems: align,
+      flexDirection: 'row' as 'row' | 'column' | ('row' | 'column')[],
+    };
 
-  if (Array.isArray(direction)) {
-    styles.flexDirection = direction.map(d =>
-      d === 'vertical' ? 'column' : 'row'
-    );
-    styles['> * + *'] = direction.map(d => createGap(d, gap));
-  } else {
-    styles.flexDirection = direction === 'vertical' ? 'column' : 'row';
-    styles['> * + *'] = createGap(direction, gap);
+    if (Array.isArray(direction)) {
+      styles.flexDirection = direction.map(d =>
+        d === 'vertical' ? 'column' : 'row'
+      );
+      styles['> * + *'] = direction.map(d => createGap(d, gap));
+    } else {
+      styles.flexDirection = direction === 'vertical' ? 'column' : 'row';
+      styles['> * + *'] = createGap(direction, gap);
+    }
+
+    return css(styles);
   }
-
-  return <Element as="div" ref={ref} css={deepmerge(styles, css)} {...props} />;
-});
+);
 
 const createGap = (direction, gap) => {
   if (direction === 'vertical') {


### PR DESCRIPTION
Support for `<Stack direction={['vertical', 'horizontal']} gap={8} />`