### PR TITLE
Fix console.log in SSE and static sandboxes

### DIFF
--- a/packages/codesandbox-api/src/dispatcher/host.ts
+++ b/packages/codesandbox-api/src/dispatcher/host.ts
@@ -1,5 +1,2 @@
-declare var process: { env: { CODESANDBOX_HOST: string | undefined } };
-
-const host = process.env.CODESANDBOX_HOST;
-
+const host = typeof process !== 'undefined' && process.env.CODESANDBOX_HOST;
 export default host || 'https://codesandbox.io';


### PR DESCRIPTION
Fixes #5575

SSE and standalone sandboxes were getting this error:
![image](https://user-images.githubusercontent.com/587016/111463168-934d8880-871f-11eb-81cf-ed981bb6e614.png)

Because sse hooks doesn't override `process`.