### PR TITLE
LSP connection maximum try attempts: 10

### DIFF
--- a/packages/app/src/app/overmind/effects/vscode/index.ts
+++ b/packages/app/src/app/overmind/effects/vscode/index.ts
@@ -776,7 +776,9 @@ export class VSCodeEffect {
   }
 
   private createWebsocketFSRequest() {
-    const socket = io(`${this.getLspEndpoint()}?type=go-to-definition`);
+    const socket = io(`${this.getLspEndpoint()}?type=go-to-definition`,{
+      reconnectionAttempts: 10,
+    });
     return {
       emit: (data, cb) => {
         socket.emit('go-to-definition', data, cb);


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?

**This PR is a proposal.**

Connecting to our LSP socket server could cause to crash the browser/tab. 

Why? I left a tab with codesandbox running in the background for 1-2 hours, and it caused 10000+ (connection) errors in the console. My browser was unresponsive, and had to force shutdown it.

## What is the current behavior?

Our `language server` tries to connect `infinite` times to our WebSocket server.

## What is the new behavior?

It only tries to connect ten times.