### PR TITLE
fix: input width for port in sandbox config

### DIFF
--- a/packages/common/src/components/Preference/PreferenceNumber.tsx
+++ b/packages/common/src/components/Preference/PreferenceNumber.tsx
@@ -5,6 +5,8 @@ import { Input } from '@codesandbox/components';
 type Props = {
   setValue: (value: number) => void;
   step?: number;
+  max?: number;
+  min?: number;
   value: number;
   style?: React.CSSProperties;
 };
@@ -14,6 +16,8 @@ export const PreferenceNumber: FunctionComponent<Props> = ({
   step,
   style,
   value,
+  max,
+  min,
 }) => {
   const handleChange = ({ target }: ChangeEvent<HTMLInputElement>) => {
     if (!Number.isNaN(+target.value)) {
@@ -28,6 +32,8 @@ export const PreferenceNumber: FunctionComponent<Props> = ({
       style={{ width: '3rem', ...style }}
       type="number"
       value={value}
+      max={max}
+      min={min}
     />
   );
 };

--- a/packages/common/src/components/Preference/index.tsx
+++ b/packages/common/src/components/Preference/index.tsx
@@ -18,6 +18,8 @@ type PreferenceType =
 type PreferenceProps<TString extends PreferenceType> = {
   className?: string;
   style?: React.CSSProperties;
+  innerClassName?: string;
+  innerStyle?: React.CSSProperties;
   title?: string;
   tooltip?: string;
   options?: any[];
@@ -51,22 +53,28 @@ export const Preference: FunctionComponent<Props> = ({
   style,
   title,
   tooltip,
+  innerClassName,
+  innerStyle,
   ...contentProps
 }) => {
   const getContent = () => {
+    const stylingProps = {
+      className: innerClassName,
+      style: innerStyle,
+    };
     switch (
       contentProps.type // need 'type' as discriminant of union type
     ) {
       case 'boolean':
-        return <PreferenceSwitch {...contentProps} />;
+        return <PreferenceSwitch {...stylingProps} {...contentProps} />;
       case 'string':
-        return <PreferenceText {...contentProps} />;
+        return <PreferenceText {...stylingProps} {...contentProps} />;
       case 'dropdown':
-        return <PreferenceDropdown {...contentProps} />;
+        return <PreferenceDropdown {...stylingProps} {...contentProps} />;
       case 'keybinding':
-        return <PreferenceKeybinding {...contentProps} />;
+        return <PreferenceKeybinding {...stylingProps} {...contentProps} />;
       default:
-        return <PreferenceNumber {...contentProps} />;
+        return <PreferenceNumber {...stylingProps} {...contentProps} />;
     }
   };
 

--- a/packages/common/src/templates/configuration/sandbox/ui.tsx
+++ b/packages/common/src/templates/configuration/sandbox/ui.tsx
@@ -149,6 +149,9 @@ export const ConfigWizard = (props: ConfigurationUIProps) => {
           <PaddedPreference
             title="Port"
             type="number"
+            innerStyle={{ width: '5rem' }}
+            min={1024}
+            max={65535}
             {...bindValue(parsedFile, 'container.port')}
           />
           <ConfigDescription>


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?
Enhancement
<!-- Is it a Bug fix, feature, docs update, ... -->

## What is the current behavior?

Currently, the input width is small and we cannot see the full port number. 

https://www.loom.com/share/83c2ac809c5d4903997110bbaec82011
<!-- You can also link to an open issue here -->

## What is the new behavior?
1. Updated the styling props. We do have style prop used in Input but it wasn't passed from parent.

https://www.loom.com/share/4b1eeccaf5f642818c3db1bc07e54bb4
<!-- if this is a feature change -->

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Tested the UI of Sandbox Config and added max and min values to make sure the number is fully visible.

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
