### PR TITLE
fix(profile): redirect to NotFound page when profile request fails

### DIFF
--- a/packages/app/src/app/overmind/namespaces/profile/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/profile/actions.ts
@@ -7,7 +7,15 @@ export const profileMounted: AsyncAction<string> = withLoadApp(
     state.profile.isLoadingProfile = true;
     state.profile.notFound = false;
 
-    const profile = await effects.api.getProfile(username);
+    let profile: Profile;
+
+    try {
+      profile = await effects.api.getProfile(username);
+    } catch (error) {
+      state.profile.isLoadingProfile = false;
+      state.profile.notFound = true;
+      return;
+    }
 
     state.profile.profiles[profile.id] = profile;
     state.profile.currentProfileId = profile.id;
@@ -16,9 +24,13 @@ export const profileMounted: AsyncAction<string> = withLoadApp(
       profile.showcasedSandboxShortid &&
       !state.editor.sandboxes[profile.showcasedSandboxShortid]
     ) {
-      state.editor.sandboxes[
-        profile.showcasedSandboxShortid
-      ] = await effects.api.getSandbox(profile.showcasedSandboxShortid);
+      try {
+        state.editor.sandboxes[
+          profile.showcasedSandboxShortid
+        ] = await effects.api.getSandbox(profile.showcasedSandboxShortid);
+      } catch (e) {
+        // Ignore it
+      }
     }
 
     state.profile.isLoadingProfile = false;

--- a/packages/app/src/app/pages/Profile/Showcase/NoSandboxAvailable.tsx
+++ b/packages/app/src/app/pages/Profile/Showcase/NoSandboxAvailable.tsx
@@ -19,7 +19,7 @@ export const NoSandboxAvailable: FunctionComponent = () => {
         <ErrorTitle>
           {`${
             isProfileCurrentUser ? `You don't` : `This user doesn't`
-          } have any sandboxes yet`}
+          } have a showcased sandbox yet`}
         </ErrorTitle>
       </Margin>
     </Centered>


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?
Bug fix.
<!-- Is it a Bug fix, feature, docs update, ... -->

## What is the current behavior?
When a user goes to `/u/:username` and `username` doesn't exist, they get a blank page.
<!-- You can also link to an open issue here -->

## What is the new behavior?
We show the `NotFound` component to the user when `getProfile` fails - regardless of the reason.
<!-- if this is a feature change -->

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Visit `/u/aarthurdennerr` for example - [production link](https://codesandbox.io/u/aarthurdennerr);
1. Verify that we show the `NotFound` component instead of a blank page;
1. Visit `/u/arthurdenner` for example - [production link](https://codesandbox.io/u/arthurdenner);
1. Verify that we show that the user doesn't have a showcased sandbox yet.

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->

## Notes

- I've added two different `try/catch` because if `getProfile` fails, we show the `NotFound`, but if the `getSandbox` fails, we want to show the profile still. Are you okay with this behaviour or should we change it?
- I've changed the text when the user doesn't have a showcased sandbox because they may have sandboxes, but none of them is showcased only. Let me know if you prefer to not change this text.

Last, if you enjoy this PR, I'd appreciate it if you can label it for Hacktoberfest with `hacktoberfest-accepted` 😄 