### PR TITLE
fix(browser window): prevent back & forward navigation on horizontally swipe

### DIFF
--- a/packages/app/src/app/index.html
+++ b/packages/app/src/app/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" style="overscroll-behavior-x: none;">
 
 <head>
   <meta charset="utf-8">
@@ -84,7 +84,7 @@
   </link>
 </head>
 
-<body style="margin: 0; padding: 0; overscroll-behavior-x: none;">
+<body style="margin: 0; padding: 0;">
   <!-- Google Tag Manager (noscript) -->
   <noscript>
     <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-T3L6RFK" height="0" width="0"


### PR DESCRIPTION
This prevents the browser navigation (back & forward) on horizontally swipe into the code editor. There was a previous fix, however, it was only working in the Safari and Chrome browser, while Firefox users were still facing the problem (which is quite annoying).

Apparently, moving `overscroll-behavior-x` property to the `html` tag fixed it, without any downside for the other browsers that were working before.

Closes #5054