### PR TITLE
Add explicit check on onClick

### DIFF
--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Explorer/Files/DirectoryEntry/Entry/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Explorer/Files/DirectoryEntry/Entry/index.tsx
@@ -137,7 +137,7 @@ const Entry: React.FC<IEntryProps> = ({
     if (e.key === 'Enter') {
       if (setCurrentModule) {
         setCurrentModuleAction();
-      } else {
+      } else if (typeof onClick === 'function') {
         onClick();
       }
     }


### PR DESCRIPTION
In this particular case `onClick` can be `undefined`, we should enable `strictNullChecks` to catch these cases at build time.

Related issue: https://sentry.io/organizations/codesandbox/issues/2233030390/?project=2071895&referrer=slack