### PR TITLE
Use data-url for markdown assets in react preset

### DIFF
--- a/packages/app/src/sandbox/eval/presets/create-react-app/utils/reactPreset.ts
+++ b/packages/app/src/sandbox/eval/presets/create-react-app/utils/reactPreset.ts
@@ -16,6 +16,7 @@ import {
 } from '../utils';
 import { initializeReactDevTools } from './initDevTools';
 import { createRefreshEntry } from './createRefreshEntry';
+import base64Transpiler from '../../../transpilers/base64';
 
 export const reactPreset = babelConfig => {
   const debug = _debug('cs:compiler:cra');
@@ -141,6 +142,10 @@ export const reactPreset = babelConfig => {
 
           preset.registerTranspiler(module => /\.json$/.test(module.path), [
             { transpiler: jsonTranspiler },
+          ]);
+
+          preset.registerTranspiler(module => /\.md$/.test(module.path), [
+            { transpiler: base64Transpiler },
           ]);
 
           preset.registerTranspiler(() => true, [

--- a/packages/app/src/sandbox/eval/transpilers/base64/mimes.json
+++ b/packages/app/src/sandbox/eval/transpilers/base64/mimes.json
@@ -30,6 +30,8 @@
   "fst": "image/vnd.fst",
   "mmr": "image/vnd.fujixerox.edmics-mmr",
   "rlc": "image/vnd.fujixerox.edmics-rlc",
+  "txt": "text/plain",
+  "md": "text/plain",
   "mdi": "image/vnd.ms-modi",
   "wdp": "image/vnd.ms-photo",
   "npx": "image/vnd.net-fpx",


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?

<!-- Is it a Bug fix, feature, docs update, ... -->

Fixes #5424 

## What is the current behavior?

<!-- You can also link to an open issue here -->

Returns content of markdown files

## What is the new behavior?

<!-- if this is a feature change -->

Returns url of markdown files

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Open the example

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
