### PR TITLE
fix(editor): refresh editor in the second launch

### DIFF
--- a/packages/app/src/app/overmind/effects/vscode/Workbench.ts
+++ b/packages/app/src/app/overmind/effects/vscode/Workbench.ts
@@ -3,7 +3,6 @@ import {
   NotificationMessage,
   NotificationStatus,
 } from '@codesandbox/notifications/lib/state';
-import router from '../router';
 
 import { KeyCode, KeyMod } from './keyCodes';
 
@@ -145,7 +144,8 @@ export class Workbench {
       label: 'Dashboard',
       category: 'Root',
       run: () => {
-        router.redirectToDashboard();
+        // hard link
+        window.location.pathname = '/dashboard/home';
       },
       keybindings: {
         primary: KeyMod.CtrlCmd | KeyCode.Escape,

--- a/packages/app/src/app/pages/Sandbox/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/index.tsx
@@ -23,6 +23,22 @@ export const Sandbox = React.memo<Props>(
     const state = useAppState();
     const actions = useActions();
 
+    /**
+     * !important Hard bug fix
+     *
+     * This address temporarily many unexpected
+     * behaviors that occurs when  navigating away
+     * from the editor and go back to it
+     * Eg: Editor -> Dashboard -> Editor
+     *
+     * @link https://www.notion.so/Unexpected-behaviors-when-navigating-away-from-the-editor-and-go-back-to-it-b5fcc670c3fb46afa8a57dd05f701bcb
+     */
+    useEffect(() => {
+      if (window.CSEditor) {
+        window.location.reload();
+      }
+    }, []);
+
     useEffect(() => {
       if (!showNewSandboxModal) {
         if (window.screen.availWidth < 800) {


### PR DESCRIPTION
*The big bug*

**Reproduce**

- Launch the editor in any template or sandbox;
- Go to the dashboard page using a navigation link;
- Relaunch the editor through a sandbox link or creating a new one;

**Bugs**

- The command palette no longer open;
- The Github link is the same as the previous session, causing a lot of inconsistency;

**What might be causing it?**

As long as the editor is in the browser memory, there are many stale states, and probably a few methods have not been triggering again in the second launch.

**Possible solution?**

- Reset the states on unmount component;
- Identify which methods need to be retriggered or be cleaned;

**Temp fix**

There is a proposal of a temporary workaround, which consists of checking in the second launch if the editor has loaded; if so, reload the entire page. ¯\*(ツ)*/¯

https://www.notion.so/28294a4d1f924b20b73533ab5b8c2419?v=adac55ed225d4d48a19a0c73579a02d0&p=b5fcc670c3fb46afa8a57dd05f701bcb