### PR TITLE
Fix Vue.js version comparison

### DIFF
--- a/packages/app/src/app/overmind/effects/vscode/LinterWorker/index.js
+++ b/packages/app/src/app/overmind/effects/vscode/LinterWorker/index.js
@@ -3,9 +3,9 @@ import semver from 'semver';
 
 import monkeypatch from './monkeypatch-babel-eslint';
 
-function isMinimalSemverVersion(version: string, minimalVersion: string) {
+function isMinimalSemverVersion(versionOrRange, minimalVersion) {
   try {
-    return semver.gte(version, minimalVersion);
+    return !semver.gtr(minimalVersion, versionOrRange);
   } catch (e) {
     // Semver couldn't be parsed, we assume that we're on the bleeding edge now, so true.
     return true;

--- a/yarn.lock
+++ b/yarn.lock
@@ -9557,10 +9557,10 @@ codesandbox-import-util-types@^2.1.9:
   resolved "https://registry.yarnpkg.com/codesandbox-import-util-types/-/codesandbox-import-util-types-2.1.9.tgz#24ba5ec3d966f51f18b78c48d32e6411da90aa74"
   integrity sha512-Vc4qh+neVfHtS3RG+7wvaErMoEKdNTnLFnyj4Dcbn3NV7v9nlPj/z6MGhHp9S+vAjegWorFzxg9lKB1WGHTt5Q==
 
-codesandbox-import-util-types@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/codesandbox-import-util-types/-/codesandbox-import-util-types-2.2.0.tgz#f94799f83838a1e8ba776189a8275870d6579ab6"
-  integrity sha512-EFXFKCSE7I2VABNa11cgkFJAY8MQCMDhD147xntXw4O/wg5DkGmvor9s0bpk4IYlTOVwZT86H0My1xRhkIzHOA==
+codesandbox-import-util-types@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/codesandbox-import-util-types/-/codesandbox-import-util-types-2.2.1.tgz#fbd0babed213eed068ad8251f5cdb1a01e573171"
+  integrity sha512-hM5rkWi1u4dyQo6KMM0QqxOqUYWPPVy1tEoZ058UjaB2YE2YYXOyqmTpOOQZ2misJMzTsZH2r+3vC051bKd5bQ==
 
 codesandbox-import-utils@^2.1.9:
   version "2.1.14"
@@ -9571,12 +9571,12 @@ codesandbox-import-utils@^2.1.9:
     istextorbinary "^2.2.1"
     lz-string "^1.4.4"
 
-codesandbox-import-utils@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/codesandbox-import-utils/-/codesandbox-import-utils-2.2.0.tgz#281b4449746b411cca8934b93fd1817cb4a3e898"
-  integrity sha512-d2sQnwbsegkjmx6x2Q7RBiLPtSDBKQHSQgekU6h8AimtaNO9d/nc/jWWR/kMnB+T6NorUxCpmoLtHWDqBihFRw==
+codesandbox-import-utils@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/codesandbox-import-utils/-/codesandbox-import-utils-2.2.1.tgz#dd037154b0b19b998e51127c23aeeed501dc9e84"
+  integrity sha512-x7dJkyiePLnOXuQKDYxTOqcWe0KB37pYJH3xadBrXZJZkeOt8Rab4VPLn9kUCb9SKdFToHXz/petWA8rghPZ7Q==
   dependencies:
-    codesandbox-import-util-types "^2.2.0"
+    codesandbox-import-util-types "^2.2.1"
     istextorbinary "^2.2.1"
     lz-string "^1.4.4"
 


### PR DESCRIPTION
`vue` dependency version in `package.json` is usually a range (e.g. `^2.6.11`), but `semver.gte()` only supports plain versions. We should use `semver.gtr()`, which also supports ranges. 

Tested that this change configures the correct `eslint` rules for the sandbox's Vue.js version.

L.E. I added the `yarn.lock` changes to this PR as I get them consistently when running `yarn install`.

Fixes #4994