### PR TITLE
Bugfix: Show error from the server for Always On in Editor

### DIFF
--- a/packages/app/src/app/overmind/namespaces/workspace/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/workspace/actions.ts
@@ -556,9 +556,14 @@ export const sandboxAlwaysOnChanged: AsyncAction<{
     });
   } catch (error) {
     state.editor.currentSandbox.alwaysOn = oldAlwaysOn;
+
+    // this is odd to handle it in the action
+    // TODO: we need a cleaner way to read graphql errors
+    const message = error.response?.errors[0]?.message;
+
     actions.internal.handleError({
       message: "We weren't able to update always on status",
-      error,
+      error: { name: 'Always on', message },
     });
   }
 };


### PR DESCRIPTION
We already do this in dashboard, but not in editor. Copied the implementation