### PR TITLE
Fix remove child bug

### DIFF
--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Explorer/Files/DirectoryEntry/Entry/EditIcons/ErrorBoundary.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Explorer/Files/DirectoryEntry/Entry/EditIcons/ErrorBoundary.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+export class ErrorBoundary extends React.Component<{}, { hasError: boolean }> {
+  state = { hasError: false };
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch() {
+    // do nothing
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return null;
+    }
+
+    return this.props.children;
+  }
+}

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Explorer/Files/DirectoryEntry/Entry/EditIcons/index.js
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Explorer/Files/DirectoryEntry/Entry/EditIcons/index.js
@@ -13,6 +13,7 @@ import {
   UndoIcon,
   // eslint-disable-next-line import/extensions
 } from '../../../icons.tsx';
+import { ErrorBoundary } from './ErrorBoundary';
 
 import { Container, Icon } from './elements';
 
@@ -43,63 +44,65 @@ function EditIcons({
 
   return (
     <div className={className}>
-      {hovering || (window.__isTouch && active) || forceShow ? (
-        <SingletonTooltip>
-          {singleton => (
-            <Container>
-              {onDownload && (
-                <Tooltip content="Export to ZIP" singleton={singleton}>
-                  <Icon onClick={handleClick(onDownload)}>
-                    <DownloadIcon />
-                  </Icon>
-                </Tooltip>
-              )}
-              {onUploadFile && (
-                <Tooltip content="Upload Files" singleton={singleton}>
-                  <Icon onClick={handleClick(onUploadFile)}>
-                    <UploadFileIcon />
-                  </Icon>
-                </Tooltip>
-              )}
-              {onDiscardChanges && (
-                <Tooltip content="Discard Changes">
-                  <Icon onClick={handleClick(onDiscardChanges)}>
-                    <UndoIcon />
-                  </Icon>
-                </Tooltip>
-              )}
-              {onEdit && (
-                <Tooltip content="Rename" singleton={singleton}>
-                  <Icon onClick={handleClick(onEdit)}>
-                    <EditIcon />
-                  </Icon>
-                </Tooltip>
-              )}
-              {onCreateFile && (
-                <Tooltip content="New File" singleton={singleton}>
-                  <Icon onClick={handleClick(onCreateFile)}>
-                    <AddFileIcon />
-                  </Icon>
-                </Tooltip>
-              )}
-              {onCreateDirectory && (
-                <Tooltip content="New Directory" singleton={singleton}>
-                  <Icon onClick={handleClick(onCreateDirectory)}>
-                    <AddDirectoryIcon />
-                  </Icon>
-                </Tooltip>
-              )}
-              {onDelete && (
-                <Tooltip content="Delete" singleton={singleton}>
-                  <Icon onClick={handleClick(onDelete)}>
-                    <CrossIcon />
-                  </Icon>
-                </Tooltip>
-              )}
-            </Container>
-          )}
-        </SingletonTooltip>
-      ) : null}
+      <ErrorBoundary>
+        {hovering || (window.__isTouch && active) || forceShow ? (
+          <SingletonTooltip>
+            {singleton => (
+              <Container>
+                {onDownload && (
+                  <Tooltip content="Export to ZIP" singleton={singleton}>
+                    <Icon onClick={handleClick(onDownload)}>
+                      <DownloadIcon />
+                    </Icon>
+                  </Tooltip>
+                )}
+                {onUploadFile && (
+                  <Tooltip content="Upload Files" singleton={singleton}>
+                    <Icon onClick={handleClick(onUploadFile)}>
+                      <UploadFileIcon />
+                    </Icon>
+                  </Tooltip>
+                )}
+                {onDiscardChanges && (
+                  <Tooltip content="Discard Changes">
+                    <Icon onClick={handleClick(onDiscardChanges)}>
+                      <UndoIcon />
+                    </Icon>
+                  </Tooltip>
+                )}
+                {onEdit && (
+                  <Tooltip content="Rename" singleton={singleton}>
+                    <Icon onClick={handleClick(onEdit)}>
+                      <EditIcon />
+                    </Icon>
+                  </Tooltip>
+                )}
+                {onCreateFile && (
+                  <Tooltip content="New File" singleton={singleton}>
+                    <Icon onClick={handleClick(onCreateFile)}>
+                      <AddFileIcon />
+                    </Icon>
+                  </Tooltip>
+                )}
+                {onCreateDirectory && (
+                  <Tooltip content="New Directory" singleton={singleton}>
+                    <Icon onClick={handleClick(onCreateDirectory)}>
+                      <AddDirectoryIcon />
+                    </Icon>
+                  </Tooltip>
+                )}
+                {onDelete && (
+                  <Tooltip content="Delete" singleton={singleton}>
+                    <Icon onClick={handleClick(onDelete)}>
+                      <CrossIcon />
+                    </Icon>
+                  </Tooltip>
+                )}
+              </Container>
+            )}
+          </SingletonTooltip>
+        ) : null}
+      </ErrorBoundary>
     </div>
   );
 }

--- a/packages/common/src/components/Tooltip/index.tsx
+++ b/packages/common/src/components/Tooltip/index.tsx
@@ -45,7 +45,7 @@ export const SingletonTooltip = styled(
       ...props,
     });
 
-    return children(singleton);
+    return <div>{children(singleton)}</div>;
   }
 )`
   ${mainStyles}


### PR DESCRIPTION
It turns out this issue is when you have google translate on, and it's actively translating the page into another language

What I did is find the root cause and set a boundary around it. This doesn't really seem fixable unless we change to the new tooltips that are also more accessible, but that would require a rewrite of the explorer that is already supposed to happen.

This is not the perfect solution as it will still crash that part of the app, but not the page and the part of the app is pretty small.

Video shows before and after

![CleanShot 2020-12-09 at 17 15 40](https://user-images.githubusercontent.com/1051509/101655846-5e57d880-3a42-11eb-8b07-e9722a8e1334.gif)






closes #5243
closes #5001
closes #5015
closes #5058
closes #5070
closes #5061
closes #5086
closes #5190
closes #5134
closes #5194
closes #5192