### PR TITLE
Fix redirect to /s from the dashboard when clicking the logo

### DIFF
--- a/packages/app/src/app/pages/Dashboard/Header/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Header/index.tsx
@@ -68,6 +68,7 @@ export const Header: React.FC<HeaderProps> = React.memo(
       >
         <Link
           href="/?from-app=1"
+          as="a"
           css={css({ display: ['none', 'none', 'block'] })}
         >
           <LogoIcon

--- a/packages/app/src/app/pages/Sandbox/Editor/Header/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Header/index.tsx
@@ -59,7 +59,13 @@ export const Header = () => {
               </Link>
             )
           ) : (
-            <Link href="/" css={{ padding: '2px' /* micro adjustment */ }}>
+            <Link
+              as="a"
+              target="_blank"
+              rel="noreferrer noopener"
+              href="/"
+              css={{ padding: '2px' /* micro adjustment */ }}
+            >
               <LogoIcon height={24} />
             </Link>
           )}


### PR DESCRIPTION
It turns out that we redirect within `create-react-app` but since the homepage is not in `create-react-app`, it doesn't work. We need to use an `a` tag to make the page opening go outside of the `create-react-app` framework.