### PR TITLE
Add custom npm registry form presets

### DIFF
--- a/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/RegistryForm.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/RegistryForm.tsx
@@ -21,8 +21,11 @@ import {
 import css from '@styled-system/css';
 import { useTheme } from 'styled-components';
 import Media from 'react-media';
+import { getFormFromPreset, RegistryPreset } from './RegistryPreset';
 
-const CustomFormField = (props: React.ComponentProps<typeof FormField>) => (
+export const CustomFormField = (
+  props: React.ComponentProps<typeof FormField>
+) => (
   <FormField
     css={css({ paddingX: 0, label: { marginBottom: 1 } })}
     direction={props.direction || 'vertical'}
@@ -45,11 +48,19 @@ type RegistryFormProps = {
   disabled?: boolean;
 };
 
-const nameMap = {
-  Github: 'GitHub',
-  Npm: 'npm',
-  Custom: 'Custom',
-};
+function getDefaultRegistryPreset(regType?: RegistryType): RegistryPreset {
+  if (!regType) {
+    return RegistryPreset.npm;
+  }
+
+  if (regType === RegistryType.Npm) {
+    return RegistryPreset.npm;
+  }
+  if (regType === RegistryType.Github) {
+    return RegistryPreset.GitHub;
+  }
+  return RegistryPreset.Custom;
+}
 
 export const RegistryForm = ({
   registry,
@@ -60,6 +71,9 @@ export const RegistryForm = ({
 }: RegistryFormProps) => {
   const theme = useTheme() as any;
 
+  const [registryPreset, setRegistryPreset] = React.useState<RegistryPreset>(
+    getDefaultRegistryPreset(registry?.registryType)
+  );
   const [registryType, setRegistryType] = React.useState<RegistryType>(
     registry?.registryType || RegistryType.Npm
   );
@@ -110,6 +124,8 @@ export const RegistryForm = ({
   // We make sure to always show one input field
   const prefilledScopes = scopes.length === 0 ? [''] : scopes;
 
+  const PresetComponent = getFormFromPreset(registryPreset);
+
   return (
     <Media query={`(min-width: ${theme.breakpoints[2]})`}>
       {isHorizontal => (
@@ -159,85 +175,31 @@ export const RegistryForm = ({
 
               <CustomFormField label="Registry Host">
                 <Select
-                  value={registryType}
+                  value={registryPreset}
                   onChange={e => {
-                    setRegistryType(e.target.value);
+                    setRegistryPreset(e.target.value);
                   }}
                   disabled={disabled}
                 >
-                  {Object.keys(RegistryType).map(type => (
-                    <option value={RegistryType[type]} key={type}>
-                      {nameMap[type] || type}
+                  {Object.keys(RegistryPreset).map(preset => (
+                    <option value={RegistryPreset[preset]} key={preset}>
+                      {RegistryPreset[preset]}
                     </option>
                   ))}
                 </Select>
               </CustomFormField>
 
-              {registryType === RegistryType.Custom && (
-                <div>
-                  <CustomFormField label="Registry URL">
-                    <Input
-                      value={registryUrl}
-                      onChange={e => setRegistryUrl(e.target.value)}
-                      required
-                      pattern="https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)"
-                      disabled={disabled}
-                    />
-                  </CustomFormField>
-                  <Text size={3} variant="muted">
-                    Is your registry behind a VPN? Please read these{' '}
-                    <a
-                      href="https://codesandbox.io/docs/custom-npm-registry"
-                      target="_blank"
-                      rel="noreferrer noopener"
-                    >
-                      docs
-                    </a>
-                    .
-                  </Text>
-                </div>
-              )}
-
-              {registryType === RegistryType.Custom && (
-                <div>
-                  <CustomFormField label="Auth Type">
-                    <Select
-                      value={authenticationType}
-                      onChange={e => {
-                        setAuthenticationType(e.target.value);
-                      }}
-                      disabled={disabled}
-                    >
-                      {Object.keys(AuthType).map(type => (
-                        <option value={AuthType[type]} key={type}>
-                          {type}
-                        </option>
-                      ))}
-                    </Select>
-                  </CustomFormField>
-                  <Text size={3} variant="muted">
-                    More information on which one to choose can be found{' '}
-                    <a
-                      href="https://codesandbox.io/docs/custom-npm-registry#auth-token"
-                      target="_blank"
-                      rel="noreferrer noopener"
-                    >
-                      here
-                    </a>
-                    .
-                  </Text>
-                </div>
-              )}
-
-              <CustomFormField label="Auth Token">
-                <Input
-                  value={authKey}
-                  required
-                  onChange={e => setAuthKey(e.target.value)}
-                  disabled={disabled}
-                  type="password"
-                />
-              </CustomFormField>
+              <PresetComponent
+                registryType={registryType}
+                registryUrl={registryUrl}
+                authKey={authKey}
+                authenticationType={authenticationType}
+                setRegistryType={setRegistryType}
+                setRegistryUrl={setRegistryUrl}
+                setAuthenticationType={setAuthenticationType}
+                setAuthKey={setAuthKey}
+                disabled={disabled}
+              />
             </Stack>
             <Stack
               align="center"

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/RegistryPreset/Artifactory.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/RegistryPreset/Artifactory.tsx
@@ -1,0 +1,57 @@
+import * as React from 'react';
+import { Input, Text } from '@codesandbox/components';
+import { AuthType, RegistryType } from 'app/graphql/types';
+import { RegistryPresetProps } from '.';
+import { CustomFormField } from '../RegistryForm';
+
+export const ArtifactoryRegistryPreset = ({
+  registryUrl,
+  setRegistryUrl,
+  disabled,
+  setAuthenticationType,
+  authKey,
+  setAuthKey,
+  setRegistryType,
+}: RegistryPresetProps) => {
+  React.useEffect(() => {
+    setRegistryType(RegistryType.Custom);
+    setAuthenticationType(AuthType.Basic);
+  }, [setRegistryType, setAuthenticationType]);
+
+  return (
+    <>
+      <div>
+        <CustomFormField label="Registry URL">
+          <Input
+            value={registryUrl}
+            onChange={e => setRegistryUrl(e.target.value)}
+            required
+            pattern="https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)"
+            disabled={disabled}
+          />
+        </CustomFormField>
+        <Text size={3} variant="muted">
+          Is your registry behind a VPN? Please read these{' '}
+          <a
+            href="https://codesandbox.io/docs/custom-npm-registry"
+            target="_blank"
+            rel="noreferrer noopener"
+          >
+            docs
+          </a>
+          .
+        </Text>
+      </div>
+
+      <CustomFormField label="Access Token (found after _auth= in `.npmrc`)">
+        <Input
+          value={authKey}
+          required
+          onChange={e => setAuthKey(e.target.value)}
+          disabled={disabled}
+          type="password"
+        />
+      </CustomFormField>
+    </>
+  );
+};

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/RegistryPreset/Artifactory.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/RegistryPreset/Artifactory.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Input, Text } from '@codesandbox/components';
+import { Input, Link, Text } from '@codesandbox/components';
 import { AuthType, RegistryType } from 'app/graphql/types';
 import { RegistryPresetProps } from '.';
 import { CustomFormField } from '../RegistryForm';
@@ -32,13 +32,13 @@ export const ArtifactoryRegistryPreset = ({
         </CustomFormField>
         <Text size={3} variant="muted">
           Is your registry behind a VPN? Please read these{' '}
-          <a
+          <Link
             href="https://codesandbox.io/docs/custom-npm-registry"
             target="_blank"
-            rel="noreferrer noopener"
+            variant="active"
           >
             docs
-          </a>
+          </Link>
           .
         </Text>
       </div>

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/RegistryPreset/Azure.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/RegistryPreset/Azure.tsx
@@ -1,0 +1,82 @@
+import * as React from 'react';
+import { Input, Text } from '@codesandbox/components';
+import { AuthType, RegistryType } from 'app/graphql/types';
+import { RegistryPresetProps } from '.';
+import { CustomFormField } from '../RegistryForm';
+
+export const AzureRegistryPreset = ({
+  registryUrl,
+  setRegistryUrl,
+  disabled,
+  setAuthenticationType,
+  setAuthKey,
+  setRegistryType,
+}: RegistryPresetProps) => {
+  React.useEffect(() => {
+    setRegistryType(RegistryType.Custom);
+    setAuthenticationType(AuthType.Basic);
+  }, [setRegistryType, setAuthenticationType]);
+
+  const [username, setUsername] = React.useState('');
+  const [token, setToken] = React.useState('');
+
+  React.useEffect(() => {
+    if (!username || !token) {
+      return;
+    }
+
+    // First unencode the token, this is what npm does as well
+    const unencodedToken = Buffer.from(token, 'base64').toString('utf-8');
+
+    const key = `${username}:${unencodedToken}`;
+    const base64Data = Buffer.from(key);
+    const authKey = base64Data.toString('base64');
+    setAuthKey(authKey);
+  }, [username, token, setAuthKey]);
+
+  return (
+    <>
+      <div>
+        <CustomFormField label="Registry URL">
+          <Input
+            value={registryUrl}
+            onChange={e => setRegistryUrl(e.target.value)}
+            required
+            pattern="https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)"
+            disabled={disabled}
+          />
+        </CustomFormField>
+        <Text size={3} variant="muted">
+          Is your registry behind a VPN? Please read these{' '}
+          <a
+            href="https://codesandbox.io/docs/custom-npm-registry"
+            target="_blank"
+            rel="noreferrer noopener"
+          >
+            docs
+          </a>
+          .
+        </Text>
+      </div>
+
+      <CustomFormField label="Username">
+        <Input
+          value={username}
+          required
+          onChange={e => setUsername(e.target.value)}
+          disabled={disabled}
+        />
+      </CustomFormField>
+
+      <CustomFormField label="Access Token (base64 encoded)">
+        <Input
+          value={token}
+          required
+          onChange={e => setToken(e.target.value)}
+          disabled={disabled}
+          type="password"
+        />
+      </CustomFormField>
+    </>
+  );
+};

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/RegistryPreset/Azure.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/RegistryPreset/Azure.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Input, Text } from '@codesandbox/components';
+import { Input, Link, Text } from '@codesandbox/components';
 import { AuthType, RegistryType } from 'app/graphql/types';
 import { RegistryPresetProps } from '.';
 import { CustomFormField } from '../RegistryForm';
@@ -48,13 +48,13 @@ export const AzureRegistryPreset = ({
         </CustomFormField>
         <Text size={3} variant="muted">
           Is your registry behind a VPN? Please read these{' '}
-          <a
+          <Link
             href="https://codesandbox.io/docs/custom-npm-registry"
             target="_blank"
-            rel="noreferrer noopener"
+            variant="active"
           >
             docs
-          </a>
+          </Link>
           .
         </Text>
       </div>

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/RegistryPreset/Custom.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/RegistryPreset/Custom.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Select, Input, Text } from '@codesandbox/components';
+import { Select, Input, Text, Link } from '@codesandbox/components';
 import { AuthType, RegistryType } from 'app/graphql/types';
 import { RegistryPresetProps } from '.';
 import { CustomFormField } from '../RegistryForm';
@@ -31,13 +31,13 @@ export const CustomRegistryPreset = ({
         </CustomFormField>
         <Text size={3} variant="muted">
           Is your registry behind a VPN? Please read these{' '}
-          <a
+          <Link
             href="https://codesandbox.io/docs/custom-npm-registry"
             target="_blank"
-            rel="noreferrer noopener"
+            variant="active"
           >
             docs
-          </a>
+          </Link>
           .
         </Text>
       </div>
@@ -60,13 +60,13 @@ export const CustomRegistryPreset = ({
         </CustomFormField>
         <Text size={3} variant="muted">
           More information on which one to choose can be found{' '}
-          <a
+          <Link
             href="https://codesandbox.io/docs/custom-npm-registry#auth-token"
             target="_blank"
-            rel="noreferrer noopener"
+            variant="active"
           >
             here
-          </a>
+          </Link>
           .
         </Text>
       </div>

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/RegistryPreset/Custom.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/RegistryPreset/Custom.tsx
@@ -1,0 +1,85 @@
+import * as React from 'react';
+import { Select, Input, Text } from '@codesandbox/components';
+import { AuthType, RegistryType } from 'app/graphql/types';
+import { RegistryPresetProps } from '.';
+import { CustomFormField } from '../RegistryForm';
+
+export const CustomRegistryPreset = ({
+  registryUrl,
+  setRegistryUrl,
+  disabled,
+  authenticationType,
+  setAuthenticationType,
+  authKey,
+  setAuthKey,
+  setRegistryType,
+}: RegistryPresetProps) => {
+  React.useEffect(() => {
+    setRegistryType(RegistryType.Custom);
+  }, [setRegistryType]);
+  return (
+    <>
+      <div>
+        <CustomFormField label="Registry URL">
+          <Input
+            value={registryUrl}
+            onChange={e => setRegistryUrl(e.target.value)}
+            required
+            pattern="https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)"
+            disabled={disabled}
+          />
+        </CustomFormField>
+        <Text size={3} variant="muted">
+          Is your registry behind a VPN? Please read these{' '}
+          <a
+            href="https://codesandbox.io/docs/custom-npm-registry"
+            target="_blank"
+            rel="noreferrer noopener"
+          >
+            docs
+          </a>
+          .
+        </Text>
+      </div>
+
+      <div>
+        <CustomFormField label="Auth Type">
+          <Select
+            value={authenticationType}
+            onChange={e => {
+              setAuthenticationType(e.target.value);
+            }}
+            disabled={disabled}
+          >
+            {Object.keys(AuthType).map(type => (
+              <option value={AuthType[type]} key={type}>
+                {type}
+              </option>
+            ))}
+          </Select>
+        </CustomFormField>
+        <Text size={3} variant="muted">
+          More information on which one to choose can be found{' '}
+          <a
+            href="https://codesandbox.io/docs/custom-npm-registry#auth-token"
+            target="_blank"
+            rel="noreferrer noopener"
+          >
+            here
+          </a>
+          .
+        </Text>
+      </div>
+
+      <CustomFormField label="Auth Token">
+        <Input
+          value={authKey}
+          required
+          onChange={e => setAuthKey(e.target.value)}
+          disabled={disabled}
+          type="password"
+        />
+      </CustomFormField>
+    </>
+  );
+};

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/RegistryPreset/GitHub.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/RegistryPreset/GitHub.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import { Input } from '@codesandbox/components';
+import { RegistryType } from 'app/graphql/types';
+import { RegistryPresetProps } from '.';
+import { CustomFormField } from '../RegistryForm';
+
+export const GitHubPreset = ({
+  disabled,
+  authKey,
+  setAuthKey,
+  setRegistryType,
+}: RegistryPresetProps) => {
+  React.useEffect(() => {
+    setRegistryType(RegistryType.Github);
+  }, [setRegistryType]);
+
+  return (
+    <CustomFormField label="Access Token">
+      <Input
+        value={authKey}
+        required
+        onChange={e => setAuthKey(e.target.value)}
+        disabled={disabled}
+        type="password"
+      />
+    </CustomFormField>
+  );
+};

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/RegistryPreset/Npm.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/RegistryPreset/Npm.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import { Input } from '@codesandbox/components';
+import { RegistryType } from 'app/graphql/types';
+import { RegistryPresetProps } from '.';
+import { CustomFormField } from '../RegistryForm';
+
+export const NpmRegistryPreset = ({
+  disabled,
+  authKey,
+  setAuthKey,
+  setRegistryType,
+}: RegistryPresetProps) => {
+  React.useEffect(() => {
+    setRegistryType(RegistryType.Npm);
+  }, [setRegistryType]);
+
+  return (
+    <CustomFormField label="Access Token">
+      <Input
+        value={authKey}
+        required
+        onChange={e => setAuthKey(e.target.value)}
+        disabled={disabled}
+        type="password"
+      />
+    </CustomFormField>
+  );
+};

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/RegistryPreset/index.ts
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/RegistryPreset/index.ts
@@ -1,0 +1,48 @@
+import { AuthType, RegistryType } from 'app/graphql/types';
+import { ArtifactoryRegistryPreset } from './Artifactory';
+import { AzureRegistryPreset } from './Azure';
+import { CustomRegistryPreset } from './Custom';
+import { GitHubPreset } from './GitHub';
+import { NpmRegistryPreset } from './Npm';
+
+export enum RegistryPreset {
+  npm = 'npm',
+  GitHub = 'GitHub',
+  Azure = 'Azure DevOps',
+  Artifactory = 'Artifactory',
+  Custom = 'Custom',
+}
+
+export type RegistryInformation = {
+  url: string;
+  authKey: string;
+  authenticationType: AuthType;
+};
+
+export type RegistryPresetProps = {
+  registryType: RegistryType;
+  registryUrl: string;
+  authKey: string;
+  authenticationType: AuthType;
+
+  setRegistryType: (type: RegistryType) => void;
+  setRegistryUrl: (url: string) => void;
+  setAuthenticationType: (type: AuthType) => void;
+  setAuthKey: (key: string) => void;
+
+  disabled: boolean;
+};
+
+export const getFormFromPreset = (
+  preset: RegistryPreset
+): React.FC<RegistryPresetProps> => {
+  const mapping = {
+    [RegistryPreset.npm]: NpmRegistryPreset,
+    [RegistryPreset.GitHub]: GitHubPreset,
+    [RegistryPreset.Azure]: AzureRegistryPreset,
+    [RegistryPreset.Artifactory]: ArtifactoryRegistryPreset,
+    [RegistryPreset.Custom]: CustomRegistryPreset,
+  };
+
+  return mapping[preset];
+};


### PR DESCRIPTION
This makes it far easier to set up an npm registry with Artifactory and Azure DevOps. It will give you exactly the form fields that the configuration wizard of the private npm requires you to fill in:

![image](https://user-images.githubusercontent.com/587016/114517770-f2c78700-9c3e-11eb-9247-f12d5ba862a3.png)

![image](https://user-images.githubusercontent.com/587016/114517857-0541c080-9c3f-11eb-88a9-105dd805c7e0.png)
