### PR TITLE
Icon - remove redundant color prop

### DIFF
--- a/packages/components/src/components/Icon/index.tsx
+++ b/packages/components/src/components/Icon/index.tsx
@@ -12,17 +12,14 @@ type IconProps = React.SVGAttributes<SVGElement> &
     title?: string;
     /** Size of the icon, the button is set to 26x26 */
     size?: number;
-    /** icon color */
-    color?: string;
   };
 
 export const Icon: React.FC<IconProps> = ({
   name = 'notFound',
   size = 16,
-  color = 'inherit',
   ...props
 }) => {
   const SVG = icons[name];
 
-  return <SVG width={size} height={size} color={color} {...props} />;
+  return <SVG width={size} height={size} {...props} />;
 };


### PR DESCRIPTION
We have `color` prop on Icon that isn't connected to theme. We don't use this anywhere in the app.

Suggested approach instead:

```jsx
<Icon name="github" css={{ color: 'blues.500' }} />
```