### PR TITLE
Merge user initialization into one function

### DIFF
--- a/packages/app/src/app/overmind/factories.ts
+++ b/packages/app/src/app/overmind/factories.ts
@@ -70,21 +70,7 @@ export const withLoadApp = <T>(
         }),
       ]);
 
-      actions.dashboard.getTeams();
-      actions.internal.setPatronPrice();
-      effects.analytics.identify('signed_in', true);
-      effects.analytics.setUserId(state.user!.id, state.user!.email);
-
-      try {
-        actions.internal.trackCurrentTeams().catch(e => {});
-        actions.internal.identifyCurrentUser().catch(e => {});
-      } catch (e) {
-        // Not majorly important
-      }
-      actions.internal.showUserSurveyIfNeeded();
-      await effects.live.getSocket();
-      actions.userNotifications.internal.initialize();
-      effects.api.preloadTemplates();
+      await actions.internal.initializeNewUser();
       state.hasLogIn = true;
     } catch (error) {
       actions.internal.handleError({


### PR DESCRIPTION
I noticed after sign in we wouldn't show all teams, and that's because we have a flow that is duplicated, and we only added it to one flow. I merged both flows into one function now.