### PR TITLE
Don't overwrite setImmediate

### DIFF
--- a/packages/sandpack-core/src/runner/eval.ts
+++ b/packages/sandpack-core/src/runner/eval.ts
@@ -1,20 +1,6 @@
-// @flow
 import buildProcess from './utils/process';
 
 const g = typeof window === 'undefined' ? self : window;
-const requestFrame = (() => {
-  const raf =
-    g.requestAnimationFrame ||
-    // @ts-ignore
-    g.mozRequestAnimationFrame ||
-    g.webkitRequestAnimationFrame ||
-    function (fn) {
-      return g.setTimeout(fn, 20);
-    };
-  return function (fn: (time: number) => void) {
-    return raf(fn);
-  };
-})();
 
 const hasGlobalDeclaration = /^const global/m;
 
@@ -39,8 +25,8 @@ export default function (
     module,
     exports,
     process,
-    setImmediate: requestFrame,
     global,
+    window: global,
     ...globals,
   };
 
@@ -58,9 +44,10 @@ export default function (
   const globalsCode = allGlobalKeys.length ? allGlobalKeys.join(', ') : '';
   const globalsValues = allGlobalKeys.map(k => allGlobals[k]);
   try {
-    const newCode = `(function evaluate(` + globalsCode + `) {` + code + `\n})`;
+    const newCode =
+      `(function $csb$eval(` + globalsCode + `) {` + code + `\n})`;
     // @ts-ignore
-    (0, eval)(newCode).apply(allGlobals.window || this, globalsValues);
+    (0, eval)(newCode).apply(allGlobals.global, globalsValues);
 
     return module.exports;
   } catch (e) {

--- a/packages/sandpack-core/src/runner/eval.ts
+++ b/packages/sandpack-core/src/runner/eval.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-eval */
 import buildProcess from './utils/process';
 
 const g = typeof window === 'undefined' ? self : window;

--- a/packages/sandpack-core/src/runner/eval.ts
+++ b/packages/sandpack-core/src/runner/eval.ts
@@ -26,8 +26,7 @@ export default function (
     module,
     exports,
     process,
-    global,
-    window: global,
+    global,    
     ...globals,
   };
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR changes the logic where we overwrite setImmediate with a custom version that did not behave correctly.

Mainly wondering why we ever implemented this? (we can optionally polyfill this with a correct implementation if we want to)

Fixes #5878 

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
