### PR TITLE
Fix date of expiring for monthly users

### DIFF
--- a/packages/app/src/app/pages/Pro/getExpiringDate.ts
+++ b/packages/app/src/app/pages/Pro/getExpiringDate.ts
@@ -1,0 +1,20 @@
+import { addMonths, format } from 'date-fns';
+
+export const getUserExpiringDate = ({
+  since,
+  duration,
+}: {
+  since: string;
+  duration: 'yearly' | 'monthly';
+}) => {
+  if (duration === 'yearly') return format(new Date(since), 'do MMM');
+
+  const day = parseInt(format(new Date(since), 'do'), 10);
+  const currentDay = parseInt(format(new Date(), 'do'), 10);
+
+  if (day === currentDay) return 'today';
+
+  if (day > currentDay) return `${day} ${format(new Date(), 'MMM')}`;
+
+  return `${day} ${format(addMonths(new Date(), 1), 'MMM')}`;
+};

--- a/packages/app/src/app/pages/Pro/index.tsx
+++ b/packages/app/src/app/pages/Pro/index.tsx
@@ -1,4 +1,4 @@
-import { format } from 'date-fns';
+import { addMonths, format } from 'date-fns';
 import { Helmet } from 'react-helmet';
 import React, { useEffect } from 'react';
 
@@ -237,35 +237,45 @@ const Expiring = ({
   user,
   updateSubscriptionClicked,
   isUpdatingSubscription,
-}) => (
-  <MaxWidth width={500}>
-    <Centered horizontal>
-      <Avatar src={user.avatarUrl} />
-      <Badge type="pro" style={{ opacity: 0.8 }}>
-        Pro
-      </Badge>
-      <Heading>Your subscription is expiring</Heading>
+}) => {
+  // if user has yearly subscription show the date he created the subscription and since it's passed they know it's next year
+  // if Monthly show the day he created and the next month on the calendar
+  const since = new Date(user.subscription.since);
+  const expiringDate =
+    user.subscription.duration === 'yearly'
+      ? format(since, 'do MMM')
+      : `${format(since, 'do')} ${format(addMonths(new Date(), 1), 'MMM')}`;
 
-      <HelpText>
-        Your subscription will be automatically cancelled on your next billing
-        date ({format(new Date(user.subscription.since), 'do MMM')}). All your
-        private sandboxes will remain available and private.
-      </HelpText>
+  return (
+    <MaxWidth width={500}>
+      <Centered horizontal>
+        <Avatar src={user.avatarUrl} />
+        <Badge type="pro" style={{ opacity: 0.8 }}>
+          Pro
+        </Badge>
+        <Heading>Your subscription is expiring</Heading>
 
-      {isUpdatingSubscription ? (
-        <Button disabled style={{ marginTop: 30 }}>
-          Creating subscription...
-        </Button>
-      ) : (
-        <Button
-          onClick={() => updateSubscriptionClicked({ coupon: '' })}
-          style={{ marginTop: 30 }}
-        >
-          Reactivate subscription
-        </Button>
-      )}
-    </Centered>
-  </MaxWidth>
-);
+        <HelpText>
+          Your subscription will be automatically cancelled on your next billing
+          date ({expiringDate}). All your private sandboxes will remain
+          available and private.
+        </HelpText>
+
+        {isUpdatingSubscription ? (
+          <Button disabled style={{ marginTop: 30 }}>
+            Creating subscription...
+          </Button>
+        ) : (
+          <Button
+            onClick={() => updateSubscriptionClicked({ coupon: '' })}
+            style={{ marginTop: 30 }}
+          >
+            Reactivate subscription
+          </Button>
+        )}
+      </Centered>
+    </MaxWidth>
+  );
+};
 
 export default ProPage;

--- a/packages/app/src/app/pages/Pro/index.tsx
+++ b/packages/app/src/app/pages/Pro/index.tsx
@@ -1,4 +1,4 @@
-import { addMonths, format } from 'date-fns';
+import { format } from 'date-fns';
 import { Helmet } from 'react-helmet';
 import React, { useEffect } from 'react';
 
@@ -26,6 +26,7 @@ import {
   BillText,
 } from './elements';
 import { SignInModalElement } from '../SignIn/Modal';
+import { getUserExpiringDate } from './getExpiringDate';
 
 const ProPage: React.FC = () => {
   const {
@@ -237,45 +238,35 @@ const Expiring = ({
   user,
   updateSubscriptionClicked,
   isUpdatingSubscription,
-}) => {
-  // if user has yearly subscription show the date he created the subscription and since it's passed they know it's next year
-  // if Monthly show the day he created and the next month on the calendar
-  const since = new Date(user.subscription.since);
-  const expiringDate =
-    user.subscription.duration === 'yearly'
-      ? format(since, 'do MMM')
-      : `${format(since, 'do')} ${format(addMonths(new Date(), 1), 'MMM')}`;
+}) => (
+  <MaxWidth width={500}>
+    <Centered horizontal>
+      <Avatar src={user.avatarUrl} />
+      <Badge type="pro" style={{ opacity: 0.8 }}>
+        Pro
+      </Badge>
+      <Heading>Your subscription is expiring</Heading>
 
-  return (
-    <MaxWidth width={500}>
-      <Centered horizontal>
-        <Avatar src={user.avatarUrl} />
-        <Badge type="pro" style={{ opacity: 0.8 }}>
-          Pro
-        </Badge>
-        <Heading>Your subscription is expiring</Heading>
+      <HelpText>
+        Your subscription will be automatically cancelled on your next billing
+        date ({getUserExpiringDate(user.subscription)}). All your private
+        sandboxes will remain available and private.
+      </HelpText>
 
-        <HelpText>
-          Your subscription will be automatically cancelled on your next billing
-          date ({expiringDate}). All your private sandboxes will remain
-          available and private.
-        </HelpText>
-
-        {isUpdatingSubscription ? (
-          <Button disabled style={{ marginTop: 30 }}>
-            Creating subscription...
-          </Button>
-        ) : (
-          <Button
-            onClick={() => updateSubscriptionClicked({ coupon: '' })}
-            style={{ marginTop: 30 }}
-          >
-            Reactivate subscription
-          </Button>
-        )}
-      </Centered>
-    </MaxWidth>
-  );
-};
+      {isUpdatingSubscription ? (
+        <Button disabled style={{ marginTop: 30 }}>
+          Creating subscription...
+        </Button>
+      ) : (
+        <Button
+          onClick={() => updateSubscriptionClicked({ coupon: '' })}
+          style={{ marginTop: 30 }}
+        >
+          Reactivate subscription
+        </Button>
+      )}
+    </Centered>
+  </MaxWidth>
+);
 
 export default ProPage;


### PR DESCRIPTION
We had an issue that no matter if you had a monthly or yearly subscription on the expiring page we would always show yearly

This fixed that by checking and if it's monthly checks the day the user subscribed, the calendar month and adds one to it.

For example, someone who subscribed on the 12th of January would see:

On Monthly: 12 of Februray
On yearly: 12 January