### PR TITLE
Move "Copy Invite URL" to button

### DIFF
--- a/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings.tsx
@@ -312,23 +312,13 @@ export const TeamSettings = () => {
               })}
               size={4}
             >
-              Members{' '}
-              {activeWorkspaceAuthorization !==
-                TeamMemberAuthorization.Read && (
-                <IconButton
-                  css={css({ marginLeft: 2 })}
-                  size={12}
-                  title="Copy Invite URL"
-                  name="link"
-                  onClick={onCopyInviteUrl}
-                />
-              )}
+              Members
             </Text>
 
             <Stack
               as="form"
               onSubmit={inviteLoading ? undefined : onInviteSubmit}
-              css={{ display: 'flex', flexGrow: 1, maxWidth: 320 }}
+              css={{ display: 'flex', flexGrow: 1, maxWidth: 480 }}
             >
               <UserSearchInput
                 inputValue={inviteValue}
@@ -344,6 +334,16 @@ export const TeamSettings = () => {
               >
                 Add Member
               </Button>
+              {activeWorkspaceAuthorization !==
+                TeamMemberAuthorization.Read && (
+                <Button
+                  variant="secondary"
+                  onClick={onCopyInviteUrl}
+                  style={{ width: 'auto', marginLeft: 8 }}
+                >
+                  Copy Invite URL
+                </Button>
+              )}
             </Stack>
           </Stack>
           <div>


### PR DESCRIPTION
Makes more apparent that you have an Invite URL by changing it from an icon on the left to a button:

![image](https://user-images.githubusercontent.com/587016/97421590-fb383980-190c-11eb-8272-71080ade7651.png)

this was it before:

![image](https://user-images.githubusercontent.com/587016/97421867-4a7e6a00-190d-11eb-9bdf-037cf3797a7c.png)

