### PR TITLE
fix text truncate

### DIFF
--- a/packages/app/src/app/components/CreateNewSandbox/CreateSandbox/SandboxCard/SandboxCard.tsx
+++ b/packages/app/src/app/components/CreateNewSandbox/CreateSandbox/SandboxCard/SandboxCard.tsx
@@ -63,6 +63,7 @@ export const SandboxCard: React.FC<ISandboxCardProps> = ({
       onKeyPress={onKeyPress}
       tabIndex={focused ? 0 : -1}
       focused={focused}
+      title={title}
     >
       <Icon color={color}>
         {official && OfficialIcon ? <OfficialIcon /> : <UserIcon />}

--- a/packages/app/src/app/components/CreateNewSandbox/CreateSandbox/SandboxCard/elements.ts
+++ b/packages/app/src/app/components/CreateNewSandbox/CreateSandbox/SandboxCard/elements.ts
@@ -11,6 +11,7 @@ export const Container = styled.button<{ focused?: boolean }>`
   cursor: pointer;
   text-decoration: none;
   border-radius: 2px;
+  overflow: hidden;
 
   &:focus {
     background-color: #242424;
@@ -43,6 +44,7 @@ export const Details = styled.div`
   flex: 1 1 auto;
   flex-direction: column;
   margin-left: 1rem;
+  overflow: hidden;
 `;
 
 export const Row = styled.div`
@@ -59,7 +61,6 @@ export const Title = styled.span`
   margin-bottom: 0.125rem;
   font-size: 13px;
   line-height: 1rem;
-  max-width: 200px;
   text-align: left;
   max-height: 16px;
   white-space: nowrap;

--- a/packages/app/src/app/pages/Dashboard/Components/Sandbox/SandboxListItem.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Sandbox/SandboxListItem.tsx
@@ -66,7 +66,15 @@ export const SandboxListItem = ({
     })}
   >
     <Grid css={{ width: 'calc(100% - 26px - 8px)' }} columnGap={2}>
-      <Column span={[12, 7, 7]} css={{ display: 'block', overflow: 'hidden' }}>
+      <Column
+        span={[12, 7, 7]}
+        css={{
+          display: 'block',
+          overflow: 'hidden',
+          paddingBottom: 4,
+          paddingTop: 4,
+        }}
+      >
         <Stack gap={4} align="center" marginLeft={2}>
           <Stack
             as="div"
@@ -101,10 +109,10 @@ export const SandboxListItem = ({
                 <span
                   css={css({
                     backgroundColor: 'green',
-                    width: 4,
-                    height: 4,
+                    width: 3,
+                    height: 3,
                     position: 'absolute',
-                    right: '-8px',
+                    right: '-6px',
                     bottom: '-4px',
                     borderRadius: '50%',
                   })}

--- a/packages/app/src/app/pages/Dashboard/Components/Sandbox/SandboxListItem.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Sandbox/SandboxListItem.tsx
@@ -65,8 +65,8 @@ export const SandboxListItem = ({
       },
     })}
   >
-    <Grid css={{ width: 'calc(100% - 26px - 8px)' }}>
-      <Column span={[12, 5, 5]}>
+    <Grid css={{ width: 'calc(100% - 26px - 8px)' }} columnGap={2}>
+      <Column span={[12, 7, 7]} css={{ display: 'block', overflow: 'hidden' }}>
         <Stack gap={4} align="center" marginLeft={2}>
           <Stack
             as="div"
@@ -84,6 +84,7 @@ export const SandboxListItem = ({
               borderColor: 'grays.500',
               backgroundColor: 'grays.700',
               flexShrink: 0,
+              position: 'relative',
               svg: {
                 filter: 'grayscale(1)',
                 opacity: 0.1,
@@ -95,9 +96,24 @@ export const SandboxListItem = ({
                 : null]: `url(${screenshotUrl})`,
             }}
           >
+            {alwaysOn && (
+              <Tooltip label="Always-On">
+                <span
+                  css={css({
+                    backgroundColor: 'green',
+                    width: 4,
+                    height: 4,
+                    position: 'absolute',
+                    right: '-8px',
+                    bottom: '-4px',
+                    borderRadius: '50%',
+                  })}
+                />
+              </Tooltip>
+            )}
             {screenshotUrl ? null : <TemplateIcon width="16" height="16" />}
           </Stack>
-          <Element style={{ width: 150 }}>
+          <Element css={{ overflow: 'hidden' }}>
             {editing ? (
               <form onSubmit={onSubmit}>
                 <Input
@@ -120,13 +136,6 @@ export const SandboxListItem = ({
             )}
           </Element>
         </Stack>
-      </Column>
-      <Column span={[0, 2, 2]} as={Stack} align="center">
-        {alwaysOn && (
-          <Text size={3} css={css({ color: 'green' })} maxWidth="100%">
-            Always-On
-          </Text>
-        )}
       </Column>
       <Column span={[0, 3, 3]} as={Stack} align="center">
         {sandbox.removedAt ? (

--- a/packages/app/src/app/pages/Dashboard/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/index.tsx
@@ -88,7 +88,6 @@ export const Dashboard: FunctionComponent = () => {
                   />
                 ) : (
                   <Element
-                    as="aside"
                     id="desktop-sidebar"
                     css={css({ display: ['none', 'none', 'block'] })}
                   >

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -21,6 +21,7 @@
     "start": "(yarn tsc --watch & yarn babel src --out-dir lib --watch & yarn cpx \"src/**/*.{css,svg,png,jpg,woff,woff2}\" lib --watch)",
     "start:storybook": "start-storybook",
     "test": "cross-env NODE_ENV=test jest --maxWorkers 2",
+    "test:update": "cross-env NODE_ENV=test jest --updateSnapshot",
     "typecheck": "tsc --noEmit"
   },
   "jest": {

--- a/packages/common/src/theme/__snapshots__/theme.test.ts.snap
+++ b/packages/common/src/theme/__snapshots__/theme.test.ts.snap
@@ -444,10 +444,10 @@ Object {
     },
     "medium": Object {
       "max": 979,
-      "min": 780,
+      "min": 768,
     },
     "small": Object {
-      "max": 779,
+      "max": 767,
       "min": 600,
     },
     "xlarge": Object {

--- a/packages/common/src/theme/breakpoints.ts
+++ b/packages/common/src/theme/breakpoints.ts
@@ -1,9 +1,9 @@
 export const media = {
   between(lowerBound, upperBound, excludeLarge = false) {
     if (excludeLarge)
-      return `@media (min-width: ${
-        lowerBound.min
-      }px) and (max-width: ${upperBound.min - 1}px)`;
+      return `@media (min-width: ${lowerBound.min}px) and (max-width: ${
+        upperBound.min - 1
+      }px)`;
     if (upperBound.max === Infinity)
       return `@media (min-width: lowerBound.min}px)`;
     return `@media (min-width: lowerBound.min}px) and (max-width: ${upperBound.max}px)`;
@@ -26,8 +26,8 @@ export const media = {
 
 export const sizes = {
   xsmall: { min: 0, max: 599 },
-  small: { min: 600, max: 779 },
-  medium: { min: 780, max: 979 },
+  small: { min: 600, max: 767 },
+  medium: { min: 768, max: 979 },
   large: { min: 980, max: 1279 },
   xlarge: { min: 1280, max: 1339 },
   xxlarge: { min: 1340, max: Infinity },


### PR DESCRIPTION
Dashboard - List View
- "Always-On" column replaced with a small green circle overlapping the sandbox image
- Sandbox name column wider
- Text overflow only when there's no room, removed fixed width

Sandbox templates list
- Text overflow only when there's no room, removed fixed width
- `title` attribute added so the full name is visible on hover (via browser default tooltip)

Breakpoints
- Found a 3px difference between sidebar toggle (770px) and main content going full width (767px)