### PR TITLE
Automatically resize embed on embed size change (while keeping ratio)

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -203,6 +203,7 @@
     "react-motion": "^0.5.0",
     "react-outside-click-handler": "^1.2.3",
     "react-refresh": "^0.7.2",
+    "react-resize-detector": "^5.2.0",
     "react-router-dom": "^5.2.0",
     "react-show": "^3.0.4",
     "react-split-pane": "^0.1.87",

--- a/packages/app/src/embed/components/App/elements.ts
+++ b/packages/app/src/embed/components/App/elements.ts
@@ -25,7 +25,7 @@ export const Fullscreen = styled.div(
   })
 );
 
-export const Moving = styled.div`
+export const Moving = styled.div<{ sidebarOpen: boolean }>`
   transition: 0.3s ease all;
   display: flex;
   align-items: center;

--- a/packages/app/src/embed/components/Content/CodeEditor.tsx
+++ b/packages/app/src/embed/components/Content/CodeEditor.tsx
@@ -20,14 +20,15 @@ import { ThemeProvider } from '@codesandbox/components';
 import { ImageViewer } from './ImageViewer';
 import MonacoDiff from './MonacoDiff';
 
-const CodeMirror = Loadable(() =>
-  import(
-    /* webpackChunkName: 'codemirror-editor' */ 'app/components/CodeEditor/CodeMirror'
-  )
+const CodeMirror = Loadable(
+  () =>
+    import(
+      /* webpackChunkName: 'codemirror-editor' */ 'app/components/CodeEditor/CodeMirror'
+    )
 );
 
-const Monaco = Loadable(() =>
-  import(/* webpackChunkName: 'monaco-editor' */ './Monaco')
+const Monaco = Loadable(
+  () => import(/* webpackChunkName: 'monaco-editor' */ './Monaco')
 );
 
 const getDependencies = (sandbox: Sandbox): { [key: string]: string } => {

--- a/packages/app/src/embed/components/Content/index.tsx
+++ b/packages/app/src/embed/components/Content/index.tsx
@@ -35,7 +35,7 @@ import * as React from 'react';
 
 // borrow the menu icon from Header in case header is not shown
 import { MenuIcon } from '../legacy/Header/elements';
-import SplitPane from '../SplitPane';
+import { SplitView as SplitPane } from '../SplitPane';
 import { CodeEditor } from './CodeEditor';
 import { Container, MenuInTabs, Tabs } from './elements';
 
@@ -371,10 +371,8 @@ export default class Content extends React.PureComponent<Props, State> {
     }
   };
 
-  setEditorSize = editorSize => {
-    this.setState({
-      editorSize,
-    });
+  setEditorSize = (editorSize: number) => {
+    this.setState({ editorSize });
   };
 
   openInNewWindow = () => {

--- a/packages/app/src/embed/components/SplitPane/elements.ts
+++ b/packages/app/src/embed/components/SplitPane/elements.ts
@@ -8,7 +8,7 @@ export const KNOB_WIDTH = 4;
  */
 export const RESIZER_GRAB_EXTRA_WIDTH = 4;
 
-export const Container = styled.div`
+export const Container = styled.div<{ isDragging: boolean }>`
   width: 100%;
   height: 100%;
 

--- a/packages/app/src/embed/components/SplitPane/index.tsx
+++ b/packages/app/src/embed/components/SplitPane/index.tsx
@@ -28,7 +28,7 @@ export function SplitView({
     1. set inital size based on props
     2. let user move it around
     3. snap to edges
-    4. stay snapped on window.resize and sidebar toggle (not implemented)
+    4. stay snapped on window.resize and sidebar toggle
     5. introduce the resizer element with animation
   */
 

--- a/packages/app/src/embed/components/SplitPane/index.tsx
+++ b/packages/app/src/embed/components/SplitPane/index.tsx
@@ -16,9 +16,11 @@ export function SplitView({
   sandbox,
   toggleLike,
   initialEditorSize = 50, // in percent
+  totalWidth,
   initialPath,
   hideDevTools,
   setEditorSize,
+  editorSize,
   setDragging: setDraggingProp,
   ...props
 }) {
@@ -48,8 +50,13 @@ export function SplitView({
   const [size, setSize] = React.useState(initialSize);
 
   React.useEffect(() => {
-    setEditorSize(size);
-  }, [size, setEditorSize]);
+    if (totalWidth) {
+      // Set editor size in %
+      setEditorSize((size / totalWidth) * 100);
+    }
+
+    // Ignore the totalWidth on purpose: we don't want the sizer to move when window size changes at all
+  }, [size, setEditorSize]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // #2. We track dragging so that we can add an overlay on top
   // of the iframe which lets us keep focus on the resize toggle
@@ -99,7 +106,8 @@ export function SplitView({
     // so we set it to the size that already is set
     handleAutomaticSnapping(newSize || size);
 
-    setEditorSize(size);
+    // Set editor size in %
+    setEditorSize((size / totalWidth) * 100);
   };
 
   const openEditor = () => {
@@ -147,7 +155,7 @@ export function SplitView({
         maxSize={maxSize}
         // @ts-ignore
         onMouseEnter={onDragStarted}
-        size={size}
+        size={(editorSize / 100) * totalWidth}
         {...props}
       >
         <PaneContainer>{children[0]}</PaneContainer>

--- a/packages/app/src/embed/components/SplitPane/index.tsx
+++ b/packages/app/src/embed/components/SplitPane/index.tsx
@@ -4,7 +4,7 @@ import { isSmallMobileScreen } from 'embed/util/mobile';
 import { GlobalActions, NavigationActions } from '../Actions';
 import { Container, PaneContainer, RESIZER_WIDTH } from './elements';
 
-export default function SplitView({
+export function SplitView({
   showEditor,
   showPreview,
   isSmallScreen,
@@ -127,12 +127,7 @@ export default function SplitView({
   const smallTouchScreen = isSmallMobileScreen();
 
   return (
-    <Container
-      isDragging={isDragging}
-      size={size}
-      maxSize={maxSize}
-      fullSize={size === maxSize}
-    >
+    <Container isDragging={isDragging}>
       <GlobalActions
         sandbox={sandbox}
         toggleLike={toggleLike}
@@ -150,6 +145,7 @@ export default function SplitView({
         onDragFinished={onDragFinished}
         minSize="0%"
         maxSize={maxSize}
+        // @ts-ignore
         onMouseEnter={onDragStarted}
         size={size}
         {...props}

--- a/packages/app/src/embed/index.js
+++ b/packages/app/src/embed/index.js
@@ -5,7 +5,7 @@ import requirePolyfills from '@codesandbox/common/lib/load-dynamic-polyfills';
 import 'normalize.css';
 import '@codesandbox/common/lib/global.css';
 import track, { identifyOnce } from '@codesandbox/common/lib/utils/analytics';
-import App from './components/App';
+import { App } from './components/App';
 
 try {
   // If this value is not set, set it to false

--- a/yarn.lock
+++ b/yarn.lock
@@ -21055,6 +21055,11 @@ lodash@^3.6.0:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 
+lodash@^4.17.20:
+  version "4.17.20"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
+  integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
+
 lodash@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-1.0.2.tgz#8f57560c83b59fc270bd3d561b690043430e2551"
@@ -26170,6 +26175,11 @@ quote-stream@^1.0.1, quote-stream@~1.0.2:
     minimist "^1.1.3"
     through2 "^2.0.0"
 
+raf-schd@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/raf-schd/-/raf-schd-4.0.2.tgz#bd44c708188f2e84c810bf55fcea9231bcaed8a0"
+  integrity sha512-VhlMZmGy6A6hrkJWHLNTGl5gtgMUm+xfGza6wbwnE914yeQ5Ybm18vgM734RZhMgfw4tacUrWseGZlpUrrakEQ==
+
 raf@^3.1.0, raf@^3.4.0, raf@^3.4.1:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.1.tgz#0742e99a4a6552f445d73e3ee0328af0ff1ede39"
@@ -26838,6 +26848,16 @@ react-refresh@^0.7.2:
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.7.2.tgz#f30978d21eb8cac6e2f2fde056a7d04f6844dd50"
   integrity sha512-u5l7fhAJXecWUJzVxzMRU2Zvw8m4QmDNHlTrT5uo3KBlYBhmChd7syAakBoay1yIiVhx/8Fi7a6v6kQZfsw81Q==
+
+react-resize-detector@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/react-resize-detector/-/react-resize-detector-5.2.0.tgz#992083834432308c551a8251a2c52306d9d16718"
+  integrity sha512-PQAc03J2eyhvaiWgEdQ8+bKbbyGJzLEr70KuivBd1IEmP/iewNakLUMkxm6MWnDqsRPty85pioyg8MvGb0qC8A==
+  dependencies:
+    lodash "^4.17.20"
+    prop-types "^15.7.2"
+    raf-schd "^4.0.2"
+    resize-observer-polyfill "^1.5.1"
 
 react-router-dom@^4.2.2:
   version "4.3.1"


### PR DESCRIPTION
The first commit is just converting some files to TS, the second commit is more interesting. This change introduces two things:

1. Editor and Preview automatically resize on sidebar close/open + window resize
2. The ratio between editor and preview is kept after resize