### PR TITLE
Replace @babel/preset-env with internal one

### DIFF
--- a/packages/app/src/sandbox/eval/transpilers/babel/worker/babel-worker.js
+++ b/packages/app/src/sandbox/eval/transpilers/babel/worker/babel-worker.js
@@ -3,7 +3,6 @@ import { flatten } from 'lodash-es';
 import refreshBabelPlugin from 'react-refresh/babel';
 import chainingPlugin from '@babel/plugin-proposal-optional-chaining';
 import coalescingPlugin from '@babel/plugin-proposal-nullish-coalescing-operator';
-import * as envPreset from '@babel/preset-env';
 
 import delay from '@codesandbox/common/lib/utils/delay';
 
@@ -42,6 +41,9 @@ const { BrowserFS } = self;
 BrowserFS.configure({ fs: 'InMemory' }, () => {});
 
 self.process = {
+  cwd() {
+    return '/';
+  },
   env: { NODE_ENV: 'development', BABEL_ENV: 'development' },
   platform: 'linux',
   argv: [],
@@ -656,11 +658,6 @@ self.addEventListener('message', async event => {
         version !== 7
       ) {
         Babel.registerPreset('env', Babel.availablePresets.latest);
-      }
-
-      if (version === 7) {
-        // Hardcode, since we want to override env
-        Babel.availablePresets.env = envPreset;
       }
 
       if (


### PR DESCRIPTION
This will lower the babel-transpiler bundle with 1MB, which is a lot. We
need to verify whether this breaks existing sandboxes by running some
sandboxes and checking the integration suite.
