### PR TITLE
Fix encoding on json files

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -20,7 +20,6 @@
     "react/jsx-filename-extension": 0,
     "react/sort-comp": 0,
     "react/destructuring-assignment": 0,
-    "react/jsx-no-useless-fragment": "warn",
     "react/state-in-constructor": 0,
     "react/jsx-props-no-spreading": 0,
     "react/static-property-placement": 0,

--- a/.eslintrc
+++ b/.eslintrc
@@ -20,6 +20,7 @@
     "react/jsx-filename-extension": 0,
     "react/sort-comp": 0,
     "react/destructuring-assignment": 0,
+    "react/jsx-no-useless-fragment": "warn",
     "react/state-in-constructor": 0,
     "react/jsx-props-no-spreading": 0,
     "react/static-property-placement": 0,


### PR DESCRIPTION

Right now when you upload a json file with emojis or any other non-utf-8 characters it shows gibberish

This fixes that by using atob in a different way

closes #1248