### PR TITLE
Dispatch 'load' event when execution of JS has finished

### DIFF
--- a/packages/app/src/sandbox/compile.ts
+++ b/packages/app/src/sandbox/compile.ts
@@ -675,6 +675,10 @@ async function compile({
       createCodeSandboxOverlay(modules);
     }
 
+    if (firstLoad) {
+      window.dispatchEvent(new Event('load'));
+    }
+
     debug(`Total time: ${Date.now() - startTime}ms`);
 
     metrics.endMeasure('compilation', { displayName: 'Compilation' });


### PR DESCRIPTION
Possibly fixes #4683

With this change we manually dispatch the `load` event to the window when execution of user code has finished. This should help with code that has `window.addEventListener('load')`, in almost all cases this event won't be triggered normally because we first need to transpile the code.

This solution is far from perfect, because with this change the `load` event is dispatched twice, and if there's code in `<script>` tags they will get the event twice...