### PR TITLE
Enable new React transform for every React version

### DIFF
--- a/packages/common/src/utils/supports-new-react-transform.ts
+++ b/packages/common/src/utils/supports-new-react-transform.ts
@@ -12,9 +12,7 @@ export function supportsNewReactTransform(
   if (reactScriptsVersion && reactVersion && reactDomVersion) {
     return (
       /^[a-z]/.test(reactScriptsVersion) ||
-      (semver.intersects(reactScriptsVersion, '^4.0.0') &&
-        semver.intersects(reactVersion, '^17.0.0') &&
-        semver.intersects(reactDomVersion, '^17.0.0'))
+      semver.intersects(reactScriptsVersion, '^4.0.0')
     );
   }
 


### PR DESCRIPTION
This enables the new React transform for any React version, the reason behind this is that React doesn't require v17 to utilize the transform, eg. React v16 works too. The React team uses CodeSandbox CI to test, and their version is `0.0.0-abc` so it doesn't work for them all the time.