### PR TITLE
add public repo note in CI docs

### DIFF
--- a/packages/homepage/content/docs/8-ci.md
+++ b/packages/homepage/content/docs/8-ci.md
@@ -41,6 +41,8 @@ your library by creating a file called `ci.json` in a folder called
 `.codesandbox` (`.codesandbox/ci.json`) in the root of your repo. An example PR
 can be found [here](https://github.com/facebook/react/pull/17175).
 
+**Note:** CodeSandbox CI only works for public repositories for now
+
 ## Configuration
 
 You can configure how your projects build on CodeSandbox CI by creating a file

--- a/packages/homepage/content/docs/8-ci.md
+++ b/packages/homepage/content/docs/8-ci.md
@@ -41,7 +41,7 @@ your library by creating a file called `ci.json` in a folder called
 `.codesandbox` (`.codesandbox/ci.json`) in the root of your repo. An example PR
 can be found [here](https://github.com/facebook/react/pull/17175).
 
-**Note:** CodeSandbox CI only works for public repositories for now
+**Note:** CodeSandbox CI only works in public repositories for now.
 
 ## Configuration
 


### PR DESCRIPTION
Adds a note on how CI only works in private repos