### PR TITLE
Make warning squiggles yellow

### DIFF
--- a/packages/common/src/themes/codesandbox-black.js
+++ b/packages/common/src/themes/codesandbox-black.js
@@ -115,7 +115,7 @@ const colors = {
   },
   editorWarning: {
     border: tokens.grays[600],
-    foreground: tokens.reds[300],
+    foreground: tokens.yellow,
   },
   editorWhitespace: {
     foreground: tokens.grays[500],


### PR DESCRIPTION
The warning squiggles were red, which made them look like errors. Now they are yellow to make them look like warnings.