### PR TITLE
Preload babel.min.js from root

### DIFF
--- a/packages/app/src/sandbox/startup.js
+++ b/packages/app/src/sandbox/startup.js
@@ -18,7 +18,11 @@ function preloadJs(url) {
   document.head.appendChild(preloadLink);
 }
 
-preloadJs(`/static/js/babel.${BABEL7_VERSION}.min.js`);
+preloadJs(
+  `${
+    process.env.CODESANDBOX_HOST || ''
+  }/static/js/babel.${BABEL7_VERSION}.min.js`
+);
 
 const WORKERS_TO_LOAD = process.env.SANDPACK ? 1 : 3;
 window.babelworkers = [];


### PR DESCRIPTION
Actually, if you load that url from `new.csb.app` it will load `new.csb.app/static/...`. This way we actually load the js from the root.