### PR TITLE
Keep imports below converted exports

### DIFF
--- a/packages/app/src/sandbox/eval/transpilers/babel/convert-esmodule/__snapshots__/index.test.ts.snap
+++ b/packages/app/src/sandbox/eval/transpilers/babel/convert-esmodule/__snapshots__/index.test.ts.snap
@@ -644,6 +644,59 @@ function a() {
 "
 `;
 
+exports[`convert-esmodule retains the order of re-exports 1`] = `
+"\\"use strict\\";
+Object.defineProperty(exports, \\"data\\", {
+  enumerable: true,
+  configurable: true,
+  get: function $csbGet() {
+    return data;
+  }
+});
+Object.defineProperty(exports, \\"__esModule\\", {
+  value: true
+});
+var $csb__tfjscore = require(\\"@tensorflow/tfjs-core\\");
+Object.keys($csb__tfjscore).forEach(function (key) {
+  if (key === \\"default\\" || key === \\"__esModule\\") return;
+  if (Object.prototype.hasOwnProperty.call(exports, key)) return;
+  Object.defineProperty(exports, key, {
+    enumerable: true,
+    configurable: true,
+    get: function $csbGet() {
+      return $csb__tfjscore[key];
+    }
+  });
+});
+var $csb__tfjsdata = require(\\"@tensorflow/tfjs-data\\");
+var data = $csb__tfjsdata;
+var $csb__tfjslayers = require(\\"@tensorflow/tfjs-layers\\");
+Object.keys($csb__tfjslayers).forEach(function (key) {
+  if (key === \\"default\\" || key === \\"__esModule\\") return;
+  if (Object.prototype.hasOwnProperty.call(exports, key)) return;
+  Object.defineProperty(exports, key, {
+    enumerable: true,
+    configurable: true,
+    get: function $csbGet() {
+      return $csb__tfjslayers[key];
+    }
+  });
+});
+var $csb__tfjsconverter = require(\\"@tensorflow/tfjs-converter\\");
+Object.keys($csb__tfjsconverter).forEach(function (key) {
+  if (key === \\"default\\" || key === \\"__esModule\\") return;
+  if (Object.prototype.hasOwnProperty.call(exports, key)) return;
+  Object.defineProperty(exports, key, {
+    enumerable: true,
+    configurable: true,
+    get: function $csbGet() {
+      return $csb__tfjsconverter[key];
+    }
+  });
+});
+"
+`;
+
 exports[`convert-esmodule works with variables that are named exports 1`] = `
 "\\"use strict\\";
 Object.defineProperty(exports, \\"__esModule\\", {

--- a/packages/app/src/sandbox/eval/transpilers/babel/convert-esmodule/__snapshots__/index.test.ts.snap
+++ b/packages/app/src/sandbox/eval/transpilers/babel/convert-esmodule/__snapshots__/index.test.ts.snap
@@ -33,6 +33,39 @@ function $_csb__interopRequireDefault(obj) {
 "
 `;
 
+exports[`convert-esmodule can convert exports containing overlapping exports 1`] = `
+"\\"use strict\\";
+Object.defineProperty(exports, \\"__esModule\\", {
+  value: true
+});
+var $csb__some = require(\\"./some.js\\");
+Object.defineProperty(exports, \\"some\\", {
+  enumerable: true,
+  configurable: true,
+  get: function $csbGet() {
+    return $csb__some_.default;
+  }
+});
+var $csb__some_ = $_csb__interopRequireDefault(require(\\"./some.js\\"));
+Object.keys($csb__some).forEach(function (key) {
+  if (key === \\"default\\" || key === \\"__esModule\\") return;
+  if (Object.prototype.hasOwnProperty.call(exports, key)) return;
+  Object.defineProperty(exports, key, {
+    enumerable: true,
+    configurable: true,
+    get: function $csbGet() {
+      return $csb__some[key];
+    }
+  });
+});
+function $_csb__interopRequireDefault(obj) {
+  return obj && obj.__esModule ? obj : {
+    default: obj
+  };
+}
+"
+`;
+
 exports[`convert-esmodule can convert function exports 1`] = `
 "\\"use strict\\";
 Object.defineProperty(exports, \\"__esModule\\", {
@@ -98,39 +131,6 @@ Object.defineProperty(exports, \\"test2\\", {
     return $csb__store.test2;
   }
 });
-"
-`;
-
-exports[`convert-esmodule can convert normal exports 2`] = `
-"\\"use strict\\";
-Object.defineProperty(exports, \\"__esModule\\", {
-  value: true
-});
-var $csb__some = require(\\"./some.js\\");
-Object.keys($csb__some).forEach(function (key) {
-  if (key === \\"default\\" || key === \\"__esModule\\") return;
-  if (Object.prototype.hasOwnProperty.call(exports, key)) return;
-  Object.defineProperty(exports, key, {
-    enumerable: true,
-    configurable: true,
-    get: function $csbGet() {
-      return $csb__some[key];
-    }
-  });
-});
-var $csb__some_ = $_csb__interopRequireDefault(require(\\"./some.js\\"));
-Object.defineProperty(exports, \\"some\\", {
-  enumerable: true,
-  configurable: true,
-  get: function $csbGet() {
-    return $csb__some_.default;
-  }
-});
-function $_csb__interopRequireDefault(obj) {
-  return obj && obj.__esModule ? obj : {
-    default: obj
-  };
-}
 "
 `;
 
@@ -278,6 +278,28 @@ Object.keys($csb__data_grid_types).forEach(function (key) {
 "
 `;
 
+exports[`convert-esmodule doesn't hoist single import above export 1`] = `
+"\\"use strict\\";
+Object.defineProperty(exports, \\"__esModule\\", {
+  value: true
+});
+var $csb__tfjscore = require(\\"@tensorflow/tfjs-core\\");
+var $csb__tfjsdata = require(\\"@tensorflow/tfjs-data\\");
+var data = $csb__tfjsdata;
+Object.keys($csb__tfjscore).forEach(function (key) {
+  if (key === \\"default\\" || key === \\"__esModule\\") return;
+  if (Object.prototype.hasOwnProperty.call(exports, key)) return;
+  Object.defineProperty(exports, key, {
+    enumerable: true,
+    configurable: true,
+    get: function $csbGet() {
+      return $csb__tfjscore[key];
+    }
+  });
+});
+"
+`;
+
 exports[`convert-esmodule doesn't remove object initializers 1`] = `
 "\\"use strict\\";
 var $csb__shared = require(\\"@react-spring/shared\\");
@@ -342,6 +364,7 @@ Object.defineProperty(exports, \\"__esModule\\", {
 });
 var $csb__testlibdom = require(\\"test-lib-dom\\");
 var $csb__testlibdom_ = require(\\"test-lib-dom\\");
+var a = () => (0, $csb__testlibdom.a);
 Object.keys($csb__testlibdom_).forEach(function (key) {
   if (key === \\"default\\" || key === \\"__esModule\\") return;
   if (Object.prototype.hasOwnProperty.call(exports, key)) return;
@@ -353,7 +376,6 @@ Object.keys($csb__testlibdom_).forEach(function (key) {
     }
   });
 });
-var a = () => (0, $csb__testlibdom.a);
 "
 `;
 
@@ -362,7 +384,6 @@ exports[`convert-esmodule handles default as exports 1`] = `
 Object.defineProperty(exports, \\"__esModule\\", {
   value: true
 });
-var $csb__Field = $_csb__interopRequireDefault(require(\\"./Field\\"));
 Object.defineProperty(exports, \\"Field\\", {
   enumerable: true,
   configurable: true,
@@ -370,6 +391,7 @@ Object.defineProperty(exports, \\"Field\\", {
     return $csb__Field.default;
   }
 });
+var $csb__Field = $_csb__interopRequireDefault(require(\\"./Field\\"));
 function $_csb__interopRequireDefault(obj) {
   return obj && obj.__esModule ? obj : {
     default: obj
@@ -469,10 +491,10 @@ Object.defineProperty(exports, \\"__esModule\\", {
 
 exports[`convert-esmodule handles import statement after default export 1`] = `
 "\\"use strict\\";
-var $csb__types = require(\\"./types\\");
 Object.defineProperty(exports, \\"__esModule\\", {
   value: true
 });
+var $csb__types = require(\\"./types\\");
 function defaultOverscanIndicesGetter(_ref) {}
 exports.default = defaultOverscanIndicesGetter;
 "
@@ -598,6 +620,58 @@ const c = 'test';
 "
 `;
 
+exports[`convert-esmodule hoists exports as well 1`] = `
+"\\"use strict\\";
+Object.defineProperty(exports, \\"__esModule\\", {
+  value: true
+});
+var $csb__a = require(\\"./a\\");
+Object.defineProperty(exports, \\"c\\", {
+  enumerable: true,
+  configurable: true,
+  get: function $csbGet() {
+    return $csb__a.c;
+  }
+});
+var $csb__b = require(\\"./b\\");
+Object.defineProperty(exports, \\"data\\", {
+  enumerable: true,
+  configurable: true,
+  get: function $csbGet() {
+    return $csb__b;
+  }
+});
+function a() {
+  return 5;
+}
+"
+`;
+
+exports[`convert-esmodule hoists function exports 1`] = `
+"\\"use strict\\";
+Object.defineProperty(exports, \\"__esModule\\", {
+  value: true
+});
+exports.test3 = test3;
+var $csb__store = require(\\"./test/store.js\\");
+Object.defineProperty(exports, \\"test\\", {
+  enumerable: true,
+  configurable: true,
+  get: function $csbGet() {
+    return $csb__store.test;
+  }
+});
+Object.defineProperty(exports, \\"test2\\", {
+  enumerable: true,
+  configurable: true,
+  get: function $csbGet() {
+    return $csb__store.test2;
+  }
+});
+function test3() {}
+"
+`;
+
 exports[`convert-esmodule hoists imports at bottom 1`] = `
 "\\"use strict\\";
 var $csb__proptypes = require(\\"prop-types\\");
@@ -657,6 +731,12 @@ Object.defineProperty(exports, \\"__esModule\\", {
   value: true
 });
 var $csb__tfjscore = require(\\"@tensorflow/tfjs-core\\");
+var $csb__tfjstest = require(\\"@tensorflow/tfjs-test\\");
+var data2 = $csb__tfjstest;
+var $csb__tfjslayers = require(\\"@tensorflow/tfjs-layers\\");
+var $csb__tfjsconverter = require(\\"@tensorflow/tfjs-converter\\");
+var $csb__tfjsdata = require(\\"@tensorflow/tfjs-data\\");
+var data = $csb__tfjsdata;
 Object.keys($csb__tfjscore).forEach(function (key) {
   if (key === \\"default\\" || key === \\"__esModule\\") return;
   if (Object.prototype.hasOwnProperty.call(exports, key)) return;
@@ -668,9 +748,6 @@ Object.keys($csb__tfjscore).forEach(function (key) {
     }
   });
 });
-var $csb__tfjsdata = require(\\"@tensorflow/tfjs-data\\");
-var data = $csb__tfjsdata;
-var $csb__tfjslayers = require(\\"@tensorflow/tfjs-layers\\");
 Object.keys($csb__tfjslayers).forEach(function (key) {
   if (key === \\"default\\" || key === \\"__esModule\\") return;
   if (Object.prototype.hasOwnProperty.call(exports, key)) return;
@@ -682,7 +759,6 @@ Object.keys($csb__tfjslayers).forEach(function (key) {
     }
   });
 });
-var $csb__tfjsconverter = require(\\"@tensorflow/tfjs-converter\\");
 Object.keys($csb__tfjsconverter).forEach(function (key) {
   if (key === \\"default\\" || key === \\"__esModule\\") return;
   if (Object.prototype.hasOwnProperty.call(exports, key)) return;

--- a/packages/app/src/sandbox/eval/transpilers/babel/convert-esmodule/index.test.ts
+++ b/packages/app/src/sandbox/eval/transpilers/babel/convert-esmodule/index.test.ts
@@ -401,7 +401,7 @@ describe('convert-esmodule', () => {
     expect(convertEsModule(code)).toMatchSnapshot();
   });
 
-  it('can convert normal exports', () => {
+  it('can convert exports containing overlapping exports', () => {
     const code = `
       export * from './some.js';
       export { default as some } from './some.js';
@@ -432,6 +432,7 @@ describe('convert-esmodule', () => {
   it('retains the order of re-exports', () => {
     const code = `
     export * from '@tensorflow/tfjs-core';
+    import * as data2 from '@tensorflow/tfjs-test';
     export * from '@tensorflow/tfjs-layers';
     export * from '@tensorflow/tfjs-converter';
     // Export data api as tf.data
@@ -447,6 +448,64 @@ describe('convert-esmodule', () => {
     expect(result.indexOf('tfjs-core')).toBeLessThan(
       result.indexOf('tfjs-layers')
     );
+  });
+
+  it("doesn't hoist single import above export", () => {
+    const code = `
+    export * from '@tensorflow/tfjs-core';
+    import * as data from '@tensorflow/tfjs-data';
+    `;
+
+    const result = convertEsModule(code);
+    expect(result).toMatchSnapshot();
+    expect(result.indexOf('tfjs-core')).toBeLessThan(
+      result.indexOf('tfjs-data')
+    );
+  });
+
+  it('keeps function under hoisted import', () => {
+    const code = `
+    function a() {
+      return data.test
+    }
+    export * from '@tensorflow/tfjs-core';
+    import * as data from '@tensorflow/tfjs-data';
+    `;
+
+    const result = convertEsModule(code);
+    expect(result.indexOf('function a')).toBeGreaterThan(
+      result.indexOf('tfjs-data')
+    );
+    expect(result.indexOf('tfjs-core')).toBeLessThan(
+      result.indexOf('tfjs-data')
+    );
+  });
+
+  it('hoists exports as well', () => {
+    const code = `
+      function a() {
+        return 5;
+      }
+
+      export { c } from './a';
+      export * as data from './b';
+    `;
+    const result = convertEsModule(code);
+    expect(result).toMatchSnapshot();
+    expect(result.indexOf('function a')).toBeGreaterThan(result.indexOf('./a'));
+    expect(result.indexOf('function a')).toBeGreaterThan(result.indexOf('./b'));
+  });
+
+  it('hoists function exports', () => {
+    const code = `
+    export { test, test2 } from './test/store.js';
+
+export function test3() {
+}
+    `;
+
+    const result = convertEsModule(code);
+    expect(result).toMatchSnapshot();
   });
 
   describe('syntax info', () => {

--- a/packages/app/src/sandbox/eval/transpilers/babel/convert-esmodule/index.test.ts
+++ b/packages/app/src/sandbox/eval/transpilers/babel/convert-esmodule/index.test.ts
@@ -429,6 +429,26 @@ describe('convert-esmodule', () => {
     expect(convertEsModule(code)).toMatchSnapshot();
   });
 
+  it('retains the order of re-exports', () => {
+    const code = `
+    export * from '@tensorflow/tfjs-core';
+    export * from '@tensorflow/tfjs-layers';
+    export * from '@tensorflow/tfjs-converter';
+    // Export data api as tf.data
+    import * as data from '@tensorflow/tfjs-data';
+    export { data };
+    `;
+
+    const result = convertEsModule(code);
+    expect(result).toMatchSnapshot();
+    expect(result.indexOf('tfjs-core')).toBeLessThan(
+      result.indexOf('tfjs-data')
+    );
+    expect(result.indexOf('tfjs-core')).toBeLessThan(
+      result.indexOf('tfjs-layers')
+    );
+  });
+
   describe('syntax info', () => {
     it('can detect jsx', () => {
       const code = `const a = <div>Hello</div>`;

--- a/packages/app/src/sandbox/eval/transpilers/babel/convert-esmodule/index.ts
+++ b/packages/app/src/sandbox/eval/transpilers/babel/convert-esmodule/index.ts
@@ -104,6 +104,8 @@ export function convertEsModule(
     const statement = program.body[i];
 
     if (statement.type === n.ExportAllDeclaration) {
+      importOffset++;
+
       // export * from './test';
       // TO:
       // const _csb = require('./test');
@@ -124,6 +126,8 @@ export function convertEsModule(
       i++;
       program.body.splice(i, 0, generateAllExportsIterator(varName));
     } else if (statement.type === n.ExportNamedDeclaration) {
+      importOffset++;
+
       // export { a } from './test';
       // TO:
       // const _csb = require('./test');

--- a/packages/app/src/sandbox/eval/transpilers/babel/convert-esmodule/index.ts
+++ b/packages/app/src/sandbox/eval/transpilers/babel/convert-esmodule/index.ts
@@ -78,19 +78,6 @@ export function convertEsModule(
     program.body.push(generateInteropRequire());
   }
 
-  /**
-   * We want wildcard exports to be at the end, to allow for definition of other exports
-   * first. It sounds strange, but there are cases like
-   * ```
-   * export function a() {}
-   * export * from './a';
-   * ```
-   *
-   * In that case the export from `./a` shouldn't override export `a`. That's why we set up
-   * a queue that we process at the end, to make sure that other exports go first.
-   */
-  const wildCardExportQueue: Statement[] = [];
-
   // If there is a declaration of `exports` (`var exports = []`), we need to rename this
   // variable as it's a reserved keyword
   let exportsDefined = false;
@@ -473,11 +460,6 @@ export function convertEsModule(
       });
     }
   }
-
-  wildCardExportQueue.forEach(statement => {
-    program.body.splice(importOffset, 0, statement);
-    importOffset++;
-  });
 
   if (
     Object.keys(varsToRename).length > 0 ||

--- a/packages/app/src/sandbox/eval/transpilers/babel/convert-esmodule/syntax.ts
+++ b/packages/app/src/sandbox/eval/transpilers/babel/convert-esmodule/syntax.ts
@@ -67,4 +67,5 @@ export const Syntax = {
   WithStatement: 'WithStatement' as 'WithStatement',
   YieldExpression: 'YieldExpression' as 'YieldExpression',
   JSXElement: 'JSXElement' as 'JSXElement',
+  ExportNamespaceSpecifier: 'ExportNamespaceSpecifier' as 'ExportNamespaceSpecifier',
 };


### PR DESCRIPTION
We hoist imports to the top, as that is how imports are treated. However, imports need to be below exports that are defined above them, this makes sure that happens.

Fixes https://github.com/tensorflow/tfjs/issues/3889