### PR TITLE
Don't delete files with similar name optimistically

### DIFF
--- a/packages/common/src/sandbox/modules.ts
+++ b/packages/common/src/sandbox/modules.ts
@@ -37,10 +37,7 @@ export function resolveDirectory(
   }
 
   // Split path
-  const splitPath = path
-    .replace(/^.\//, '')
-    .split('/')
-    .filter(Boolean);
+  const splitPath = path.replace(/^.\//, '').split('/').filter(Boolean);
 
   const foundDirectoryShortid = splitPath.reduce(
     (dirId: string | undefined, pathPart: string, i: number) => {
@@ -82,14 +79,15 @@ export function getModulesAndDirectoriesInDirectory(
   directories: Array<Directory>
 ) {
   const { path } = directory;
+  const parentPath = `${path}/`;
   return {
     removedModules: modules.filter(moduleItem =>
-      moduleItem.path.startsWith(path)
+      moduleItem.path.startsWith(parentPath)
     ),
     removedDirectories: directories.filter(
       directoryItem =>
-        directoryItem.path.startsWith(path) && directoryItem !== directory
-    )
+        directoryItem.path.startsWith(parentPath) && directoryItem !== directory
+    ),
   };
 }
 
@@ -108,15 +106,9 @@ export function getModulesInDirectory(
   }
 
   // Split path
-  const splitPath = path
-    .replace(/^.\//, '')
-    .split('/')
-    .filter(Boolean);
+  const splitPath = path.replace(/^.\//, '').split('/').filter(Boolean);
 
-  const dirPath = path
-    .replace(/^.\//, '')
-    .split('/')
-    .filter(Boolean);
+  const dirPath = path.replace(/^.\//, '').split('/').filter(Boolean);
   dirPath.pop();
 
   const dir = resolveDirectory(
@@ -137,7 +129,7 @@ export function getModulesInDirectory(
     modules: modulesInFoundDirectory,
     foundDirectoryShortid,
     lastPath,
-    splitPath
+    splitPath,
   };
 }
 
@@ -155,7 +147,7 @@ export const resolveModule = (
     modules: modulesInFoundDirectory,
     lastPath,
     splitPath,
-    foundDirectoryShortid
+    foundDirectoryShortid,
   } = getModulesInDirectory(path, modules, directories, startdirectoryShortid);
 
   // Find module with same name
@@ -265,7 +257,7 @@ export const getChildren = memoize(
     id: string
   ) => [
     ...directories.filter(d => d.directoryShortid === id),
-    ...modules.filter(m => m.directoryShortid === id)
+    ...modules.filter(m => m.directoryShortid === id),
   ],
   memoizeFunction
 );


### PR DESCRIPTION
We used to return everything starting with the name of a directory in
`getModulesAndDirectoriesInDirectory`. This isn't right, because if you
have this:

- /app
- /app/index.js
- /app-components

`getModulesAndDirectoriesInDirectory(..., ..., '/app')` would also
include `/app-components`. Luckily we only do this client side, so when
someone deletes the folder `/app`, `/app-components` doesn't get
deleted. But it's confusing that the folder gets hidden. This fixes that.

I tested it by:

1. Creating 4 folders, 2 in the root and 2 in a subfolder
2. Deleting the subfolder
3. Verify that all folders in the subfolder are deleted, and other subfolder is still there.