### PR TITLE
Add extra validation for showing delete template

### DIFF
--- a/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenus/SandboxMenu.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenus/SandboxMenu.tsx
@@ -43,10 +43,21 @@ export const SandboxMenu: React.FC<SandboxMenuProps> = ({
 
   // TODO(@CompuIves): remove the `item.sandbox.teamId === null` check, once the server is not
   // responding with teamId == null for personal templates anymore.
-  const hasAccess = React.useMemo(
-    () => item.sandbox.teamId === activeTeam || item.sandbox.teamId === null,
-    [item, activeTeam]
-  );
+  const hasAccess = React.useMemo(() => {
+    if (item.sandbox.teamId === activeTeam) {
+      return true;
+    }
+
+    if (item.sandbox.teamId === null) {
+      if (!item.sandbox.authorId) {
+        return false;
+      }
+
+      return true;
+    }
+
+    return false;
+  }, [item, activeTeam]);
 
   const isOwner = React.useMemo(() => {
     if (item.type !== 'template') {


### PR DESCRIPTION
Currently, to delete a template we let you do it if the template's team is null and this resulted in people having a button to delete recently used templates that had no team but also had no author id either

These are Github templates you cannot delete

This adds a check for that

closes #5026