### PR TITLE
Quickfix teamId being undefined

### DIFF
--- a/packages/app/src/app/pages/Sandbox/Editor/Header/ForkButton/ForkButton.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Header/ForkButton/ForkButton.tsx
@@ -189,15 +189,14 @@ export const ForkButton: React.FC<ForkButtonProps> = props => {
               marginTop: -4,
             }}
           >
-            <TeamOrUserItem
-              forkClicked={props.forkClicked}
-              item={currentSpace}
-              disabled={state.activeWorkspaceAuthorization === 'READ'}
-              isPersonal={
-                currentSpace &&
-                currentSpace.teamId === state.personalWorkspaceId
-              }
-            />
+            {currentSpace && (
+              <TeamOrUserItem
+                forkClicked={props.forkClicked}
+                item={currentSpace}
+                disabled={state.activeWorkspaceAuthorization === 'READ'}
+                isPersonal={currentSpace.teamId === state.personalWorkspaceId}
+              />
+            )}
 
             <Menu.Divider />
             {otherWorkspaces.map((space, i) => (


### PR DESCRIPTION
It's not a good long-term fix. I think we shouldn't render the component if we haven't fetched the teams yet.