### PR TITLE
fall back to empty object if deps object does not exist

### DIFF
--- a/packages/app/src/app/pages/Sandbox/SearchDependencies/Dependency.tsx
+++ b/packages/app/src/app/pages/Sandbox/SearchDependencies/Dependency.tsx
@@ -100,7 +100,7 @@ export const Dependency = ({ dependency }: { dependency: DependencyType }) => {
   const selectedVersion =
     hitToVersionMap[dependency.objectID] || dependency.tags.latest;
 
-  const versionInstalled = installedDependencies[dependency.name];
+  const versionInstalled = (installedDependencies || {})[dependency.name];
 
   const isDependencySelected = Boolean(
     json(selectedDependencies)[dependency.objectID]


### PR DESCRIPTION
Sometimes when importing a sandbox the dependencies object in the package.json empty and that will crash when trying to see what version you have installed


closes #5120