### PR TITLE
Don't render a tooltip if the label is null

### DIFF
--- a/packages/app/src/app/pages/common/Modals/MoveSandboxFolderModal/DirectoryPicker/SandboxesItem/FolderEntry/index.tsx
+++ b/packages/app/src/app/pages/common/Modals/MoveSandboxFolderModal/DirectoryPicker/SandboxesItem/FolderEntry/index.tsx
@@ -47,7 +47,7 @@ import {
 type Props = {
   name: string;
   path: string;
-  disabled?: string;
+  disabled?: string | null;
   url?: string;
   readOnly?: string;
   folders: { path: string }[];
@@ -240,7 +240,7 @@ class FolderEntry extends React.Component<Props, State> {
       connectDragSource(
         <div>
           <ContextMenu items={menuItems}>
-            <Tooltip label={disabled}>
+            <Tooltip label={disabled || null}>
               <UnTypedContainer
                 as={onSelect ? 'div' : undefined}
                 onClick={onSelect ? this.handleSelect : undefined}

--- a/packages/app/src/app/pages/common/Modals/MoveSandboxFolderModal/DirectoryPicker/SandboxesItem/index.tsx
+++ b/packages/app/src/app/pages/common/Modals/MoveSandboxFolderModal/DirectoryPicker/SandboxesItem/index.tsx
@@ -85,7 +85,7 @@ class SandboxesItemComponent extends React.Component<
             const disabledMessage =
               teamId == null
                 ? "It's currently not possible to move sandboxes to 'All Sandboxes' in a personal workspace"
-                : undefined;
+                : null;
 
             return (
               <Container>

--- a/packages/components/src/components/Tooltip/index.tsx
+++ b/packages/components/src/components/Tooltip/index.tsx
@@ -81,7 +81,7 @@ export const TooltipStyles = createGlobalStyle(
   animation
 );
 interface TooltipProps {
-  label: string;
+  label: string | null;
   children: React.ReactElement;
 }
 
@@ -91,9 +91,17 @@ interface TooltipProps {
  * TooltipPopup and create the triangle in another component
  */
 
+/**
+ * Render a tooltip around the children, if you pass `null` to `label` the Tooltip
+ * won't be rendered.
+ */
 const Tooltip: React.FC<TooltipProps> = props => {
   const [trigger, tooltip] = useTooltip();
   const { isVisible, triggerRect } = tooltip;
+
+  if (props.label === null) {
+    return props.children;
+  }
 
   return (
     <>


### PR DESCRIPTION
I wonder what you think of this @siddharthkp. With this change we don't render the tooltip if `label` is `null`.