### PR TITLE
Dashboard settings - dont show created by the person who left

### DIFF
--- a/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/WorkspaceSettings.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/WorkspaceSettings.tsx
@@ -244,9 +244,11 @@ export const WorkspaceSettings = () => {
               {team.users.length}{' '}
               {team.users.length === 1 ? 'member' : 'members'}
             </Text>
-            <Text size={3} variant="muted">
-              Created by {created.username}
-            </Text>
+            {created && (
+              <Text size={3} variant="muted">
+                Created by {created.username}
+              </Text>
+            )}
           </Stack>
           {activeWorkspaceAuthorization === TeamMemberAuthorization.Admin && (
             <Button


### PR DESCRIPTION
```js
const created = team.users.find(user => user.id === team.creatorId);
```

^ This is empty when the creator is no longer part of team.

Nice to have: If `created` is empty, fetch the creator information from the public API

Fixes https://github.com/codesandbox/codesandbox-client/issues/5301