### PR TITLE
fix(rename sandbox): refactor to turn its transition smoother

### DIFF
--- a/packages/app/src/app/pages/Sandbox/Editor/Header/SandboxName/elements.ts
+++ b/packages/app/src/app/pages/Sandbox/Editor/Header/SandboxName/elements.ts
@@ -10,9 +10,8 @@ export const Folder = styled.div`
 `;
 
 export const Form = styled.form`
-  position: absolute;
-  left: 0;
-  right: 0;
+  position: relative;
+  top: -1px;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -29,6 +28,7 @@ export const NameInput = styled(AutosizeInput)`
       padding: 0;
       text-align: center;
       color: ${theme['input.foreground']};
+      font: inherit;
     }
   `};
 `;

--- a/packages/app/src/app/pages/Sandbox/Editor/Header/SandboxName/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Header/SandboxName/index.tsx
@@ -11,6 +11,7 @@ import { Sandbox } from '@codesandbox/common/lib/types';
 import { useAppState, useActions } from 'app/overmind';
 import React, {
   ChangeEvent,
+  CSSProperties,
   FunctionComponent,
   KeyboardEvent,
   useEffect,
@@ -117,6 +118,11 @@ export const SandboxName: FunctionComponent = () => {
 
   const owned = hasPermission(currentSandbox.authorization, 'owner');
 
+  const disabledStyle: CSSProperties = {
+    opacity: updatingName ? 0 : 1,
+    pointerEvents: updatingName ? 'none' : 'auto',
+  };
+
   const SandboxNameElement = () => {
     if (updatingName && !git) {
       return (
@@ -159,8 +165,8 @@ export const SandboxName: FunctionComponent = () => {
   return (
     <Main style={fadeIn ? { opacity: 1 } : null}>
       <Stack align="center">
-        {!customTemplate && owned && !git && !updatingName && (
-          <Folder>
+        {!customTemplate && owned && !git && (
+          <Folder style={disabledStyle}>
             {isLoggedIn ? (
               <Button
                 variant="link"
@@ -187,8 +193,8 @@ export const SandboxName: FunctionComponent = () => {
 
         <SandboxNameElement />
 
-        {!updatingName && !git ? (
-          <Element as="span" marginLeft={owned ? 0 : 2}>
+        {!git ? (
+          <Element as="span" marginLeft={owned ? 0 : 2} style={disabledStyle}>
             <PrivacyTooltip />
           </Element>
         ) : null}


### PR DESCRIPTION
It improves the transition between states on the Rename Sandbox component.


https://user-images.githubusercontent.com/4838076/117943778-67f0af80-b304-11eb-9ca6-cb4543043fa2.mov



https://user-images.githubusercontent.com/4838076/117943722-59a29380-b304-11eb-804c-a31848ec213c.mov




