### PR TITLE
fix(dashboard sidebar): align folder icon too all items of the menu

### DIFF
--- a/packages/app/src/app/pages/Dashboard/Sidebar/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Sidebar/index.tsx
@@ -669,7 +669,7 @@ const NestableRowItem: React.FC<NestableRowItemProps> = ({
               })}
             />
           ) : (
-            <Element as="span" css={css({ width: 5, flexShrink: 0 })} />
+            <Element as="span" css={css({ width: 4, flexShrink: 0 })} />
           )}
 
           <Stack align="center" gap={2} css={{ width: 'calc(100% - 28px)' }}>


### PR DESCRIPTION
**Sidebar dashboard tweak**
It was just a pixel, but once you see it you can't unsee it

![image](https://user-images.githubusercontent.com/4838076/111191007-8ca00380-85af-11eb-8d98-7ee2518b6836.png)
