### PR TITLE
Fix React Refresh boundary export changes

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -203,7 +203,7 @@
     "react-modal": "^3.6.1",
     "react-motion": "^0.5.0",
     "react-outside-click-handler": "^1.2.3",
-    "react-refresh": "^0.7.2",
+    "react-refresh": "0.9.0",
     "react-router-dom": "^5.2.0",
     "react-show": "^3.0.4",
     "react-split-pane": "^0.1.87",

--- a/packages/app/src/sandbox/compile.ts
+++ b/packages/app/src/sandbox/compile.ts
@@ -461,7 +461,7 @@ async function compile({
     }
   }
 
-  dispatch({ type: 'start' });
+  dispatch({ type: 'start', firstLoad });
   metrics.measure('compilation');
 
   const startTime = Date.now();

--- a/packages/app/src/sandbox/compile.ts
+++ b/packages/app/src/sandbox/compile.ts
@@ -639,7 +639,8 @@ async function compile({
         if (
           firstLoad &&
           localStorage.getItem('running') &&
-          Date.now() - +localStorage.getItem('running') > 8000
+          Date.now() - +localStorage.getItem('running') > 8000 &&
+          !process.env.SANDPACK
         ) {
           localStorage.removeItem('running');
           showRunOnClick();

--- a/packages/app/src/sandbox/eval/presets/create-react-app/utils/reactPreset.ts
+++ b/packages/app/src/sandbox/eval/presets/create-react-app/utils/reactPreset.ts
@@ -45,7 +45,7 @@ export const reactPreset = babelConfig => {
           dependencies['react-dom'] &&
           isMinimalReactVersion(dependencies['react-dom'], '16.9.0')
         ) {
-          return { ...dependencies, 'react-refresh': '0.8.1' };
+          return { ...dependencies, 'react-refresh': '0.9.0' };
         }
 
         return dependencies;

--- a/packages/app/src/sandbox/eval/transpilers/react/refresh-transpiler.ts
+++ b/packages/app/src/sandbox/eval/transpilers/react/refresh-transpiler.ts
@@ -151,23 +151,27 @@ module.exports = {
 
 // const _csbRefreshUtils = require('${HELPER_PATH}');
 
-// if (_csbRefreshUtils.isReactRefreshBoundary && _csbRefreshUtils.isReactRefreshBoundary(module.exports)) {
-//   _csbRefreshUtils.registerExportsForReactRefresh(module.exports, module.id)
-//   const currentExports = { ...module.exports };
-//   const isHotUpdate = !!module.hot.data;
-//   const prevExports = isHotUpdate ? module.hot.data.prevExports : null;
+// const isHotUpdate = !!module.hot.data;
+// const prevExports = isHotUpdate ? module.hot.data.prevExports : null;
+// if (_csbRefreshUtils.isReactRefreshBoundary) {
+//   if (_csbRefreshUtils.isReactRefreshBoundary(module.exports)) {
+//     _csbRefreshUtils.registerExportsForReactRefresh(module.exports, module.id)
+//     const currentExports = { ...module.exports };
 
-//   module.hot.dispose(function hotDisposeCallback(data) {
-//     data.prevExports = currentExports;
-//   });
+//     module.hot.dispose(function hotDisposeCallback(data) {
+//       data.prevExports = currentExports;
+//     });
 
-//   if (isHotUpdate && _csbRefreshUtils.shouldInvalidateReactRefreshBoundary(currentExports, prevExports)) {
+//     if (isHotUpdate && _csbRefreshUtils.shouldInvalidateReactRefreshBoundary(prevExports, currentExports)) {
+//       module.hot.invalidate();
+//     } else {
+//       module.hot.accept();
+//     }
+
+//     _csbRefreshUtils.enqueueUpdate();
+//   } else if (isHotUpdate && _csbRefreshUtils.isReactRefreshBoundary(prevExports)) {
 //     module.hot.invalidate();
-//   } else {
-//     module.hot.accept();
 //   }
-
-//   _csbRefreshUtils.enqueueUpdate();
 // }
 // `;
 
@@ -176,8 +180,8 @@ module.exports = {
  * to a single line so we don't mess with the source mapping when showing errors.
  */
 const getWrapperCode = (sourceCode: string) =>
-  `var prevRefreshReg=window.$RefreshReg$;var prevRefreshSig=window.$RefreshSig$;var RefreshRuntime=require("react-refresh/runtime");window.$RefreshReg$=(type,id)=>{const fullId=module.id+" "+id;RefreshRuntime.register(type,fullId)};window.$RefreshSig$=RefreshRuntime.createSignatureFunctionForTransform;try{${sourceCode}
-}finally{window.$RefreshReg$=prevRefreshReg;window.$RefreshSig$=prevRefreshSig}const _csbRefreshUtils=require("${HELPER_PATH}");if(_csbRefreshUtils.isReactRefreshBoundary&&_csbRefreshUtils.isReactRefreshBoundary(module.exports)){_csbRefreshUtils.registerExportsForReactRefresh(module.exports,module.id);const currentExports={...module.exports};const isHotUpdate=!!module.hot.data;const prevExports=isHotUpdate?module.hot.data.prevExports:null;module.hot.dispose((function hotDisposeCallback(data){data.prevExports=currentExports}));if(isHotUpdate&&_csbRefreshUtils.shouldInvalidateReactRefreshBoundary(currentExports,prevExports)){module.hot.invalidate()}else{module.hot.accept()}_csbRefreshUtils.enqueueUpdate()}`.trim();
+  `var prevRefreshReg=window.$RefreshReg$,prevRefreshSig=window.$RefreshSig$,RefreshRuntime=require("react-refresh/runtime");window.$RefreshReg$=(e,r)=>{const s=module.id+" "+r;RefreshRuntime.register(e,s)},window.$RefreshSig$=RefreshRuntime.createSignatureFunctionForTransform;try{${sourceCode}
+}finally{window.$RefreshReg$=prevRefreshReg,window.$RefreshSig$=prevRefreshSig}const _csbRefreshUtils=require("${HELPER_PATH}"),isHotUpdate=!!module.hot.data,prevExports=isHotUpdate?module.hot.data.prevExports:null;if(_csbRefreshUtils.isReactRefreshBoundary)if(_csbRefreshUtils.isReactRefreshBoundary(module.exports)){_csbRefreshUtils.registerExportsForReactRefresh(module.exports,module.id);const e={...module.exports};module.hot.dispose((function(r){r.prevExports=e})),isHotUpdate&&_csbRefreshUtils.shouldInvalidateReactRefreshBoundary(prevExports,e)?module.hot.invalidate():module.hot.accept(),_csbRefreshUtils.enqueueUpdate()}else isHotUpdate&&_csbRefreshUtils.isReactRefreshBoundary(prevExports)&&module.hot.invalidate();`;
 
 class RefreshTranspiler extends Transpiler {
   constructor() {

--- a/packages/app/src/sandbox/eval/transpilers/react/refresh-transpiler.ts
+++ b/packages/app/src/sandbox/eval/transpilers/react/refresh-transpiler.ts
@@ -61,6 +61,47 @@ function isReactRefreshBoundary(moduleExports) {
   return hasExports && areAllExportsComponents;
 };
 
+// When this signature changes, it's unsafe to stop at this refresh boundary.
+function getRefreshBoundarySignature(moduleExports) {
+  const signature = [];
+  signature.push(Refresh.getFamilyByType(moduleExports));
+  if (moduleExports == null || typeof moduleExports !== 'object') {
+    // Exit if we can't iterate over exports.
+    // (This is important for legacy environments.)
+    return signature;
+  }
+  for (const key in moduleExports) {
+    if (key === '__esModule') {
+      continue;
+    }
+    const desc = Object.getOwnPropertyDescriptor(moduleExports, key);
+    if (desc && desc.get) {
+      continue;
+    }
+    const exportValue = moduleExports[key];
+    signature.push(key);
+    signature.push(Refresh.getFamilyByType(exportValue));
+  }
+  return signature;
+};
+
+function shouldInvalidateReactRefreshBoundary(
+  prevExports,
+  nextExports,
+) {
+  const prevSignature = getRefreshBoundarySignature(prevExports);
+  const nextSignature = getRefreshBoundarySignature(nextExports);
+  if (prevSignature.length !== nextSignature.length) {
+    return true;
+  }
+  for (let i = 0; i < nextSignature.length; i++) {
+    if (prevSignature[i] !== nextSignature[i]) {
+      return true;
+    }
+  }
+  return false;
+};
+
 var registerExportsForReactRefresh = (moduleExports, moduleID) => {
   Refresh.register(moduleExports, moduleID + ' %exports%');
   if (moduleExports == null || typeof moduleExports !== 'object') {
@@ -83,46 +124,60 @@ var registerExportsForReactRefresh = (moduleExports, moduleID) => {
 module.exports = {
   enqueueUpdate: debounce(enqueueUpdate, 30),
   isReactRefreshBoundary,
-  registerExportsForReactRefresh
+  registerExportsForReactRefresh,
+  shouldInvalidateReactRefreshBoundary
 };
 `.trim();
 
-/**
-var prevRefreshReg = window.$RefreshReg$;
-var prevRefreshSig = window.$RefreshSig$;
-var RefreshRuntime = require('react-refresh/runtime');
+// const getWrapperCode = (sourceCode: string) =>
+//   `
+// var prevRefreshReg = window.$RefreshReg$;
+// var prevRefreshSig = window.$RefreshSig$;
+// var RefreshRuntime = require('react-refresh/runtime');
 
-window.$RefreshReg$ = (type, id) => {
-  // Note module.id is webpack-specific, this may vary in other bundlers
-  const fullId = module.id + ' ' + id;
-  RefreshRuntime.register(type, fullId);
-}
-window.$RefreshSig$ = RefreshRuntime.createSignatureFunctionForTransform;
+// window.$RefreshReg$ = (type, id) => {
+//   // Note module.id is webpack-specific, this may vary in other bundlers
+//   const fullId = module.id + ' ' + id;
+//   RefreshRuntime.register(type, fullId);
+// }
+// window.$RefreshSig$ = RefreshRuntime.createSignatureFunctionForTransform;
 
-try {
-  ${sourceCode}
-} finally {
-  window.$RefreshReg$ = prevRefreshReg;
-  window.$RefreshSig$ = prevRefreshSig;
-}
+// try {
+//   ${sourceCode}
+// } finally {
+//   window.$RefreshReg$ = prevRefreshReg;
+//   window.$RefreshSig$ = prevRefreshSig;
+// }
 
-const _csbRefreshUtils = require('${HELPER_PATH}');
+// const _csbRefreshUtils = require('${HELPER_PATH}');
 
-if (_csbRefreshUtils.isReactRefreshBoundary && _csbRefreshUtils.isReactRefreshBoundary(module.exports)) {
-  _csbRefreshUtils.registerExportsForReactRefresh(module.exports, module.id)
-  module.hot.accept();
-  _csbRefreshUtils.enqueueUpdate();
-}
-`
- */
+// if (_csbRefreshUtils.isReactRefreshBoundary && _csbRefreshUtils.isReactRefreshBoundary(module.exports)) {
+//   _csbRefreshUtils.registerExportsForReactRefresh(module.exports, module.id)
+//   const currentExports = { ...module.exports };
+//   const isHotUpdate = !!module.hot.data;
+//   const prevExports = isHotUpdate ? module.hot.data.prevExports : null;
+
+//   module.hot.dispose(function hotDisposeCallback(data) {
+//     data.prevExports = currentExports;
+//   });
+
+//   if (isHotUpdate && _csbRefreshUtils.shouldInvalidateReactRefreshBoundary(currentExports, prevExports)) {
+//     module.hot.invalidate();
+//   } else {
+//     module.hot.accept();
+//   }
+
+//   _csbRefreshUtils.enqueueUpdate();
+// }
+// `;
 
 /**
  * This is the compressed version of the code in the comment above. We compress the code
  * to a single line so we don't mess with the source mapping when showing errors.
  */
 const getWrapperCode = (sourceCode: string) =>
-  `var prevRefreshReg=window.$RefreshReg$,prevRefreshSig=window.$RefreshSig$,RefreshRuntime=require("react-refresh/runtime");window.$RefreshReg$=((e,r)=>{const s=module.id+" "+r;RefreshRuntime.register(e,s)}),window.$RefreshSig$=RefreshRuntime.createSignatureFunctionForTransform;try{${sourceCode}
-}finally{window.$RefreshReg$=prevRefreshReg,window.$RefreshSig$=prevRefreshSig}const _csbRefreshUtils=require("${HELPER_PATH}");_csbRefreshUtils.isReactRefreshBoundary&&_csbRefreshUtils.isReactRefreshBoundary(module.exports)&&(_csbRefreshUtils.registerExportsForReactRefresh(module.exports,module.id),module.hot.accept(),_csbRefreshUtils.enqueueUpdate());`.trim();
+  `var prevRefreshReg=window.$RefreshReg$;var prevRefreshSig=window.$RefreshSig$;var RefreshRuntime=require("react-refresh/runtime");window.$RefreshReg$=(type,id)=>{const fullId=module.id+" "+id;RefreshRuntime.register(type,fullId)};window.$RefreshSig$=RefreshRuntime.createSignatureFunctionForTransform;try{${sourceCode}
+}finally{window.$RefreshReg$=prevRefreshReg;window.$RefreshSig$=prevRefreshSig}const _csbRefreshUtils=require("${HELPER_PATH}");if(_csbRefreshUtils.isReactRefreshBoundary&&_csbRefreshUtils.isReactRefreshBoundary(module.exports)){_csbRefreshUtils.registerExportsForReactRefresh(module.exports,module.id);const currentExports={...module.exports};const isHotUpdate=!!module.hot.data;const prevExports=isHotUpdate?module.hot.data.prevExports:null;module.hot.dispose((function hotDisposeCallback(data){data.prevExports=currentExports}));if(isHotUpdate&&_csbRefreshUtils.shouldInvalidateReactRefreshBoundary(currentExports,prevExports)){module.hot.invalidate()}else{module.hot.accept()}_csbRefreshUtils.enqueueUpdate()}`.trim();
 
 class RefreshTranspiler extends Transpiler {
   constructor() {

--- a/packages/sandpack-core/src/manager.ts
+++ b/packages/sandpack-core/src/manager.ts
@@ -395,6 +395,26 @@ export default class Manager implements IEvaluator {
         { force, globals }
       );
 
+      if (this.webpackHMR) {
+        // Check if any module has been invalidated, because in that case we need to
+        // restart evaluation.
+
+        const invalidatedModules = this.getTranspiledModules().filter(t => {
+          if (t.hmrConfig?.invalidated) {
+            t.compilation = null;
+            t.hmrConfig = null;
+
+            return true;
+          }
+
+          return false;
+        });
+
+        if (invalidatedModules.length > 0) {
+          return this.evaluateModule(module, { force, globals });
+        }
+      }
+
       this.setHmrStatus('idle');
 
       return exports;

--- a/packages/sandpack-core/src/manager.ts
+++ b/packages/sandpack-core/src/manager.ts
@@ -370,7 +370,7 @@ export default class Manager implements IEvaluator {
   evaluateModule(
     module: Module,
     { force = false, globals }: { force?: boolean; globals?: object } = {}
-  ) {
+  ): any {
     if (this.hardReload && !this.isFirstLoad) {
       // Do a hard reload
       document.location.reload();

--- a/packages/sandpack-core/src/transpiled-module/hmr.ts
+++ b/packages/sandpack-core/src/transpiled-module/hmr.ts
@@ -5,6 +5,7 @@ export default class HMR {
   type?: 'accept' | 'decline';
   dirty: boolean = false;
   selfAccepted: boolean = false;
+  invalidated = false;
 
   callDisposeHandler() {
     if (this.disposeHandler) {
@@ -36,7 +37,7 @@ export default class HMR {
     }
   }
 
-  setType(type: 'accept' | 'decline') {
+  setType(type: 'accept' | 'decline' | undefined) {
     this.type = type;
   }
 
@@ -61,5 +62,14 @@ export default class HMR {
     }
 
     return !this.isHot() && isEntry;
+  }
+
+  /**
+   * Setting the module to invalidated means that we MUST evaluate it again, which means
+   * that we throw away its compilation and hmrConfig, and we're going to force a second evaluation
+   * once this has been run.
+   */
+  setInvalidated(invalidated: boolean) {
+    this.invalidated = invalidated;
   }
 }

--- a/packages/sandpack-core/src/transpiled-module/transpiled-module.ts
+++ b/packages/sandpack-core/src/transpiled-module/transpiled-module.ts
@@ -274,13 +274,13 @@ export class TranspiledModule {
   }
 
   resetCompilation() {
+    if (this.compilation) {
+      this.compilation = null;
+    }
+
     if (this.hmrConfig && this.hmrConfig.isHot()) {
       this.hmrConfig.setDirty(true);
     } else {
-      if (this.compilation) {
-        this.compilation = null;
-      }
-
       Array.from(this.initiators)
         .filter(t => t.compilation)
         .forEach(dep => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -26751,10 +26751,10 @@ react-redux@^7.0.2:
     prop-types "^15.7.2"
     react-is "^16.8.6"
 
-react-refresh@^0.7.2:
-  version "0.7.2"
-  resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.7.2.tgz#f30978d21eb8cac6e2f2fde056a7d04f6844dd50"
-  integrity sha512-u5l7fhAJXecWUJzVxzMRU2Zvw8m4QmDNHlTrT5uo3KBlYBhmChd7syAakBoay1yIiVhx/8Fi7a6v6kQZfsw81Q==
+react-refresh@0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.9.0.tgz#71863337adc3e5c2f8a6bfddd12ae3bfe32aafbf"
+  integrity sha512-Gvzk7OZpiqKSkxsQvO/mbTN1poglhmAV7gR/DdIrRrSMXraRQQlfikRJOr3Nb9GTMPC5kof948Zy6jJZIFtDvQ==
 
 react-router-dom@^4.2.2:
   version "4.3.1"


### PR DESCRIPTION
This PR does three things:

1. It calls `module.hot.invalidate()` if the export structure of a module changes within React Refresh context
2. It adds `module.hot.invalidate` functionality 🙂 
3. Stops showing `Aw Snap` message on Sandpack

This will make React refreshes when exports change much more stable, and will in general improve the experience for Sandpack.