### PR TITLE
Send active team id to server for github imports

### DIFF
--- a/packages/app/src/app/overmind/effects/api/index.ts
+++ b/packages/app/src/app/overmind/effects/api/index.ts
@@ -33,7 +33,7 @@ import {
   transformModule,
   transformSandbox,
 } from '../utils/sandbox';
-import apiFactory, { Api, ApiConfig } from './apiFactory';
+import apiFactory, { Api, ApiConfig, Params } from './apiFactory';
 import {
   IDirectoryAPIResponse,
   IModuleAPIResponse,
@@ -100,8 +100,11 @@ export default {
       `/sandboxes/${sandboxId}/npm_registry/${name.replace('/', '%2f')}`
     );
   },
-  async getSandbox(id: string): Promise<Sandbox> {
-    const sandbox = await api.get<SandboxAPIResponse>(`/sandboxes/${id}`);
+  async getSandbox(id: string, params?: Params): Promise<Sandbox> {
+    const sandbox = await api.get<SandboxAPIResponse>(
+      `/sandboxes/${id}`,
+      params
+    );
 
     // We need to add client side properties for tracking
     return transformSandbox(sandbox);

--- a/packages/app/src/app/overmind/namespaces/editor/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/editor/actions.ts
@@ -298,7 +298,8 @@ export const sandboxChanged = withLoadApp<{
   }
 
   try {
-    const sandbox = await effects.api.getSandbox(newId);
+    const params = state.activeTeam ? { teamId: state.activeTeam } : undefined;
+    const sandbox = await effects.api.getSandbox(newId, params);
 
     actions.internal.setCurrentSandbox(sandbox);
   } catch (error) {


### PR DESCRIPTION
Relates https://github.com/codesandbox/codesandbox-server/issues/316 and https://github.com/codesandbox/codesandbox-server/pull/340

In order to allow users (who do not have personal pro) to import private repos into a team they are part of that does have team pro, we need to be able to tell what the active team is. This param was being sent in `forkSandbox` but not via the normal static Github URL import (`/s/github/user/repo`).