### PR TITLE
fix(embed): tests splitpane resizer position

### DIFF
--- a/packages/app/src/embed/components/SplitPane/elements.js
+++ b/packages/app/src/embed/components/SplitPane/elements.js
@@ -57,6 +57,28 @@ export const Container = styled.div`
     transition: ${props => (props.isDragging ? null : 'width 200ms ease')};
     overflow: hidden;
   }
+
+  /*
+    When previewwindow=tests, SplitPane takes the above styles and the
+    resizer between Test and Test Summary appears vertical. Below styles
+    override the resizer to appear horizontally.
+
+    Note: Better fix will be injecting a custom className to resizer and
+    adding the styles based on className. ( SplitPane doesnt accept className prop )
+  */
+  .Pane .Resizer {
+    width: 100%;
+    height: ${RESIZER_WIDTH}px;
+    cursor: ns-resize;
+  }
+
+  .Pane .Resizer::after {
+    width: 41px;
+    height: ${KNOB_WIDTH}px;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+  }
 `;
 
 export const PaneContainer = styled.div`


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?
Bug Fix
<!-- Is it a Bug fix, feature, docs update, ... -->

## What is the current behavior?
If we select `previewwindow=tests` the splitpane resizer appears vertically.

https://www.loom.com/share/cb108505dfbd4a23bbb1c5343fcc6fec
<!-- You can also link to an open issue here -->

## What is the new behavior?
Make the resizer horizontal. 
https://www.loom.com/share/40e7c5e5d62e488b85fbc3251a2b83fc
<!-- if this is a feature change -->

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Tested embed with previewwindow=tests
2. Tested normal embeds 

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
