### PR TITLE
Fix sandbox read notification click

### DIFF
--- a/packages/app/src/app/components/Notifications/notifications/SandboxInvitation.tsx
+++ b/packages/app/src/app/components/Notifications/notifications/SandboxInvitation.tsx
@@ -63,13 +63,13 @@ export const SandboxInvitation = ({
         if (isMenuClicked(event)) return;
         if (!read) {
           await updateReadStatus(id);
-          history.push(
-            sandboxUrl({
-              id: sandboxId,
-              alias: sandboxAlias,
-            })
-          );
         }
+        history.push(
+          sandboxUrl({
+            id: sandboxId,
+            alias: sandboxAlias,
+          })
+        );
       }}
       key={sandboxId}
       css={css({ padding: 0 })}


### PR DESCRIPTION
Now you can still open the sandbox of the invite, even if you've read it.