### PR TITLE
context menu position: ref + getBoundingClientRect

### DIFF
--- a/packages/components/src/components/Menu/index.tsx
+++ b/packages/components/src/components/Menu/index.tsx
@@ -234,7 +234,7 @@ const MenuIconButton = props => (
 
 interface MenuListProps {
   children: any;
-  style: React.CSSProperties;
+  style?: React.CSSProperties;
 }
 
 const MenuList = React.forwardRef<HTMLDivElement, MenuListProps>(

--- a/packages/components/src/components/Menu/index.tsx
+++ b/packages/components/src/components/Menu/index.tsx
@@ -8,7 +8,7 @@ import {
 } from 'styled-components';
 import { Link } from 'react-router-dom';
 import * as ReachMenu from './reach-menu.fork';
-import { Element, Button, IconButton, List } from '../..';
+import { Element, Button, IconButton } from '../..';
 
 const transitions = {
   slide: keyframes({
@@ -143,12 +143,29 @@ const ContextMenu = ({ visible, setVisibility, position, ...props }) => {
     };
   });
 
-  if (!visible) return null;
+  const menuRef = React.useRef<HTMLDivElement>(null);
+  const [computedMenuHeight, setComputedMenuHeight] = React.useState<number>(0);
+  const [computedMenuWidth, setComputedMenuWidth] = React.useState<number>(0);
+  const [menuIsReadyToShow, setMenuIsReadyToShow] = React.useState(false);
 
-  const numberOfItems = React.Children.count(props.children);
-  const SUGGESTED_ITEM_HEIGHT = 31;
-  const suggestedHeight = numberOfItems * SUGGESTED_ITEM_HEIGHT;
-  const suggestedWidth = 180;
+  React.useEffect(() => {
+    // for the initial render, the menu is not ready to be shown
+    // because the element height cannot be computed
+    setMenuIsReadyToShow(false);
+    setTimeout(() => {
+      // once the ref is set and the menu is rendered in the dom
+      // use its height to adjust the position of the popover
+      if (menuRef.current) {
+        const boundingRect = menuRef.current.getBoundingClientRect();
+
+        setComputedMenuHeight(boundingRect.height);
+        setComputedMenuWidth(boundingRect.width);
+        setMenuIsReadyToShow(true);
+      }
+    });
+  }, [position.x, position.y]);
+
+  if (!visible) return null;
 
   return (
     <Element as={ReachMenu.Menu} {...props}>
@@ -165,17 +182,24 @@ const ContextMenu = ({ visible, setVisibility, position, ...props }) => {
                 position: 'fixed',
                 left: Math.min(
                   position.x,
-                  window.innerWidth - (popoverRect.width || suggestedWidth) - 16
+                  window.innerWidth -
+                    (popoverRect.width || computedMenuWidth) -
+                    16
                 ),
                 top: Math.min(
                   position.y,
                   window.innerHeight -
-                    (popoverRect.height || suggestedHeight) -
-                    8
+                    (popoverRect.height || computedMenuHeight) -
+                    16
                 ),
               })}
             >
-              <Menu.List>{props.children}</Menu.List>
+              <Menu.List
+                style={{ visibility: menuIsReadyToShow ? 'visible' : 'hidden' }}
+                ref={menuRef}
+              >
+                {props.children}
+              </Menu.List>
             </ReachMenu.MenuPopover>
           </MenuContext.Provider>
         );
@@ -208,20 +232,27 @@ const MenuIconButton = props => (
   <IconButton as={ReachMenu.MenuButton} {...props} />
 );
 
-const MenuList = props => {
-  const { trigger, portal } = React.useContext(MenuContext);
-  return (
-    <List
-      as={ReachMenu.MenuList}
-      data-component="MenuList"
-      data-trigger={trigger}
-      portal={portal}
-      {...props}
-    >
-      {props.children}
-    </List>
-  );
-};
+interface MenuListProps {
+  children: any;
+  style: React.CSSProperties;
+}
+
+const MenuList = React.forwardRef<HTMLDivElement, MenuListProps>(
+  (props, ref) => {
+    const { trigger, portal } = React.useContext(MenuContext);
+    return (
+      <ReachMenu.MenuList
+        style={props.style}
+        ref={ref}
+        data-component="MenuList"
+        data-trigger={trigger}
+        portal={portal}
+      >
+        {props.children}
+      </ReachMenu.MenuList>
+    );
+  }
+);
 
 const MenuItem = props => (
   <Element as={ReachMenu.MenuItem} data-component="MenuItem" {...props} />


### PR DESCRIPTION
Background: Last week I solved one issue with the context menu rendering at a big offset on the dashboard, but it was still an approximation based on the number of menu items passed.

Problem with the current solution: computing based on the number of `children` does not work (eg: on profile page it still renders below the viewport) because a Fragment will be seen as a single child in the count.

Experimental solution:
- when a new menu is triggered with a change of position (x,y), the menu is set on visibility hidden and renders all its children
- on the next cycle, the ref should be set with the menu rendered and the height/width are taken from the DOM

Potential problems:
- Still a fragile solution, if for whatever reason the menu does not render on the first pass, the bounding rect computations will fail
- I get a ref warning in the console in development env when opening a context menu, couldn't find the problem, maybe the forwardRef on the MenuList is not used properly
- Wasn't able to set the ref on a `List` element which is a styled component instance, hence I used the Reach component directly, as it also forwards the ref of its div

