### PR TITLE
Allow users to change username and display name

### DIFF
--- a/packages/app/src/app/graphql/types.ts
+++ b/packages/app/src/app/graphql/types.ts
@@ -17,7 +17,7 @@ export type Scalars = {
    * The `DateTime` scalar type represents a date and time in the UTC
    * timezone. The DateTime appears in a JSON response as an ISO8601 formatted
    * string, including UTC timezone ("Z"). The parsed date and time string will
-   * be converted to UTC and any UTC offset other than 0 will be rejected.
+   * be converted to UTC if there is an offset.
    */
   DateTime: any;
   /**
@@ -130,10 +130,9 @@ export type CurrentUser = {
   collection: Maybe<Collection>;
   collections: Array<Collection>;
   email: Scalars['String'];
-  firstName: Maybe<Scalars['String']>;
   id: Scalars['UUID4'];
-  lastName: Maybe<Scalars['String']>;
   likedSandboxes: Array<Sandbox>;
+  name: Maybe<Scalars['String']>;
   notificationPreferences: Maybe<NotificationPreferences>;
   notifications: Array<Notification>;
   personalWorkspaceId: Scalars['UUID4'];
@@ -344,212 +343,128 @@ export enum RegistryType {
 
 export type RootMutationType = {
   __typename?: 'RootMutationType';
-  /** Clear notification unread count */
-  clearNotificationCount: User;
-  /** Cancel deletion of current user */
-  cancelDeleteCurrentUser: Scalars['String'];
-  reactivateSubscription: ProSubscription;
-  /** Create or Update a private registry */
-  createOrUpdatePrivateNpmRegistry: PrivateRegistry;
-  /** Set a user's notification preferences */
-  updateNotificationPreferences: NotificationPreferences;
-  /** Rename a collection and all subfolders */
-  renameCollection: Array<Collection>;
   /** Accept an invitation to a team */
   acceptTeamInvitation: Team;
-  /** Request deletion of current user */
-  deleteCurrentUser: Scalars['String'];
-  /** bookmark a template */
-  bookmarkTemplate: Maybe<Template>;
-  /** Archive one notification */
-  archiveNotification: Notification;
-  unresolveComment: Comment;
-  /** Set minimum privacy level for workspace */
-  setTeamMinimumPrivacy: WorkspaceSandboxSettings;
-  updateComment: Comment;
-  deleteWorkspace: Scalars['String'];
-  /** Set team member authorization levels */
-  changeTeamMemberAuthorizations: Team;
-  setPreventSandboxesLeavingWorkspace: Array<Sandbox>;
-  setPreventSandboxesExport: Array<Sandbox>;
-  setSandboxesFrozen: Array<Sandbox>;
-  createComment: Comment;
-  /** Revoke an invitation to a team */
-  revokeTeamInvitation: Team;
-  /** Add sandboxes to a collection and/or team */
-  addToCollectionOrTeam: Array<Maybe<Sandbox>>;
-  /** Create a team */
-  createTeam: Team;
-  softCancelSubscription: ProSubscription;
-  setWorkspaceSandboxSettings: WorkspaceSandboxSettings;
-  revokeSandboxInvitation: Invitation;
-  /** Remove a collaborator */
-  removeCollaborator: Collaborator;
-  /** Invite someone to a team */
-  inviteToTeam: Team;
-  /** Reject an invitation to a team */
-  rejectTeamInvitation: Scalars['String'];
-  createSandboxInvitation: Invitation;
-  /** Mark all notifications as read */
-  markAllNotificationsAsRead: User;
-  /** update subscription details (not billing details) */
-  updateSubscription: ProSubscription;
-  /** Delete a collection and all subfolders */
-  deleteCollection: Array<Collection>;
-  /** Delete a private registry */
-  deletePrivateNpmRegistry: Maybe<PrivateRegistry>;
-  /** set sandbox always on status */
-  setSandboxAlwaysOn: Sandbox;
-  /** Unbookmark a template */
-  unbookmarkTemplate: Maybe<Template>;
-  /** Soft delete a comment. Note: all child comments will also be deleted. */
-  deleteComment: Comment;
-  /** Set the description of the team */
-  setTeamDescription: Team;
-  /** Invite someone to a team via email */
-  inviteToTeamViaEmail: Scalars['String'];
-  permanentlyDeleteSandboxes: Array<Sandbox>;
-  /** Change authorization of a collaborator */
-  changeCollaboratorAuthorization: Collaborator;
-  /** Delete sandboxes */
-  deleteSandboxes: Array<Sandbox>;
-  setSandboxesPrivacy: Array<Sandbox>;
-  /** Mark one notification as read */
-  markNotificationAsRead: Notification;
-  /** Create a collection */
-  createCollection: Collection;
-  /** Make templates from sandboxes */
-  makeSandboxesTemplates: Array<Template>;
-  /** Set the default authorization for any new members joining this workspace */
-  setDefaultTeamMemberAuthorization: WorkspaceSandboxSettings;
-  /** Convert templates back to sandboxes */
-  unmakeSandboxesTemplates: Array<Template>;
-  /** Leave a team */
-  leaveTeam: Scalars['String'];
-  /** Redeem an invite token from a team */
-  redeemTeamInviteToken: Team;
-  redeemSandboxInvitation: Invitation;
-  /** Archive all notifications */
-  archiveAllNotifications: User;
-  resolveComment: Comment;
-  createPreviewComment: Comment;
-  /** Update notification read status */
-  updateNotificationReadStatus: Notification;
-  changeSandboxInvitationAuthorization: Invitation;
-  createCodeComment: Comment;
   /** Add a collaborator */
   addCollaborator: Collaborator;
-  renameSandbox: Sandbox;
   /** Add sandboxes to a collection */
   addToCollection: Collection;
-  /** Set the name of the team */
-  setTeamName: Team;
-  updateSubscriptionBillingInterval: ProSubscription;
+  /** Add sandboxes to a collection and/or team */
+  addToCollectionOrTeam: Array<Maybe<Sandbox>>;
+  /** Archive all notifications */
+  archiveAllNotifications: User;
+  /** Archive one notification */
+  archiveNotification: Notification;
+  /** bookmark a template */
+  bookmarkTemplate: Maybe<Template>;
+  /** Cancel deletion of current user */
+  cancelDeleteCurrentUser: Scalars['String'];
+  /** Change authorization of a collaborator */
+  changeCollaboratorAuthorization: Collaborator;
+  changeSandboxInvitationAuthorization: Invitation;
+  /** Set team member authorization levels */
+  changeTeamMemberAuthorizations: Team;
+  /** Clear notification unread count */
+  clearNotificationCount: User;
+  createCodeComment: Comment;
+  /** Create a collection */
+  createCollection: Collection;
+  createComment: Comment;
+  /** Create or Update a private registry */
+  createOrUpdatePrivateNpmRegistry: PrivateRegistry;
+  createPreviewComment: Comment;
+  createSandboxInvitation: Invitation;
+  /** Create a team */
+  createTeam: Team;
+  /** Delete a collection and all subfolders */
+  deleteCollection: Array<Collection>;
+  /** Soft delete a comment. Note: all child comments will also be deleted. */
+  deleteComment: Comment;
+  /** Request deletion of current user */
+  deleteCurrentUser: Scalars['String'];
+  /** Delete a private registry */
+  deletePrivateNpmRegistry: Maybe<PrivateRegistry>;
+  /** Delete sandboxes */
+  deleteSandboxes: Array<Sandbox>;
+  deleteWorkspace: Scalars['String'];
+  /** Invite someone to a team */
+  inviteToTeam: Team;
+  /** Invite someone to a team via email */
+  inviteToTeamViaEmail: Scalars['String'];
+  /** Leave a team */
+  leaveTeam: Scalars['String'];
+  /** Make templates from sandboxes */
+  makeSandboxesTemplates: Array<Template>;
+  /** Mark all notifications as read */
+  markAllNotificationsAsRead: User;
+  /** Mark one notification as read */
+  markNotificationAsRead: Notification;
+  permanentlyDeleteSandboxes: Array<Sandbox>;
   previewUpdateSubscriptionBillingInterval: BillingPreview;
+  reactivateSubscription: ProSubscription;
+  redeemSandboxInvitation: Invitation;
+  /** Redeem an invite token from a team */
+  redeemTeamInviteToken: Team;
+  /** Reject an invitation to a team */
+  rejectTeamInvitation: Scalars['String'];
+  /** Remove a collaborator */
+  removeCollaborator: Collaborator;
   /** Remove someone from a team */
   removeFromTeam: Team;
-};
-
-export type RootMutationTypeReactivateSubscriptionArgs = {
-  subscriptionId: Scalars['UUID4'];
-  teamId: Scalars['UUID4'];
-};
-
-export type RootMutationTypeCreateOrUpdatePrivateNpmRegistryArgs = {
-  authType: Maybe<AuthType>;
-  enabledScopes: Array<Scalars['String']>;
-  limitToScopes: Scalars['Boolean'];
-  proxyEnabled: Scalars['Boolean'];
-  registryAuthKey: Maybe<Scalars['String']>;
-  registryType: RegistryType;
-  registryUrl: Maybe<Scalars['String']>;
-  teamId: Scalars['UUID4'];
-};
-
-export type RootMutationTypeUpdateNotificationPreferencesArgs = {
-  emailCommentMention: Maybe<Scalars['Boolean']>;
-  emailCommentReply: Maybe<Scalars['Boolean']>;
-  emailNewComment: Maybe<Scalars['Boolean']>;
-};
-
-export type RootMutationTypeRenameCollectionArgs = {
-  newPath: Scalars['String'];
-  newTeamId: Maybe<Scalars['UUID4']>;
-  path: Scalars['String'];
-  teamId: Maybe<Scalars['UUID4']>;
+  /** Rename a collection and all subfolders */
+  renameCollection: Array<Collection>;
+  renameSandbox: Sandbox;
+  resolveComment: Comment;
+  revokeSandboxInvitation: Invitation;
+  /** Revoke an invitation to a team */
+  revokeTeamInvitation: Team;
+  /** Set the default authorization for any new members joining this workspace */
+  setDefaultTeamMemberAuthorization: WorkspaceSandboxSettings;
+  setPreventSandboxesExport: Array<Sandbox>;
+  setPreventSandboxesLeavingWorkspace: Array<Sandbox>;
+  /** set sandbox always on status */
+  setSandboxAlwaysOn: Sandbox;
+  setSandboxesFrozen: Array<Sandbox>;
+  setSandboxesPrivacy: Array<Sandbox>;
+  /** Set the description of the team */
+  setTeamDescription: Team;
+  /** Set minimum privacy level for workspace */
+  setTeamMinimumPrivacy: WorkspaceSandboxSettings;
+  /** Set the name of the team */
+  setTeamName: Team;
+  setWorkspaceSandboxSettings: WorkspaceSandboxSettings;
+  softCancelSubscription: ProSubscription;
+  /** Unbookmark a template */
+  unbookmarkTemplate: Maybe<Template>;
+  /** Convert templates back to sandboxes */
+  unmakeSandboxesTemplates: Array<Template>;
+  unresolveComment: Comment;
+  updateComment: Comment;
+  /** Change details of current user */
+  updateCurrentUser: User;
+  /** Set a user's notification preferences */
+  updateNotificationPreferences: NotificationPreferences;
+  /** Update notification read status */
+  updateNotificationReadStatus: Notification;
+  /** update subscription details (not billing details) */
+  updateSubscription: ProSubscription;
+  updateSubscriptionBillingInterval: ProSubscription;
 };
 
 export type RootMutationTypeAcceptTeamInvitationArgs = {
   teamId: Scalars['UUID4'];
 };
 
