### PR TITLE
fix(profile): show no sandboxes found message in Liked Sandboxes Page

### DIFF
--- a/packages/app/src/app/pages/Profile2/LikedSandboxes.tsx
+++ b/packages/app/src/app/pages/Profile2/LikedSandboxes.tsx
@@ -33,6 +33,16 @@ export const LikedSandboxes = () => {
     // only show public sandboxes on profile
     .filter(sandbox => sandbox.privacy === 0);
 
+  if (!sandboxes.length) {
+    return (
+      <Stack justify="center" align="center">
+        <Text variant="muted" size={4} weight="medium" align="center">
+          This user does not have any liked sandboxes yet
+        </Text>
+      </Stack>
+    );
+  }
+
   return (
     <Stack as="section" direction="vertical" gap={6}>
       <Stack justify="space-between" align="center">
@@ -84,6 +94,8 @@ const Pagination = () => {
   } = useOvermind();
 
   const numberOfPages = Math.ceil(givenLikeCount / SANDBOXES_PER_PAGE);
+
+  if (numberOfPages < 2) return null;
 
   return (
     <nav role="navigation" aria-label="Pagination Navigation">

--- a/packages/app/src/app/pages/Profile2/LikedSandboxes.tsx
+++ b/packages/app/src/app/pages/Profile2/LikedSandboxes.tsx
@@ -33,7 +33,7 @@ export const LikedSandboxes = () => {
     // only show public sandboxes on profile
     .filter(sandbox => sandbox.privacy === 0);
 
-  if (!sandboxes.length) {
+  if (!isLoadingSandboxes && sandboxes.length === 0) {
     return (
       <Stack justify="center" align="center">
         <Text variant="muted" size={4} weight="medium" align="center">


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?
Enhancement
<!-- Is it a Bug fix, feature, docs update, ... -->

## What is the current behavior?
Shows no messages but have active buttons as seen in below screenshot.

![image](https://user-images.githubusercontent.com/22376783/105609895-4c53ae80-5dd2-11eb-9373-c51355c35a41.png)

<!-- You can also link to an open issue here -->

## What is the new behavior?
Shows no sandboxes message.
![image](https://user-images.githubusercontent.com/22376783/105609912-67beb980-5dd2-11eb-87cf-7041c5501df2.png)

<!-- if this is a feature change -->

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Tested with no liked sandboxes
2. Tested with Liked Sandboxes

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->

____
Can we add a `.nvmrc` file?  Whenever opening a new session to run scripts, I need to manually use the node version for eg: `nvm use 10.22.1`