### PR TITLE
Fix typo in a share modal copy

### DIFF
--- a/packages/app/src/app/pages/common/Modals/ShareModal/index.tsx
+++ b/packages/app/src/app/pages/common/Modals/ShareModal/index.tsx
@@ -151,7 +151,7 @@ export const ShareModal: React.FC<Props> = () => {
         <Collapsible title="Embed" defaultOpen>
           <Element paddingX={4}>
             <Text block variant="muted">
-              Customize the embed to better integrate dwith your website, blog
+              Customize the embed to better integrate with your website, blog
               or documentation{' '}
             </Text>
             <Element


### PR DESCRIPTION
## What kind of change does this PR introduce?
Typo fix

## What is the current behavior?
![image](https://user-images.githubusercontent.com/6474067/96633864-fe826280-1319-11eb-92d9-a4fd7c49a389.png)


## What is the new behavior?
Typo is fixed

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.
This is a simple copy change, I haven't spin up the project for this

## Checklist

- [ ] Documentation N/A
- [ ] Testing N/A
- [x] Ready to be merged
- [ ] Added myself to contributors table N/A
