### PR TITLE
Fix z-index bug #5751

### DIFF
--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/SignInBanner.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/SignInBanner.tsx
@@ -33,7 +33,6 @@ export const SignInBanner = ({ theme }) => {
         borderTop: '1px solid',
         borderColor: 'sideBar.border',
         filter: dark ? 'drop-shadow(0px -16px 8px rgba(0,0,0,.32))' : null,
-        zIndex: 999,
       })}
     >
       <Stack


### PR DESCRIPTION
Simply deleted z-index row because it didn't affect anything but caused bug #5751.

## What kind of change does this PR introduce?

It's a fix of a bug that I've opened as #5751 issue.

## What is the current behavior?

Pop-up that's being rendered by right-clicking at bottom of workspace is behind of "Sign in" banner and affecting UX.

## What is the new behavior?

"Sign-in" banner doesn't have `zIndex: 999` in styles now and it implements right behavior. Right-click at the bottom of workspace as unauthorized user are not causing z-index bug anymore.
 
## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

I didn't run locally whole project. I just made this:
1. Open Chrome devtools and look for React component name.
2. Clone repo and find this React component in code.
3. Delete zIndex: 999 row.
4. It was impossible to mismatch the component because of unique component name.

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->
