### PR TITLE
fix: module selection ui in share option

### DIFF
--- a/packages/app/src/app/pages/common/Modals/ShareModal/index.tsx
+++ b/packages/app/src/app/pages/common/Modals/ShareModal/index.tsx
@@ -274,7 +274,7 @@ export const ShareModal: React.FC<Props> = () => {
                   maxHeight: 300,
                   overflow: 'auto',
                   '> div > div[class*="FileContainer"]': {
-                    paddingLeft: 0,
+                    paddingLeft: '12px',
                   },
                 })}
               >

--- a/packages/app/src/embed/components/Sidebar/FileTree/elements.js
+++ b/packages/app/src/embed/components/Sidebar/FileTree/elements.js
@@ -19,8 +19,8 @@ export const FileContainer = styled.div(props =>
 export const IconContainer = styled.span(
   css({
     display: 'inline-flex',
-    width: 16,
-    height: 16,
+    width: '16px',
+    height: '16px',
     justifyContent: 'center',
     alignItems: 'center',
 


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?
Bug Fix
<!-- Is it a Bug fix, feature, docs update, ... -->

## What is the current behavior?
File Tree ui for embed URLs in share modal shows distorted UI, the sizes of items are way too big. Check below screenshot: 
![image](https://user-images.githubusercontent.com/22376783/108633047-19b3d900-7498-11eb-9e21-20e2a2d67547.png)

![image](https://user-images.githubusercontent.com/22376783/108633051-20425080-7498-11eb-8ae5-a47b174cb77a.png)

<!-- You can also link to an open issue here -->

## What is the new behavior?
Fixed the UI to match embed file tree styles. 
https://www.loom.com/share/65d77f64bd0649a69416a04b1de9ed89
<!-- if this is a feature change -->

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Tested on a large application with nested folders
2. Tested both embed UI and share modal UI.

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->


- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
