### PR TITLE
Fix: svg imports in vue 2 should return a url

### DIFF
--- a/packages/app/src/sandbox/eval/presets/vue-cli/index.ts
+++ b/packages/app/src/sandbox/eval/presets/vue-cli/index.ts
@@ -38,11 +38,6 @@ export default function initialize() {
     },
     {
       setup: async (manager: Manager) => {
-        // TODO: Remove this, Ives mentioned a flag in the meeting two weeks ago, just forgot how it works...
-        manager.clearCache();
-        manager.clearCompiledCache();
-        manager.clearTranspilationCache();
-
         const dependencies = manager.manifest.dependencies;
         const vue = dependencies.find(dep => dep.name === 'vue');
         const isV3 = vue && isMinimalSemverVersion(vue.version, '3.0.0');

--- a/packages/app/src/sandbox/eval/presets/vue-cli/index.ts
+++ b/packages/app/src/sandbox/eval/presets/vue-cli/index.ts
@@ -38,6 +38,11 @@ export default function initialize() {
     },
     {
       setup: async (manager: Manager) => {
+        // TODO: Remove this, Ives mentioned a flag in the meeting two weeks ago, just forgot how it works...
+        manager.clearCache();
+        manager.clearCompiledCache();
+        manager.clearTranspilationCache();
+
         const dependencies = manager.manifest.dependencies;
         const vue = dependencies.find(dep => dep.name === 'vue');
         const isV3 = vue && isMinimalSemverVersion(vue.version, '3.0.0');

--- a/packages/app/src/sandbox/eval/presets/vue-cli/v2.ts
+++ b/packages/app/src/sandbox/eval/presets/vue-cli/v2.ts
@@ -96,7 +96,6 @@ export default function initialize(vuePreset: Preset) {
     { transpiler: binaryTranspiler },
     { transpiler: base64Transpiler },
   ]);
-  // TODO: Is this correct? Or is there a way to get the actual link?
   vuePreset.registerTranspiler(module => /\.svg$/.test(module.path), [
     { transpiler: base64Transpiler },
   ]);

--- a/packages/app/src/sandbox/eval/presets/vue-cli/v2.ts
+++ b/packages/app/src/sandbox/eval/presets/vue-cli/v2.ts
@@ -96,6 +96,10 @@ export default function initialize(vuePreset: Preset) {
     { transpiler: binaryTranspiler },
     { transpiler: base64Transpiler },
   ]);
+  // TODO: Is this correct? Or is there a way to get the actual link?
+  vuePreset.registerTranspiler(module => /\.svg$/.test(module.path), [
+    { transpiler: base64Transpiler },
+  ]);
   vuePreset.registerTranspiler(module => /!noop/.test(module.path), [
     { transpiler: noopTranspiler },
   ]);

--- a/packages/app/src/sandbox/eval/transpilers/base64/index.ts
+++ b/packages/app/src/sandbox/eval/transpilers/base64/index.ts
@@ -1,19 +1,25 @@
-import { TranspilerResult, Transpiler } from 'sandpack-core';
+import { TranspilerResult, Transpiler, LoaderContext } from 'sandpack-core';
+import { extname } from 'path';
+// @ts-ignore
+import mimeTypes from './mimes.json';
+
+function getMimeType(filePath: string): string | null | undefined {
+  const extension = extname(filePath).slice(1);
+  return mimeTypes[extension];
+}
 
 class Base64Transpiler extends Transpiler {
   constructor() {
     super('base64-loader');
   }
 
-  doTranspilation(code: string) {
+  doTranspilation(code: string, loaderContext: LoaderContext) {
     return new Promise<TranspilerResult>((resolve, reject) => {
       const reader = new FileReader();
 
-      // Is there a way to get the filename? (kinda needed for mime types)
-      // @ts-ignore
       const blob: Blob =
         typeof code === 'string'
-          ? new Blob([code], { type: 'image/svg+xml' })
+          ? new Blob([code], { type: getMimeType(loaderContext.path) })
           : code;
 
       reader.readAsDataURL(blob);

--- a/packages/app/src/sandbox/eval/transpilers/base64/index.ts
+++ b/packages/app/src/sandbox/eval/transpilers/base64/index.ts
@@ -6,16 +6,27 @@ class Base64Transpiler extends Transpiler {
   }
 
   doTranspilation(code: string) {
-    return new Promise<TranspilerResult>(resolve => {
+    return new Promise<TranspilerResult>((resolve, reject) => {
       const reader = new FileReader();
+
+      // Is there a way to get the filename? (kinda needed for mime types)
       // @ts-ignore
-      reader.readAsDataURL(code);
+      const blob: Blob =
+        typeof code === 'string'
+          ? new Blob([code], { type: 'image/svg+xml' })
+          : code;
+
+      reader.readAsDataURL(blob);
 
       reader.onloadend = () => {
         const base64data = reader.result;
         resolve({
           transpiledCode: `module.exports = "${base64data.toString()}"`,
         });
+      };
+
+      reader.onerror = err => {
+        reject(err);
       };
     });
   }


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?

<!-- Is it a Bug fix, feature, docs update, ... -->

Bug fix with vue v2 svg imports #1664 

Closes #1664 

## What is the current behavior?

<!-- You can also link to an open issue here -->

SVG Import returns svg content

## What is the new behavior?

<!-- if this is a feature change -->

SVG Import returns a data-url of the svg

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Run the linked sandbox in the issue
2. It renders the svg properly 🎉

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
