### PR TITLE
Allow array exports

### DIFF
--- a/packages/app/src/sandbox/eval/transpilers/babel/convert-esmodule/__snapshots__/index.test.ts.snap
+++ b/packages/app/src/sandbox/eval/transpilers/babel/convert-esmodule/__snapshots__/index.test.ts.snap
@@ -179,6 +179,21 @@ exports.default = $csb__default;
 "
 `;
 
+exports[`convert-esmodule can do array exports 1`] = `
+"\\"use strict\\";
+exports.y = exports.x = void  0;
+Object.defineProperty(exports, \\"__esModule\\", {
+  value: true
+});
+function a() {
+  return [1, 2];
+}
+const [x, y] = a();
+exports.x = x;
+exports.y = y;
+"
+`;
+
 exports[`convert-esmodule can handle as imports 1`] = `
 "\\"use strict\\";
 var $csb__b = require(\\"./b\\");

--- a/packages/app/src/sandbox/eval/transpilers/babel/convert-esmodule/index.test.ts
+++ b/packages/app/src/sandbox/eval/transpilers/babel/convert-esmodule/index.test.ts
@@ -574,6 +574,19 @@ export function test3() {
     expect(result).toMatchSnapshot();
   });
 
+  it('can do array exports', () => {
+    const code = `
+    function a() {
+      return [1, 2];
+    }
+
+    export const [x, y] = a();
+    `;
+
+    const result = convertEsModule(code);
+    expect(result).toMatchSnapshot();
+  });
+
   describe('syntax info', () => {
     it('can detect jsx', () => {
       const code = `const a = <div>Hello</div>`;

--- a/packages/app/src/sandbox/eval/transpilers/babel/convert-esmodule/index.ts
+++ b/packages/app/src/sandbox/eval/transpilers/babel/convert-esmodule/index.ts
@@ -341,6 +341,24 @@ export function convertEsModule(
                   exportNames.add(node.id.name);
                   return generateExportStatement(node.id.name, node.id.name);
                 }
+                if (node.id.type === n.ArrayPattern) {
+                  // export const [a, b] = c;
+
+                  return flatten(
+                    node.id.elements.map(property => {
+                      if (property.type !== n.Identifier) {
+                        return false;
+                      }
+
+                      exportNames.add(property.name);
+                      trackedExports[property.name] = property.name;
+                      return generateExportStatement(
+                        property.name,
+                        property.name
+                      );
+                    })
+                  ).filter(Boolean);
+                }
 
                 return null;
               })


### PR DESCRIPTION
Our esmodule converter for node_modules didn't take `export const [a, b] = c()` into account, with this change it does.