### PR TITLE
Accept folders in upload files button

### DIFF
--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/Files/DirectoryEntry/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/Files/DirectoryEntry/index.tsx
@@ -2,6 +2,7 @@ import * as CSSProps from 'styled-components/cssprop'; // eslint-disable-line
 import {
   getChildren as calculateChildren,
   inDirectory,
+  getFiles,
 } from '@codesandbox/common/lib/sandbox/modules';
 import { Directory, Module } from '@codesandbox/common/lib/types';
 import { useOvermind } from 'app/overmind';
@@ -14,34 +15,6 @@ import DirectoryEntryModal from './DirectoryEntryModal';
 import { EntryContainer, Opener, Overlay } from './elements';
 import Entry from './Entry';
 import validateTitle from './validateTitle';
-
-const readDataURL = (file: File): Promise<string | ArrayBuffer> =>
-  new Promise(resolve => {
-    const reader = new FileReader();
-    reader.onload = e => {
-      resolve(e.target.result);
-    };
-    reader.readAsDataURL(file);
-  });
-
-type parsedFiles = { [k: string]: { dataURI: string; type: string } };
-const getFiles = async (files: File[] | FileList): Promise<parsedFiles> => {
-  const returnedFiles = {};
-  await Promise.all(
-    Array.from(files)
-      .filter(Boolean)
-      .map(async file => {
-        const dataURI = await readDataURL(file);
-        // @ts-ignore
-        returnedFiles[file.path || file.name] = {
-          dataURI,
-          type: file.type,
-        };
-      })
-  );
-
-  return returnedFiles;
-};
 
 type ItemTypes = 'module' | 'directory';
 
@@ -222,6 +195,7 @@ const DirectoryEntry: React.FunctionComponent<Props> = ({
     const fileSelector = document.createElement('input');
     fileSelector.setAttribute('type', 'file');
     fileSelector.setAttribute('multiple', 'true');
+    fileSelector.setAttribute('webkitdirectory', '');
     fileSelector.onchange = async event => {
       const target = event.target as HTMLInputElement;
       const files = await getFiles(target.files);

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Explorer/Files/DirectoryEntry/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Explorer/Files/DirectoryEntry/index.tsx
@@ -1,47 +1,20 @@
+import * as CSSProps from 'styled-components/cssprop'; // eslint-disable-line
 import {
   getChildren as calculateChildren,
   inDirectory,
+  getFiles,
 } from '@codesandbox/common/lib/sandbox/modules';
 import { Directory, Module } from '@codesandbox/common/lib/types';
 import { useOvermind } from 'app/overmind';
 import React from 'react';
 import { DropTarget, DropTargetMonitor } from 'react-dnd';
 import { NativeTypes } from 'react-dnd-html5-backend';
-import * as CSSProps from 'styled-components/cssprop'; // eslint-disable-line
 
 import DirectoryChildren from './DirectoryChildren';
 import DirectoryEntryModal from './DirectoryEntryModal';
 import { EntryContainer, Opener, Overlay } from './elements';
 import Entry from './Entry';
 import validateTitle from './validateTitle';
-
-const readDataURL = (file: File): Promise<string | ArrayBuffer> =>
-  new Promise(resolve => {
-    const reader = new FileReader();
-    reader.onload = e => {
-      resolve(e.target.result);
-    };
-    reader.readAsDataURL(file);
-  });
-
-type parsedFiles = { [k: string]: { dataURI: string; type: string } };
-const getFiles = async (files: File[] | FileList): Promise<parsedFiles> => {
-  const returnedFiles = {};
-  await Promise.all(
-    Array.from(files)
-      .filter(Boolean)
-      .map(async file => {
-        const dataURI = await readDataURL(file);
-        // @ts-ignore
-        returnedFiles[file.path || file.name] = {
-          dataURI,
-          type: file.type,
-        };
-      })
-  );
-
-  return returnedFiles;
-};
 
 type ItemTypes = 'module' | 'directory';
 
@@ -241,6 +214,7 @@ const DirectoryEntry: React.FunctionComponent<Props> = ({
     const fileSelector = document.createElement('input');
     fileSelector.setAttribute('type', 'file');
     fileSelector.setAttribute('multiple', 'true');
+    fileSelector.setAttribute('webkitdirectory', '');
     fileSelector.onchange = async event => {
       const target = event.target as HTMLInputElement;
       const files = await getFiles(target.files);

--- a/packages/common/src/sandbox/modules.ts
+++ b/packages/common/src/sandbox/modules.ts
@@ -377,3 +377,33 @@ export const inDirectory = memoize(
   },
   inDirectoryMemoize
 );
+
+const readDataURL = (file: File): Promise<string | ArrayBuffer> =>
+  new Promise(resolve => {
+    const reader = new FileReader();
+    reader.onload = e => {
+      resolve(e.target.result);
+    };
+    reader.readAsDataURL(file);
+  });
+
+type parsedFiles = { [k: string]: { dataURI: string; type: string } };
+export const getFiles = async (
+  files: File[] | FileList
+): Promise<parsedFiles> => {
+  const returnedFiles = {};
+  await Promise.all(
+    Array.from(files)
+      .filter(Boolean)
+      .map(async file => {
+        const dataURI = await readDataURL(file);
+        // @ts-ignore
+        returnedFiles[file.path || file.webkitRelativePath || file.name] = {
+          dataURI,
+          type: file.type,
+        };
+      })
+  );
+
+  return returnedFiles;
+};


### PR DESCRIPTION
This PR makes it so that you can upload whole folders using the "Upload files" buttons on the sidebar using the new https://caniuse.com/#feat=input-file-directory that is supported in most browsers

In others, it just won't let you select a folder


closes #1981