### PR TITLE
fix vertical position for context menu

### DIFF
--- a/packages/components/src/components/Menu/index.tsx
+++ b/packages/components/src/components/Menu/index.tsx
@@ -146,7 +146,7 @@ const ContextMenu = ({ visible, setVisibility, position, ...props }) => {
   if (!visible) return null;
 
   const numberOfItems = React.Children.count(props.children);
-  const SUGGESTED_ITEM_HEIGHT = 36;
+  const SUGGESTED_ITEM_HEIGHT = 31;
   const suggestedHeight = numberOfItems * SUGGESTED_ITEM_HEIGHT;
   const suggestedWidth = 180;
 
@@ -171,7 +171,7 @@ const ContextMenu = ({ visible, setVisibility, position, ...props }) => {
                   position.y,
                   window.innerHeight -
                     (popoverRect.height || suggestedHeight) -
-                    16
+                    8
                 ),
               })}
             >


### PR DESCRIPTION
Issue was seen when you open context menu on sandbox cards that are located in the lower part of the screen while the dashboard is open.

Still not perfect, couldn't figure out how to position the reach menu component on top of the anchor. but at least the height is now computed based on the right height for the items (31px instead of 36px)

However, `React.Children` computes the dividers as well, hence we still have a slight offset, but at least it doesn't feel broken anymore) and depends on how many dividers the menu has.

We could make a fix by "meta" looking at the children and compute the dividers separately, but I wouldn't want to get a fragile implementation in the shared component.