### PR TITLE
Remove SW caching of API urls in sandbox

### DIFF
--- a/packages/app/config/webpack.prod.js
+++ b/packages/app/config/webpack.prod.js
@@ -242,7 +242,7 @@ module.exports = merge(commonConfig, {
       maximumFileSizeToCacheInBytes: 1024 * 1024 * 20, // 20mb
       runtimeCaching: [
         {
-          urlPattern: /api\/v1\/sandboxes/,
+          urlPattern: /api\/v1\//,
           handler: 'networkFirst',
           options: {
             cache: {


### PR DESCRIPTION
With private npm we need to ensure that we always get the latest API
response back, right now we cache /api/v1/npm_registry/... in the SW,
which sometimes makes private npm packages return old results.
