### PR TITLE
Use user avatarUrl in sidebar if in personal workspace

### DIFF
--- a/packages/app/src/app/pages/Dashboard/Sidebar/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Sidebar/index.tsx
@@ -53,7 +53,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
     name: string;
     avatarUrl: string;
   } | null>(null);
-  const { dashboard, activeTeam, activeTeamInfo } = state;
+  const { dashboard, activeTeam, activeTeamInfo, user } = state;
 
   React.useEffect(() => {
     actions.dashboard.getAllFolders();
@@ -62,13 +62,15 @@ export const Sidebar: React.FC<SidebarProps> = ({
   React.useEffect(() => {
     if (state.activeTeam) {
       const team = dashboard.teams.find(({ id }) => id === state.activeTeam);
-
-      if (team)
+      if (team) {
+        const isPersonalWorkspace = team.id === state.personalWorkspaceId;
         setActiveAccount({
           id: team.id,
           name: team.name,
-          avatarUrl: team.avatarUrl,
+          avatarUrl:
+            isPersonalWorkspace && user ? user.avatarUrl : team.avatarUrl,
         });
+      }
     }
   }, [state.activeTeam, state.activeTeamInfo, dashboard.teams]);
 


### PR DESCRIPTION
Addresses [this issue](https://www.notion.so/28294a4d1f924b20b73533ab5b8c2419?v=adac55ed225d4d48a19a0c73579a02d0&p=9b6dcc7be3154654804ecef4efb77fa3) from the big polish list 💅 

In the sidebar it was using the text `TeamAvatar` rather than the Google or Github photo in the personal workspace.

I've done a frontend fix to detect whether we're in the personal workspace, and if so, just use the `user.avatarUrl`.

However, I think there's something going wrong potentially with the server because for the personal `Team` that is created on sign up, it isn't pulling through the Github or Google URL from the `User` or `PendingUser`, so I'll have a look at fixing that as well.

Before ☹️

![Screenshot 2021-04-16 at 14 38 50](https://user-images.githubusercontent.com/37520401/115033144-fdde1980-9ec1-11eb-8aed-94c2c87fb137.png)

After 🎉

![Screenshot 2021-04-16 at 14 38 34](https://user-images.githubusercontent.com/37520401/115033150-fe76b000-9ec1-11eb-8957-c88f6ea6b873.png)
