### PR TITLE
Dashboard: Lazily update stale sandbox thumbnails

### DIFF
--- a/packages/app/src/app/pages/Dashboard/Components/Sandbox/SandboxCard.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Sandbox/SandboxCard.tsx
@@ -208,39 +208,12 @@ export const SandboxCard = ({
   ...props
 }: SandboxItemComponentProps) => {
   const [stoppedScrolling, setStoppedScrolling] = React.useState(false);
-  const [guaranteedScreenshotUrl, setGuaranteedScreenshotUrl] = React.useState<
-    string
-  >(screenshotUrl);
-
-  const lastSandboxId = React.useRef(sandbox.id);
-  const imageLoaded = useImageLoaded(guaranteedScreenshotUrl);
-
   React.useEffect(() => {
     // We only want to render the screenshot once the user has stopped scrolling
     if (!isScrolling && !stoppedScrolling) {
       setStoppedScrolling(true);
     }
   }, [isScrolling, stoppedScrolling]);
-
-  React.useEffect(() => {
-    // We always try to show the cached screenshot first, if someone looks at a sandbox we will try to
-    // generate a new one based on the latest contents.
-    const generateScreenshotUrl = `/api/v1/sandboxes/${sandbox.id}/screenshot.png`;
-    if (
-      stoppedScrolling &&
-      (lastSandboxId.current !== sandbox.id || !guaranteedScreenshotUrl)
-    ) {
-      setGuaranteedScreenshotUrl(
-        sandbox.screenshotUrl || generateScreenshotUrl
-      );
-      lastSandboxId.current = sandbox.id;
-    }
-  }, [
-    stoppedScrolling,
-    guaranteedScreenshotUrl,
-    sandbox.id,
-    sandbox.screenshotUrl,
-  ]);
 
   return (
     <Stack
@@ -268,32 +241,12 @@ export const SandboxCard = ({
         },
       })}
     >
