### PR TITLE
Make host fallback to codesandbox.test

### DIFF
--- a/packages/common/src/utils/host.ts
+++ b/packages/common/src/utils/host.ts
@@ -10,7 +10,7 @@ export default () => {
   }
 
   if (process.env.NODE_ENV === 'development') {
-    return `https://${process.env.DEV_DOMAIN}`;
+    return `https://${process.env.DEV_DOMAIN || 'codesandbox.test'}`;
   }
 
   if ('STAGING_BRANCH' in process.env) {


### PR DESCRIPTION
This will ensure that the local Docker environment will work, as this env var is not set in that environment.