### PR TITLE
Only create a single babel worker when in sandpack

### DIFF
--- a/packages/app/src/sandbox/eval/transpilers/babel/index.ts
+++ b/packages/app/src/sandbox/eval/transpilers/babel/index.ts
@@ -16,6 +16,7 @@ import regexGetRequireStatements from './worker/simple-get-require-statements';
 import { getSyntaxInfoFromAst, getSyntaxInfoFromCode } from './syntax-info';
 
 const global = window as any;
+const WORKER_COUNT = process.env.SANDPACK ? 1 : 3;
 
 // Right now this is in a worker, but when we're going to allow custom plugins
 // we need to move this out of the worker again, because the config needs
@@ -24,7 +25,10 @@ class BabelTranspiler extends WorkerTranspiler {
   worker: Worker;
 
   constructor() {
-    super('babel-loader', BabelWorker, 3, { hasFS: true, preload: true });
+    super('babel-loader', BabelWorker, WORKER_COUNT, {
+      hasFS: true,
+      preload: true,
+    });
   }
 
   startupWorkersInitialized = false;

--- a/packages/app/src/sandbox/startup.js
+++ b/packages/app/src/sandbox/startup.js
@@ -7,8 +7,8 @@ import setupScreenshotListener from 'sandbox-hooks/screenshot';
 import { listenForPreviewSecret } from 'sandbox-hooks/preview-secret';
 import { isStandalone } from 'codesandbox-api';
 
+window.babelworkers = [];
 if (!process.env.SANDPACK) {
-  window.babelworkers = [];
   for (let i = 0; i < 3; i++) {
     const worker = new BabelWorker();
     window.babelworkers.push(worker);

--- a/packages/app/src/sandbox/startup.js
+++ b/packages/app/src/sandbox/startup.js
@@ -3,24 +3,26 @@ import BabelWorker from 'worker-loader?publicPath=/&name=babel-transpiler.[hash:
 /* eslint-enable import/default */
 import hookConsole from 'sandbox-hooks/console';
 import setupHistoryListeners from 'sandbox-hooks/url-listeners';
-import setupScreenshotListener from 'sandbox-hooks/screenshot'
+import setupScreenshotListener from 'sandbox-hooks/screenshot';
 import { listenForPreviewSecret } from 'sandbox-hooks/preview-secret';
 import { isStandalone } from 'codesandbox-api';
 
-window.babelworkers = [];
-for (let i = 0; i < 3; i++) {
-  const worker = new BabelWorker();
-  window.babelworkers.push(worker);
+if (!process.env.SANDPACK) {
+  window.babelworkers = [];
+  for (let i = 0; i < 3; i++) {
+    const worker = new BabelWorker();
+    window.babelworkers.push(worker);
 
-  // Warm up the babel worker
-  worker.postMessage({
-    type: 'warmup',
-    path: 'test.js',
-    code: 'const a = "b"',
-    config: { presets: ['env'] },
-    version: 7,
-    loaderOptions: {},
-  });
+    // Warm up the babel worker
+    worker.postMessage({
+      type: 'warmup',
+      path: 'test.js',
+      code: 'const a = "b"',
+      config: { presets: ['env'] },
+      version: 7,
+      loaderOptions: {},
+    });
+  }
 }
 
 if (!isStandalone) {
@@ -28,5 +30,5 @@ if (!isStandalone) {
   setupHistoryListeners();
   hookConsole();
   listenForPreviewSecret();
-  setupScreenshotListener()
+  setupScreenshotListener();
 }


### PR DESCRIPTION
Babel Worker is memory expensive. This will make sure that we only spawn a single worker in Sandpack, because Sandpack is usually rendered multiple times in a single window.