### PR TITLE
Avoid stale collections in Move Sandbox modal

### DIFF
--- a/packages/app/src/app/pages/common/Modals/MoveSandboxFolderModal/DirectoryPicker/SandboxesItem/index.tsx
+++ b/packages/app/src/app/pages/common/Modals/MoveSandboxFolderModal/DirectoryPicker/SandboxesItem/index.tsx
@@ -56,7 +56,11 @@ class SandboxesItemComponent extends React.Component<
 
     return connectDropTarget(
       <div>
-        <Query variables={{ teamId }} query={PATHED_SANDBOXES_FOLDER_QUERY}>
+        <Query
+          variables={{ teamId }}
+          query={PATHED_SANDBOXES_FOLDER_QUERY}
+          fetchPolicy="network-only"
+        >
           {result => {
             if (result.loading) {
               return (


### PR DESCRIPTION
The "Move Sandbox" model fetches collections (folders) for itself and caches that with the help of `Query from react-apollo`.

Problem: While using the dashboard, if you open the move modal through the context menu, it caches the collections at that point (in react-apollo's copy).

This means that when collections are updated in the dashboard (added or deleted in overmind state), it doesn't reflect in the move modal. The 2 states are out of sync and you see folders missing/or undeleted (as reported by @linqcan)

Ideal fix: Refactor Move modal from class component + react-apollo to hooks and overmind.

Hot/short fix (this one): Disable caching of collections in the Move modal using `fetchPolicy=network-only`. This means the Move modal always has the latest state of collections at the cost of an additional network request.

For most use cases, you will only pay the cost of the network request if you are organising collections and sandboxes and open the move modal multiple times. For single use, there is no difference compared to production right now.