### PR TITLE
fix(profile):prevent redirection on clicking close icon for upgrade banner

### DIFF
--- a/packages/app/src/app/pages/Profile2/AllSandboxes.tsx
+++ b/packages/app/src/app/pages/Profile2/AllSandboxes.tsx
@@ -308,3 +308,4 @@ const UpgradeBanner = () => {
     </Stack>
   );
 };
+

--- a/packages/app/src/app/pages/Profile2/AllSandboxes.tsx
+++ b/packages/app/src/app/pages/Profile2/AllSandboxes.tsx
@@ -242,7 +242,7 @@ const UpgradeBanner = () => {
   const dontShowUpgradeMessage = (
     event: React.MouseEvent<HTMLButtonElement>
   ) => {
-    event.stopPropagation();
+    event.preventDefault();
     browser.storage.set('PROFILE_SHOW_UPGRADE', false);
     setShowUpgradeMessage(false);
   };


### PR DESCRIPTION

<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

Hey 👋 

## What kind of change does this PR introduce?
Bug Fix
<!-- Is it a Bug fix, feature, docs update, ... -->

## What is the current behavior?
When we close the `Upgrade to Pro` message on the Profile page it takes us to the `pro` pricing page. I am not sure if this is the intended behavior. Screen rec for the issue: 

https://www.loom.com/share/b23fe204f9c64455adea2859ff417196
<!-- You can also link to an open issue here -->

## What is the new behavior?
To not redirect to the pricing page on clicking the close button.

https://www.loom.com/share/86d2f04677e543ac968cec403afb5939
<!-- if this is a feature change -->

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Checked redirection with close button
2. Confirmed that clicking on banner still takes to the Pricing page

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
