### PR TITLE
Move Inter loading to Google Fonts in Sandpack

### DIFF
--- a/packages/app/src/sandbox/status-screen/indicator-screen.html
+++ b/packages/app/src/sandbox/status-screen/indicator-screen.html
@@ -1,4 +1,3 @@
-<link href="/static/fonts/inter/inter.css" rel="stylesheet">
 <style>
   body {
     color: #fff;
@@ -115,3 +114,4 @@
     </div>
   </div>
 </div>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@200;400&display=swap" rel="stylesheet">

--- a/packages/app/src/sandbox/status-screen/loading-screen.html
+++ b/packages/app/src/sandbox/status-screen/loading-screen.html
@@ -1,4 +1,3 @@
-<link href="/static/fonts/inter/inter.css" rel="stylesheet">
 <style>
   body {
     color: #fff;
@@ -247,3 +246,4 @@
   </div>
   <div class="text">Downloading dependencies</div>
 </div>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@200;400&display=swap" rel="stylesheet">

--- a/packages/app/src/sandbox/status-screen/run-on-click-screen.html
+++ b/packages/app/src/sandbox/status-screen/run-on-click-screen.html
@@ -1,4 +1,3 @@
-<link href="/static/fonts/inter/inter.css" rel="stylesheet" />
 <style>
   body {
     color: #fff;
@@ -132,3 +131,4 @@
     <p style="color:rgba(255,255,255,0.9)">Click to continue execution</p>
   </div>
 </div>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@200;400&display=swap" rel="stylesheet">


### PR DESCRIPTION
I noticed today that the bundler took a long while to load because it was downloading all Inter fonts. With this change we'll only download 2 specimen for in the bundler, and I think it will not block the loading of the loading screen.