### PR TITLE
fix: add support for using less in react project

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ Thanks goes to these wonderful people
     <td align="center"><a href="https://pablo.pink"><img src="https://avatars0.githubusercontent.com/u/4324982?v=4" width="100px;" alt="Pablo Varela"/><br /><sub><b>Pablo Varela</b></sub></a><br /><a href="https://github.com/codesandbox/codesandbox-client/commits?author=pablopunk" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/ryanpwaldon"><img src="https://avatars0.githubusercontent.com/u/12480362?v=4" width="100px;" alt="Ryan Waldon"/><br /><sub><b>Ryan Waldon</b></sub></a><br /><a href="https://github.com/codesandbox/codesandbox-client/commits?author=ryanpwaldon" title="Code">💻</a></td>
     <td align="center"><a href="http://cherniavskii.com"><img src="https://avatars.githubusercontent.com/u/13808724?v=4" width="100px;" alt="Andrew Cherniavskii"/><br /><sub><b>Andrew Cherniavskii</b></sub></a><br /><a href="https://github.com/codesandbox/codesandbox-client/commits?author=cherniavskii" title="Code">💻</a></td>
+    <td align="center"><a href="http://cherniavskii.com"><img src="https://avatars.githubusercontent.com/u/26377630?v=4" width="100px;" alt="Uyarn"/><br /><sub><b>Uyarn</b></sub></a><br /><a href="https://github.com/codesandbox/codesandbox-client/commits?author=uyarn" title="Code">🐑</a></td>
   </tr>
 </table>
 

--- a/packages/app/src/sandbox/eval/presets/create-react-app/utils/reactPreset.ts
+++ b/packages/app/src/sandbox/eval/presets/create-react-app/utils/reactPreset.ts
@@ -7,7 +7,9 @@ import rawTranspiler from '../../../transpilers/raw';
 import svgrTranspiler from '../../../transpilers/svgr';
 import sassTranspiler from '../../../transpilers/sass';
 import refreshTranspiler from '../../../transpilers/react/refresh-transpiler';
+import lessTranspiler from '../../../transpilers/less';
 import styleProcessor from '../../../transpilers/postcss';
+
 import {
   hasRefresh,
   aliases,
@@ -100,6 +102,15 @@ export const reactPreset = babelConfig => {
           preset.registerTranspiler(module => /\.svg$/.test(module.path), [
             { transpiler: svgrTranspiler },
             { transpiler: babelTranspiler, options: babelConfig },
+          ]);
+
+          preset.registerTranspiler(module => /\.less$/.test(module.path), [
+            { transpiler: lessTranspiler },
+            { transpiler: styleProcessor },
+            {
+              transpiler: stylesTranspiler,
+              options: { hmrEnabled: true },
+            },
           ]);
 
           preset.registerTranspiler(


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->
Support using less file as style file in React project
## What kind of change does this PR introduce?
Add less transpile in react preset
<!-- Is it a Bug fix, feature, docs update, ... -->

## What is the current behavior?
It doesn't support use less in react project

<!-- You can also link to an open issue here -->

## What is the new behavior?

 support use less in react project

<!-- if this is a feature change -->

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Make sandbox as a docker image and run it as my own service
2. Find out that it didn't support less file
3. Add less transpiler into the source code and run it again
4. it works

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
