### PR TITLE
Adjust the size of the info icon in Always On

### DIFF
--- a/packages/app/src/app/pages/Dashboard/Content/routes/AlwaysOn/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/AlwaysOn/index.tsx
@@ -63,9 +63,10 @@ const Info = () => {
         backgroundColor: 'grays.600',
         borderRadius: 'medium',
         padding: 2,
+        paddingX: 3,
       })}
     >
-      <Icon name="info" size={24} css={{ flexShrink: 0 }} />
+      <Icon name="info" size={16} css={{ flexShrink: 0 }} />
       <Text variant="muted">
         Pilot users can make up to 3 server sandboxes Always-On.{' '}
         <Button


### PR DESCRIPTION
Tweak to the info icon size, just saw this one and thought it would be a nice one to quickly pick up.

Old:
<img width="1005" alt="Screenshot 2020-12-10 at 14 20 16" src="https://user-images.githubusercontent.com/587016/101777878-5f950e00-3af3-11eb-8b96-c479c37e3414.png">

New:
<img width="1039" alt="Screenshot 2020-12-10 at 14 22 51" src="https://user-images.githubusercontent.com/587016/101777885-63289500-3af3-11eb-94a4-fab82679596b.png">
