### PR TITLE
Fix styling of the following name tag

### DIFF
--- a/packages/app/src/app/pages/Sandbox/Editor/Content/EditorToast.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Content/EditorToast.tsx
@@ -47,7 +47,7 @@ export const EditorToast = () => {
             fontSize: '12px',
             float: 'right',
             width: 'max-content',
-            borderBottomLeftRadius: 2,
+            borderTopLeftRadius: 2,
             color:
               (followingUser.color[0] * 299 +
                 followingUser.color[1] * 587 +


### PR DESCRIPTION
The border radius will now be at the top left, instead of bottom left:
<img width="200" alt="Screenshot 2020-10-13 at 15 53 07" src="https://user-images.githubusercontent.com/587016/95869992-44648700-0d6c-11eb-8e51-9aaa0290c320.png">
