### PR TITLE
Fix resolving ES6 scopes in esconvert

### DIFF
--- a/packages/app/src/sandbox/eval/transpilers/babel/convert-esmodule/__snapshots__/index.test.ts.snap
+++ b/packages/app/src/sandbox/eval/transpilers/babel/convert-esmodule/__snapshots__/index.test.ts.snap
@@ -186,6 +186,16 @@ function $_csb__interopRequireDefault(obj) {
 "
 `;
 
+exports[`convert-esmodule can handle block scopes 1`] = `
+"\\"use strict\\";
+var $csb__utils = require(\\"@interop-ui/utils\\");
+if (true) {
+  let e = c;
+}
+(0, $csb__utils.getOppositeSide)();
+"
+`;
+
 exports[`convert-esmodule can handle class properties 1`] = `
 "\\"use strict\\";
 var $csb__test = require(\\"./test\\");

--- a/packages/app/src/sandbox/eval/transpilers/babel/convert-esmodule/index.test.ts
+++ b/packages/app/src/sandbox/eval/transpilers/babel/convert-esmodule/index.test.ts
@@ -142,6 +142,19 @@ describe('convert-esmodule', () => {
     expect(convertEsModule(code)).toMatchSnapshot();
   });
 
+  it('can handle block scopes', () => {
+    const code = `
+    import{makeRect as t,getOppositeSide as e,getCollisions as n}from"@interop-ui/utils";
+
+    if (true) {
+      let e = c;
+    }
+    e();
+
+    `;
+    expect(convertEsModule(code)).toMatchSnapshot();
+  });
+
   it('handles export mutations', () => {
     const code = `
       export default function test() {}

--- a/packages/app/src/sandbox/eval/transpilers/babel/convert-esmodule/index.ts
+++ b/packages/app/src/sandbox/eval/transpilers/babel/convert-esmodule/index.ts
@@ -486,7 +486,7 @@ export function convertEsModule(
     });
 
     // A second pass where we rename all references to imports that were marked before.
-    const scopeManager = escope.analyze(program);
+    const scopeManager = escope.analyze(program, {ecmaVersion: 6});
 
     scopeManager.acquire(program);
     scopeManager.scopes.forEach(scope => {


### PR DESCRIPTION
`escope` was wrongly configured to not treat block scoped vars (`let`, `const`) as block-scoped. This fixes that issue.