### PR TITLE
Stop using string manipulation for import renames

### DIFF
--- a/packages/app/src/sandbox/eval/presets/angular-cli/index.ts
+++ b/packages/app/src/sandbox/eval/presets/angular-cli/index.ts
@@ -1,6 +1,7 @@
 // @flow
 import { join, absolute } from '@codesandbox/common/lib/utils/path';
 import { Manager, TranspiledModule, Preset } from 'sandpack-core';
+import csbDynamicImportTranspiler from 'sandpack-core/lib/transpiler/transpilers/csb-dynamic-import';
 
 import angular2Transpiler from '../../transpilers/angular2-template';
 import typescriptTranspiler from '../../transpilers/typescript';
@@ -225,6 +226,7 @@ export default function initialize() {
   preset.registerTranspiler(module => /\.tsx?$/.test(module.path), [
     { transpiler: angular2Transpiler, options: { preTranspilers: styles } },
     { transpiler: typescriptTranspiler },
+    { transpiler: csbDynamicImportTranspiler },
   ]);
 
   preset.registerTranspiler(module => /\.m?js$/.test(module.path), [

--- a/packages/app/src/sandbox/eval/presets/cxjs/index.ts
+++ b/packages/app/src/sandbox/eval/presets/cxjs/index.ts
@@ -1,4 +1,5 @@
 import { Preset } from 'sandpack-core';
+import csbDynamicImportTranspiler from 'sandpack-core/lib/transpiler/transpilers/csb-dynamic-import';
 
 import babelTranspiler from '../../transpilers/babel';
 import jsonTranspiler from '../../transpilers/json';
@@ -55,6 +56,7 @@ export default function initialize() {
 
   cxjsPreset.registerTranspiler(module => /\.tsx?$/.test(module.path), [
     { transpiler: tsTranspiler },
+    { transpiler: csbDynamicImportTranspiler },
   ]);
 
   cxjsPreset.registerTranspiler(module => /\.css$/.test(module.path), [

--- a/packages/app/src/sandbox/eval/presets/dojo/index.ts
+++ b/packages/app/src/sandbox/eval/presets/dojo/index.ts
@@ -1,5 +1,6 @@
 import { join, absolute } from '@codesandbox/common/lib/utils/path';
 import { Preset } from 'sandpack-core';
+import csbDynamicImportTranspiler from 'sandpack-core/lib/transpiler/transpilers/csb-dynamic-import';
 
 import typescriptTranspiler from '../../transpilers/typescript';
 import rawTranspiler from '../../transpilers/raw';
@@ -38,6 +39,7 @@ export default function initialize() {
 
   preset.registerTranspiler(module => /\.tsx?$/.test(module.path), [
     { transpiler: typescriptTranspiler },
+    { transpiler: csbDynamicImportTranspiler }
   ]);
 
   preset.registerTranspiler(module => /\.m?jsx?$/.test(module.path), [

--- a/packages/app/src/sandbox/eval/presets/vue-cli/v2.ts
+++ b/packages/app/src/sandbox/eval/presets/vue-cli/v2.ts
@@ -1,4 +1,5 @@
 import { Preset } from 'sandpack-core';
+
 import babelTranspiler from '../../transpilers/babel';
 import typescriptTranspiler from '../../transpilers/typescript';
 import jsonTranspiler from '../../transpilers/json';
@@ -67,6 +68,7 @@ export default function initialize(vuePreset: Preset) {
   ]);
   vuePreset.registerTranspiler(module => /\.m?tsx?$/.test(module.path), [
     { transpiler: typescriptTranspiler },
+    { transpiler: babelTranspiler },
   ]);
   vuePreset.registerTranspiler(module => /\.json$/.test(module.path), [
     { transpiler: jsonTranspiler },

--- a/packages/app/src/sandbox/eval/presets/vue-cli/v3.ts
+++ b/packages/app/src/sandbox/eval/presets/vue-cli/v3.ts
@@ -72,6 +72,7 @@ export default function initialize(vuePreset: Preset) {
   ]);
   vuePreset.registerTranspiler(module => /\.m?tsx?$/.test(module.path), [
     { transpiler: typescriptTranspiler },
+    { transpiler: babelTranspiler },
   ]);
   vuePreset.registerTranspiler(module => /\.json$/.test(module.path), [
     { transpiler: jsonTranspiler },

--- a/packages/sandpack-core/src/preset/preset.test.ts
+++ b/packages/sandpack-core/src/preset/preset.test.ts
@@ -69,7 +69,7 @@ describe('preset', () => {
       };
 
       expect(preset.getQuery(module, evaluator)).toEqual(
-        '!codesandbox-dynamic-imports-loader!babel-loader'
+        '!babel-loader'
       );
     });
 
@@ -80,7 +80,7 @@ describe('preset', () => {
       };
 
       expect(preset.getQuery(module, evaluator)).toEqual(
-        '!codesandbox-dynamic-imports-loader!modules-loader!style-loader'
+        '!modules-loader!style-loader'
       );
     });
 
@@ -91,7 +91,7 @@ describe('preset', () => {
       };
 
       expect(preset.getQuery(module, evaluator, '!babel-loader')).toEqual(
-        '!codesandbox-dynamic-imports-loader!babel-loader'
+        '!babel-loader'
       );
     });
 
@@ -102,7 +102,7 @@ describe('preset', () => {
       };
 
       expect(preset.getQuery(module, evaluator, 'babel-loader')).toEqual(
-        '!codesandbox-dynamic-imports-loader!babel-loader!modules-loader!style-loader'
+        '!babel-loader!modules-loader!style-loader'
       );
     });
   });

--- a/packages/sandpack-core/src/preset/preset.ts
+++ b/packages/sandpack-core/src/preset/preset.ts
@@ -73,7 +73,7 @@ export class Preset {
   preTranspilers: TranspilerDefinition[] = [];
 
   postTranspilers: TranspilerDefinition[] = [
-    { transpiler: csbDynamicImportTranspiler },
+    // { transpiler: csbDynamicImportTranspiler },
   ];
 
   constructor(

--- a/yarn.lock
+++ b/yarn.lock
@@ -26538,10 +26538,10 @@ react-hotkeys@2.0.0:
   dependencies:
     prop-types "^15.6.1"
 
-react-icon-base@^2.1.0:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/react-icon-base/-/react-icon-base-2.1.2.tgz#a17101dad9c1192652356096860a9ab43a0766c7"
-  integrity sha512-NRlRo0RPxWRMQT7osj8UCBSSXsGOxhF1pre84ildhuft5S2U382NOs7tg29osWSjbO90L2a3VTCqadA/LnAzHQ==
+react-icon-base@2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/react-icon-base/-/react-icon-base-2.1.0.tgz#a196e33fdf1e7aaa1fda3aefbb68bdad9e82a79d"
+  integrity sha1-oZbjP98eeqof2jrvu2i9rZ6Cp50=
 
 react-icons@^2.2.7:
   version "2.2.7"


### PR DESCRIPTION
We now use transpilers for renaming `import` to `$csbImport` instead of string manipulation. 

Fixes #5079