### PR TITLE
should still propagate hyperlink clicks

### DIFF
--- a/packages/sandbox-hooks/url-listeners.js
+++ b/packages/sandbox-hooks/url-listeners.js
@@ -26,8 +26,8 @@ function pathWithHash(location) {
 }
 
 function isInsideVue(el) {
-  if (el === document.body) return false
-  return el.__vue__ || el._vnode || isInsideVue(el.parentElement)
+  if (el === document.body) return false;
+  return el.__vue__ || el._vnode || isInsideVue(el.parentElement);
 }
 
 export default function setupHistoryListeners() {
@@ -131,7 +131,6 @@ export default function setupHistoryListeners() {
           sendUrlChange(document.location.href);
         }
         ev.preventDefault();
-        ev.stopPropagation();
       }
     },
     true


### PR DESCRIPTION
I do not think we should `stopPropagation` here, cause this stops the event bubbling up. It is the `preventDefault` we want to prevent the browser to trigger the link.

Let me know if there is some reason we want to actually stop the click event.

Fixes: https://github.com/codesandbox/codesandbox-client/issues/4523