### PR TITLE
Fix Tests on Firefox

### DIFF
--- a/standalone-packages/browser-jsdom/index.js
+++ b/standalone-packages/browser-jsdom/index.js
@@ -10,4 +10,10 @@ const jsdomloc = path.resolve(path.join('./node_modules/jsdom', jsdompkg.main));
 const outLoc = `out/jsdom-${jsdompkg.version}.js`;
 const outMinLoc = `out/jsdom-${jsdompkg.version}.min.js`;
 cp.execSync(`node_modules/.bin/browserify -s JSDOM ${jsdomloc} > ${outLoc}`);
+
+// this changes the necessary code for tests to work on Firefox since SharedArrayBuffer is not supported as a choice on Firefox
+
+const file = fs.readFileSync(outLoc).toString().replace(`Object.getOwnPropertyDescriptor(SharedArrayBuffer.prototype, "byteLength").get`, `window.SharedArrayBuffer ? Object.getOwnPropertyDescriptor(SharedArrayBuffer.prototype, "byteLength").get :null;`)
+fs.writeFileSync(outLoc, file)
+
 cp.execSync(`node_modules/.bin/terser ${outLoc} > ${outMinLoc}`);


### PR DESCRIPTION
You don't wanna know how deep I had to go

Updating it JSDom does not fix it because its a dependency that uses it and that dependency is supposed to run in node

closes #4303

Example
https://pr4935.build.csb.dev/s/n9m2w9q8x0?file=/index.test.js