### PR TITLE
Fix permissions on personal workspace sandboxes

### DIFF
--- a/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenus/SandboxMenu.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenus/SandboxMenu.tsx
@@ -41,14 +41,16 @@ export const SandboxMenu: React.FC<SandboxMenuProps> = ({
   const label = isTemplate ? 'Template' : 'Sandbox';
   const isPro = user && Boolean(user.subscription);
 
-  const hasAccess = React.useMemo(() => item.sandbox.teamId === activeTeam, [
-    item,
-    activeTeam,
-  ]);
+  // TODO(@CompuIves): remove the `item.sandbox.teamId === null` check, once the server is not
+  // responding with teamId == null for personal templates anymore.
+  const hasAccess = React.useMemo(
+    () => item.sandbox.teamId === activeTeam || item.sandbox.teamId === null,
+    [item, activeTeam]
+  );
 
   const isOwner = React.useMemo(() => {
     if (item.type !== 'template') {
-      return item.sandbox.teamId === activeTeam;
+      return item.sandbox.teamId === activeTeam || item.sandbox.teamId === null;
     }
 
     return (


### PR DESCRIPTION
The server still returns `teamId === null` on sandboxes in a personal workspace for backwards compatibility reasons. That breaks our check on workspace, and makes it seem like the user has no access to the sandbox.

Here we check for `teamId === null` to also make sure that you're an owner. Because the server only responds with `teamId = null` if it's in *your* personal workspace.