### PR TITLE
Create binary before sending it to webpack loader

### DIFF
--- a/packages/sandpack-core/src/transpiler/transpilers/webpack/index.ts
+++ b/packages/sandpack-core/src/transpiler/transpilers/webpack/index.ts
@@ -33,6 +33,9 @@ export class WebpackTranspiler extends Transpiler {
       return result;
     };
 
+    // Todo; this whole conversion from http strings to buffers should be done on the CodeSandbox
+    // side in a pre-transpiler. Ideally code like this should be unaware of the implementation
+    // details of http strings, and just work with buffers instead.
     const codeIsHttp = code.startsWith('http');
     const webpackCode = codeIsHttp
       ? await fetch(loaderContext._module.module.code)

--- a/packages/sandpack-core/src/transpiler/transpilers/webpack/index.ts
+++ b/packages/sandpack-core/src/transpiler/transpilers/webpack/index.ts
@@ -8,7 +8,11 @@ import { Transpiler, TranspilerResult } from '../..';
  * transpilers. It's a best effort on making webpack loaders work dynamically in Sandpack.
  */
 export class WebpackTranspiler extends Transpiler {
-  private webpackLoader: Promise<(code: string) => string>;
+  private webpackLoader: Promise<{
+    raw?: boolean;
+    (code: string | Buffer): string;
+  }>;
+
   constructor(webpackLoader: string, evaluator: IEvaluator) {
     super(webpackLoader);
 
@@ -29,9 +33,18 @@ export class WebpackTranspiler extends Transpiler {
       return result;
     };
 
+    const codeIsHttp = code.startsWith('http');
+    const webpackCode = codeIsHttp
+      ? await fetch(loaderContext._module.module.code)
+          .then(x => x.arrayBuffer())
+          .then(buffer => Buffer.from(buffer))
+      : Buffer.from(code);
+
     const webpackLoaderContext = { ...loaderContext, async: asyncFunc };
 
-    const webpackResult = await loader.apply(webpackLoaderContext, [code]);
+    const webpackResult = await loader.apply(webpackLoaderContext, [
+      loader.raw ? webpackCode : webpackCode.toString('utf-8'),
+    ]);
 
     return {
       transpiledCode: webpackResult,


### PR DESCRIPTION
This will make binary loaders from webpack (like `arraybuffer-loader`) work.