### PR TITLE
Add Event to the test globals

### DIFF
--- a/packages/app/src/sandbox/eval/tests/jest-lite.ts
+++ b/packages/app/src/sandbox/eval/tests/jest-lite.ts
@@ -199,6 +199,9 @@ export default class TestRunner {
       document: jsdomDocument,
       window: jsdomWindow,
       global: jsdomWindow,
+
+      // When calling `Event` we don't want the native `Event` but the JSDOM version
+      Event: jsdomWindow.Event,
     };
 
     Object.keys(jestRuntimeGlobals).forEach(globalKey => {


### PR DESCRIPTION
This is a fix for dispatching events in tests, however, we should find a
solution to mock all globals with the JSDOM equivalent for a longer term
solution.

Fixes #5605
