### PR TITLE
Fix moving tab to top in devtools

### DIFF
--- a/packages/app/src/app/components/Preview/DevTools/Tabs/index.tsx
+++ b/packages/app/src/app/components/Preview/DevTools/Tabs/index.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import Tooltip from '@codesandbox/common/lib/components/Tooltip';
 import { ViewTab } from '@codesandbox/common/lib/templates/template';
 import { DevToolsTabPosition } from '@codesandbox/common/lib/types';
+import track from '@codesandbox/common/lib/utils/analytics';
 
 import { Status, IViews } from '..';
 import { Actions, Container, Tabs } from './elements';
@@ -72,7 +73,14 @@ export const DevToolTabs = ({
                 setPane(i);
               }}
               devToolIndex={devToolIndex}
-              moveTab={moveTab}
+              moveTab={(prevPos, newPos) => {
+                if (moveTab) {
+                  track('DevTools - Move Pane', {
+                    pane: view.id,
+                  });
+                  moveTab(prevPos, newPos);
+                }
+              }}
               closeTab={
                 pane.closeable && panes.length !== 1 ? closeTab : undefined
               }

--- a/packages/app/src/app/components/Preview/DevTools/index.tsx
+++ b/packages/app/src/app/components/Preview/DevTools/index.tsx
@@ -531,17 +531,7 @@ export class DevTools extends React.PureComponent<Props, State> {
               setPane={this.setPane}
               devToolIndex={devToolIndex}
               status={this.state.status}
-              moveTab={
-                this.props.moveTab
-                  ? (prevPos, nextPos) => {
-                      track('DevTools - Move Pane', {
-                        pane: this.props.viewConfig.views[prevPos.tabPosition]
-                          .id,
-                      });
-                      this.props.moveTab(prevPos, nextPos);
-                    }
-                  : undefined
-              }
+              moveTab={this.props.moveTab}
               closeTab={this.props.closeTab}
             />
 


### PR DESCRIPTION
It was impossible to move bottom devtools to the top part, because of an undefined value in track. This fixes that by moving the track to where we know view is defined.

Tested moving tabs from top to bottom, other way around and in same row.