### PR TITLE
fix: theme support for sandbox name input

### DIFF
--- a/packages/app/src/app/pages/Sandbox/Editor/Header/SandboxName/elements.ts
+++ b/packages/app/src/app/pages/Sandbox/Editor/Header/SandboxName/elements.ts
@@ -19,16 +19,18 @@ export const Form = styled.form`
 `;
 
 export const NameInput = styled(AutosizeInput)`
-  input {
-    display: inline-block;
-    background-color: transparent;
-    outline: 0;
-    border: 0;
-    color: white;
-    margin: 0;
-    padding: 0;
-    text-align: center;
-  }
+  ${({ theme }) => css`
+    input {
+      display: inline-block;
+      background-color: transparent;
+      outline: 0;
+      border: 0;
+      margin: 0;
+      padding: 0;
+      text-align: center;
+      color: ${theme['input.foreground']};
+    }
+  `};
 `;
 
 export const Main = styled.div`


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?
Closes #5490 
<!-- Is it a Bug fix, feature, docs update, ... -->

## What is the current behavior?
Text not visible in light themes
<!-- You can also link to an open issue here -->

## What is the new behavior?
make text compatible to theme
<!-- if this is a feature change -->

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Tried with different themes. 

**Night Owl Light:** 
![image](https://user-images.githubusercontent.com/22376783/108389398-a1e67400-7235-11eb-9e7f-367606d2dece.png)

**Github Light**
![image](https://user-images.githubusercontent.com/22376783/108389454-b0cd2680-7235-11eb-8c94-27bad02649ac.png)

**Cobalt2**
![image](https://user-images.githubusercontent.com/22376783/108389542-c93d4100-7235-11eb-8b67-45996b54a3ce.png)


**CSB Black**
![image](https://user-images.githubusercontent.com/22376783/108389595-d3f7d600-7235-11eb-94a9-d084d6323e89.png)

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->


- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

___
Kind of naive question, but isnt it possible to do something like this?

```
background: ${props => props.theme['input.foreground']};
```

I was seeing a issue in editor while doing so.