### PR TITLE
feat: alias react-native-svg

### DIFF
--- a/packages/app/src/sandbox/eval/presets/create-react-app/utils.ts
+++ b/packages/app/src/sandbox/eval/presets/create-react-app/utils.ts
@@ -99,4 +99,6 @@ export const aliases = {
     'expo-asset/build/Image/assetPathUtils',
   'react-native/Libraries/Image/resolveAssetSource$':
     'expo-asset/build/resolveAssetSource',
+  // Alias react-native-svg to svgs
+  'react-native-svg': 'svgs'
 };

--- a/packages/app/src/sandbox/eval/presets/create-react-app/utils.ts
+++ b/packages/app/src/sandbox/eval/presets/create-react-app/utils.ts
@@ -100,5 +100,5 @@ export const aliases = {
   'react-native/Libraries/Image/resolveAssetSource$':
     'expo-asset/build/resolveAssetSource',
   // Alias react-native-svg to svgs
-  'react-native-svg': 'svgs'
+  'react-native-svg$': 'svgs'
 };


### PR DESCRIPTION
## What kind of change does this PR introduce?

Is it a feature

## What is the current behavior?

Don't support for react-native-svg 

## What is the new behavior?

support react-native-svg by svgs