### PR TITLE
Upgrade disabled pattern for Menu items

### DIFF
--- a/packages/app/src/app/components/Notifications/Filters.tsx
+++ b/packages/app/src/app/components/Notifications/Filters.tsx
@@ -47,7 +47,12 @@ export const Filters = () => {
         />
         <Menu.List>
           {Object.entries(options).map(([key, label]) => (
-            <Menu.Item key={key} onSelect={() => filterNotifications(key)}>
+            <Menu.Item
+              key={key}
+              onSelect={() => {
+                filterNotifications(key);
+              }}
+            >
               <Checkbox
                 checked={userNotifications.activeFilters.includes(key)}
                 label={label}
@@ -65,7 +70,11 @@ export const Filters = () => {
           size={12}
         />
         <Menu.List>
-          <Menu.Item onSelect={() => archiveAllNotifications()}>
+          <Menu.Item
+            onSelect={() => {
+              archiveAllNotifications();
+            }}
+          >
             Clear all notifications
           </Menu.Item>
           {!userNotifications.notifications.every(

--- a/packages/app/src/app/components/Notifications/notifications/Menu.tsx
+++ b/packages/app/src/app/components/Notifications/notifications/Menu.tsx
@@ -33,14 +33,16 @@ export const Menu = ({ read, id }) => {
       </Element>
       <BaseMenu.List>
         <BaseMenu.Item
-          className="no-click"
-          onSelect={() => archiveNotification(id)}
+          onSelect={() => {
+            archiveNotification(id);
+          }}
         >
           Clear notification
         </BaseMenu.Item>
         <BaseMenu.Item
-          className="no-click"
-          onSelect={() => updateReadStatus(id)}
+          onSelect={() => {
+            updateReadStatus(id);
+          }}
         >
           Mark as {read ? 'Unread' : 'Read'}
         </BaseMenu.Item>

--- a/packages/app/src/app/components/WorkspaceSelect/WorkspaceSelect.tsx
+++ b/packages/app/src/app/components/WorkspaceSelect/WorkspaceSelect.tsx
@@ -131,7 +131,9 @@ export const WorkspaceSelect: React.FC<WorkspaceSelectProps> = React.memo(
                   textAlign: 'left',
                 })}
                 style={{ paddingLeft: 8 }}
-                onSelect={() => history.push(dashboardUrls.createWorkspace())}
+                onSelect={() => {
+                  history.push(dashboardUrls.createWorkspace());
+                }}
               >
                 <Stack
                   justify="center"

--- a/packages/app/src/app/pages/Dashboard/Components/Filters/FilterOptions/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Filters/FilterOptions/index.tsx
@@ -43,72 +43,71 @@ export const FilterOptions: FunctionComponent<Props> = React.memo(
 
     return (
       <Menu>
-          <Menu.Button>
-            <Text
-              variant={blacklistedTemplates.length ? 'active' : 'muted'}
-              paddingRight={2}
-            >
-              Filters
-            </Text>
-          </Menu.Button>
-          <Menu.List>
-            {templates ? (
-              orderBy(possibleTemplates, 'niceName').map(
-                ({ id, name, niceName }) => {
-                  const selected = isTemplateSelected(id);
-                  return (
-                    <Menu.Item
-                      field="title"
-                      key={id || name}
-                      onSelect={() => {
-                        toggleTemplate(id, !selected);
-                        return { CLOSE_MENU: false };
-                      }}
-                      css={css({
-                        label: {
-                          color: selected ? 'inherit' : 'mutedForeground',
-                        },
-                      })}
-                    >
-                      <Checkbox
-                        onChange={noop}
-                        checked={selected}
-                        label={niceName || name}
-                      />
-                    </Menu.Item>
+        <Menu.Button>
+          <Text
+            variant={blacklistedTemplates.length ? 'active' : 'muted'}
+            paddingRight={2}
+          >
+            Filters
+          </Text>
+        </Menu.Button>
+        <Menu.List>
+          {templates ? (
+            orderBy(possibleTemplates, 'niceName').map(
+              ({ id, name, niceName }) => {
+                const selected = isTemplateSelected(id);
+                return (
+                  <Menu.Item
+                    key={id || name}
+                    onSelect={() => {
+                      toggleTemplate(id, !selected);
+                      return { CLOSE_MENU: false };
+                    }}
+                    css={css({
+                      label: {
+                        color: selected ? 'inherit' : 'mutedForeground',
+                      },
+                    })}
+                  >
+                    <Checkbox
+                      onChange={noop}
+                      checked={selected}
+                      label={niceName || name}
+                    />
+                  </Menu.Item>
+                );
+              }
+            )
+          ) : (
+            <Menu.Item onSelect={() => {}}>No environments found</Menu.Item>
+          )}
+          {templates && (
+            <Menu.Item
+              key="all"
+              onSelect={() => {
+                if (allSelected) {
+                  blacklistedTemplatesChanged(
+                    possibleTemplates.map(({ id }) => id)
                   );
+                } else {
+                  blacklistedTemplatesCleared();
                 }
-              )
-            ) : (
-              <Menu.Item>No environments found</Menu.Item>
-            )}
-            {templates && (
-              <Menu.Item
-                key="all"
-                onSelect={() => {
-                  if (allSelected) {
-                    blacklistedTemplatesChanged(
-                      possibleTemplates.map(({ id }) => id)
-                    );
-                  } else {
-                    blacklistedTemplatesCleared();
-                  }
 
-                  return { CLOSE_MENU: false };
-                }}
-                css={css({
-                  color: allSelected ? 'body' : 'muted',
-                })}
-              >
-                <Checkbox
-                  onChange={noop}
-                  checked={allSelected}
-                  label="Select All"
-                />
-              </Menu.Item>
-            )}
-          </Menu.List>
-        </Menu>
+                return { CLOSE_MENU: false };
+              }}
+              css={css({
+                color: allSelected ? 'body' : 'muted',
+              })}
+            >
+              <Checkbox
+                onChange={noop}
+                checked={allSelected}
+                label="Select All"
+              />
+            </Menu.Item>
+          )}
+        </Menu.List>
+      </Menu>
     );
   }
 );

--- a/packages/app/src/app/pages/Dashboard/Components/Filters/SortOptions/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Filters/SortOptions/index.tsx
@@ -46,7 +46,7 @@ export const SortOptions: FunctionComponent = React.memo(() => {
       </Stack>
       <Menu.List>
         {Object.keys(FIELD_TO_NAME).map(key => (
-          <Menu.Item field="title" key={key} onSelect={() => setField(key)}>
+          <Menu.Item key={key} onSelect={() => setField(key)}>
             <Text variant={FIELD_TO_NAME[key] === field ? 'body' : 'muted'}>
               {FIELD_TO_NAME[key]}
             </Text>

--- a/packages/app/src/app/pages/Dashboard/Components/Filters/ViewOptions/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Filters/ViewOptions/index.tsx
@@ -28,28 +28,27 @@ export const ViewOptions: FunctionComponent = React.memo(() => {
 
   return (
     <Menu>
-        <Menu.Button>
-          {viewMode === 'grid' ? <GridIcon /> : <ListIcon />}
-        </Menu.Button>
-        <Menu.List>
-          {STATES.map(viewState => (
-            <Menu.Item
-              key={viewState.key}
-              field={viewState.key}
-              onSelect={() => viewModeChanged({ mode: viewState.key })}
-            >
-              <Stack gap={4} align="center" justify="space-between">
-                <Text variant={viewMode === viewState.key ? 'body' : 'muted'}>
-                  {viewState.name}
-                </Text>
-                {viewState.icon({
-                  width: 10,
-                  active: viewMode === viewState.key,
-                })}
-              </Stack>
-            </Menu.Item>
-          ))}
-        </Menu.List>
-      </Menu>
+      <Menu.Button>
+        {viewMode === 'grid' ? <GridIcon /> : <ListIcon />}
+      </Menu.Button>
+      <Menu.List>
+        {STATES.map(viewState => (
+          <Menu.Item
+            key={viewState.key}
+            onSelect={() => viewModeChanged({ mode: viewState.key })}
+          >
+            <Stack gap={4} align="center" justify="space-between">
+              <Text variant={viewMode === viewState.key ? 'body' : 'muted'}>
+                {viewState.name}
+              </Text>
+              {viewState.icon({
+                width: 10,
+                active: viewMode === viewState.key,
+              })}
+            </Stack>
+          </Menu.Item>
+        ))}
+      </Menu.List>
+    </Menu>
   );
 });

--- a/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenu.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenu.tsx
@@ -118,7 +118,7 @@ export const ContextMenu: React.FC<IContextMenuProps> = ({
   );
 };
 
-export const MenuItem = ({ onSelect, ...props }) => {
+export const MenuItem = ({ onSelect, children, ...props }) => {
   const { setVisibility } = React.useContext(Context);
   return (
     <Menu.Item
@@ -127,6 +127,8 @@ export const MenuItem = ({ onSelect, ...props }) => {
         setVisibility(false);
       }}
       {...props}
-    />
+    >
+      {children}
+    </Menu.Item>
   );
 };

--- a/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenus/SandboxMenu.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenus/SandboxMenu.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useOvermind } from 'app/overmind';
 import { useHistory, useLocation } from 'react-router-dom';
-import { Menu, Tooltip } from '@codesandbox/components';
+import { Menu } from '@codesandbox/components';
 import getTemplate, { TemplateType } from '@codesandbox/common/lib/templates';
 
 import {
@@ -181,25 +181,15 @@ export const SandboxMenu: React.FC<SandboxMenuProps> = ({
         </MenuItem>
       ) : null}
 
-      <Tooltip
-        label={
-          preventSandboxExport
-            ? 'You do not have permission to export this sandbox'
-            : null
-        }
+      <MenuItem
+        disabled={preventSandboxExport}
+        disabledTooltip="You do not have permission to export this sandbox"
+        onSelect={() => {
+          actions.dashboard.downloadSandboxes([sandbox.id]);
+        }}
       >
-        <div>
-          <MenuItem
-            data-disabled={preventSandboxExport ? true : null}
-            onSelect={() => {
-              if (preventSandboxExport) return;
-              actions.dashboard.downloadSandboxes([sandbox.id]);
-            }}
-          >
-            Export {label}
-          </MenuItem>
-        </div>
-      </Tooltip>
+        Export {label}
+      </MenuItem>
 
       {hasAccess && activeWorkspaceAuthorization !== 'READ' && isPro ? (
         <>

--- a/packages/app/src/app/pages/Dashboard/Sidebar/ContextMenu.tsx
+++ b/packages/app/src/app/pages/Dashboard/Sidebar/ContextMenu.tsx
@@ -109,7 +109,7 @@ export const ContextMenu: React.FC<ContextMenuProps> = ({
   );
 };
 
-const MenuItem = ({ onSelect, ...props }) => {
+const MenuItem = ({ onSelect, children, ...props }) => {
   const { setVisibility } = React.useContext(Context);
   return (
     <Menu.Item
@@ -118,6 +118,8 @@ const MenuItem = ({ onSelect, ...props }) => {
         setVisibility(false);
       }}
       {...props}
-    />
+    >
+      {children}
+    </Menu.Item>
   );
 };

--- a/packages/app/src/app/pages/Pro/pages/WorkspacePlanSelection.tsx
+++ b/packages/app/src/app/pages/Pro/pages/WorkspacePlanSelection.tsx
@@ -254,15 +254,11 @@ export const WorkspacePlanSelection: React.FC<{
                       },
                     })}
                     style={{ paddingLeft: 8 }}
-                    data-disabled={
+                    disabled={
                       userAuthorization !== TeamMemberAuthorization.Admin
-                        ? true
-                        : null
                     }
-                    onSelect={event => {
-                      if (userAuthorization === TeamMemberAuthorization.Admin) {
-                        setActiveTeam({ id: workspace.id });
-                      } else event.preventDefault();
+                    onSelect={() => {
+                      setActiveTeam({ id: workspace.id });
                     }}
                   >
                     <Stack gap={2} align="center" css={{ width: '100%' }}>

--- a/packages/app/src/app/pages/Profile/AllSandboxes.tsx
+++ b/packages/app/src/app/pages/Profile/AllSandboxes.tsx
@@ -117,7 +117,6 @@ export const AllSandboxes = () => {
           </Stack>
           <Menu.List>
             <Menu.Item
-              field="title"
               onSelect={() => {
                 sortByChanged('view_count');
               }}
@@ -125,7 +124,6 @@ export const AllSandboxes = () => {
               <Text variant="body">Sort by views</Text>
             </Menu.Item>
             <Menu.Item
-              field="title"
               onSelect={() => {
                 sortByChanged('inserted_at');
               }}

--- a/packages/app/src/app/pages/Profile/ContextMenu.tsx
+++ b/packages/app/src/app/pages/Profile/ContextMenu.tsx
@@ -78,12 +78,8 @@ export const ContextMenu = () => {
         setVisibility={setVisibility}
         position={position}
       >
-        <Menu.Item data-disabled onSelect={() => {}}>
-          Pin sandbox
-        </Menu.Item>
-        <Menu.Item data-disabled onSelect={() => {}}>
-          Set as header
-        </Menu.Item>
+        <Menu.Item disabled>Pin sandbox</Menu.Item>
+        <Menu.Item disabled>Set as header</Menu.Item>
         <Menu.Divider />
         <Menu.Item
           onSelect={() => {
@@ -150,18 +146,16 @@ export const ContextMenu = () => {
           <Menu.Divider />
 
           <Menu.Item
-            data-disabled={isPro ? null : true}
+            disabled={!isPro}
             onSelect={() => {
-              if (!isPro) return;
               changeSandboxPrivacy({ id: sandboxId, privacy: 1 });
             }}
           >
             Make sandbox unlisted
           </Menu.Item>
           <Menu.Item
-            data-disabled={isPro ? null : true}
+            disabled={!isPro}
             onSelect={() => {
-              if (!isPro) return;
               changeSandboxPrivacy({ id: sandboxId, privacy: 2 });
             }}
           >

--- a/packages/app/src/app/pages/Profile/ContextMenu.tsx
+++ b/packages/app/src/app/pages/Profile/ContextMenu.tsx
@@ -78,11 +78,17 @@ export const ContextMenu = () => {
         setVisibility={setVisibility}
         position={position}
       >
-        <Menu.Item data-disabled>Pin sandbox</Menu.Item>
-        <Menu.Item data-disabled>Set as header</Menu.Item>
+        <Menu.Item data-disabled onSelect={() => {}}>
+          Pin sandbox
+        </Menu.Item>
+        <Menu.Item data-disabled onSelect={() => {}}>
+          Set as header
+        </Menu.Item>
         <Menu.Divider />
         <Menu.Item
-          onSelect={() => changeSandboxPrivacy({ id: sandboxId, privacy: 0 })}
+          onSelect={() => {
+            changeSandboxPrivacy({ id: sandboxId, privacy: 0 });
+          }}
         >
           Make sandbox public
         </Menu.Item>
@@ -95,11 +101,19 @@ export const ContextMenu = () => {
       {myProfile && !likesPage && (
         <span>
           {isFeatured ? (
-            <Menu.Item onSelect={() => removeFeaturedSandboxes({ sandboxId })}>
+            <Menu.Item
+              onSelect={() => {
+                removeFeaturedSandboxes({ sandboxId });
+              }}
+            >
               Unpin sandbox
             </Menu.Item>
           ) : (
-            <Menu.Item onSelect={() => addFeaturedSandboxes({ sandboxId })}>
+            <Menu.Item
+              onSelect={() => {
+                addFeaturedSandboxes({ sandboxId });
+              }}
+            >
               Pin sandbox
             </Menu.Item>
           )}
@@ -107,7 +121,11 @@ export const ContextMenu = () => {
       )}
       {myProfile && !likesPage && (
         <>
-          <Menu.Item onSelect={() => newSandboxShowcaseSelected(sandboxId)}>
+          <Menu.Item
+            onSelect={() => {
+              newSandboxShowcaseSelected(sandboxId);
+            }}
+          >
             Set as header
           </Menu.Item>
           <Menu.Divider />

--- a/packages/app/src/app/pages/Sandbox/Editor/Content/Preview/ResponsiveWrapper/PresetMenu.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Content/Preview/ResponsiveWrapper/PresetMenu.tsx
@@ -45,20 +45,12 @@ export const PresetMenu = ({
       </Menu.Button>
       <Menu.List>
         {sortedPresetsByWidth.map(preset => (
-          <Menu.Item
-            key={preset}
-            field={preset}
-            onSelect={() => onSelect(presets[preset])}
-          >
+          <Menu.Item key={preset} onSelect={() => onSelect(presets[preset])}>
             {preset}
           </Menu.Item>
         ))}
         {canChangePresets ? (
-          <Menu.Item
-            key="edit-presets"
-            field="edit-presets"
-            onSelect={openEditPresets}
-          >
+          <Menu.Item key="edit-presets" onSelect={openEditPresets}>
             Edit Presets
           </Menu.Item>
         ) : null}

--- a/packages/app/src/app/pages/Sandbox/Editor/Header/ForkButton/ForkButton.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Header/ForkButton/ForkButton.tsx
@@ -25,7 +25,6 @@ const TeamItem = (props: TeamItemProps) => (
     style={{
       paddingTop: 8,
       paddingBottom: 8,
-      fontWeight: 500,
       opacity: 1,
       cursor: 'pointer',
     }}
@@ -38,24 +37,23 @@ const TeamItem = (props: TeamItemProps) => (
   </Menu.Item>
 );
 
-const DisabledTeamItem = (props: TeamItemProps) => (
-  <Menu.Item
+const DisabledTeamItem = (props: Omit<TeamItemProps, 'onSelect'>) => (
+  <Stack
+    as={Menu.Item}
+    align="center"
+    gap={2}
+    disabled
+    disabledTooltip="You don't have access to fork sandboxes in this workspace"
     style={{
       paddingTop: 8,
       paddingBottom: 8,
-      fontWeight: 500,
       opacity: 0.4,
       cursor: 'not-allowed',
     }}
-    onSelect={props.onSelect}
   >
-    <Tooltip label="You don't have access to fork sandboxes in this workspace.">
-      <Stack gap={2} align="center">
-        <TeamAvatar size="small" avatar={props.avatar} name={props.name} />
-        <Text>{props.name}</Text>
-      </Stack>
-    </Tooltip>
-  </Menu.Item>
+    <TeamAvatar size="small" avatar={props.avatar} name={props.name} />
+    <Text>{props.name}</Text>
+  </Stack>
 );
 
 interface ITeamItem {
@@ -77,7 +75,6 @@ const TeamOrUserItem: React.FC<TeamOrUserItemProps> = props => {
       <DisabledTeamItem
         name={props.item.teamName}
         avatar={props.item.teamAvatar}
-        onSelect={() => {}}
       />
     );
   }

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Comments/Comment.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Comments/Comment.tsx
@@ -84,12 +84,12 @@ export const Comment = React.memo<{
               <Menu.IconButton name="more" title="Comment actions" size={12} />
               <Menu.List>
                 <Menu.Item
-                  onSelect={() =>
+                  onSelect={() => {
                     actions.comments.resolveComment({
                       commentId: comment.id,
                       isResolved: !comment.isResolved,
-                    })
-                  }
+                    });
+                  }}
                 >
                   Mark as {comment.isResolved ? 'unresolved' : 'resolved'}
                 </Menu.Item>
@@ -102,11 +102,11 @@ export const Comment = React.memo<{
                 </Menu.Item>
                 {state.user.id === comment.user.id && (
                   <Menu.Item
-                    onSelect={() =>
+                    onSelect={() => {
                       actions.comments.deleteComment({
                         commentId: comment.id,
-                      })
-                    }
+                      });
+                    }}
                   >
                     Delete
                   </Menu.Item>

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/NotOwnedSandboxInfo/BookmarkTemplateButton/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/NotOwnedSandboxInfo/BookmarkTemplateButton/index.tsx
@@ -123,7 +123,12 @@ export const BookmarkTemplateButton = () => {
         </Menu.Button>
         <Menu.List>
           {bookmarkInfos.map(({ entity: { name } }, index: number) => (
-            <Menu.Item key={name} onSelect={() => handleToggleFollow(index)}>
+            <Menu.Item
+              key={name}
+              onSelect={() => {
+                handleToggleFollow(index);
+              }}
+            >
               {bookmarkInfos[index].isBookmarked ? 'Remove from ' : 'Add to '}
               {index === 0 ? 'My Bookmarks' : name}
             </Menu.Item>

--- a/packages/app/src/app/pages/common/Modals/PreferencesModal/PreferencesSync/Profile.tsx
+++ b/packages/app/src/app/pages/common/Modals/PreferencesModal/PreferencesSync/Profile.tsx
@@ -125,7 +125,13 @@ export const Profile = ({ setting }: { setting: SettingSync }) => {
                 <Menu.Divider />
               </>
             ) : null}
-            <Menu.Item onSelect={() => setRename(true)}>Rename</Menu.Item>
+            <Menu.Item
+              onSelect={() => {
+                setRename(true);
+              }}
+            >
+              Rename
+            </Menu.Item>
             <Menu.Item
               onSelect={() => {
                 track('Preferences Profiles - Download Profile');

--- a/packages/app/src/app/pages/common/UserMenu/index.tsx
+++ b/packages/app/src/app/pages/common/UserMenu/index.tsx
@@ -124,14 +124,22 @@ export const UserMenu: FunctionComponent & {
             </Menu.Link>
           )}
 
-          <Menu.Item onClick={() => gotUploadedFiles(null)}>
+          <Menu.Item
+            onSelect={() => {
+              gotUploadedFiles(null);
+            }}
+          >
             <Stack align="center" gap={1}>
               <Icon name="folder" size={24} />
               <Text>Storage Management</Text>
             </Stack>
           </Menu.Item>
 
-          <Menu.Item onClick={() => modalOpened({ modal: 'preferences' })}>
+          <Menu.Item
+            onSelect={() => {
+              modalOpened({ modal: 'preferences' });
+            }}
+          >
             <Stack align="center" gap={2} paddingLeft={1}>
               <Icon name="gear" size={16} />
               <Text>Preferences</Text>
@@ -140,7 +148,11 @@ export const UserMenu: FunctionComponent & {
 
           <Menu.Divider />
 
-          <Menu.Item onClick={() => modalOpened({ modal: 'feedback' })}>
+          <Menu.Item
+            onSelect={() => {
+              modalOpened({ modal: 'feedback' });
+            }}
+          >
             <Stack align="center" gap={1}>
               <Icon name="feedback" size={24} />
               <Text>Submit Feedback</Text>
@@ -149,7 +161,11 @@ export const UserMenu: FunctionComponent & {
 
           <Menu.Divider />
 
-          <Menu.Item onClick={() => signOutClicked()}>
+          <Menu.Item
+            onSelect={() => {
+              signOutClicked();
+            }}
+          >
             <Stack align="center" gap={1}>
               <Icon name="signout" size={24} />
               <Text>Sign out</Text>

--- a/packages/components/src/components/Button/index.tsx
+++ b/packages/components/src/components/Button/index.tsx
@@ -100,7 +100,7 @@ const commonStyles = {
 
 export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
-    IElementProps {
+    Omit<IElementProps, 'style'> {
   variant?: 'primary' | 'secondary' | 'link' | 'danger';
   loading?: boolean;
   href?: string;

--- a/packages/components/src/components/Element/index.tsx
+++ b/packages/components/src/components/Element/index.tsx
@@ -19,6 +19,7 @@ export interface IElementProps {
   paddingLeft?: number;
   paddingRight?: number;
   css?: Object;
+  style?: Object;
 }
 
 export const Element = styled.div<IElementProps>(props =>

--- a/packages/components/src/components/Element/index.tsx
+++ b/packages/components/src/components/Element/index.tsx
@@ -1,7 +1,9 @@
+import React from 'react';
 import styled from 'styled-components';
 import css from '@styled-system/css';
 
 export interface IElementProps {
+  as?: string | React.ComponentType<any>;
   margin?: number;
   marginX?: number;
   marginY?: number;

--- a/packages/components/src/components/Menu/index.tsx
+++ b/packages/components/src/components/Menu/index.tsx
@@ -256,14 +256,14 @@ const MenuList = React.forwardRef<HTMLDivElement, MenuListProps>(
 
 type MenuItemProps = ReachMenu.MenuItemImplProps & {
   disabled?: boolean;
-  tooltip?: string;
+  disabledTooltip?: string;
 };
 
 const noop = () => {};
 const MenuItem: React.FC<MenuItemProps> = ({
   disabled,
   onSelect,
-  tooltip,
+  disabledTooltip,
   ...props
 }) => {
   const conditionalOnSelect = disabled ? noop : onSelect;
@@ -277,7 +277,7 @@ const MenuItem: React.FC<MenuItemProps> = ({
     />
   );
 
-  if (tooltip) return <Tooltip label={tooltip}>{Item}</Tooltip>;
+  if (disabledTooltip) return <Tooltip label={disabledTooltip}>{Item}</Tooltip>;
   return Item;
 };
 

--- a/packages/components/src/components/Menu/index.tsx
+++ b/packages/components/src/components/Menu/index.tsx
@@ -254,16 +254,17 @@ const MenuList = React.forwardRef<HTMLDivElement, MenuListProps>(
   }
 );
 
-type MenuItemProps = ReachMenu.MenuItemImplProps &
-  IElementProps & {
-    disabled?: boolean;
-    disabledTooltip?: string;
-  };
+type MenuItemProps = IElementProps & {
+  disabled?: boolean;
+  disabledTooltip?: string;
+  onSelect?: ReachMenu.MenuItemImplProps['onSelect'];
+  children: React.ReactNode;
+};
 
 const noop = () => {};
 const MenuItem: React.FC<MenuItemProps> = ({
   disabled,
-  onSelect,
+  onSelect = noop,
   disabledTooltip,
   ...props
 }) => {

--- a/packages/components/src/components/Menu/index.tsx
+++ b/packages/components/src/components/Menu/index.tsx
@@ -8,7 +8,7 @@ import {
 } from 'styled-components';
 import { Link } from 'react-router-dom';
 import * as ReachMenu from './reach-menu.fork';
-import { Element, Button, IconButton, Tooltip } from '../..';
+import { Element, IElementProps, Button, IconButton, Tooltip } from '../..';
 
 const transitions = {
   slide: keyframes({
@@ -254,10 +254,11 @@ const MenuList = React.forwardRef<HTMLDivElement, MenuListProps>(
   }
 );
 
-type MenuItemProps = ReachMenu.MenuItemImplProps & {
-  disabled?: boolean;
-  disabledTooltip?: string;
-};
+type MenuItemProps = ReachMenu.MenuItemImplProps &
+  IElementProps & {
+    disabled?: boolean;
+    disabledTooltip?: string;
+  };
 
 const noop = () => {};
 const MenuItem: React.FC<MenuItemProps> = ({
@@ -269,7 +270,8 @@ const MenuItem: React.FC<MenuItemProps> = ({
   const conditionalOnSelect = disabled ? noop : onSelect;
 
   const Item = (
-    <ReachMenu.MenuItem
+    <Element
+      as={ReachMenu.MenuItem}
       data-component="MenuItem"
       data-disabled={disabled ? true : null}
       onSelect={conditionalOnSelect}

--- a/packages/components/src/components/Menu/index.tsx
+++ b/packages/components/src/components/Menu/index.tsx
@@ -8,7 +8,7 @@ import {
 } from 'styled-components';
 import { Link } from 'react-router-dom';
 import * as ReachMenu from './reach-menu.fork';
-import { Element, Button, IconButton } from '../..';
+import { Element, Button, IconButton, Tooltip } from '../..';
 
 const transitions = {
   slide: keyframes({
@@ -254,9 +254,32 @@ const MenuList = React.forwardRef<HTMLDivElement, MenuListProps>(
   }
 );
 
-const MenuItem = props => (
-  <Element as={ReachMenu.MenuItem} data-component="MenuItem" {...props} />
-);
+type MenuItemProps = ReachMenu.MenuItemImplProps & {
+  disabled?: boolean;
+  tooltip?: string;
+};
+
+const noop = () => {};
+const MenuItem: React.FC<MenuItemProps> = ({
+  disabled,
+  onSelect,
+  tooltip,
+  ...props
+}) => {
+  const conditionalOnSelect = disabled ? noop : onSelect;
+
+  const Item = (
+    <ReachMenu.MenuItem
+      data-component="MenuItem"
+      data-disabled={disabled ? true : null}
+      onSelect={conditionalOnSelect}
+      {...props}
+    />
+  );
+
+  if (tooltip) return <Tooltip label={tooltip}>{Item}</Tooltip>;
+  return Item;
+};
 
 type MenuLinkProps = {
   to?: string;
@@ -265,12 +288,7 @@ type MenuLinkProps = {
   children: any;
 };
 
-const MenuLink: React.FunctionComponent<MenuLinkProps> = ({
-  children,
-  to,
-  title,
-  href,
-}) => {
+const MenuLink: React.FC<MenuLinkProps> = ({ children, to, title, href }) => {
   if (to) {
     return (
       <ReachMenu.MenuLink

--- a/packages/components/src/components/Menu/menu.stories.tsx
+++ b/packages/components/src/components/Menu/menu.stories.tsx
@@ -11,6 +11,8 @@ export default {
   component: Menu,
 };
 
+const noop = () => {};
+
 export const Access = () => {
   const permissions = ['Can View', 'Can Edit', 'Can Comment'];
   const [selected, select] = React.useState(permissions[0]);
@@ -23,21 +25,7 @@ export const Access = () => {
       </Text>{' '}
       <Menu>
         <Menu.Button css={{ color: 'white' }}>
-          {selected}{' '}
-          <Element
-            as="svg"
-            marginLeft={2}
-            width="7"
-            height="4"
-            viewBox="0 0 7 4"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M3.95023 4L0.90033 1.23979e-06L7 7.15256e-07L3.95023 4Z"
-              fill="currentColor"
-            />
-          </Element>
+          {selected} <Icon name="caret" size={8} marginLeft={1} />
         </Menu.Button>
         <Menu.List>
           {permissions.map(permission => (
@@ -137,7 +125,7 @@ export const MenuWithLinks = () => (
             Menu Link with Icon
           </Stack>
         </Menu.Link>
-        <Menu.Item>Menu Item</Menu.Item>
+        <Menu.Item onSelect={noop}>Menu Item</Menu.Item>
         <Menu.Link href="/internal">
           <Stack align="center">Menu Link</Stack>
         </Menu.Link>
@@ -152,9 +140,9 @@ export const DefaultOpen = () => (
     <Menu defaultOpen>
       <Menu.Button variant="primary">Open Menu</Menu.Button>
       <Menu.List>
-        <Menu.Item>Menu Item</Menu.Item>
-        <Menu.Item>Menu Item</Menu.Item>
-        <Menu.Item>Menu Item</Menu.Item>
+        <Menu.Item onSelect={noop}>Menu Item</Menu.Item>
+        <Menu.Item onSelect={noop}>Menu Item</Menu.Item>
+        <Menu.Item onSelect={noop}>Menu Item</Menu.Item>
       </Menu.List>
     </Menu>
   </>
@@ -189,6 +177,56 @@ export const DisabledItem = () => (
         >
           Not disabled option
         </Menu.Item>
+      </Menu.List>
+    </Menu>
+  </>
+);
+
+export const StackItem = () => {
+  const permissions = ['Can View', 'Can Edit', 'Can Comment'];
+  const [selected, select] = React.useState(permissions[0]);
+
+  return (
+    <Stack justify="flex-end" align="center" css={{ '> *': { lineHeight: 1 } }}>
+      <MenuStyles />
+      <Text size={2} variant="muted">
+        Everyone with link
+      </Text>{' '}
+      <Menu>
+        <Menu.Button css={{ color: 'white' }}>
+          {selected} <Icon name="caret" size={8} marginLeft={1} />
+        </Menu.Button>
+        <Menu.List>
+          {permissions.map(permission => (
+            <Stack
+              as={Menu.Item}
+              justify="space-between"
+              align="center"
+              onSelect={() => select(permission)}
+            >
+              {permission}
+              {selected === permission ? (
+                <Icon name="simpleCheck" size={12} />
+              ) : null}
+            </Stack>
+          ))}
+        </Menu.List>
+      </Menu>
+    </Stack>
+  );
+};
+
+export const Customisable = () => (
+  <>
+    <MenuStyles />
+    <Menu defaultOpen>
+      <Menu.Button variant="primary">Open Menu</Menu.Button>
+      <Menu.List>
+        <Menu.Item style={{ color: 'red' }} onSelect={noop}>
+          Menu Item
+        </Menu.Item>
+        <Menu.Item onSelect={noop}>Menu Item</Menu.Item>
+        <Menu.Item onSelect={noop}>Menu Item</Menu.Item>
       </Menu.List>
     </Menu>
   </>

--- a/packages/components/src/components/Menu/menu.stories.tsx
+++ b/packages/components/src/components/Menu/menu.stories.tsx
@@ -177,12 +177,16 @@ export const DisabledItem = () => (
         </Tooltip>
         <Menu.Item
           disabled
-          tooltip="You do not have permission to export this sandbox"
+          disabledTooltip="You do not have permission to export this sandbox"
           onSelect={() => alert(1)}
         >
           Disabled Option
         </Menu.Item>
-        <Menu.Item disabled={false} onSelect={() => alert(1)}>
+        <Menu.Item
+          disabled={false}
+          disabledTooltip="You do not have permission to export this sandbox"
+          onSelect={() => alert(1)}
+        >
           Not disabled option
         </Menu.Item>
       </Menu.List>

--- a/packages/components/src/components/Menu/menu.stories.tsx
+++ b/packages/components/src/components/Menu/menu.stories.tsx
@@ -167,19 +167,23 @@ export const DisabledItem = () => (
     <Menu>
       <Menu.Button variant="primary">Open Menu</Menu.Button>
       <Menu.List>
-        <Menu.Item onSelect={() => {}}>Active option</Menu.Item>
+        <Menu.Item onSelect={() => alert(1)}>Active option</Menu.Item>
         <Tooltip label="You do not have permission to export this sandbox">
           <div>
-            <Menu.Item data-disabled onSelect={() => {}}>
-              Disabled Option
+            <Menu.Item data-disabled onSelect={() => alert(1)}>
+              Backward compatible disabled
             </Menu.Item>
           </div>
         </Tooltip>
         <Menu.Item
           disabled
           tooltip="You do not have permission to export this sandbox"
+          onSelect={() => alert(1)}
         >
           Disabled Option
+        </Menu.Item>
+        <Menu.Item disabled={false} onSelect={() => alert(1)}>
+          Not disabled option
         </Menu.Item>
       </Menu.List>
     </Menu>

--- a/packages/components/src/components/Menu/menu.stories.tsx
+++ b/packages/components/src/components/Menu/menu.stories.tsx
@@ -11,8 +11,6 @@ export default {
   component: Menu,
 };
 
-const noop = () => {};
-
 export const Access = () => {
   const permissions = ['Can View', 'Can Edit', 'Can Comment'];
   const [selected, select] = React.useState(permissions[0]);
@@ -125,7 +123,7 @@ export const MenuWithLinks = () => (
             Menu Link with Icon
           </Stack>
         </Menu.Link>
-        <Menu.Item onSelect={noop}>Menu Item</Menu.Item>
+        <Menu.Item>Menu Item</Menu.Item>
         <Menu.Link href="/internal">
           <Stack align="center">Menu Link</Stack>
         </Menu.Link>
@@ -140,9 +138,9 @@ export const DefaultOpen = () => (
     <Menu defaultOpen>
       <Menu.Button variant="primary">Open Menu</Menu.Button>
       <Menu.List>
-        <Menu.Item onSelect={noop}>Menu Item</Menu.Item>
-        <Menu.Item onSelect={noop}>Menu Item</Menu.Item>
-        <Menu.Item onSelect={noop}>Menu Item</Menu.Item>
+        <Menu.Item>Menu Item</Menu.Item>
+        <Menu.Item>Menu Item</Menu.Item>
+        <Menu.Item>Menu Item</Menu.Item>
       </Menu.List>
     </Menu>
   </>
@@ -222,11 +220,9 @@ export const Customisable = () => (
     <Menu defaultOpen>
       <Menu.Button variant="primary">Open Menu</Menu.Button>
       <Menu.List>
-        <Menu.Item style={{ color: 'red' }} onSelect={noop}>
-          Menu Item
-        </Menu.Item>
-        <Menu.Item onSelect={noop}>Menu Item</Menu.Item>
-        <Menu.Item onSelect={noop}>Menu Item</Menu.Item>
+        <Menu.Item style={{ color: 'red' }}>Menu Item</Menu.Item>
+        <Menu.Item>Menu Item</Menu.Item>
+        <Menu.Item>Menu Item</Menu.Item>
       </Menu.List>
     </Menu>
   </>

--- a/packages/components/src/components/Menu/menu.stories.tsx
+++ b/packages/components/src/components/Menu/menu.stories.tsx
@@ -4,6 +4,7 @@ import { Element } from '../Element';
 import { Icon } from '../Icon';
 import { Stack } from '../Stack';
 import { Text } from '../Text';
+import { Tooltip, TooltipStyles } from '../Tooltip';
 
 export default {
   title: 'components/Menu',
@@ -154,6 +155,32 @@ export const DefaultOpen = () => (
         <Menu.Item>Menu Item</Menu.Item>
         <Menu.Item>Menu Item</Menu.Item>
         <Menu.Item>Menu Item</Menu.Item>
+      </Menu.List>
+    </Menu>
+  </>
+);
+
+export const DisabledItem = () => (
+  <>
+    <MenuStyles />
+    <TooltipStyles />
+    <Menu>
+      <Menu.Button variant="primary">Open Menu</Menu.Button>
+      <Menu.List>
+        <Menu.Item onSelect={() => {}}>Active option</Menu.Item>
+        <Tooltip label="You do not have permission to export this sandbox">
+          <div>
+            <Menu.Item data-disabled onSelect={() => {}}>
+              Disabled Option
+            </Menu.Item>
+          </div>
+        </Tooltip>
+        <Menu.Item
+          disabled
+          tooltip="You do not have permission to export this sandbox"
+        >
+          Disabled Option
+        </Menu.Item>
       </Menu.List>
     </Menu>
   </>


### PR DESCRIPTION
```js
// old
<Tooltip label={preventSandboxExport ? "You do not have permission to export this sandbox": null}>
  <div>
    <Menu.Item      
      onSelect={preventSandboxExport ? onSelect : null}
      data-disabled={preventSandboxExport}
    >
      Export sandbox
    </Menu.Item>
  </div>
</Tooltip>

// new (backward compatible)
<Menu.Item
  onSelect={onSelect}
  disabled={preventSandboxExport}
  disabledTooltip="You do not have permission to export this sandbox"
>
  Export sandbox
</Menu.Item>
```

`disabledTooltip` is only shown when `disabled=true`, that's why it's not called `tooltip` to avoid confusion

<details>

![image](https://user-images.githubusercontent.com/1863771/112825030-8e77c580-908b-11eb-87c5-dc0f639ad115.png)

</details>