### PR TITLE
fix optional chaining eslint

### DIFF
--- a/packages/app/src/app/overmind/effects/vscode/LinterWorker/index.js
+++ b/packages/app/src/app/overmind/effects/vscode/LinterWorker/index.js
@@ -368,7 +368,7 @@ const TYPESCRIPT_PARSER_OPTIONS = {
     '@typescript-eslint/no-useless-constructor': 'warn',
     // Fixes optional chaining
     'no-unused-expressions': 'off',
-    '@typescript-eslint/no-unused-expressions': 'error',
+    '@typescript-eslint/no-unused-expressions': 'warn',
   },
 };
 

--- a/packages/app/src/app/overmind/effects/vscode/LinterWorker/index.js
+++ b/packages/app/src/app/overmind/effects/vscode/LinterWorker/index.js
@@ -366,6 +366,9 @@ const TYPESCRIPT_PARSER_OPTIONS = {
     ],
     'no-useless-constructor': 'off',
     '@typescript-eslint/no-useless-constructor': 'warn',
+    // Fixes optional chaining
+    'no-unused-expressions': 'off',
+    '@typescript-eslint/no-unused-expressions': 'error',
   },
 };
 


### PR DESCRIPTION
Fixes issue with typescript and optional chaining: https://www.karltarvas.com/2020/04/07/typescript-no-unused-expressions.html