### PR TITLE
allow access to process from within VSCode

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,4 +7,4 @@ ADD .git /workspace/.git
 WORKDIR /workspace
 RUN git reset --hard
 RUN apt update
-RUN apt install -y nano less
+RUN apt install -y nano less tmux

--- a/docker/run-docker.sh
+++ b/docker/run-docker.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
-
-yarn
-NODE_OPTIONS=--max_old_space_size=8192 yarn run start:dev_api
+yarn && yarn start:dev_api
+tail -f /dev/null

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "start": "yarn build:deps && cross-env NODE_ENV=development lerna run start --scope @codesandbox/common --scope @codesandbox/components --scope app --parallel",
     "start:common": "lerna run start --scope @codesandbox/common --stream",
     "start:components": "lerna run start --scope @codesandbox/components --stream",
-    "start:dev_api": "concurrently --raw \"cd packages/app && yarn start:dev_api\" \"cd packages/common && yarn start\" \"cd packages/components && yarn start\"",
+    "start:dev_api": "(tmux new-session -d -s csb \"NODE_OPTIONS=--max_old_space_size=8192 concurrently --raw 'cd packages/app && yarn start:dev_api' 'cd packages/common && yarn start' 'cd packages/components && yarn start'\" || tmux attach -t csb) && tmux attach -t csb",
     "start:dynamic": "lerna run dev --scope dynamic-pages --stream",
     "start:fast": "cross-env NODE_ENV=development concurrently --raw \"cd packages/app && yarn start\" \"cd packages/common && yarn start\" \"cd packages/components && yarn start\"",
     "start:profiling": "cross-env NODE_ENV=production PROFILING=true concurrently --raw \"cd packages/app && yarn start\" \"cd packages/common && yarn start\" \"cd packages/components && yarn start\"",


### PR DESCRIPTION
This will rather start the client process in a tmux session, which can be accessed from within VSCode. It is inserted behind the `start:dev_api`.

It does not matter if process is already running or not. If it is running the `start:dev_api` command will open the existing session. If not, it will start the process and open the tmux session.

To exit a tmux session you use `ctrl + b`