-      <div
-        ref={thumbnailRef}
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          height: '160px',
-          backgroundColor: '#242424',
-          backgroundSize: 'cover',
-          backgroundPosition: 'center center',
-          backgroundRepeat: 'no-repeat',
-          borderBottom: '1px solid',
-          borderColor: '#242424',
-          [imageLoaded
-            ? 'backgroundImage'
-            : null]: `url(${guaranteedScreenshotUrl})`,
-        }}
-      >
-        {imageLoaded ? null : (
-          <TemplateIcon
-            style={{ filter: 'grayscale(1)', opacity: 0.1 }}
-            width="60"
-            height="60"
-          />
-        )}
-      </div>
+      <Thumbnail
+        sandboxId={sandbox.id}
+        thumbnailRef={thumbnailRef}
+        TemplateIcon={TemplateIcon}
+        screenshotUrl={screenshotUrl}
+      />
       <div
         style={{
           position: 'absolute',
@@ -309,7 +262,6 @@ export const SandboxCard = ({
       >
         <TemplateIcon width="16" height="16" />
       </div>
-
       <SandboxTitle
         originalGit={sandbox.originalGit}
         prNumber={sandbox.prNumber}
@@ -325,7 +277,6 @@ export const SandboxCard = ({
         newTitle={newTitle}
         sandboxTitle={sandboxTitle}
       />
-
       <SandboxStats
         noDrag={noDrag}
         lastUpdated={lastUpdated}
@@ -333,6 +284,66 @@ export const SandboxCard = ({
         sandboxLocation={sandboxLocation}
       />
     </Stack>
+  );
+};
+
+const Thumbnail = ({
+  sandboxId,
+  thumbnailRef,
+  TemplateIcon,
+  screenshotUrl,
+}) => {
+  // 0. Use template icon as starting point and fallback
+  // 1. Use screenshotUrl if can be successfully loaded
+  // 2. After timeout, fetch latest screenshot. if successfully loaded, switch
+  const SCREENSHOT_TIMEOUT = 5000;
+
+  const [latestScreenshotUrl, setLatestScreenshotUrl] = React.useState(null);
+
+  const screenshotUrlLoaded = useImageLoaded(screenshotUrl);
+  const latestScreenshotUrlLoaded = useImageLoaded(latestScreenshotUrl);
+
+  let screenshotToUse: string;
+  if (latestScreenshotUrlLoaded) screenshotToUse = latestScreenshotUrl;
+  else if (screenshotUrlLoaded) screenshotToUse = screenshotUrl;
+
+  React.useEffect(
+    function lazyLoadLatestScreenshot() {
+      const timer = window.setTimeout(() => {
+        const url = `https://codesandbox.io/api/v1/sandboxes/${sandboxId}/screenshot.png`;
+        setLatestScreenshotUrl(url);
+      }, SCREENSHOT_TIMEOUT);
+
+      return () => window.clearTimeout(timer);
+    },
+    [sandboxId, setLatestScreenshotUrl]
+  );
+
+  return (
+    <div
+      ref={thumbnailRef}
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        height: '160px',
+        backgroundColor: '#242424',
+        backgroundSize: 'cover',
+        backgroundPosition: 'center center',
+        backgroundRepeat: 'no-repeat',
+        borderBottom: '1px solid',
+        borderColor: '#242424',
+        [screenshotToUse ? 'backgroundImage' : null]: `url(${screenshotToUse})`,
+      }}
+    >
+      {!screenshotUrlLoaded && (
+        <TemplateIcon
+          style={{ filter: 'grayscale(1)', opacity: 0.1 }}
+          width="60"
+          height="60"
+        />
+      )}
+    </div>
   );
 };
 

--- a/packages/app/src/app/pages/Dashboard/Components/Sandbox/SandboxCard.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Sandbox/SandboxCard.tsx
@@ -246,6 +246,7 @@ export const SandboxCard = ({
         thumbnailRef={thumbnailRef}
         TemplateIcon={TemplateIcon}
         screenshotUrl={screenshotUrl}
+        screenshotOutdated={sandbox.screenshotOutdated}
       />
       <div
         style={{
@@ -292,10 +293,11 @@ const Thumbnail = ({
   thumbnailRef,
   TemplateIcon,
   screenshotUrl,
+  screenshotOutdated,
 }) => {
   // 0. Use template icon as starting point and fallback
-  // 1. Use screenshotUrl if can be successfully loaded
-  // 2. After timeout, fetch latest screenshot. if successfully loaded, switch
+  // 1. se sandbox.screenshotUrl if it can be successfully loaded (might not exist)
+  // 2. If screenshot is outdated, lazily load a newer screenshot. Switch when image loaded.
   const SCREENSHOT_TIMEOUT = 5000;
 
   const [latestScreenshotUrl, setLatestScreenshotUrl] = React.useState(null);
@@ -310,13 +312,14 @@ const Thumbnail = ({
   React.useEffect(
     function lazyLoadLatestScreenshot() {
       const timer = window.setTimeout(() => {
+        if (!screenshotOutdated) return;
         const url = `https://codesandbox.io/api/v1/sandboxes/${sandboxId}/screenshot.png`;
         setLatestScreenshotUrl(url);
       }, SCREENSHOT_TIMEOUT);
 
       return () => window.clearTimeout(timer);
     },
-    [sandboxId, setLatestScreenshotUrl]
+    [sandboxId, screenshotOutdated, setLatestScreenshotUrl]
   );
 
   return (

--- a/packages/app/src/app/pages/Dashboard/Components/Sandbox/SandboxCard.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Sandbox/SandboxCard.tsx
@@ -17,18 +17,23 @@ import { SandboxItemComponentProps } from './types';
 const useImageLoaded = (url: string) => {
   const [loaded, setLoaded] = React.useState(false);
   React.useEffect(() => {
-    if (!url) return;
-
     const img = new Image();
-    img.onload = () => {
-      setLoaded(true);
-    };
 
-    img.src = url;
+    if (url) {
+      img.onload = () => {
+        setLoaded(true);
+      };
 
-    if (img.complete) {
-      setLoaded(true);
+      img.src = url;
+
+      if (img.complete) {
+        setLoaded(true);
+      }
     }
+
+    return function cleanup() {
+      img.src = '';
+    };
   }, [url]);
 
   return loaded;

--- a/packages/app/src/app/pages/Dashboard/Components/Sandbox/SandboxCard.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Sandbox/SandboxCard.tsx
@@ -17,6 +17,8 @@ import { SandboxItemComponentProps } from './types';
 const useImageLoaded = (url: string) => {
   const [loaded, setLoaded] = React.useState(false);
   React.useEffect(() => {
+    if (!url) return;
+
     const img = new Image();
     img.onload = () => {
       setLoaded(true);


### PR DESCRIPTION
Moved Sandbox Thumbnail into a component.

Sandbox thumbnail logic:

0. Use template icon as starting point and fallback
1. Use `sandbox.screenshotUrl` if it can be successfully loaded (might not exist)
2. If `sandbox.screenshotOutdated`, lazily load latest screenshot. Switch when image is loaded.

FAQ: Why don't we directly load the latest screenshot?

Generating the latest screenshot takes a few seconds, so it's faster to use the cached `screenshotUrl` and then lazily fetch the latest one.