### PR TITLE
fix(profile): apply default value to user bio on cancel

### DIFF
--- a/packages/app/src/app/pages/Profile2/ProfileCard.tsx
+++ b/packages/app/src/app/pages/Profile2/ProfileCard.tsx
@@ -43,7 +43,7 @@ export const ProfileCard = () => {
   };
 
   const onCancel = () => {
-    setBio(user.bio);
+    setBio(user.bio || '');
     setSocialLinks(user.socialLinks);
     setEditing(false);
   };


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?
Bug fix.
<!-- Is it a Bug fix, feature, docs update, ... -->

## What is the current behavior?
The following workflow breaks the app:

- Edit profile
- Cancel
- Edit profile
<!-- You can also link to an open issue here -->

## What is the new behavior?
The `bio` is set to an empty string if `user.bio` is falsy (`null` in this case).

We can fix this in the `Textarea` component using `defaultValue ||  ''` as its initial state.

Let me know if you prefer this fix instead.
<!-- if this is a feature change -->

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. See current behaviour.

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
