### PR TITLE
Remove dependency on react-icons in @csb/components

### DIFF
--- a/packages/components/src/components/Tags/Tag.tsx
+++ b/packages/components/src/components/Tags/Tag.tsx
@@ -37,7 +37,7 @@ export function Tag({ tag, onRemove }: TagProps) {
           onClick={() => onRemove(tag)}
           marginLeft={1}
         >
-          <Icon size={8} name="cross" />
+          <Icon size={7} name="cross" />
         </Button>
       )}
     </TagElement>

--- a/packages/components/src/components/Tags/Tag.tsx
+++ b/packages/components/src/components/Tags/Tag.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import styled from 'styled-components';
 import css from '@styled-system/css';
-import CrossIcon from 'react-icons/lib/md/clear';
 
 import { Stack } from '../Stack';
 import { Button } from '../Button';
 import { Text } from '../Text';
+import { Icon } from '../Icon';
 
 const TagElement = styled(Stack).attrs({
   inline: true,
@@ -37,7 +37,7 @@ export function Tag({ tag, onRemove }: TagProps) {
           onClick={() => onRemove(tag)}
           marginLeft={1}
         >
-          <CrossIcon />
+          <Icon name="cross" />
         </Button>
       )}
     </TagElement>

--- a/packages/components/src/components/Tags/Tag.tsx
+++ b/packages/components/src/components/Tags/Tag.tsx
@@ -37,7 +37,7 @@ export function Tag({ tag, onRemove }: TagProps) {
           onClick={() => onRemove(tag)}
           marginLeft={1}
         >
-          <Icon name="cross" />
+          <Icon size={8} name="cross" />
         </Button>
       )}
     </TagElement>


### PR DESCRIPTION
It was the only place where we use `react-icons` in `@codesandbox/components`, and it's not marked as a dependency. We'll have to check the test snapshot to see if it changes styling significantly.