### PR TITLE
Redirect to sandbox Git page instead of forked sandbox on creation

### DIFF
--- a/packages/app/src/app/overmind/namespaces/git/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/git/actions.ts
@@ -166,11 +166,7 @@ export const createRepoClicked = async ({
     state.git.isExported = true;
     state.currentModal = null;
 
-    actions.editor.internal.forkSandbox({
-      sandboxId: `github/${git.username}/${git.repo}/tree/${git.branch}/${
-        git.path || ''
-      }`,
-    });
+    effects.router.updateSandboxUrl({ git });
   } catch (error) {
     actions.internal.handleError({
       error,


### PR DESCRIPTION
I'd like your opinion on this @christianalfoni, I think this is better.

With this change we change where you get redirected to when you create a repo from the sandbox. Normally you would get redirected to the fork of the imported repo, with this change you directly go to the imported repo. I think this is important for a couple reasons:

1. When you import a repo, you'd expect to go to the sandbox linked to it
2. You can share this sandbox with others to contribute, and it stays up to date with GitHub
3. It's a bit less flaky, I've seen in support the fork going wrong sometimes for private sandboxes
4. People now still have the choice to fork when they go to the repo sandbox, but at least they know what the "root" sandbox is and we have a good explanation of it in the sidebar.

While debugging something I got "lost" when creating a repo, I didn't know how to get to the imported sandbox when I created a repo from the sandbox, and I had to go to the repo to find the original sandbox.
