### PR TITLE
Fix large amount of exports causing stack size exceeded error

### DIFF
--- a/packages/common/src/utils/dependencies.ts
+++ b/packages/common/src/utils/dependencies.ts
@@ -71,7 +71,7 @@ export async function getAbsoluteDependencies(dependencies: Object) {
       try {
         const { version } = await getAbsoluteDependency(
           dep,
-          nonAbsoluteDependencies[dep]
+          newDependencies[dep]
         );
 
         newDependencies[dep] = version;


### PR DESCRIPTION
Some files which have over 5.000 exports caused our generated to create a huge line of 

```
exports.a = exports.b = exports.c = exports.d = void 0;
```

This in itself is not a problem, but when another AST parser goes over this it will crash with a `Maximum call stack size exceeded`. It will be worth checking how other converters like TypeScript handles this.

Fixes #5022