### PR TITLE
Update BUG.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG.md
+++ b/.github/ISSUE_TEMPLATE/BUG.md
@@ -9,12 +9,9 @@ about: Did something not work?
 
 <!-- Please ensure you've completed the following steps by replacing [ ] with [x]-->
 
-- [ ] I have read the
-      [Contributing Guidelines](https://github.com/codesandbox/codesandbox-client/blob/master/CONTRIBUTING.md)
-      for this project.
-- [ ] I agree to follow the
-      [Code of Conduct](https://github.com/codesandbox/codesandbox-client/blob/master/CODE_OF_CONDUCT.md)
-      that this project adheres to.
+- [ ] I have read the [Contributing Guidelines][contributing] for this project.
+- [ ] I agree to follow the [Code of Conduct][code_of_conduct] that this project
+      adheres to.
 - [ ] I have searched the issue tracker for an issue that matches the one I want
       to file, without success.
 
@@ -34,6 +31,11 @@ Your best chance of getting this bug looked at quickly is to provide an example.
 
 | Software         | Name/Version |
 | ---------------- | ------------ |
-| Сodesandbox      |
-| Browser          |
-| Operating System |
+| Сodesandbox      |              |
+| Browser          |              |
+| Operating System |              |
+
+<!-- prettier-ignore-start -->
+[code_of_conduct]: https://github.com/codesandbox/codesandbox-client/blob/master/CODE_OF_CONDUCT.md
+[contributing]: https://github.com/codesandbox/codesandbox-client/blob/master/CONTRIBUTING.md
+<!-- prettier-ignore-end -->


### PR DESCRIPTION
Now the checks' text will be on one line instead of:
<img width="522" alt="Schermafbeelding 2020-11-25 om 15 17 51" src="https://user-images.githubusercontent.com/6643991/100239310-8a973380-2f31-11eb-8e61-10c046dd7c26.png">