### PR TITLE
Use blobToBase64 when exporting to github

### DIFF
--- a/packages/app/src/app/overmind/effects/git/export-to-github.ts
+++ b/packages/app/src/app/overmind/effects/git/export-to-github.ts
@@ -1,7 +1,7 @@
 import { Sandbox } from '@codesandbox/common/lib/types';
 import JSZip from 'jszip';
 import { createZip, BLOB_ID } from '../zip/create-zip';
-import http from '../http'
+import http from '../http';
 
 export interface IAPIModule {
   content: string;
@@ -40,7 +40,7 @@ export default async function deploy(sandbox: Sandbox) {
       if (content.startsWith(BLOB_ID)) {
         isBinary = true;
         content = content.replace(BLOB_ID, '');
-        content = await http.blobToBase64(content)
+        content = await http.blobToBase64(content); // eslint-disable-line no-await-in-loop
       }
 
       apiData.sandbox.push({

--- a/packages/app/src/app/overmind/effects/git/export-to-github.ts
+++ b/packages/app/src/app/overmind/effects/git/export-to-github.ts
@@ -1,6 +1,7 @@
 import { Sandbox } from '@codesandbox/common/lib/types';
 import JSZip from 'jszip';
 import { createZip, BLOB_ID } from '../zip/create-zip';
+import http from '../http'
 
 export interface IAPIModule {
   content: string;
@@ -39,6 +40,7 @@ export default async function deploy(sandbox: Sandbox) {
       if (content.startsWith(BLOB_ID)) {
         isBinary = true;
         content = content.replace(BLOB_ID, '');
+        content = await http.blobToBase64(content)
       }
 
       apiData.sandbox.push({

--- a/packages/app/src/app/overmind/effects/http.ts
+++ b/packages/app/src/app/overmind/effects/http.ts
@@ -18,6 +18,8 @@ export default {
             reader.onload = function () {
               // Github interprets base64 differently, so this fixes it, insane right?
               // https://stackoverflow.com/questions/39234218/github-api-upload-an-image-to-repo-from-base64-array?rq=1
+              // Further note of explanation: readAsDataURL returns "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAZAAAA..."
+              // Github only wants everything after "base64,"
               resolve(
                 window.btoa(
                   window.atob((reader.result as string).replace(/^(.+,)/, ''))


### PR DESCRIPTION
Fixes https://github.com/codesandbox/codesandbox-server/issues/389
Fixes https://github.com/codesandbox/codesandbox-client/issues/4504

https://www.loom.com/share/025f51b436f44586b9b9469e7fe778e9

We weren't using `blobToBase64` in `export-to-github` so when the binary files were going to the git importer, it was sending the URL of the asset (like `https://rawcdn.githack.com/sbinlondon/csb-vue-test/669c16821bf80094ae68409afd690ed92fe9cc85/src/assets/logo.png`) rather than the base-64 encoded string it should have done.

The linter fussed at me for using an await in a loop so please let me know if we need to update this to a `Promise.all` or if it's ok to do `eslint-disable`.

Also still need to test and make sure that syncing files doesn't break it again/we are using `blobToBase64` everywhere we need to be.