-export type RootMutationTypeBookmarkTemplateArgs = {
+export type RootMutationTypeAddCollaboratorArgs = {
+  authorization: Authorization;
+  sandboxId: Scalars['ID'];
+  username: Scalars['String'];
+};
+
+export type RootMutationTypeAddToCollectionArgs = {
+  collectionPath: Scalars['String'];
+  sandboxIds: Maybe<Array<Maybe<Scalars['ID']>>>;
   teamId: Maybe<Scalars['UUID4']>;
-  templateId: Scalars['UUID4'];
-};
-
-export type RootMutationTypeArchiveNotificationArgs = {
-  notificationId: Scalars['UUID4'];
-};
-
-export type RootMutationTypeUnresolveCommentArgs = {
-  commentId: Scalars['UUID4'];
-  sandboxId: Scalars['ID'];
-};
-
-export type RootMutationTypeSetTeamMinimumPrivacyArgs = {
-  minimumPrivacy: Scalars['Int'];
-  teamId: Scalars['UUID4'];
-  updateDrafts: Scalars['Boolean'];
-};
-
-export type RootMutationTypeUpdateCommentArgs = {
-  codeReferences: Maybe<Array<CodeReference>>;
-  commentId: Scalars['UUID4'];
-  content: Maybe<Scalars['String']>;
-  imageReferences: Maybe<Array<ImageReference>>;
-  sandboxId: Scalars['ID'];
-  userReferences: Maybe<Array<UserReference>>;
-};
-
-export type RootMutationTypeDeleteWorkspaceArgs = {
-  teamId: Scalars['UUID4'];
-};
-
-export type RootMutationTypeChangeTeamMemberAuthorizationsArgs = {
-  memberAuthorizations: Maybe<Array<MemberAuthorization>>;
-  teamId: Scalars['UUID4'];
-};
-
-export type RootMutationTypeSetPreventSandboxesLeavingWorkspaceArgs = {
-  preventSandboxLeaving: Scalars['Boolean'];
-  sandboxIds: Array<Scalars['ID']>;
-};
-
-export type RootMutationTypeSetPreventSandboxesExportArgs = {
-  preventSandboxExport: Scalars['Boolean'];
-  sandboxIds: Array<Scalars['ID']>;
-};
-
-export type RootMutationTypeSetSandboxesFrozenArgs = {
-  isFrozen: Scalars['Boolean'];
-  sandboxIds: Array<Scalars['ID']>;
-};
-
-export type RootMutationTypeCreateCommentArgs = {
-  codeReference: Maybe<CodeReference>;
-  codeReferences: Maybe<Array<CodeReference>>;
-  content: Scalars['String'];
-  id: Maybe<Scalars['ID']>;
-  imageReferences: Maybe<Array<ImageReference>>;
-  parentCommentId: Maybe<Scalars['ID']>;
-  sandboxId: Scalars['ID'];
-  userReferences: Maybe<Array<UserReference>>;
-};
-
-export type RootMutationTypeRevokeTeamInvitationArgs = {
-  teamId: Scalars['UUID4'];
-  userId: Scalars['UUID4'];
 };
 
 export type RootMutationTypeAddToCollectionOrTeamArgs = {
@@ -558,91 +473,13 @@ export type RootMutationTypeAddToCollectionOrTeamArgs = {
   teamId: Maybe<Scalars['UUID4']>;
 };
 
-export type RootMutationTypeCreateTeamArgs = {
-  name: Scalars['String'];
-  pilot: Maybe<Scalars['Boolean']>;
+export type RootMutationTypeArchiveNotificationArgs = {
+  notificationId: Scalars['UUID4'];
 };
 
-export type RootMutationTypeSoftCancelSubscriptionArgs = {
-  subscriptionId: Scalars['UUID4'];
-  teamId: Scalars['UUID4'];
-};
-
-export type RootMutationTypeSetWorkspaceSandboxSettingsArgs = {
-  preventSandboxExport: Scalars['Boolean'];
-  preventSandboxLeaving: Scalars['Boolean'];
-  teamId: Scalars['UUID4'];
-};
-
-export type RootMutationTypeRevokeSandboxInvitationArgs = {
-  invitationId: Scalars['UUID4'];
-  sandboxId: Scalars['ID'];
-};
-
-export type RootMutationTypeRemoveCollaboratorArgs = {
-  sandboxId: Scalars['ID'];
-  username: Scalars['String'];
-};
-
-export type RootMutationTypeInviteToTeamArgs = {
-  authorization: Maybe<TeamMemberAuthorization>;
-  teamId: Scalars['UUID4'];
-  username: Scalars['String'];
-};
-
-export type RootMutationTypeRejectTeamInvitationArgs = {
-  teamId: Scalars['UUID4'];
-};
-
-export type RootMutationTypeCreateSandboxInvitationArgs = {
-  authorization: Authorization;
-  email: Scalars['String'];
-  sandboxId: Scalars['ID'];
-};
-
-export type RootMutationTypeUpdateSubscriptionArgs = {
-  quantity: Maybe<Scalars['Int']>;
-  subscriptionId: Scalars['UUID4'];
-  teamId: Scalars['UUID4'];
-};
-
-export type RootMutationTypeDeleteCollectionArgs = {
-  path: Scalars['String'];
-  teamId: Maybe<Scalars['UUID4']>;
-};
-
-export type RootMutationTypeDeletePrivateNpmRegistryArgs = {
-  teamId: Scalars['UUID4'];
-};
-
-export type RootMutationTypeSetSandboxAlwaysOnArgs = {
-  alwaysOn: Scalars['Boolean'];
-  sandboxId: Scalars['ID'];
-};
-
-export type RootMutationTypeUnbookmarkTemplateArgs = {
+export type RootMutationTypeBookmarkTemplateArgs = {
   teamId: Maybe<Scalars['UUID4']>;
   templateId: Scalars['UUID4'];
-};
-
-export type RootMutationTypeDeleteCommentArgs = {
-  commentId: Scalars['UUID4'];
-  sandboxId: Scalars['ID'];
-};
-
-export type RootMutationTypeSetTeamDescriptionArgs = {
-  description: Scalars['String'];
-  teamId: Scalars['UUID4'];
-};
-
-export type RootMutationTypeInviteToTeamViaEmailArgs = {
-  authorization: Maybe<TeamMemberAuthorization>;
-  email: Scalars['String'];
-  teamId: Scalars['UUID4'];
-};
-
-export type RootMutationTypePermanentlyDeleteSandboxesArgs = {
-  sandboxIds: Array<Scalars['ID']>;
 };
 
 export type RootMutationTypeChangeCollaboratorAuthorizationArgs = {
@@ -651,75 +488,15 @@ export type RootMutationTypeChangeCollaboratorAuthorizationArgs = {
   username: Scalars['String'];
 };
 
-export type RootMutationTypeDeleteSandboxesArgs = {
-  sandboxIds: Array<Scalars['ID']>;
-};
-
-export type RootMutationTypeSetSandboxesPrivacyArgs = {
-  privacy: Maybe<Scalars['Int']>;
-  sandboxIds: Array<Scalars['ID']>;
-};
-
-export type RootMutationTypeMarkNotificationAsReadArgs = {
-  notificationId: Scalars['UUID4'];
-};
-
-export type RootMutationTypeCreateCollectionArgs = {
-  path: Scalars['String'];
-  teamId: Maybe<Scalars['UUID4']>;
-};
-
-export type RootMutationTypeMakeSandboxesTemplatesArgs = {
-  sandboxIds: Array<Scalars['ID']>;
-};
-
-export type RootMutationTypeSetDefaultTeamMemberAuthorizationArgs = {
-  defaultAuthorization: TeamMemberAuthorization;
-  teamId: Scalars['UUID4'];
-};
-
-export type RootMutationTypeUnmakeSandboxesTemplatesArgs = {
-  sandboxIds: Array<Scalars['ID']>;
-};
-
-export type RootMutationTypeLeaveTeamArgs = {
-  teamId: Scalars['UUID4'];
-};
-
-export type RootMutationTypeRedeemTeamInviteTokenArgs = {
-  inviteToken: Scalars['String'];
-};
-
-export type RootMutationTypeRedeemSandboxInvitationArgs = {
-  invitationToken: Scalars['String'];
-  sandboxId: Scalars['ID'];
-};
-
-export type RootMutationTypeResolveCommentArgs = {
-  commentId: Scalars['UUID4'];
-  sandboxId: Scalars['ID'];
-};
-
-export type RootMutationTypeCreatePreviewCommentArgs = {
-  anchorReference: PreviewReference;
-  codeReferences: Maybe<Array<CodeReference>>;
-  content: Scalars['String'];
-  id: Maybe<Scalars['ID']>;
-  imageReferences: Maybe<Array<ImageReference>>;
-  parentCommentId: Maybe<Scalars['ID']>;
-  sandboxId: Scalars['ID'];
-  userReferences: Maybe<Array<UserReference>>;
-};
-
-export type RootMutationTypeUpdateNotificationReadStatusArgs = {
-  notificationId: Scalars['UUID4'];
-  read: Scalars['Boolean'];
-};
-
 export type RootMutationTypeChangeSandboxInvitationAuthorizationArgs = {
   authorization: Authorization;
   invitationId: Scalars['UUID4'];
   sandboxId: Scalars['ID'];
+};
+
+export type RootMutationTypeChangeTeamMemberAuthorizationsArgs = {
+  memberAuthorizations: Maybe<Array<MemberAuthorization>>;
+  teamId: Scalars['UUID4'];
 };
 
 export type RootMutationTypeCreateCodeCommentArgs = {
@@ -733,32 +510,103 @@ export type RootMutationTypeCreateCodeCommentArgs = {
   userReferences: Maybe<Array<UserReference>>;
 };
 
-export type RootMutationTypeAddCollaboratorArgs = {
-  authorization: Authorization;
-  sandboxId: Scalars['ID'];
-  username: Scalars['String'];
-};
-
-export type RootMutationTypeRenameSandboxArgs = {
-  id: Scalars['ID'];
-  title: Scalars['String'];
-};
-
-export type RootMutationTypeAddToCollectionArgs = {
-  collectionPath: Scalars['String'];
-  sandboxIds: Maybe<Array<Maybe<Scalars['ID']>>>;
+export type RootMutationTypeCreateCollectionArgs = {
+  path: Scalars['String'];
   teamId: Maybe<Scalars['UUID4']>;
 };
 
-export type RootMutationTypeSetTeamNameArgs = {
-  name: Scalars['String'];
+export type RootMutationTypeCreateCommentArgs = {
+  codeReference: Maybe<CodeReference>;
+  codeReferences: Maybe<Array<CodeReference>>;
+  content: Scalars['String'];
+  id: Maybe<Scalars['ID']>;
+  imageReferences: Maybe<Array<ImageReference>>;
+  parentCommentId: Maybe<Scalars['ID']>;
+  sandboxId: Scalars['ID'];
+  userReferences: Maybe<Array<UserReference>>;
+};
+
+export type RootMutationTypeCreateOrUpdatePrivateNpmRegistryArgs = {
+  authType: Maybe<AuthType>;
+  enabledScopes: Array<Scalars['String']>;
+  limitToScopes: Scalars['Boolean'];
+  proxyEnabled: Scalars['Boolean'];
+  registryAuthKey: Maybe<Scalars['String']>;
+  registryType: RegistryType;
+  registryUrl: Maybe<Scalars['String']>;
   teamId: Scalars['UUID4'];
 };
 
-export type RootMutationTypeUpdateSubscriptionBillingIntervalArgs = {
-  billingInterval: SubscriptionInterval;
-  subscriptionId: Scalars['UUID4'];
+export type RootMutationTypeCreatePreviewCommentArgs = {
+  anchorReference: PreviewReference;
+  codeReferences: Maybe<Array<CodeReference>>;
+  content: Scalars['String'];
+  id: Maybe<Scalars['ID']>;
+  imageReferences: Maybe<Array<ImageReference>>;
+  parentCommentId: Maybe<Scalars['ID']>;
+  sandboxId: Scalars['ID'];
+  userReferences: Maybe<Array<UserReference>>;
+};
+
+export type RootMutationTypeCreateSandboxInvitationArgs = {
+  authorization: Authorization;
+  email: Scalars['String'];
+  sandboxId: Scalars['ID'];
+};
+
+export type RootMutationTypeCreateTeamArgs = {
+  name: Scalars['String'];
+  pilot: Maybe<Scalars['Boolean']>;
+};
+
+export type RootMutationTypeDeleteCollectionArgs = {
+  path: Scalars['String'];
+  teamId: Maybe<Scalars['UUID4']>;
+};
+
+export type RootMutationTypeDeleteCommentArgs = {
+  commentId: Scalars['UUID4'];
+  sandboxId: Scalars['ID'];
+};
+
+export type RootMutationTypeDeletePrivateNpmRegistryArgs = {
   teamId: Scalars['UUID4'];
+};
+
+export type RootMutationTypeDeleteSandboxesArgs = {
+  sandboxIds: Array<Scalars['ID']>;
+};
+
+export type RootMutationTypeDeleteWorkspaceArgs = {
+  teamId: Scalars['UUID4'];
+};
+
+export type RootMutationTypeInviteToTeamArgs = {
+  authorization: Maybe<TeamMemberAuthorization>;
+  teamId: Scalars['UUID4'];
+  username: Scalars['String'];
+};
+
+export type RootMutationTypeInviteToTeamViaEmailArgs = {
+  authorization: Maybe<TeamMemberAuthorization>;
+  email: Scalars['String'];
+  teamId: Scalars['UUID4'];
+};
+
+export type RootMutationTypeLeaveTeamArgs = {
+  teamId: Scalars['UUID4'];
+};
+
+export type RootMutationTypeMakeSandboxesTemplatesArgs = {
+  sandboxIds: Array<Scalars['ID']>;
+};
+
+export type RootMutationTypeMarkNotificationAsReadArgs = {
+  notificationId: Scalars['UUID4'];
+};
+
+export type RootMutationTypePermanentlyDeleteSandboxesArgs = {
+  sandboxIds: Array<Scalars['ID']>;
 };
 
 export type RootMutationTypePreviewUpdateSubscriptionBillingIntervalArgs = {
@@ -767,9 +615,169 @@ export type RootMutationTypePreviewUpdateSubscriptionBillingIntervalArgs = {
   teamId: Scalars['UUID4'];
 };
 
+export type RootMutationTypeReactivateSubscriptionArgs = {
+  subscriptionId: Scalars['UUID4'];
+  teamId: Scalars['UUID4'];
+};
+
+export type RootMutationTypeRedeemSandboxInvitationArgs = {
+  invitationToken: Scalars['String'];
+  sandboxId: Scalars['ID'];
+};
+
+export type RootMutationTypeRedeemTeamInviteTokenArgs = {
+  inviteToken: Scalars['String'];
+};
+
+export type RootMutationTypeRejectTeamInvitationArgs = {
+  teamId: Scalars['UUID4'];
+};
+
+export type RootMutationTypeRemoveCollaboratorArgs = {
+  sandboxId: Scalars['ID'];
+  username: Scalars['String'];
+};
+
 export type RootMutationTypeRemoveFromTeamArgs = {
   teamId: Scalars['UUID4'];
   userId: Scalars['UUID4'];
+};
+
+export type RootMutationTypeRenameCollectionArgs = {
+  newPath: Scalars['String'];
+  newTeamId: Maybe<Scalars['UUID4']>;
+  path: Scalars['String'];
+  teamId: Maybe<Scalars['UUID4']>;
+};
+
+export type RootMutationTypeRenameSandboxArgs = {
+  id: Scalars['ID'];
+  title: Scalars['String'];
+};
+
+export type RootMutationTypeResolveCommentArgs = {
+  commentId: Scalars['UUID4'];
+  sandboxId: Scalars['ID'];
+};
+
+export type RootMutationTypeRevokeSandboxInvitationArgs = {
+  invitationId: Scalars['UUID4'];
+  sandboxId: Scalars['ID'];
+};
+
+export type RootMutationTypeRevokeTeamInvitationArgs = {
+  teamId: Scalars['UUID4'];
+  userId: Scalars['UUID4'];
+};
+
+export type RootMutationTypeSetDefaultTeamMemberAuthorizationArgs = {
+  defaultAuthorization: TeamMemberAuthorization;
+  teamId: Scalars['UUID4'];
+};
+
+export type RootMutationTypeSetPreventSandboxesExportArgs = {
+  preventSandboxExport: Scalars['Boolean'];
+  sandboxIds: Array<Scalars['ID']>;
+};
+
+export type RootMutationTypeSetPreventSandboxesLeavingWorkspaceArgs = {
+  preventSandboxLeaving: Scalars['Boolean'];
+  sandboxIds: Array<Scalars['ID']>;
+};
+
+export type RootMutationTypeSetSandboxAlwaysOnArgs = {
+  alwaysOn: Scalars['Boolean'];
+  sandboxId: Scalars['ID'];
+};
+
+export type RootMutationTypeSetSandboxesFrozenArgs = {
+  isFrozen: Scalars['Boolean'];
+  sandboxIds: Array<Scalars['ID']>;
+};
+
+export type RootMutationTypeSetSandboxesPrivacyArgs = {
+  privacy: Maybe<Scalars['Int']>;
+  sandboxIds: Array<Scalars['ID']>;
+};
+
+export type RootMutationTypeSetTeamDescriptionArgs = {
+  description: Scalars['String'];
+  teamId: Scalars['UUID4'];
+};
+
+export type RootMutationTypeSetTeamMinimumPrivacyArgs = {
+  minimumPrivacy: Scalars['Int'];
+  teamId: Scalars['UUID4'];
+  updateDrafts: Scalars['Boolean'];
+};
+
+export type RootMutationTypeSetTeamNameArgs = {
+  name: Scalars['String'];
+  teamId: Scalars['UUID4'];
+};
+
+export type RootMutationTypeSetWorkspaceSandboxSettingsArgs = {
+  preventSandboxExport: Scalars['Boolean'];
+  preventSandboxLeaving: Scalars['Boolean'];
+  teamId: Scalars['UUID4'];
+};
+
+export type RootMutationTypeSoftCancelSubscriptionArgs = {
+  subscriptionId: Scalars['UUID4'];
+  teamId: Scalars['UUID4'];
+};
+
+export type RootMutationTypeUnbookmarkTemplateArgs = {
+  teamId: Maybe<Scalars['UUID4']>;
+  templateId: Scalars['UUID4'];
+};
+
+export type RootMutationTypeUnmakeSandboxesTemplatesArgs = {
+  sandboxIds: Array<Scalars['ID']>;
+};
+
+export type RootMutationTypeUnresolveCommentArgs = {
+  commentId: Scalars['UUID4'];
+  sandboxId: Scalars['ID'];
+};
+
+export type RootMutationTypeUpdateCommentArgs = {
+  codeReferences: Maybe<Array<CodeReference>>;
+  commentId: Scalars['UUID4'];
+  content: Maybe<Scalars['String']>;
+  imageReferences: Maybe<Array<ImageReference>>;
+  sandboxId: Scalars['ID'];
+  userReferences: Maybe<Array<UserReference>>;
+};
+
+export type RootMutationTypeUpdateCurrentUserArgs = {
+  bio: Maybe<Scalars['String']>;
+  name: Maybe<Scalars['String']>;
+  socialLinks: Maybe<Array<Scalars['String']>>;
+  username: Scalars['String'];
+};
+
+export type RootMutationTypeUpdateNotificationPreferencesArgs = {
+  emailCommentMention: Maybe<Scalars['Boolean']>;
+  emailCommentReply: Maybe<Scalars['Boolean']>;
+  emailNewComment: Maybe<Scalars['Boolean']>;
+};
+
+export type RootMutationTypeUpdateNotificationReadStatusArgs = {
+  notificationId: Scalars['UUID4'];
+  read: Scalars['Boolean'];
+};
+
+export type RootMutationTypeUpdateSubscriptionArgs = {
+  quantity: Maybe<Scalars['Int']>;
+  subscriptionId: Scalars['UUID4'];
+  teamId: Scalars['UUID4'];
+};
+
+export type RootMutationTypeUpdateSubscriptionBillingIntervalArgs = {
+  billingInterval: SubscriptionInterval;
+  subscriptionId: Scalars['UUID4'];
+  teamId: Scalars['UUID4'];
 };
 
 export type RootQueryType = {
@@ -856,45 +864,45 @@ export type RootSubscriptionTypeSandboxChangedArgs = {
 /** A Sandbox */
 export type Sandbox = {
   __typename?: 'Sandbox';
-  authorId: Maybe<Scalars['UUID4']>;
-  screenshotUrl: Maybe<Scalars['String']>;
-  forkedTemplate: Maybe<Template>;
-  collaborators: Array<Collaborator>;
-  insertedAt: Scalars['String'];
-  likeCount: Scalars['Int'];
-  invitations: Array<Invitation>;
-  updatedAt: Scalars['String'];
+  alias: Maybe<Scalars['String']>;
+  alwaysOn: Maybe<Scalars['Boolean']>;
   author: Maybe<User>;
-  screenshotOutdated: Scalars['Boolean'];
-  permissions: Maybe<SandboxProtectionSettings>;
+  authorId: Maybe<Scalars['UUID4']>;
+  authorization: Authorization;
   /** If the sandbox has created a PR, this will refer to the git that you will merge into */
   baseGit: Maybe<Git>;
-  comments: Array<Comment>;
-  description: Maybe<Scalars['String']>;
-  title: Maybe<Scalars['String']>;
-  forkCount: Scalars['Int'];
+  collaborators: Array<Collaborator>;
+  collection: Maybe<Collection>;
   comment: Maybe<Comment>;
-  /** If a PR has been opened on the sandbox, this will be set to the PR number */
-  prNumber: Maybe<Scalars['Int']>;
-  removedAt: Maybe<Scalars['String']>;
-  alwaysOn: Maybe<Scalars['Boolean']>;
-  isSse: Maybe<Scalars['Boolean']>;
-  alias: Maybe<Scalars['String']>;
-  team: Maybe<Team>;
-  teamId: Maybe<Scalars['UUID4']>;
+  comments: Array<Comment>;
   /** If the sandbox is a template this will be set */
   customTemplate: Maybe<Template>;
-  authorization: Authorization;
+  description: Maybe<Scalars['String']>;
+  forkCount: Scalars['Int'];
+  forkedTemplate: Maybe<Template>;
   /** If the sandbox has a git repo tied to it this will be set */
   git: Maybe<Git>;
-  viewCount: Scalars['Int'];
   id: Scalars['ID'];
-  privacy: Scalars['Int'];
-  source: Source;
-  collection: Maybe<Collection>;
+  insertedAt: Scalars['String'];
+  invitations: Array<Invitation>;
+  isFrozen: Scalars['Boolean'];
+  isSse: Maybe<Scalars['Boolean']>;
+  likeCount: Scalars['Int'];
   /** If the sandbox has been forked from a git sandbox this will be set */
   originalGit: Maybe<Git>;
-  isFrozen: Scalars['Boolean'];
+  permissions: Maybe<SandboxProtectionSettings>;
+  /** If a PR has been opened on the sandbox, this will be set to the PR number */
+  prNumber: Maybe<Scalars['Int']>;
+  privacy: Scalars['Int'];
+  removedAt: Maybe<Scalars['String']>;
+  screenshotOutdated: Scalars['Boolean'];
+  screenshotUrl: Maybe<Scalars['String']>;
+  source: Source;
+  team: Maybe<Team>;
+  teamId: Maybe<Scalars['UUID4']>;
+  title: Maybe<Scalars['String']>;
+  updatedAt: Scalars['String'];
+  viewCount: Scalars['Int'];
 };
 
 /** A Sandbox */
@@ -1003,11 +1011,11 @@ export type Template = {
 export type User = {
   __typename?: 'User';
   avatarUrl: Scalars['String'];
-  firstName: Maybe<Scalars['String']>;
+  bio: Maybe<Scalars['String']>;
   id: Scalars['UUID4'];
-  lastName: Maybe<Scalars['String']>;
   name: Maybe<Scalars['String']>;
   personalWorkspaceId: Scalars['UUID4'];
+  socialLinks: Maybe<Array<Scalars['String']>>;
   username: Scalars['String'];
 };
 
@@ -2193,6 +2201,20 @@ export type ReactivateSubscriptionMutation = {
   reactivateSubscription: { __typename?: 'ProSubscription' } & Pick<
     ProSubscription,
     'id'
+  >;
+};
+
+export type UpdateCurrentUserMutationVariables = Exact<{
+  username: Scalars['String'];
+  name: Maybe<Scalars['String']>;
+  bio: Maybe<Scalars['String']>;
+  socialLinks: Maybe<Array<Scalars['String']>>;
+}>;
+
+export type UpdateCurrentUserMutation = { __typename?: 'RootMutationType' } & {
+  updateCurrentUser: { __typename?: 'User' } & Pick<
+    User,
+    'username' | 'name' | 'bio' | 'socialLinks'
   >;
 };
 

--- a/packages/app/src/app/overmind/effects/api/index.ts
+++ b/packages/app/src/app/overmind/effects/api/index.ts
@@ -617,14 +617,6 @@ export default {
   makeGitSandbox(sandboxId: string): Promise<Sandbox> {
     return api.post<Sandbox>(`/sandboxes/${sandboxId}/make_git_sandbox`, null);
   },
-  updateUserProfile(username: string, bio: string, socialLinks: string[]) {
-    return api.patch(`/users/${username}`, {
-      user: {
-        bio,
-        socialLinks,
-      },
-    });
-  },
   updateUserFeaturedSandboxes(
     username: string,
     featuredSandboxIds: string[]

--- a/packages/app/src/app/overmind/effects/gql/dashboard/mutations.ts
+++ b/packages/app/src/app/overmind/effects/gql/dashboard/mutations.ts
@@ -71,6 +71,8 @@ import {
   SoftCancelSubscriptionMutationVariables,
   ReactivateSubscriptionMutation,
   ReactivateSubscriptionMutationVariables,
+  UpdateCurrentUserMutation,
+  UpdateCurrentUserMutationVariables,
 } from 'app/graphql/types';
 import { gql, Query } from 'overmind-graphql';
 
@@ -600,6 +602,30 @@ export const reactivateSubscription: Query<
   mutation reactivateSubscription($teamId: UUID4!, $subscriptionId: UUID4!) {
     reactivateSubscription(teamId: $teamId, subscriptionId: $subscriptionId) {
       id
+    }
+  }
+`;
+
+export const updateCurrentUser: Query<
+  UpdateCurrentUserMutation,
+  UpdateCurrentUserMutationVariables
+> = gql`
+  mutation updateCurrentUser(
+    $username: String!
+    $name: String
+    $bio: String
+    $socialLinks: [String!]
+  ) {
+    updateCurrentUser(
+      username: $username
+      name: $name
+      bio: $bio
+      socialLinks: $socialLinks
+    ) {
+      username
+      name
+      bio
+      socialLinks
     }
   }
 `;

--- a/packages/app/src/app/overmind/namespaces/profile/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/profile/actions.ts
@@ -218,6 +218,8 @@ export const updateUserProfile = async (
     onCancel: any;
   }
 ) => {
+  if (!state.profile.current) return;
+
   const usernameChanged = state.profile.current.username !== username;
 
   try {

--- a/packages/app/src/app/overmind/namespaces/profile/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/profile/actions.ts
@@ -192,35 +192,81 @@ export const sandboxDeleted = async ({ state, effects }: Context) => {
   state.profile.isLoadingSandboxes = false;
 };
 
-export const updateUserProfile = async (
-  { actions, effects, state }: Context,
-  { bio = '', socialLinks = [] }: Pick<Profile, 'bio' | 'socialLinks'>
+export const validateUsernameUpdate = async (
+  { effects, state }: Context,
+  userName: string
 ) => {
-  if (!state.profile.current) return;
+  if (!state.profile) return;
+  const validity = await effects.api.validateUsername(userName);
+  // eslint-disable-next-line consistent-return
+  return validity.available;
+};
 
-  // optimistic update
-  const oldBio = state.profile.current.bio;
-  state.profile.current.bio = bio;
-  const oldSocialLinks = state.profile.current.socialLinks;
-  state.profile.current.socialLinks = socialLinks;
+export const updateUserProfile = async (
+  { state, actions, effects }: Context,
+  {
+    username,
+    name,
+    bio,
+    socialLinks,
+    onCancel,
+  }: {
+    username: string;
+    name: string;
+    bio: string;
+    socialLinks: string[];
+    onCancel: any;
+  }
+) => {
+  const usernameChanged = state.profile.current.username !== username;
 
   try {
-    await effects.api.updateUserProfile(
-      state.profile.current.id,
+    if (usernameChanged) {
+      const confirmed = await actions.modals.alertModal.open({
+        title: 'Change Username',
+        message:
+          'Are you sure you want to change your username? You will need to update any external links to your CodeSandbox profile or sandboxes.',
+        type: 'danger',
+      });
+
+      if (!confirmed) throw new Error();
+    }
+
+    const response = await effects.gql.mutations.updateCurrentUser({
+      username,
+      name,
       bio,
-      socialLinks
-    );
+      socialLinks,
+    });
+
+    // Pessimistic state update
+    state.profile.current.name = response.updateCurrentUser.name;
+    state.profile.current.username = response.updateCurrentUser.username;
+    state.profile.current.bio = response.updateCurrentUser.bio;
+    state.profile.current.socialLinks = response.updateCurrentUser.socialLinks;
 
     effects.analytics.track('Profile - User profile updated');
-  } catch (error) {
-    // revert optimistic update
-    state.profile.current.bio = oldBio;
-    state.profile.current.socialLinks = oldSocialLinks;
 
-    actions.internal.handleError({
-      message: "We weren't able to update your bio",
-      error,
-    });
+    // Redirect user to new username path only if username has changed
+    if (usernameChanged) {
+      location.href = `/u/${username}`;
+    }
+  } catch (error) {
+    // Reset state in ProfileCard
+    onCancel();
+
+    if (
+      error.response &&
+      error.response.errors[0].message.includes('Username')
+    ) {
+      effects.notificationToast.error(
+        `There was a problem updating your profile: ${error.response.errors[0].message}.`
+      );
+    } else {
+      effects.notificationToast.error(
+        'There was a problem updating your profile.'
+      );
+    }
   }
 };
 

--- a/packages/common/src/types/index.ts
+++ b/packages/common/src/types/index.ts
@@ -601,14 +601,14 @@ export type Profile = {
   sandboxCount: number;
   templateCount: number;
   receivedLikeCount: number;
-  name: string;
+  name: string | null;
   id: string;
   givenLikeCount: number;
   forkedCount: number;
   badges: Badge[];
   avatarUrl: string;
-  bio?: string;
-  socialLinks?: string[];
+  bio?: string | null;
+  socialLinks?: string[] | null;
   featuredSandboxes: Sandbox[];
   personalWorkspaceId: string;
   teams: Array<{


### PR DESCRIPTION
Requires https://github.com/codesandbox/codesandbox-server/pull/315 to be merged and deployed first.

* Removes REST API call for updating profile (bio and social links)
* Makes use of new Graphql mutation `UpdateCurrentUser` to update profile info (username, display name, bio, social links)
* Alerts user with modal when changing username, so that they know they'll need to update their external links

See it in action: https://www.loom.com/share/813da73b839141a8a16f1cfde85e73b0

I think I did all the Graphql updating okay but let me know if I missed anything since this is my first time contributing to the client repo.