### PR TITLE
Fix new cursor of new user overwriting existing cursors

### DIFF
--- a/packages/app/src/app/overmind/namespaces/live/liveMessageOperators.ts
+++ b/packages/app/src/app/overmind/namespaces/live/liveMessageOperators.ts
@@ -12,7 +12,7 @@ import {
 import { logBreadcrumb } from '@codesandbox/common/lib/utils/analytics/sentry';
 import { NotificationStatus } from '@codesandbox/notifications/lib/state';
 import { camelizeKeys } from 'humps';
-import { json, mutate } from 'overmind';
+import { mutate } from 'overmind';
 
 import { Operator } from 'app/overmind';
 import { getSavedCode } from 'app/overmind/utils/sandbox';

--- a/packages/app/src/app/overmind/namespaces/live/liveMessageOperators.ts
+++ b/packages/app/src/app/overmind/namespaces/live/liveMessageOperators.ts
@@ -470,14 +470,10 @@ export const onUserSelection: Operator<LiveMessage<{
     );
 
     if (user) {
-      effects.vscode.updateUserSelections(module, [
-        {
-          userId: userSelectionLiveUserId,
-          name: user.username,
-          selection,
-          color: json(user.color),
-        },
-      ]);
+      effects.vscode.updateUserSelections(
+        module,
+        actions.live.internal.getSelectionsForModule(module)
+      );
 
       if (isFollowingUser) {
         actions.live.revealCursorPosition({


### PR DESCRIPTION
Whenever a third user would type, the cursor of the second user would become hidden. This fixes that.