### PR TITLE
Update links within issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG.md
+++ b/.github/ISSUE_TEMPLATE/BUG.md
@@ -10,10 +10,10 @@ about: Did something not work?
 <!-- Please ensure you've completed the following steps by replacing [ ] with [x]-->
 
 - [ ] I have read the
-      [Contributing Guidelines](https://github.com/electron/electron/blob/master/CONTRIBUTING.md)
+      [Contributing Guidelines](https://github.com/codesandbox/codesandbox-client/blob/master/CONTRIBUTING.md)
       for this project.
 - [ ] I agree to follow the
-      [Code of Conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md)
+      [Code of Conduct](https://github.com/codesandbox/codesandbox-client/blob/master/CODE_OF_CONDUCT.md)
       that this project adheres to.
 - [ ] I have searched the issue tracker for an issue that matches the one I want
       to file, without success.


### PR DESCRIPTION
## What kind of change does this PR introduce?

An update of the links to the Code of Conduct and Contributing Guidelines contained within the issue tracking template. Whilst not a massive change, it does ensure some consistency.

## What is the current behavior?

Currently, both the Code of Conduct and the Contributing Guidelines links point to documents held within the `electron` repository.

## What is the new behavior?

These links now correctly point to the `codesandbox` versions of these documents.

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Create a new issue
2. Open the Contributing Guidelines link in a new tab; verify the document is the `codesandbox` version and not the `electron` version
3. Open the Code of Conduct link in a new tab; verify the document is the `codesandbox` version and not the `electron` version

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table N/A
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
