### PR TITLE
Bugfix: Discover collections should not shuffle on re-render

### DIFF
--- a/packages/app/src/app/pages/Dashboard/Content/routes/Discover/Curate.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Discover/Curate.tsx
@@ -210,6 +210,7 @@ export const Collection: React.FC<CollectionTypes> = ({ album }) => {
           <Input
             id="title"
             defaultValue={album.title}
+            autoFocus
             style={{ maxWidth: 300, fontSize: 16, fontWeight: 700 }}
           />
           <Button type="submit" autoWidth>

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Discover/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Discover/index.tsx
@@ -45,7 +45,7 @@ export const Discover = () => {
   } = useActions();
 
   React.useEffect(() => {
-    getPage(sandboxesTypes.DISCOVER);
+    if (!curatedAlbums.length) getPage(sandboxesTypes.DISCOVER);
     if (!sandboxes.LIKED) getPage(sandboxesTypes.LIKED);
   }, [getPage, sandboxes.LIKED]);
 
@@ -61,12 +61,22 @@ export const Discover = () => {
     })
   );
 
-  const fiveRandomAlbums = shuffle(
-    sampleSize(
-      curatedAlbums.filter(album => album.id !== PICKED_SANDBOXES_ALBUM),
-      5
-    )
-  );
+  // We want to randomly pick 5 collections to show
+  // but don't want it to update on every render
+  const fiveRandomAlbumIds = React.useMemo(() => {
+    return shuffle(
+      sampleSize(
+        curatedAlbums
+          .map(album => album.id)
+          .filter(id => id !== PICKED_SANDBOXES_ALBUM),
+        5
+      )
+    );
+  }, []);
+
+  const fiveRandomAlbums = fiveRandomAlbumIds.map(albumId => {
+    return curatedAlbums.find(album => album.id === albumId);
+  });
 
   return (
     <Element

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Discover/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Discover/index.tsx
@@ -72,7 +72,7 @@ export const Discover = () => {
         5
       )
     );
-  }, []);
+  }, [curatedAlbums.length]);
 
   const fiveRandomAlbums = fiveRandomAlbumIds.map(albumId => {
     return curatedAlbums.find(album => album.id === albumId);

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Discover/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Discover/index.tsx
@@ -76,9 +76,9 @@ export const Discover = () => {
     [curatedAlbums]
   );
 
-  const fiveRandomAlbums = fiveRandomAlbumIds.map(albumId => {
-    return curatedAlbums.find(album => album.id === albumId);
-  });
+  const fiveRandomAlbums = fiveRandomAlbumIds.map((albumId) =>
+    curatedAlbums.find((album) => album.id === albumId)
+  );
 
   return (
     <Element

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Discover/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Discover/index.tsx
@@ -63,16 +63,18 @@ export const Discover = () => {
 
   // We want to randomly pick 5 collections to show
   // but don't want it to update on every render
-  const fiveRandomAlbumIds = React.useMemo(() => {
-    return shuffle(
-      sampleSize(
-        curatedAlbums
-          .map(album => album.id)
-          .filter(id => id !== PICKED_SANDBOXES_ALBUM),
-        5
-      )
-    );
-  }, [curatedAlbums.length]);
+  const fiveRandomAlbumIds = React.useMemo(
+    () =>
+      shuffle(
+        sampleSize(
+          curatedAlbums
+            .map(album => album.id)
+            .filter(id => id !== PICKED_SANDBOXES_ALBUM),
+          5
+        )
+      ),
+    [curatedAlbums]
+  );
 
   const fiveRandomAlbums = fiveRandomAlbumIds.map(albumId => {
     return curatedAlbums.find(album => album.id === albumId);


### PR DESCRIPTION
my bad, easy fix