### PR TITLE
Remove assumption that dist-tags is always set in npm manifest

### DIFF
--- a/packages/app/src/app/overmind/namespaces/editor/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/editor/actions.ts
@@ -135,7 +135,8 @@ export const addNpmDependency: AsyncAction<{
             currentSandbox.id,
             name
           );
-          const absoluteVersion = manifest['dist-tags'][newVersion];
+          const distTags = manifest['dist-tags'];
+          const absoluteVersion = distTags ? distTags[newVersion] : null;
 
           if (absoluteVersion) {
             newVersion = absoluteVersion;

--- a/packages/common/src/types/index.ts
+++ b/packages/common/src/types/index.ts
@@ -387,7 +387,7 @@ type PackageVersionInfo = {
 export type NpmManifest = {
   name: string;
   description: string;
-  'dist-tags': {
+  'dist-tags'?: {
     [tag: string]: string;
   };
   versions: {

--- a/packages/sandpack-core/src/npm/dynamic/fetch-protocols/npm-registry.ts
+++ b/packages/sandpack-core/src/npm/dynamic/fetch-protocols/npm-registry.ts
@@ -26,7 +26,7 @@ type PackageVersionInfo = {
 type PackageRegistryInfo = {
   name: string;
   description: string;
-  'dist-tags': {
+  'dist-tags'?: {
     [tag: string]: string;
   };
   versions: {
@@ -171,7 +171,7 @@ export class NpmRegistryFetcher implements FetchProtocol {
 
     const metadata = await this.getPackageMetadata(name);
 
-    if (metadata['dist-tags'][version]) {
+    if (metadata['dist-tags'] && metadata['dist-tags'][version]) {
       return metadata['dist-tags'][version];
     }
 


### PR DESCRIPTION
Apparently that's not always the case 😄 