### PR TITLE
Step 1: Do not register webpack service worker in Sandpack

### DIFF
--- a/packages/app/src/sandbox/index.js
+++ b/packages/app/src/sandbox/index.js
@@ -14,6 +14,7 @@ import { show404 } from 'sandbox-hooks/not-found-screen';
 import compile, { getCurrentManager } from './compile';
 
 const host = process.env.CODESANDBOX_HOST;
+const withServiceWorker = !process.env.SANDPACK;
 const debug = _debug('cs:sandbox');
 
 export const SCRIPT_VERSION =
@@ -26,7 +27,9 @@ endMeasure('boot', { lastTime: 0, displayName: 'Boot' });
 const ID = Math.floor(Math.random() * 1000000);
 
 requirePolyfills().then(() => {
-  registerServiceWorker('/sandbox-service-worker.js', {});
+  if (withServiceWorker) {
+    registerServiceWorker('/sandbox-service-worker.js', {});
+  }
 
   function sendReady() {
     dispatch({ type: 'initialized', id: ID });

--- a/packages/common/src/config/env.ts
+++ b/packages/common/src/config/env.ts
@@ -21,5 +21,8 @@ export default Object.keys(process.env)
       'process.env.LOCAL_SERVER': Boolean(LOCAL_SERVER),
       'process.env.STAGING': 'STAGING_BRANCH' in process.env,
       'process.env.VSCODE': Boolean(JSON.stringify(process.env.VSCODE)),
+      'process.env.SANDPACK': Boolean(
+        JSON.parse(process.env.SANDPACK || 'false')
+      ),
     }
   );

--- a/packages/common/src/types/global.d.ts
+++ b/packages/common/src/types/global.d.ts
@@ -8,6 +8,7 @@ declare namespace NodeJS {
     STAGING_BRANCH?: string;
     ROOT_URL?: string;
     VSCODE?: string;
+    SANDPACK?: string;
   }
 }
 


### PR DESCRIPTION
- [POC: Sandpack Service Worker to Resolve Relative Files](https://github.com/codesandbox/codesandbox-client/pull/5137)
- **[Step 1: Do not register webpack service worker in Sandpack](https://github.com/codesandbox/codesandbox-client/pull/5138)**
- [Step 2: Setup webpack build for sandpack service worker](https://github.com/souldzin/codesandbox-client/pull/1)

## What kind of change does this PR introduce?

This will do undesirable caching, since the same host is used for various projects. Also, it will block us from using a service worker for handling relative resources.

## Context

- See the POC above for more context :smile:

## What is the current behavior?

Currently a service worker is always registered to optimize asset loading with caching. But! Since the same service worker can be used for multiple projects, this can be problematic. It will also conflict with using a service worker to communicate with the file resolver.

## What is the new behavior?

| Description | Screenshot |
|-------------|-------------|
| :tada: Sandpack asset host is being hit and still works | ![Screen Shot 2020-11-16 at 1 07 27 PM](https://user-images.githubusercontent.com/4908127/99297281-a867e880-280d-11eb-875f-dc27593b4b4d.png) |
| :tada: No sandpack service worker is loaded | ![Screen Shot 2020-11-16 at 1 19 11 PM](https://user-images.githubusercontent.com/4908127/99297801-5c697380-280e-11eb-84f5-2854673aa521.png) |

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

I've been testing this sandpack behavior in integration with GitLab. Here's how this was tested:

1. Build sandpack assets with `yarn run prepublishOnly`
2. Start a HTTPS server to host these assets
3. In GitLab project `yarn link "smooshpack"`
4. In GitLab project update [`application_setting_implementation.rb`](https://gitlab.com/gitlab-org/gitlab/blob/cf3844aff88ad3611e1d03d9d998a0135a14404b/app%2Fmodels%2Fapplication_setting_implementation.rb#L394) with path to local server hosting the sandpack assets.

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [X] Documentation N/A
- [ ] Testing <!-- We can only merge the PR if this is checked -->
- [X] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->
