### PR TITLE
fix(homepage): uniform CTA

### DIFF
--- a/packages/homepage/src/pages/ide/index.js
+++ b/packages/homepage/src/pages/ide/index.js
@@ -74,7 +74,7 @@ export default () => {
           `}
         >
           <Button cta href="https://codesandbox.io/s/">
-            Get Started
+            Get started for free
           </Button>
         </div>
         <div>

--- a/packages/homepage/src/screens/home/explore/index.js
+++ b/packages/homepage/src/screens/home/explore/index.js
@@ -65,7 +65,7 @@ const Experiment = () => (
         }}
         href="/s"
       >
-        Get started, it’s free
+        Get started for free
       </Button>
     </div>
     <Container>

--- a/packages/homepage/src/screens/home/hero/index.js
+++ b/packages/homepage/src/screens/home/hero/index.js
@@ -89,7 +89,7 @@ export default () => (
           }}
           href="/s"
         >
-          Create Sandbox, it’s free
+          Get started for free
         </Button>
       </motion.div>
     </motion.div>


### PR DESCRIPTION
As discussed with @tromika, we'd like to uniform all call-to-actions copies on the homepage and in the IDE page, then we can make sure that our changes are affecting somehow the users.