### PR TITLE
feat: add Inter to google font picker

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1605,6 +1605,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "ryanpwaldon",
+      "name": "Ryan Waldon",
+      "avatar_url": "https://avatars0.githubusercontent.com/u/12480362?v=4",
+      "profile": "https://github.com/ryanpwaldon",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "contributorsPerLine": 7,

--- a/README.md
+++ b/README.md
@@ -259,7 +259,8 @@ Thanks goes to these wonderful people
   <tr>
     <td align="center"><a href="https://github.com/NinoMaj"><img src="https://avatars0.githubusercontent.com/u/20380632?v=4" width="100px;" alt="Nino"/><br /><sub><b>Nino</b></sub></a><br /><a href="https://github.com/codesandbox/codesandbox-client/commits?author=NinoMaj" title="Documentation">📖</a></td>
     <td align="center"><a href="https://saurabhdaware.in/"><img src="https://avatars1.githubusercontent.com/u/30949385?v=4" width="100px;" alt="Saurabh Daware"/><br /><sub><b>Saurabh Daware</b></sub></a><br /><a href="https://github.com/codesandbox/codesandbox-client/commits?author=saurabhdaware" title="Code">💻</a> <a href="#plugin-saurabhdaware" title="Plugin/utility libraries">🔌</a></td>
-    <td align="center"><a href="https://pablo.pink"><img src="https://avatars0.githubusercontent.com/u/4324982?v=4" width="100px;" alt="Pablo P Varela"/><br /><sub><b>Pablo P Varela</b></sub></a><br /><a href="https://github.com/codesandbox/codesandbox-client/commits?author=pablopunk" title="Code">💻</a></td>
+    <td align="center"><a href="https://pablo.pink"><img src="https://avatars0.githubusercontent.com/u/4324982?v=4" width="100px;" alt="Pablo Varela"/><br /><sub><b>Pablo Varela</b></sub></a><br /><a href="https://github.com/codesandbox/codesandbox-client/commits?author=pablopunk" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/ryanpwaldon"><img src="https://avatars0.githubusercontent.com/u/12480362?v=4" width="100px;" alt="Ryan Waldon"/><br /><sub><b>Ryan Waldon</b></sub></a><br /><a href="https://github.com/codesandbox/codesandbox-client/commits?author=ryanpwaldon" title="Code">💻</a></td>
   </tr>
 </table>
 

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Explorer/ExternalResources/google-fonts.ts
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Explorer/ExternalResources/google-fonts.ts
@@ -972,4 +972,5 @@ export const fonts = [
   'Sulphur Point',
   'Solway',
   'Gupter',
+  'Inter',
 ];


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?

Feature (minor addition).

<!-- Is it a Bug fix, feature, docs update, ... -->

## What is the new behavior?

User can now add the Inter font as an external resource (via the Google Fonts picker).

<!-- if this is a feature change -->

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Visit an existing sandbox;
2. Select _Inter_ via the Google Fonts picker;
3. Inter is successfully added as an external resource, and is functional as intended.

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->

## Notes

Inter was only added to Google Fonts on the 6th of March, so I presume it was unintentionally left out. But if, for whatever reason, you prefer not to include it – that's totally fine 😄