### PR TITLE
Add order by views on dashboard

### DIFF
--- a/packages/app/src/app/overmind/namespaces/dashboard/state.ts
+++ b/packages/app/src/app/overmind/namespaces/dashboard/state.ts
@@ -201,6 +201,10 @@ export const state: State = {
           return field.toLowerCase();
         }
 
+        if (orderField === 'views') {
+          return sandbox.viewCount;
+        }
+
         return sandbox[orderField];
       }) as Sandbox[]).filter(
         x =>

--- a/packages/app/src/app/pages/Dashboard/Components/Filters/SortOptions/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Filters/SortOptions/index.tsx
@@ -6,6 +6,7 @@ const FIELD_TO_NAME = {
   insertedAt: 'Last Created',
   updatedAt: 'Last Modified',
   title: 'Name',
+  views: 'Views',
 };
 
 export const SortOptions: FunctionComponent = React.memo(() => {
@@ -31,27 +32,27 @@ export const SortOptions: FunctionComponent = React.memo(() => {
 
   return (
     <Menu>
-        <Stack align="center">
-          <Menu.Button>
-            <Text variant="muted">{FIELD_TO_NAME[field]}</Text>
-          </Menu.Button>
-          <IconButton
-            name="arrowDown"
-            size={11}
-            title="Reverse sort direction"
-            onClick={toggleSort}
-            css={{ transform: `rotate(${order === 'desc' ? 0 : 180}deg)` }}
-          />
-        </Stack>
-        <Menu.List>
-          {Object.keys(FIELD_TO_NAME).map(key => (
-            <Menu.Item field="title" key={key} onSelect={() => setField(key)}>
-              <Text variant={FIELD_TO_NAME[key] === field ? 'body' : 'muted'}>
-                {FIELD_TO_NAME[key]}
-              </Text>
-            </Menu.Item>
-          ))}
-        </Menu.List>
-      </Menu>
+      <Stack align="center">
+        <Menu.Button>
+          <Text variant="muted">{FIELD_TO_NAME[field]}</Text>
+        </Menu.Button>
+        <IconButton
+          name="arrowDown"
+          size={11}
+          title="Reverse sort direction"
+          onClick={toggleSort}
+          css={{ transform: `rotate(${order === 'desc' ? 0 : 180}deg)` }}
+        />
+      </Stack>
+      <Menu.List>
+        {Object.keys(FIELD_TO_NAME).map(key => (
+          <Menu.Item field="title" key={key} onSelect={() => setField(key)}>
+            <Text variant={FIELD_TO_NAME[key] === field ? 'body' : 'muted'}>
+              {FIELD_TO_NAME[key]}
+            </Text>
+          </Menu.Item>
+        ))}
+      </Menu.List>
+    </Menu>
   );
 });


### PR DESCRIPTION
Adds the possibility to order sandboxes in the dashboard by views

![CleanShot 2020-11-17 at 16 47 32](https://user-images.githubusercontent.com/1051509/99412232-cb20fc80-28f4-11eb-884e-8e474c407e70.gif)
