### PR TITLE
feat(profile): allow selection of showcased sandbox when none is selected

### DIFF
--- a/packages/app/src/app/pages/Profile/Showcase/NoSandboxAvailable.tsx
+++ b/packages/app/src/app/pages/Profile/Showcase/NoSandboxAvailable.tsx
@@ -1,6 +1,7 @@
 import React, { FunctionComponent } from 'react';
 import Centered from '@codesandbox/common/lib/components/flex/Centered';
 import Margin from '@codesandbox/common/lib/components/spacing/Margin';
+import { Button } from '@codesandbox/common/lib/components/Button';
 
 import { useOvermind } from 'app/overmind';
 
@@ -8,6 +9,9 @@ import { ErrorTitle } from './elements';
 
 export const NoSandboxAvailable: FunctionComponent = () => {
   const {
+    actions: {
+      profile: { selectSandboxClicked },
+    },
     state: {
       profile: { isProfileCurrentUser },
     },
@@ -21,6 +25,15 @@ export const NoSandboxAvailable: FunctionComponent = () => {
             isProfileCurrentUser ? `You don't` : `This user doesn't`
           } have a showcased sandbox yet`}
         </ErrorTitle>
+        {isProfileCurrentUser && (
+          <Centered horizontal>
+            <Margin top={1}>
+              <Button onClick={() => selectSandboxClicked()} small>
+                Select Sandbox
+              </Button>
+            </Margin>
+          </Centered>
+        )}
       </Margin>
     </Centered>
   );

--- a/packages/app/src/app/pages/common/Modals/SelectSandboxModal/index.tsx
+++ b/packages/app/src/app/pages/common/Modals/SelectSandboxModal/index.tsx
@@ -39,13 +39,13 @@ export const SelectSandboxModal: FunctionComponent = () => {
         {userSandboxes.filter(Boolean).map(sandbox => (
           <ListAction
             justify="space-between"
-            disabled={sandbox.id === showcasedSandbox.id}
+            disabled={sandbox.id === showcasedSandbox?.id}
             key={sandbox.id}
             onClick={() => newSandboxShowcaseSelected(sandbox.id)}
           >
             <Element>
               {getSandboxName(sandbox)}
-              {sandbox.id === showcasedSandbox.id && ' (Selected)'}
+              {sandbox.id === showcasedSandbox?.id && ' (Selected)'}
             </Element>
 
             <Element>


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?
Feature? It's a leftover from #4998 that I noticed today. 🤦🏽‍♂️ 
<!-- Is it a Bug fix, feature, docs update, ... -->

## What is the current behavior?
There is no way to select a sandbox to be showcased in case the user doesn't have one.

<img width="800" alt="current-showcase-behaviour" src="https://user-images.githubusercontent.com/13774309/95857738-58a08800-0d5c-11eb-80a5-d216c52c99fc.png">

<!-- You can also link to an open issue here -->

## What is the new behavior?
There is a button to select one sandbox to be showcased when the user doesn't have one.

<img width="800" alt="proposed-showcase-behaviour" src="https://user-images.githubusercontent.com/13774309/95857840-808feb80-0d5c-11eb-99d3-4f1fabc3f5a6.png">
<!-- if this is a feature change -->

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Visit your profile;
1. Select a sandbox as showcased;
1. Verify that you're able to change the showcased sanbox;
1. Delete the showcased sandbox;
4. Verify that you're able to select a sandbox to be showcased.

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
