### PR TITLE
Fix console.log in SSE and static sandboxes

### DIFF
--- a/packages/codesandbox-api/src/dispatcher/host.ts
+++ b/packages/codesandbox-api/src/dispatcher/host.ts
@@ -1,5 +1,2 @@
-declare var process: { env: { CODESANDBOX_HOST: string | undefined } };
-
-const host = process.env.CODESANDBOX_HOST;
-
+const host = typeof process !== 'undefined' && process.env.CODESANDBOX_HOST;
 export default host || 'https://codesandbox.io';


### PR DESCRIPTION
This reverts commit 2d40f51ad914b8166a6909b24359d1775d72857d.

Last time the sandboxes didn't load properly, I still can't reproduce this problem and I'm getting the feeling that something went wrong with the deploy. I want to deploy this again when we have low traffic, and closely watch this.