### PR TITLE
fix(router): keep existing state when replacing

### DIFF
--- a/packages/app/src/app/overmind/effects/router.ts
+++ b/packages/app/src/app/overmind/effects/router.ts
@@ -13,7 +13,7 @@ export default new (class RouterEffect {
     alias?: string | null;
     git?: GitInfo | null;
   }) {
-    window.history.replaceState({}, '', sandboxUrl({ id, alias, git }));
+    window.history.replaceState(window.history.state, '', sandboxUrl({ id, alias, git }));
   }
 
   updateSandboxUrl(


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?

This is a proposal rather than a fix. I would say that the state should be preserved when calling `history.replaceState` instead of being deleted. I came from https://github.com/codesandbox/codesandbox-client/issues/4905 but I don't remember anymore a case where the current solution would fail...

## What is the current behavior?

<!-- You can also link to an open issue here -->

## What is the new behavior?

<!-- if this is a feature change -->

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Step A
2. Step B
3. Step C

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Testing <!-- We can only merge the PR if this is checked -->
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
