### PR TITLE
Vue router fix

### DIFF
--- a/packages/app/src/app/overmind/effects/vscode/LinterWorker/index.js
+++ b/packages/app/src/app/overmind/effects/vscode/LinterWorker/index.js
@@ -71,6 +71,8 @@ const allRules = {
     .default,
   '@typescript-eslint/no-useless-constructor': require('@typescript-eslint/eslint-plugin/dist/rules/no-useless-constructor')
     .default,
+  '@typescript-eslint/no-unused-expressions': require('@typescript-eslint/eslint-plugin/dist/rules/no-unused-expressions')
+    .default,
 };
 /* eslint-enable global-require */
 

--- a/packages/sandbox-hooks/url-listeners.js
+++ b/packages/sandbox-hooks/url-listeners.js
@@ -25,11 +25,6 @@ function pathWithHash(location) {
   return `${location.pathname}${location.hash}`;
 }
 
-function isInsideVue(el) {
-  if (el === document.body) return false;
-  return el.__vue__ || el._vnode || isInsideVue(el.parentElement);
-}
-
 export default function setupHistoryListeners() {
   function handleMessage(data, source) {
     if (source) {
@@ -52,14 +47,11 @@ export default function setupHistoryListeners() {
         origHistoryProto.replaceState.call(window.history, state, '', url);
         const newURL = document.location.href;
         sendUrlChange(newURL);
-        if (newURL.indexOf('#') === -1) {
-          window.dispatchEvent(new PopStateEvent('popstate', { state }));
-        } else {
-          disableNextHashChange = true;
-          window.dispatchEvent(
-            new HashChangeEvent('hashchange', { oldURL, newURL })
-          );
-        }
+        window.dispatchEvent(new PopStateEvent('popstate', { state }));
+        disableNextHashChange = true;
+        window.dispatchEvent(
+          new HashChangeEvent('hashchange', { oldURL, newURL })
+        );
       }
     },
 
@@ -107,34 +99,6 @@ export default function setupHistoryListeners() {
       disableNextHashChange = false;
     }
   });
-
-  document.addEventListener(
-    'click',
-    ev => {
-      const el = ev.target;
-      if (
-        el.nodeName === 'A' &&
-        !isInsideVue(el) && // workaround for vue-router <router-link>
-        el.href.indexOf('#') !== -1 &&
-        el.href.substr(-1) !== '#'
-      ) {
-        const url = el.href;
-        const oldURL = document.location.href;
-        origHistoryProto.replaceState.call(window.history, null, '', url);
-        const newURL = document.location.href;
-        if (oldURL !== newURL) {
-          disableNextHashChange = true;
-          window.dispatchEvent(
-            new HashChangeEvent('hashchange', { oldURL, newURL })
-          );
-          pushHistory(pathWithHash(document.location), null);
-          sendUrlChange(document.location.href);
-        }
-        ev.preventDefault();
-      }
-    },
-    true
-  );
 
   pushHistory(pathWithHash(document.location), null);
 

--- a/packages/sandbox-hooks/url-listeners.js
+++ b/packages/sandbox-hooks/url-listeners.js
@@ -48,10 +48,12 @@ export default function setupHistoryListeners() {
         const newURL = document.location.href;
         sendUrlChange(newURL);
         window.dispatchEvent(new PopStateEvent('popstate', { state }));
-        disableNextHashChange = true;
-        window.dispatchEvent(
-          new HashChangeEvent('hashchange', { oldURL, newURL })
-        );
+        if (newURL.indexOf('#') !== -1) {
+          disableNextHashChange = true;
+          window.dispatchEvent(
+            new HashChangeEvent('hashchange', { oldURL, newURL })
+          );
+        }
       }
     },
 


### PR DESCRIPTION
Okay, 

So there is an issue with Vue not using `HashChangeEvent`, but rather `popState`: https://github.com/vuejs/vue-router/issues/1807. So this is actually not working in production now.

That means we have three approaches to solve this:

1. We detect if Vue is running
2. We detect if nothing is using a hash listener
3. We fire off both HashChange and popState in our `go` method

So my reasoning:

1. Having framework specific code in something as generic as `url-listeners` is not ideal
2. We would have to hack the browser API
3. If it works... most straightforward and least intrusive

Since router libraries will only listen to one of the events, I implemented 3. Tested with `vue-router` and `react-router-dom`. 

We do not need the intercepting click here anymore, which fixes the original issue.