### PR TITLE
fix: disable button on empty preset name

### DIFF
--- a/packages/app/src/app/pages/common/Modals/AddPreset/index.tsx
+++ b/packages/app/src/app/pages/common/Modals/AddPreset/index.tsx
@@ -123,7 +123,7 @@ export const AddPreset: FunctionComponent<Props> = ({ id, user }) => {
             <Button
               autoWidth
               type="submit"
-              disabled={!name || !width || !height}
+              disabled={!name || !name.trim() || !width || !height}
             >
               Add Preset
             </Button>


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?
Enhancement
<!-- Is it a Bug fix, feature, docs update, ... -->

## What is the current behavior?
We can create a custom preset with only spaces
<!-- You can also link to an open issue here -->

## What is the new behavior?
Disable button if the name is empty.

![image](https://user-images.githubusercontent.com/22376783/107911244-25783a80-6f82-11eb-8787-f3c2d89cdc8e.png)

<!-- if this is a feature change -->

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Tested spaces
2. With valid name
3. No value

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
