### PR TITLE
Fix collaborator heads not updating

### DIFF
--- a/packages/app/src/app/pages/Sandbox/Editor/Header/CollaboratorHeads/CollaboratorHeads.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Header/CollaboratorHeads/CollaboratorHeads.tsx
@@ -105,10 +105,7 @@ const CollaboratorHead = (props: ICollaboratorHeadProps) => (
 
 export const CollaboratorHeads: FunctionComponent = () => {
   const { state, actions } = useOvermind();
-
-  const liveUsers = React.useMemo(() => state.live.roomInfo?.users || [], [
-    state.live.roomInfo,
-  ]);
+  const liveUsers = state.live.roomInfo?.users || [];
 
   const liveUserId = state.live.liveUserId;
   const followingUserId = state.live.followingUserId;


### PR DESCRIPTION
Fix a case where the collaborator heads don't update because `liveRoomInfo` doesn't update but `liveRoomInfo.users` does.

![image](https://user-images.githubusercontent.com/587016/95223184-9439d000-07f9-11eb-9fc4-c04450685d54.png)
