### PR TITLE
Allow user to change avatar in personal team workspace

### DIFF
--- a/packages/app/src/app/components/WorkspaceSelect/WorkspaceSelect.tsx
+++ b/packages/app/src/app/components/WorkspaceSelect/WorkspaceSelect.tsx
@@ -22,7 +22,7 @@ interface WorkspaceSelectProps {
 export const WorkspaceSelect: React.FC<WorkspaceSelectProps> = React.memo(
   ({ activeAccount, disabled, onSelect }) => {
     const state = useAppState();
-    const { dashboard } = state;
+    const { dashboard, user } = state;
     const history = useHistory();
 
     const personalWorkspace = dashboard.teams.find(
@@ -110,7 +110,11 @@ export const WorkspaceSelect: React.FC<WorkspaceSelectProps> = React.memo(
                   }
                 >
                   <TeamAvatar
-                    avatar={team.avatarUrl}
+                    avatar={
+                      team.id === state.personalWorkspaceId && user
+                        ? user.avatarUrl
+                        : team.avatarUrl
+                    }
                     name={team.name}
                     size="small"
                   />

--- a/packages/app/src/app/components/WorkspaceSelect/WorkspaceSelect.tsx
+++ b/packages/app/src/app/components/WorkspaceSelect/WorkspaceSelect.tsx
@@ -64,7 +64,7 @@ export const WorkspaceSelect: React.FC<WorkspaceSelectProps> = React.memo(
               <Stack gap={2} as="span" align="center">
                 <Stack as="span" align="center" justify="center">
                   <TeamAvatar
-                    avatar={activeAccount.avatarUrl}
+                    avatar={state.activeTeamInfo.avatarUrl}
                     name={activeAccount.name}
                   />
                 </Stack>

--- a/packages/app/src/app/overmind/namespaces/dashboard/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/dashboard/actions.ts
@@ -1174,6 +1174,7 @@ export const setTeamInfo = async (
     team => team.id === state.activeTeam
   );
   const oldActiveTeamInfo = state.activeTeamInfo;
+
   try {
     await effects.gql.mutations.setTeamName({
       name,

--- a/packages/app/src/app/overmind/namespaces/dashboard/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/dashboard/actions.ts
@@ -1174,7 +1174,6 @@ export const setTeamInfo = async (
     team => team.id === state.activeTeam
   );
   const oldActiveTeamInfo = state.activeTeamInfo;
-
   try {
     await effects.gql.mutations.setTeamName({
       name,
@@ -1332,7 +1331,12 @@ export const updateTeamAvatar = async (
 ) => {
   if (!state.activeTeamInfo) return;
   const oldAvatar = state.activeTeamInfo.avatarUrl;
+  const isPersonalWorkspace =
+    state.activeTeamInfo.id === state.personalWorkspaceId;
   state.activeTeamInfo.avatarUrl = url;
+  if (isPersonalWorkspace) {
+    state.user.avatarUrl = url;
+  }
 
   effects.analytics.track('Team - Update Team Avatar', { dashboardVersion: 2 });
 
@@ -1340,6 +1344,9 @@ export const updateTeamAvatar = async (
     await effects.api.updateTeamAvatar(name, url, teamId);
   } catch (error) {
     state.activeTeamInfo.avatarUrl = oldAvatar;
+    if (isPersonalWorkspace) {
+      state.user.avatarUrl = oldAvatar;
+    }
 
     actions.internal.handleError({
       message: "We weren't able to update your team avatar",

--- a/packages/app/src/app/overmind/namespaces/dashboard/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/dashboard/actions.ts
@@ -1329,7 +1329,7 @@ export const updateTeamAvatar = async (
     teamId: string;
   }
 ) => {
-  if (!state.activeTeamInfo) return;
+  if (!state.activeTeamInfo || !state.user) return;
   const oldAvatar = state.activeTeamInfo.avatarUrl;
   const isPersonalWorkspace =
     state.activeTeamInfo.id === state.personalWorkspaceId;
@@ -1345,6 +1345,7 @@ export const updateTeamAvatar = async (
   } catch (error) {
     state.activeTeamInfo.avatarUrl = oldAvatar;
     if (isPersonalWorkspace) {
+      // @ts-ignore
       state.user.avatarUrl = oldAvatar;
     }
 

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/WorkspaceSettings.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/WorkspaceSettings.tsx
@@ -156,7 +156,7 @@ export const WorkspaceSettings = () => {
       <Grid
         columnGap={4}
         css={css({
-          gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))',
+          gridTemplateColumns: 'repeat(auto-fit, minmax(250px, 1fr))',
         })}
       >
         <Card>
@@ -267,7 +267,7 @@ export const WorkspaceSettings = () => {
               />
               <Stack direction="vertical" gap={2} css={{ width: '100%' }}>
                 <Stack justify="space-between">
-                  <Text size={6} weight="bold">
+                  <Text size={6} weight="bold" css={{ wordBreak: 'break-all' }}>
                     {team.name}
                   </Text>
                   {activeWorkspaceAuthorization ===

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/WorkspaceSettings.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/WorkspaceSettings.tsx
@@ -45,11 +45,12 @@ export const WorkspaceSettings = () => {
   const [file, setFile] = useState<{ name: string; url: string } | null>(null);
 
   const getFile = async avatar => {
-    const url = await new Promise(resolve => {
+    const url = await new Promise((resolve, reject) => {
       const reader = new FileReader();
       reader.onload = e => {
         resolve(e.target.result);
       };
+      reader.onerror = reject;
       reader.readAsDataURL(avatar);
     });
 
@@ -72,9 +73,8 @@ export const WorkspaceSettings = () => {
         description,
         file,
       });
-      setLoading(false);
       setEditing(false);
-    } catch {
+    } finally {
       setLoading(false);
     }
   };

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Settings/UserSettings/WorkspaceSettings.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Settings/UserSettings/WorkspaceSettings.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { format } from 'date-fns';
 import {
   Avatar,
@@ -9,6 +9,8 @@ import {
   Tooltip,
   Icon,
   Link,
+  IconButton,
+  Element,
 } from '@codesandbox/components';
 import {
   github as GitHubIcon,
@@ -24,6 +26,42 @@ import { Card } from '../components';
 export const WorkspaceSettings = () => {
   const { user, activeTeam, activeTeamInfo } = useAppState();
   const actions = useActions();
+
+  const [editing, setEditing] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [file, setFile] = useState<{ name: string; url: string } | null>(null);
+
+  const getFile = async avatar => {
+    const url = await new Promise(resolve => {
+      const reader = new FileReader();
+      reader.onload = e => {
+        resolve(e.target.result);
+      };
+      reader.readAsDataURL(avatar);
+    });
+
+    const stringUrl = url as string;
+
+    setFile({
+      name: avatar.name,
+      url: stringUrl,
+    });
+  };
+
+  const onSubmit = async event => {
+    event.preventDefault();
+    setLoading(true);
+    try {
+      await actions.dashboard.updateTeamAvatar({
+        ...file,
+        teamId: activeTeam,
+      });
+      setLoading(false);
+      setEditing(false);
+    } catch {
+      setLoading(false);
+    }
+  };
 
   useEffect(() => {
     actions.dashboard.dashboardMounted();
@@ -44,15 +82,165 @@ export const WorkspaceSettings = () => {
       })}
     >
       <Card>
-        <Stack direction="vertical" gap={2}>
+        {editing ? (
+          <Stack as="form" onSubmit={onSubmit} direction="vertical" gap={2}>
+            <Stack gap={4}>
+              <Element css={css({ position: 'relative', height: 56 })}>
+                <Element css={css({ position: 'relative', height: 56 })}>
+                  <Tooltip
+                    label={`
+                      Account managed by ${
+                        user.provider === 'google' ? 'Google' : 'GitHub'
+                      }
+                      `}
+                  >
+                    <Stack
+                      align="center"
+                      justify="center"
+                      css={css({
+                        position: 'absolute',
+                        bottom: 0,
+                        transform: 'translateY(50%) translateX(50%)',
+                        right: 0,
+                        zIndex: 10,
+                        backgroundColor: 'sideBar.background',
+                        borderRadius: '50%',
+                        width: 18,
+                        height: 18,
+                        border: '1px solid',
+                        borderColor: 'sideBar.border',
+                      })}
+                    >
+                      {user.provider === 'google' ? (
+                        <GoogleIcon width="12" height="12" />
+                      ) : (
+                        <GitHubIcon width="12" height="12" />
+                      )}
+                    </Stack>
+                  </Tooltip>
+                  <Avatar
+                    user={user}
+                    css={css({ size: 14, opacity: 0.6 })}
+                    file={file ? file.url : null}
+                  />
+                </Element>
+
+                <label htmlFor="avatar" aria-label="Upload your avatar">
+                  <input
+                    css={css({
+                      width: '0.1px',
+                      height: '0.1px',
+                      opacity: 0,
+                      overflow: 'hidden',
+                      position: 'absolute',
+                      zIndex: -1,
+                    })}
+                    type="file"
+                    onChange={e => getFile(e.target.files[0])}
+                    id="avatar"
+                    name="avatar"
+                    accept="image/png, image/jpeg"
+                  />
+                  <Element
+                    css={css({
+                      width: '100%',
+                      height: '100%',
+                      position: 'absolute',
+                      left: 0,
+                      top: 0,
+                      cursor: 'pointer',
+                    })}
+                  >
+                    <svg
+                      width={18}
+                      height={15}
+                      fill="none"
+                      viewBox="0 0 18 15"
+                      css={css({
+                        position: 'absolute',
+                        left: '50%',
+                        top: '50%',
+                        transform: 'translate(-50%, -50%)',
+                      })}
+                    >
+                      <path
+                        fill="#fff"
+                        fillRule="evenodd"
+                        d="M13 2h3.286C17.233 2 18 2.768 18 3.714v9.572c0 .947-.767 1.714-1.714 1.714H1.714A1.714 1.714 0 010 13.286V3.714C0 2.768.768 2 1.714 2H5a4.992 4.992 0 014-2c1.636 0 3.088.786 4 2zm0 6a4 4 0 11-8 0 4 4 0 018 0zM8.8 6h.4v1.8H11v.4H9.2V10h-.4V8.2H7v-.4h1.8V6z"
+                        clipRule="evenodd"
+                      />
+                    </svg>
+                  </Element>
+                </label>
+              </Element>
+
+              <Stack
+                direction="vertical"
+                gap={2}
+                css={{ width: 'calc(100% - 64px)' }}
+              >
+                <Stack justify="space-between">
+                  <Text size={6} weight="bold" maxWidth="100%" variant="muted">
+                    {user.username}
+                  </Text>
+                  <IconButton
+                    name="edit"
+                    size={12}
+                    title="Edit team"
+                    onClick={() => setEditing(false)}
+                  />
+                </Stack>
+                <Text size={3} maxWidth="100%">
+                  {user.name}
+                </Text>
+                <Text size={3} maxWidth="100%" variant="muted">
+                  {user.email}
+                </Text>
+                <Button
+                  variant="link"
+                  autoWidth
+                  css={css({
+                    height: 'auto',
+                    fontSize: 3,
+                    color: 'button.background',
+                    padding: 0,
+                  })}
+                  onClick={() => {
+                    actions.dashboard.requestAccountClosing();
+                  }}
+                >
+                  Request Account Deletion
+                </Button>
+                <Stack justify="flex-start" gap={1}>
+                  <Button
+                    variant="link"
+                    css={{ width: 100 }}
+                    disabled={loading}
+                    onClick={() => setEditing(false)}
+                  >
+                    Cancel
+                  </Button>
+                  <Button
+                    type="submit"
+                    css={{ width: 100 }}
+                    disabled={loading}
+                    loading={loading}
+                  >
+                    Save
+                  </Button>
+                </Stack>
+              </Stack>
+            </Stack>
+          </Stack>
+        ) : (
           <Stack gap={4}>
             <div style={{ position: 'relative', height: 56 }}>
               <Tooltip
                 label={`
-              Account managed by ${
-                user.provider === 'google' ? 'Google' : 'GitHub'
-              }
-              `}
+                      Account managed by ${
+                        user.provider === 'google' ? 'Google' : 'GitHub'
+                      }
+                      `}
               >
                 <Stack
                   align="center"
@@ -86,9 +274,17 @@ export const WorkspaceSettings = () => {
               gap={2}
               css={{ width: 'calc(100% - 64px)' }}
             >
-              <Text size={6} weight="bold" maxWidth="100%" variant="muted">
-                {user.username}
-              </Text>
+              <Stack justify="space-between">
+                <Text size={6} weight="bold" maxWidth="100%" variant="muted">
+                  {user.username}
+                </Text>
+                <IconButton
+                  name="edit"
+                  size={12}
+                  title="Edit team"
+                  onClick={() => setEditing(true)}
+                />
+              </Stack>
               <Text size={3} maxWidth="100%">
                 {user.name}
               </Text>
@@ -112,7 +308,7 @@ export const WorkspaceSettings = () => {
               </Button>
             </Stack>
           </Stack>
-        </Stack>
+        )}
       </Card>
 
       <Card>

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Settings/UserSettings/WorkspaceSettings.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Settings/UserSettings/WorkspaceSettings.tsx
@@ -32,11 +32,12 @@ export const WorkspaceSettings = () => {
   const [file, setFile] = useState<{ name: string; url: string } | null>(null);
 
   const getFile = async avatar => {
-    const url = await new Promise(resolve => {
+    const url = await new Promise((resolve, reject) => {
       const reader = new FileReader();
       reader.onload = e => {
         resolve(e.target.result);
       };
+      reader.onerror = reject;
       reader.readAsDataURL(avatar);
     });
 
@@ -56,9 +57,8 @@ export const WorkspaceSettings = () => {
         ...file,
         teamId: activeTeam,
       });
-      setLoading(false);
       setEditing(false);
-    } catch {
+    } finally {
       setLoading(false);
     }
   };
@@ -121,7 +121,7 @@ export const WorkspaceSettings = () => {
                   <Avatar
                     user={user}
                     css={css({ size: 14, opacity: 0.6 })}
-                    file={file ? file.url : null}
+                    file={file?.url}
                   />
                 </Element>
 

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Settings/UserSettings/WorkspaceSettings.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Settings/UserSettings/WorkspaceSettings.tsx
@@ -78,7 +78,7 @@ export const WorkspaceSettings = () => {
     <Grid
       columnGap={4}
       css={css({
-        gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))',
+        gridTemplateColumns: 'repeat(auto-fit, minmax(250px, 1fr))',
       })}
     >
       <Card>

--- a/packages/components/src/components/Avatar/index.tsx
+++ b/packages/components/src/components/Avatar/index.tsx
@@ -5,6 +5,7 @@ import { Element } from '../Element';
 import { Text } from '../Text';
 
 interface IAvatarProps {
+  file?: string | null;
   user: {
     id?: string;
     username: string;
@@ -55,10 +56,10 @@ export const Pro = styled(Text).attrs({ size: 1, weight: 'bold' })(
   })
 );
 
-export const Avatar = ({ user, ...props }: IAvatarProps) =>
+export const Avatar = ({ user, file, ...props }: IAvatarProps) =>
   user && (
     <AvatarContainer {...props}>
-      <AvatarImage src={user.avatarUrl} alt={user.username} />
+      <AvatarImage src={file || user.avatarUrl} alt={user.username} />
       {user.subscriptionSince ? <Pro>Pro</Pro> : null}
     </AvatarContainer>
   );

--- a/packages/components/src/components/Avatar/index.tsx
+++ b/packages/components/src/components/Avatar/index.tsx
@@ -5,7 +5,7 @@ import { Element } from '../Element';
 import { Text } from '../Text';
 
 interface IAvatarProps {
-  file?: string | null;
+  file?: string;
   user: {
     id?: string;
     username: string;
@@ -59,7 +59,7 @@ export const Pro = styled(Text).attrs({ size: 1, weight: 'bold' })(
 export const Avatar = ({ user, file, ...props }: IAvatarProps) =>
   user && (
     <AvatarContainer {...props}>
-      <AvatarImage src={file || user.avatarUrl} alt={user.username} />
+      <AvatarImage src={file ?? user.avatarUrl} alt={user.username} />
       {user.subscriptionSince ? <Pro>Pro</Pro> : null}
     </AvatarContainer>
   );


### PR DESCRIPTION
Allow user to change avatar in personal team workspace.

![Screenshot 2021-04-22 at 14 24 20](https://user-images.githubusercontent.com/37520401/115722584-0b3e4c80-a377-11eb-8252-da59b422f527.png)
![Screenshot 2021-04-22 at 14 27 22](https://user-images.githubusercontent.com/37520401/115722591-0c6f7980-a377-11eb-92fd-e4f7b0d122ed.png)
![Screenshot 2021-04-22 at 14 28 13](https://user-images.githubusercontent.com/37520401/115722593-0d081000-a377-11eb-96a0-6a99de294389.png)

@siddharthkp @DannyRuchtie I think now I am conflicted because it would make sense to allow name and username edit here. But I don't think it should necessarily be moved out of the sidebar because that is historically where users could do that. Should we have it in both places? Or moved it all to personal workspace settings? Or only have avatar upload in personal workspace settings for now?