### PR TITLE
Do standalone check for all codesandbox.io domains

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -107,7 +107,7 @@
     "browser-resolve": "CompuIves/node-browser-resolve",
     "circular-json": "^0.4.0",
     "codemirror": "^5.27.4",
-    "codesandbox-api": "0.0.30",
+    "codesandbox-api": "0.0.31",
     "codesandbox-import-utils": "^2.2.2",
     "color": "^0.11.4",
     "compare-versions": "^3.1.0",

--- a/packages/codesandbox-api/package.json
+++ b/packages/codesandbox-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codesandbox-api",
-  "version": "0.0.30",
+  "version": "0.0.31",
   "description": "",
   "keywords": [],
   "repository": {

--- a/packages/codesandbox-api/src/dispatcher/index.ts
+++ b/packages/codesandbox-api/src/dispatcher/index.ts
@@ -13,11 +13,7 @@ function checkIsStandalone() {
   }
 
   if (window.opener || window.parent !== window) {
-    if (
-      window.location &&
-      window.location.href.indexOf(host) > -1 &&
-      window.location.href.indexOf('/embed') > -1
-    ) {
+    if (window.location && window.location.href.indexOf(host) > -1) {
       // If this location href is codesandbox.io or something, we're most probably in an embed
       // iframed on another page. This means that we're actually standalone, but we're fooled
       // by the fact that we're embedded somewhere else.

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -53,7 +53,7 @@
     "@tippy.js/react": "^3.1.1",
     "babel-plugin-preval": "^3.0.1",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.26.2",
-    "codesandbox-api": "0.0.30",
+    "codesandbox-api": "0.0.31",
     "color": "0.11.4",
     "date-fns": "^2.0.0",
     "dot-object": "1.9.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -44,7 +44,7 @@
     "@reach/visually-hidden": "0.10.2",
     "@styled-system/css": "^5.1.4",
     "chromatic": "^4.0.2",
-    "codesandbox-api": "0.0.30",
+    "codesandbox-api": "0.0.31",
     "color": "3.1.2",
     "date-fns": "^2.8.1",
     "deepmerge": "^4.2.2",

--- a/packages/executors/package.json
+++ b/packages/executors/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@codesandbox/common": "^1.0.8",
     "axios": "^0.19.2",
-    "codesandbox-api": "0.0.30",
+    "codesandbox-api": "0.0.31",
     "debug": "^4.1.1",
     "socket.io-client": "^2.2.0"
   },

--- a/packages/sandbox-hooks/package.json
+++ b/packages/sandbox-hooks/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@codesandbox/common": "^1.0.8",
-    "codesandbox-api": "0.0.30",
+    "codesandbox-api": "0.0.31",
     "console-feed": "^3.1.9",
     "css-line-break": "^1.1.1",
     "react-dev-utils": "3.1.1"

--- a/packages/sandpack-core/package.json
+++ b/packages/sandpack-core/package.json
@@ -21,7 +21,7 @@
     "@babel/runtime": "^7.11.2",
     "@codesandbox/common": "^1.0.8",
     "browser-resolve": "CompuIves/node-browser-resolve",
-    "codesandbox-api": "^0.0.30",
+    "codesandbox-api": "^0.0.31",
     "localforage-driver-memory": "^1.0.5",
     "lodash-es": "^4.17.15",
     "sandbox-hooks": "0.1.0",

--- a/packages/sse-hooks/package.json
+++ b/packages/sse-hooks/package.json
@@ -13,7 +13,7 @@
     "build:dev": "rollup -c rollup.config.js"
   },
   "dependencies": {
-    "codesandbox-api": "0.0.30",
+    "codesandbox-api": "0.0.31",
     "sandbox-hooks": "0.1.0"
   },
   "devDependencies": {

--- a/standalone-packages/sandpack/package.json
+++ b/standalone-packages/sandpack/package.json
@@ -65,7 +65,7 @@
     "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$"
   },
   "dependencies": {
-    "codesandbox-api": "^0.0.30",
+    "codesandbox-api": "^0.0.31",
     "codesandbox-import-utils": "^1.2.3",
     "lodash.isequal": "^4.5.0"
   },

--- a/standalone-packages/sandpack/yarn.lock
+++ b/standalone-packages/sandpack/yarn.lock
@@ -1158,10 +1158,10 @@ code-point-at@^1.0.0:
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
   integrity sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=
 
-codesandbox-api@^0.0.30:
-  version "0.0.30"
-  resolved "https://registry.yarnpkg.com/codesandbox-api/-/codesandbox-api-0.0.30.tgz#0117b01964172d60b000971500f2b4f66b75d3c7"
-  integrity sha512-/SSzdR87jU626dbimyXXeYAU7q7rn+ckb5jMBRMTP35cxQEN2+PsJ5Xsi/Cl/HGMnz7MJUC/LKpO0OLdZYxZtQ==
+codesandbox-api@^0.0.31:
+  version "0.0.31"
+  resolved "https://registry.yarnpkg.com/codesandbox-api/-/codesandbox-api-0.0.31.tgz#bae44d326b4ac7acadf9c5e88840ccc79b4bfd69"
+  integrity sha512-9NnDD6f32G3gUTuzy8FIFAY9iXZ1fezExozRnTmF4ImmKQFipmVuxY8XfAN7lwvUWWjLzr0J37AFz6YUkivfHA==
 
 codesandbox-import-util-types@^1.3.7:
   version "1.3.7"


### PR DESCRIPTION
It turns out that if you open CodeSandbox from an external page,
window.opener will be set as well. We need to mark it as standalone
manually in this case.


Fixes https://github.com/codesandbox/codesandboxer/issues/72