### PR TITLE
fix(dependencies): show latest version on Dependency

### DIFF
--- a/packages/app/src/app/pages/Sandbox/SearchDependencies/Dependency.tsx
+++ b/packages/app/src/app/pages/Sandbox/SearchDependencies/Dependency.tsx
@@ -84,7 +84,8 @@ export const Dependency = ({ dependency }: { dependency: DependencyType }) => {
     actions,
   } = useOvermind();
 
-  const selectedVersion = hitToVersionMap[dependency.objectID];
+  const selectedVersion =
+    hitToVersionMap[dependency.objectID] || dependency.tags.latest;
 
   const versions = Object.keys(dependency.versions).sort((a, b) => {
     try {


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?
Bug fix
<!-- Is it a Bug fix, feature, docs update, ... -->

## What is the current behavior?
We have sorted versions in version selector which by defaults shows the newest release [ first value ] in most cases. But when we select and add the dependency we push the latest tag in API. Check line here: https://github.com/codesandbox/codesandbox-client/blob/master/packages/app/src/app/pages/Sandbox/SearchDependencies/index.tsx#L20

https://www.loom.com/share/fc794bba8ee2403c8cde304c806fdc23
<!-- You can also link to an open issue here -->

## What is the new behavior?
Show the latest version for the dependency by default. 
https://www.loom.com/share/bc0500fa4507436da06e7698634974fd

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Testing <!-- We can only merge the PR if this is checked -->
- [ ] Ready to be merged - Requires review on the new behavior

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->

Is there any easy way to debug or visualize overmind state?  I am usually checking through hooks context value which becomes difficult to check all values in the nested object. Thanks 👋 