### PR TITLE
Fix jest globals

### DIFF
--- a/packages/app/src/sandbox/eval/tests/jest-lite.test.js
+++ b/packages/app/src/sandbox/eval/tests/jest-lite.test.js
@@ -39,7 +39,7 @@ describe('TestRunner class', () => {
     });
   });
 
-  describe('testGlobals', () => {
+  describe('getRuntimeGlobals', () => {
     it('returns an object', async () => {
       const testRunner = new TestRunner();
 
@@ -56,7 +56,7 @@ describe('TestRunner class', () => {
         document: _document,
         window: _window,
         global: _global,
-      } = testRunner.testGlobals();
+      } = testRunner.getRuntimeGlobals();
 
       expect(_it).toBeInstanceOf(Function);
       expect(_test).toBeInstanceOf(Function);
@@ -75,7 +75,7 @@ describe('TestRunner class', () => {
       beforeEach(async () => {
         testRunner = new TestRunner();
         await testRunner.initJSDOM();
-        _test = testRunner.testGlobals().test;
+        _test = testRunner.getRuntimeGlobals().test;
         fnSpy = jest.fn();
       });
 

--- a/packages/app/src/sandbox/eval/tests/jest-lite.test.js
+++ b/packages/app/src/sandbox/eval/tests/jest-lite.test.js
@@ -53,18 +53,12 @@ describe('TestRunner class', () => {
         test: _test,
         expect: _expect,
         jest: _jest,
-        document: _document,
-        window: _window,
-        global: _global,
       } = testRunner.getRuntimeGlobals();
 
       expect(_it).toBeInstanceOf(Function);
       expect(_test).toBeInstanceOf(Function);
       expect(_expect).toBeInstanceOf(Function);
       expect(_jest).toBeInstanceOf(Object);
-      expect(_document).toBeInstanceOf(Object);
-      expect(_window).toBeInstanceOf(Object);
-      expect(_global).toBeInstanceOf(Object);
     });
 
     xdescribe('test', () => {

--- a/packages/app/src/sandbox/eval/tests/jest-lite.ts
+++ b/packages/app/src/sandbox/eval/tests/jest-lite.ts
@@ -114,7 +114,7 @@ export default class TestRunner {
     this.sendMessage(messages.INITIALIZE);
   }
 
-  private getRuntimeGlobals(module: Module) {
+  public getRuntimeGlobals(module: Module) {
     const test = (testName: TestName, fn?: TestFn) =>
       dispatchJest({
         fn,

--- a/packages/sandpack-core/src/runner/eval.ts
+++ b/packages/sandpack-core/src/runner/eval.ts
@@ -60,7 +60,7 @@ export default function (
   try {
     const newCode = `(function evaluate(` + globalsCode + `) {` + code + `\n})`;
     // @ts-ignore
-    (0, eval)(newCode).apply(this, globalsValues);
+    (0, eval)(newCode).apply(allGlobals.window || this, globalsValues);
 
     return module.exports;
   } catch (e) {


### PR DESCRIPTION
Explanation (copied from code base):

```
  /**
   * In this function we actually set some globals on the global window. This is because there are modules out
   * there that try to overwrite some globals that we try to set. For example, this code won't work:
   *
   * ```js
   * const test = 5;
   * ```
   *
   * if we add test to the scope in the function:
   *
   * ```ts
   * function evaluate(test) {
   *   const test = 5; // <- Error!
   * }
   * ```
   *
   * Because of this, we have to put these globals on the global window. The big disadvantage of this is that
   * we cannot run these tests in parallel. If we would want to do that we could introduce the globals in separate
   * scope (separate function) that wraps the inner function, like this:
   *
   * ```ts
   * (function jestGlobals(test) {
   *   (function evaluate() {
   *     const test = 5; // <- No Error!
   *   })()
   * })
   * ```
   *
   * Right now we're making sure to clean the globals up in postRun
   *
   * Related issue: https://github.com/codesandbox/codesandbox-client/issues/4922
   */
```

Fixes #4922
Fixes #4887
