### PR TITLE
Fix missing editor icons in load state

### DIFF
--- a/packages/app/src/app/overmind/utils/items.ts
+++ b/packages/app/src/app/overmind/utils/items.ts
@@ -86,7 +86,16 @@ export function getDisabledItems(store: any): INavigationItem[] {
   const { currentSandbox } = store.editor;
 
   if (!currentSandbox) {
-    return [PROJECT_SUMMARY, SEARCH, CONFIGURATION, GITHUB, DEPLOYMENT, LIVE];
+    return [
+      PROJECT_SUMMARY,
+      FILES,
+      SEARCH,
+      CONFIGURATION,
+      GITHUB,
+      COMMENTS,
+      DEPLOYMENT,
+      LIVE,
+    ];
   }
 
   if (currentSandbox.git) {


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?

<!-- Is it a Bug fix, feature, docs update, ... -->

Bug Fix: Currently not all icons are shown when loading

See video on polish list https://www.notion.so/28294a4d1f924b20b73533ab5b8c2419?v=adac55ed225d4d48a19a0c73579a02d0&p=a6e82222882c42389623726e9460cd45

## What is the current behavior?

<!-- You can also link to an open issue here -->

Icons are missing in loading skeleton

## What is the new behavior?

<!-- if this is a feature change -->

All missing icons are now being displayed in the loading skeleton

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
