### PR TITLE
Hide fork menu item for read user

### DIFF
--- a/packages/app/src/app/overmind/effects/vscode/Workbench.ts
+++ b/packages/app/src/app/overmind/effects/vscode/Workbench.ts
@@ -201,15 +201,23 @@ export class Workbench {
       },
     });
 
-    this.appendMenuItem(MenuId.MenubarFileMenu, {
-      // Z to be the last item after vscode group 4
-      group: '4_zsandbox',
-      order: 1,
-      command: {
-        id: 'codesandbox.sandbox.fork',
-        title: '&&Fork Sandbox',
-      },
-    });
+    if (
+      this.controller.getState().editor?.currentSandbox?.teamId ===
+        this.controller.getState().activeTeam &&
+      this.controller.getState().activeWorkspaceAuthorization === 'READ'
+    ) {
+      // don't add the option to fork
+    } else {
+      this.appendMenuItem(MenuId.MenubarFileMenu, {
+        // Z to be the last item after vscode group 4
+        group: '4_zsandbox',
+        order: 1,
+        command: {
+          id: 'codesandbox.sandbox.fork',
+          title: '&&Fork Sandbox',
+        },
+      });
+    }
 
     this.appendMenuItem(MenuId.MenubarFileMenu, {
       group: '4_zsandbox',

--- a/packages/app/src/app/overmind/effects/vscode/Workbench.ts
+++ b/packages/app/src/app/overmind/effects/vscode/Workbench.ts
@@ -202,12 +202,12 @@ export class Workbench {
     });
 
     if (
-      this.controller.getState().editor?.currentSandbox?.teamId ===
-        this.controller.getState().activeTeam &&
-      this.controller.getState().activeWorkspaceAuthorization === 'READ'
+      !(
+        this.controller.getState().editor?.currentSandbox?.teamId ===
+          this.controller.getState().activeTeam &&
+        this.controller.getState().activeWorkspaceAuthorization === 'READ'
+      )
     ) {
-      // don't add the option to fork
-    } else {
       this.appendMenuItem(MenuId.MenubarFileMenu, {
         // Z to be the last item after vscode group 4
         group: '4_zsandbox',


### PR DESCRIPTION
Tiny polish thing that came up in user testing. Want a review on implementation, not sure if this is a good way.

Read users don't have the ability to fork. Clicking this menu option leads to an error notification, so hiding it.

Note: Left the option in the command palette if you seek it out - it will still give you an error notification. Not sure if there's a way to show it but disable.

