### PR TITLE
Fix default extensions for sandpack (prefer mjs)

### DIFF
--- a/packages/app/src/sandbox/eval/presets/create-react-app/v3.ts
+++ b/packages/app/src/sandbox/eval/presets/create-react-app/v3.ts
@@ -122,7 +122,19 @@ export default function initialize() {
   let refreshInitialized = false;
   const preset = new Preset(
     'create-react-app',
-    ['web.js', 'js', 'json', 'web.jsx', 'jsx', 'ts', 'tsx', 'mjs'],
+    [
+      'web.mjs',
+      'mjs',
+      'web.js',
+      'js',
+      'web.ts',
+      'ts',
+      'web.tsx',
+      'tsx',
+      'json',
+      'web.jsx',
+      'jsx',
+    ],
     aliases,
     {
       hasDotEnv: true,

--- a/packages/sandpack-core/src/manager.ts
+++ b/packages/sandpack-core/src/manager.ts
@@ -772,10 +772,6 @@ export default class Manager implements IEvaluator {
     currentPath: string,
     defaultExtensions: Array<string> = DEFAULT_EXTENSIONS
   ): Module {
-    if (path === 'graphql/type/definition') {
-      debugger;
-    }
-
     const dirredPath = pathUtils.dirname(currentPath);
     if (this.cachedPaths[dirredPath] === undefined) {
       this.cachedPaths[dirredPath] = {};

--- a/packages/sandpack-core/src/manager.ts
+++ b/packages/sandpack-core/src/manager.ts
@@ -38,6 +38,7 @@ import { splitQueryFromPath } from './transpiled-module/utils/query-path';
 import { IEvaluator } from './evaluator';
 import { setContributedProtocols } from './npm/dynamic/fetch-protocols';
 import { FileFetcher } from './npm/dynamic/fetch-protocols/file';
+import { DEFAULT_EXTENSIONS } from './utils/extensions';
 
 declare const BrowserFS: any;
 
@@ -769,8 +770,12 @@ export default class Manager implements IEvaluator {
   resolveModule(
     path: string,
     currentPath: string,
-    defaultExtensions: Array<string> = ['js', 'jsx', 'json', 'mjs']
+    defaultExtensions: Array<string> = DEFAULT_EXTENSIONS
   ): Module {
+    if (path === 'graphql/type/definition') {
+      debugger;
+    }
+
     const dirredPath = pathUtils.dirname(currentPath);
     if (this.cachedPaths[dirredPath] === undefined) {
       this.cachedPaths[dirredPath] = {};

--- a/packages/sandpack-core/src/npm/dynamic/fetch-npm-module.ts
+++ b/packages/sandpack-core/src/npm/dynamic/fetch-npm-module.ts
@@ -248,7 +248,7 @@ type DependencyVersionResult =
 async function getDependencyVersion(
   currentTModule: TranspiledModule,
   manager: Manager,
-  defaultExtensions: string[] = DEFAULT_EXTENSIONS
+  defaultExtensions: string[] = DEFAULT_EXTENSIONS,
   dependencyName: string
 ): Promise<DependencyVersionResult | null> {
   const { manifest } = manager;

--- a/packages/sandpack-core/src/npm/dynamic/fetch-npm-module.ts
+++ b/packages/sandpack-core/src/npm/dynamic/fetch-npm-module.ts
@@ -9,6 +9,7 @@ import { getFetchProtocol } from './fetch-protocols';
 import { getDependencyName } from '../../utils/get-dependency-name';
 import { packageFilter } from '../../utils/resolve-utils';
 import { TranspiledModule } from '../../transpiled-module';
+import { DEFAULT_EXTENSIONS } from '../../utils/extensions';
 
 export type Meta = {
   [path: string]: true;
@@ -128,7 +129,7 @@ function resolvePath(
   path: string,
   currentTModule: TranspiledModule,
   manager: Manager,
-  defaultExtensions: Array<string> = ['js', 'jsx', 'json', 'mjs'],
+  defaultExtensions: Array<string> = DEFAULT_EXTENSIONS,
   meta: Meta = {}
 ): Promise<string> {
   const currentPath = currentTModule.module.path;
@@ -247,7 +248,7 @@ type DependencyVersionResult =
 async function getDependencyVersion(
   currentTModule: TranspiledModule,
   manager: Manager,
-  defaultExtensions: string[] = ['js', 'jsx', 'json', 'mjs'],
+  defaultExtensions: string[] = DEFAULT_EXTENSIONS
   dependencyName: string
 ): Promise<DependencyVersionResult | null> {
   const { manifest } = manager;
@@ -337,7 +338,7 @@ export default async function fetchModule(
   path: string,
   currentTModule: TranspiledModule,
   manager: Manager,
-  defaultExtensions: Array<string> = ['js', 'jsx', 'json', 'mjs']
+  defaultExtensions: Array<string> = DEFAULT_EXTENSIONS
 ): Promise<Module> {
   const currentPath = currentTModule.module.path;
   // Get the last part of the path as dependency name for paths like

--- a/packages/sandpack-core/src/utils/extensions.ts
+++ b/packages/sandpack-core/src/utils/extensions.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_EXTENSIONS = ['mjs', 'js', 'jsx', 'json'];


### PR DESCRIPTION
We should prefer `mjs` over `js`. This changes that.

Fixes #4958