### PR TITLE
Respect initialpath in embed "Open Sandbox" link

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "0.1.2",
+  "version": "0.1.1",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/app/src/embed/components/Actions/index.js
+++ b/packages/app/src/embed/components/Actions/index.js
@@ -22,6 +22,7 @@ export function GlobalActions({
   openPreview,
   smallTouchScreen,
   previewVisible,
+  initialPath,
 }) {
   const smallTouchScreenButton = previewVisible ? (
     <Button onClick={openEditor}>View Source</Button>
@@ -70,7 +71,13 @@ export function GlobalActions({
           as="a"
           target="_blank"
           rel="noopener noreferrer"
-          href={`${sandboxUrl(sandbox)}?from-embed`}
+          href={
+            initialPath
+              ? `${sandboxUrl(
+                  sandbox
+                )}?from-embed&initialpath=${encodeURIComponent(initialPath)}`
+              : `${sandboxUrl(sandbox)}?from-embed`
+          }
         >
           Open Sandbox
         </Button>

--- a/packages/app/src/embed/components/Content/index.tsx
+++ b/packages/app/src/embed/components/Content/index.tsx
@@ -408,6 +408,7 @@ export default class Content extends React.PureComponent<Props, State> {
       toggleSidebar,
       toggleLike,
       editorSize,
+      initialPath,
     } = this.props;
 
     const { isInProjectView } = this.state;
@@ -475,7 +476,7 @@ export default class Content extends React.PureComponent<Props, State> {
           url={options.url ? options.url : undefined}
           currentModule={mainModule}
           settings={this.getPreferences()}
-          initialPath={this.props.initialPath}
+          initialPath={initialPath}
           isInProjectView={isInProjectView}
           onClearErrors={this.clearErrors}
           onAction={this.handleAction}
@@ -506,6 +507,7 @@ export default class Content extends React.PureComponent<Props, State> {
           openInNewWindow={this.openInNewWindow}
           toggleLike={toggleLike}
           initialEditorSize={editorSize}
+          initialPath={initialPath}
           setEditorSize={this.setEditorSize}
           hideDevTools={hideDevTools}
           setDragging={this.setDragging}

--- a/packages/app/src/embed/components/SplitPane/index.js
+++ b/packages/app/src/embed/components/SplitPane/index.js
@@ -16,6 +16,7 @@ export default function SplitView({
   sandbox,
   toggleLike,
   initialEditorSize = 50, // in percent
+  initialPath,
   hideDevTools,
   setEditorSize,
   setDragging: setDraggingProp,
@@ -141,6 +142,7 @@ export default function SplitView({
         openEditor={openEditor}
         openPreview={openPreview}
         smallTouchScreen={smallTouchScreen}
+        initialPath={initialPath}
       />
       <SplitPane
         split="vertical"


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?

<!-- Is it a Bug fix, feature, docs update, ... -->
Bug fix #4924

## What is the current behavior?

Open Sandbox link does not respect initialpath and always loads the preview on the base path, even though the person is seeing the initialpath one.

![Screenshot 2020-09-24 at 00 18 39](https://user-images.githubusercontent.com/760314/94040330-63ba6500-fdfb-11ea-86d1-6ddc47e577fe.png)

## What is the new behavior?

initialpath param is added (if present) to the Open Sandbox link so it opens on the correct page

<!-- if this is a feature change -->

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Step A
Ran `yarn start` and tested with and without initialpath changed by the user
![Screenshot 2020-09-23 at 23 09 23](https://user-images.githubusercontent.com/760314/94039762-b21b3400-fdfa-11ea-99a2-2861d8ac946f.png)

2. Step B
3. Step C

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
