### PR TITLE
Remove outdated session expired error message

### DIFF
--- a/packages/app/src/app/overmind/internalActions.ts
+++ b/packages/app/src/app/overmind/internalActions.ts
@@ -1,4 +1,3 @@
-import { identify } from '@codesandbox/common/lib/utils/analytics';
 import {
   ModuleTab,
   NotificationButton,

--- a/packages/app/src/app/overmind/internalActions.ts
+++ b/packages/app/src/app/overmind/internalActions.ts
@@ -441,28 +441,6 @@ export const handleError: Action<{
     return;
   }
 
-  const { response } = error as ApiError;
-
-  if (response?.status === 401) {
-    // Reset existing sign in info
-    identify('signed_in', false);
-    effects.analytics.setAnonymousId();
-
-    // Allow user to sign in again in notification
-    effects.notificationToast.add({
-      message: 'Your session seems to be expired, please log in again...',
-      status: NotificationStatus.ERROR,
-      actions: {
-        primary: {
-          label: 'Sign in',
-          run: () => actions.signInClicked(),
-        },
-      },
-    });
-
-    return;
-  }
-
   error.message = actions.internal.getErrorMessage({ error });
 
   const notificationActions: NotificationMessage['actions'] = {};


### PR DESCRIPTION
This cannot be the case anymore, as the server lets the client know when a user is not signed in anymore using a cookie.