### PR TITLE
Feat/ab framework implementation + redesign sign banner

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -77,7 +77,7 @@
     "@apollo/react-hooks": "^3.1.3",
     "@babel/plugin-transform-destructuring": "^7.5.0",
     "@babel/preset-env": "^7.5.5",
-    "@codesandbox/ab": "^1.0.2",
+    "@codesandbox/ab": "^1.0.4",
     "@codesandbox/common": "^1.0.8",
     "@codesandbox/components": "^0.0.3",
     "@codesandbox/executors": "^0.1.0",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -77,6 +77,7 @@
     "@apollo/react-hooks": "^3.1.3",
     "@babel/plugin-transform-destructuring": "^7.5.0",
     "@babel/preset-env": "^7.5.5",
+    "@codesandbox/ab": "^1.0.2",
     "@codesandbox/common": "^1.0.8",
     "@codesandbox/components": "^0.0.3",
     "@codesandbox/executors": "^0.1.0",

--- a/packages/app/src/app/overmind/namespaces/editor/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/editor/actions.ts
@@ -553,6 +553,10 @@ export const codeChanged = (
 ) => {
   effects.analytics.trackOnce('Change Code');
 
+  if (!state.user) {
+    state.editor.changeCounter++;
+  }
+
   if (!state.editor.currentSandbox) {
     return;
   }

--- a/packages/app/src/app/overmind/namespaces/editor/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/editor/actions.ts
@@ -78,7 +78,10 @@ export const persistCursorToUrl = debounce(
     // and all the browsers do too.
     if (newUrl) {
       effects.router.replace(
-        newUrl.toString().replace(/%2F/g, '/').replace('%3A', ':')
+        newUrl
+          .toString()
+          .replace(/%2F/g, '/')
+          .replace('%3A', ':')
       );
     }
   },
@@ -552,10 +555,6 @@ export const codeChanged = (
   }
 ) => {
   effects.analytics.trackOnce('Change Code');
-
-  if (!state.user) {
-    state.editor.changeCounter++;
-  }
 
   if (!state.editor.currentSandbox) {
     return;

--- a/packages/app/src/app/overmind/namespaces/editor/state.ts
+++ b/packages/app/src/app/overmind/namespaces/editor/state.ts
@@ -28,6 +28,7 @@ import { mainModule as getMainModule } from '../../utils/main-module';
 import { parseConfigurations } from '../../utils/parse-configurations';
 
 type State = {
+  changeCounter: number;
   /**
    * Never use this! It doesn't reflect the id of the current sandbox. Use editor.currentSandbox.id instead.
    */
@@ -90,6 +91,7 @@ type State = {
 };
 
 export const state: State = {
+  changeCounter: 0,
   hasLoadedInitialModule: false,
   sandboxes: {},
   currentId: null,

--- a/packages/app/src/app/overmind/namespaces/editor/state.ts
+++ b/packages/app/src/app/overmind/namespaces/editor/state.ts
@@ -28,7 +28,6 @@ import { mainModule as getMainModule } from '../../utils/main-module';
 import { parseConfigurations } from '../../utils/parse-configurations';
 
 type State = {
-  changeCounter: number;
   /**
    * Never use this! It doesn't reflect the id of the current sandbox. Use editor.currentSandbox.id instead.
    */
@@ -91,7 +90,6 @@ type State = {
 };
 
 export const state: State = {
-  changeCounter: 0,
   hasLoadedInitialModule: false,
   sandboxes: {},
   currentId: null,

--- a/packages/app/src/app/pages/Sandbox/Editor/Header/SignInAd.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Header/SignInAd.tsx
@@ -1,24 +1,19 @@
 import React, { useEffect, useState } from 'react';
 import css from '@styled-system/css';
 import { Stack, Text, Button } from '@codesandbox/components';
-import { useActions } from 'app/overmind';
+import { useAppState } from 'app/overmind';
 import track from '@codesandbox/common/lib/utils/analytics';
 import { motion, AnimatePresence } from 'framer-motion';
 
 export const SignInBanner = () => {
-  const { signInClicked } = useActions();
+  const state = useAppState();
   const [show, setShow] = useState(false);
 
   useEffect(() => {
-    const timer = window.setTimeout(() => {
+    if (state.editor.changeCounter >= 3) {
       setShow(true);
-      // 3 minutes
-    }, 180000);
-
-    return () => {
-      clearTimeout(timer);
-    };
-  }, []);
+    }
+  }, [state.editor.changeCounter]);
 
   return (
     <AnimatePresence>

--- a/packages/app/src/app/pages/Sandbox/Editor/Header/SignInAd.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Header/SignInAd.tsx
@@ -38,30 +38,32 @@ export const SignInBanner = () => {
         >
           <Button
             autoWidth
-            css={css({
-              color: '#F7A239',
-              height: 'auto',
-              padding: 0,
-              fontSize: 3,
-              paddingRight: '.3em',
-              ':hover:not(:disabled), :focus:not(:disabled)': {
-                color: '#F7A239',
-              },
-            })}
+            css={css({ lineHeight: 1 })}
             onClick={() => {
               track('Header Sign In Ad Clicked');
               signInClicked();
             }}
             variant="link"
           >
-            Sign up for free
+            <Text
+              css={css({
+                color: '#F7A239',
+                height: 'auto',
+                padding: 0,
+                fontSize: 3,
+                paddingRight: '.3em',
+              })}
+            >
+              Sign up for free
+            </Text>
+
+            <Text>
+              to save your work{' '}
+              <span role="img" aria-label="sparkles">
+                ✨
+              </span>
+            </Text>
           </Button>
-          <Text css={css({ lineHeight: 1 })}>
-            to save your work{' '}
-            <span role="img" aria-label="sparkles">
-              ✨
-            </span>
-          </Text>
 
           <Button
             css={css({

--- a/packages/app/src/app/pages/Sandbox/Editor/Header/SignInAd.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Header/SignInAd.tsx
@@ -1,11 +1,12 @@
 import React, { useEffect, useState } from 'react';
 import css from '@styled-system/css';
 import { Stack, Text, Button } from '@codesandbox/components';
-import { useAppState } from 'app/overmind';
+import { useActions, useAppState } from 'app/overmind';
 import track from '@codesandbox/common/lib/utils/analytics';
 import { motion, AnimatePresence } from 'framer-motion';
 
 export const SignInBanner = () => {
+  const { signInClicked } = useActions();
   const state = useAppState();
   const [show, setShow] = useState(false);
 

--- a/packages/app/src/app/pages/Sandbox/Editor/Header/SignInAd.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Header/SignInAd.tsx
@@ -18,94 +18,74 @@ export const SignInBanner = () => {
 
   return (
     <AnimatePresence>
-      {show ? (
-        <motion.div
+      {show && (
+        <Stack
+          as={motion.div}
           animate={{ y: 0 }}
           initial={{ y: -70 }}
           exit={{ y: -70 }}
           transition={{ ease: 'easeOut' }}
+          padding={4}
+          justify="center"
+          align="center"
+          css={css({
+            position: 'absolute',
+            width: '100vw',
+            height: 49,
+            zIndex: 9999,
+            backgroundColor: 'statusBar.background',
+          })}
         >
-          <Stack
-            padding={4}
+          <Button
+            autoWidth
             css={css({
-              position: 'absolute',
-              backgroundColor: 'button.background',
-              width: '100vw',
-              height: 49,
-              alignItems: 'center',
-              color: 'sideBar.foreground',
-              zIndex: 9999,
+              color: '#F7A239',
+              height: 'auto',
+              padding: 0,
+              fontSize: 3,
+              paddingRight: '.3em',
+              ':hover:not(:disabled), :focus:not(:disabled)': {
+                color: '#F7A239',
+              },
             })}
+            onClick={() => {
+              track('Header Sign In Ad Clicked');
+              signInClicked();
+            }}
+            variant="link"
           >
-            <Stack
-              align="center"
-              justify="space-between"
-              css={css({ width: '100%' })}
-            >
-              <Stack
-                gap={4}
-                align="center"
-                css={css({ margin: 'auto !important' })}
-              >
-                <Stack
-                  paddingY={1}
-                  paddingX={2}
-                  css={css({
-                    backgroundColor: 'sideBar.foreground',
-                    color: 'button.background',
-                    fontWeight: 'bold',
-                    textAlign: 'center',
-                    fontSize: '1',
-                    borderRadius: 'small',
-                  })}
-                >
-                  Tip
-                </Stack>
-                <Text>
-                  Register to save your work, code on any device, deploy, and
-                  collaborate
-                </Text>
-              </Stack>
-              <Stack gap={4}>
-                <Button
-                  autoWidth
-                  css={css({
-                    color: 'sideBar.foreground',
-                    ':hover:not(:disabled), :focus:not(:disabled)': {
-                      color: 'sideBar.foreground',
-                    },
-                  })}
-                  onClick={() => {
-                    track('Header Sign In Ad Clicked');
-                    signInClicked();
-                  }}
-                  variant="link"
-                >
-                  Sign in to Save
-                </Button>
-                <Button
-                  css={css({
-                    width: 6,
-                    padding: 0,
-                    display: 'block',
-                    color: 'sideBar.foreground',
-                  })}
-                  variant="link"
-                  padding={0}
-                  onClick={() => setShow(false)}
-                >
-                  <svg width={24} height={24} fill="none" viewBox="0 0 24 24">
-                    <path
-                      fill="currentColor"
-                      d="M17.508 7.301l-1.083-1.09-4.872 4.909-4.871-4.91-1.083 1.091 4.872 4.91-4.872 4.909 1.083 1.09 4.871-4.909 4.872 4.91 1.082-1.091-4.871-4.91 4.872-4.909z"
-                    />
-                  </svg>
-                </Button>
-              </Stack>
-            </Stack>
-          </Stack>
-        </motion.div>
-      ) : null}
+            Sign up for free
+          </Button>
+          <Text css={css({ lineHeight: 1 })}>
+            to save your work{' '}
+            <span role="img" aria-label="sparkles">
+              ✨
+            </span>
+          </Text>
+
+          <Button
+            css={css({
+              width: 6,
+              padding: 0,
+              display: 'block',
+              color: 'sideBar.foreground',
+              position: 'absolute',
+              right: '1em',
+              top: '1em',
+            })}
+            variant="link"
+            padding={0}
+            onClick={() => setShow(false)}
+          >
+            <svg width={24} height={24} fill="none" viewBox="0 0 24 24">
+              <path
+                fill="currentColor"
+                d="M17.508 7.301l-1.083-1.09-4.872 4.909-4.871-4.91-1.083 1.091 4.872 4.91-4.872 4.909 1.083 1.09 4.871-4.909 4.872 4.91 1.082-1.091-4.871-4.91 4.872-4.909z"
+              />
+            </svg>
+          </Button>
+        </Stack>
+      )}
     </AnimatePresence>
   );
 };

--- a/packages/app/src/app/pages/Sandbox/Editor/Header/SignInAd.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Header/SignInAd.tsx
@@ -12,17 +12,28 @@ export const SignInBanner = () => {
   const [show, setShow] = useState(false);
 
   const experimentPromise = useExperimentResult('editor-signin-banner-trigger');
+  const [bannerTriggerOnce, setBannerTriggerOnce] = useState(false);
 
   useEffect(() => {
-    let timer;
+    let timer: number | undefined;
 
+    /**
+     * Experiment
+     */
     experimentPromise.then(experiment => {
-      if (experiment === ExperimentValues.A) {
+      /**
+       * A
+       */
+      if (experiment === ExperimentValues.A && bannerTriggerOnce === false) {
         timer = window.setTimeout(() => {
           setShow(true);
+          setBannerTriggerOnce(true);
           // 3 minutes
         }, 180000);
       } else if (
+        /**
+         * B
+         */
         experiment === ExperimentValues.B &&
         state.editor.changeCounter === 3
       ) {
@@ -33,7 +44,7 @@ export const SignInBanner = () => {
     return () => {
       clearTimeout(timer);
     };
-  }, [state.editor.changeCounter, experimentPromise]);
+  }, [state.editor.changeCounter, experimentPromise, bannerTriggerOnce]);
 
   return (
     <AnimatePresence>

--- a/packages/app/src/app/pages/Sandbox/Editor/Header/SignInAd.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Header/SignInAd.tsx
@@ -1,14 +1,13 @@
 import React, { useEffect, useState } from 'react';
 import css from '@styled-system/css';
 import { Stack, Text, Button } from '@codesandbox/components';
-import { useActions, useAppState } from 'app/overmind';
+import { useActions } from 'app/overmind';
 import track from '@codesandbox/common/lib/utils/analytics';
 import { motion, AnimatePresence } from 'framer-motion';
 import { ExperimentValues, useExperimentResult } from '@codesandbox/ab';
 
 export const SignInBanner = () => {
   const { signInClicked } = useActions();
-  const state = useAppState();
   const [show, setShow] = useState(false);
 
   const experimentPromise = useExperimentResult('editor-signin-banner-trigger');
@@ -35,16 +34,20 @@ export const SignInBanner = () => {
          * B
          */
         experiment === ExperimentValues.B &&
-        state.editor.changeCounter === 3
+        bannerTriggerOnce === false
       ) {
-        setShow(true);
+        timer = window.setTimeout(() => {
+          setShow(true);
+          setBannerTriggerOnce(true);
+          // 3 minutes
+        }, 180000);
       }
     });
 
     return () => {
       clearTimeout(timer);
     };
-  }, [state.editor.changeCounter, experimentPromise, bannerTriggerOnce]);
+  }, [experimentPromise, bannerTriggerOnce]);
 
   return (
     <AnimatePresence>

--- a/packages/app/src/app/pages/index.tsx
+++ b/packages/app/src/app/pages/index.tsx
@@ -1,14 +1,18 @@
-import { DNT, trackPageview } from '@codesandbox/common/lib/utils/analytics';
+import {
+  DNT,
+  trackPageview,
+  identify,
+} from '@codesandbox/common/lib/utils/analytics';
 import _debug from '@codesandbox/common/lib/utils/debug';
 import { notificationState } from '@codesandbox/common/lib/utils/notifications';
 import { Toasts } from '@codesandbox/notifications';
-import { useAppState, useActions, useEffects } from 'app/overmind';
+import { useAppState, useActions } from 'app/overmind';
 import { Loadable } from 'app/utils/Loadable';
 import React, { useEffect } from 'react';
 import { SignInModal } from 'app/components/SignInModal';
 import { Redirect, Route, Switch, withRouter } from 'react-router-dom';
 import { CreateSandboxModal } from 'app/components/CreateNewSandbox/CreateSandbox/CreateSandboxModal';
-import { useInitializeExperimentStore } from '@codesandbox/ab';
+import { initializeExperimentStore } from '@codesandbox/ab';
 import {
   getExperimentUserId,
   AB_TESTING_URL,
@@ -137,20 +141,19 @@ const CodeSadbox = () => this[`💥`].kaboom();
 
 const Boundary = withRouter(ErrorBoundary);
 
+initializeExperimentStore(
+  AB_TESTING_URL,
+  getExperimentUserId,
+  async (key, value) => {
+    await identify(key, value);
+  }
+);
+
 const RoutesComponent: React.FC = () => {
   const { appUnmounted } = useActions();
   const { modals, activeTeamInfo } = useAppState();
-  const { analytics } = useEffects();
 
   useEffect(() => () => appUnmounted(), [appUnmounted]);
-
-  useInitializeExperimentStore(
-    AB_TESTING_URL,
-    getExperimentUserId,
-    async (key, value) => {
-      await analytics.identify(key, value);
-    }
-  );
 
   return (
     <Container>

--- a/packages/app/src/app/pages/index.tsx
+++ b/packages/app/src/app/pages/index.tsx
@@ -2,12 +2,17 @@ import { DNT, trackPageview } from '@codesandbox/common/lib/utils/analytics';
 import _debug from '@codesandbox/common/lib/utils/debug';
 import { notificationState } from '@codesandbox/common/lib/utils/notifications';
 import { Toasts } from '@codesandbox/notifications';
-import { useAppState, useActions } from 'app/overmind';
+import { useAppState, useActions, useEffects } from 'app/overmind';
 import { Loadable } from 'app/utils/Loadable';
 import React, { useEffect } from 'react';
 import { SignInModal } from 'app/components/SignInModal';
 import { Redirect, Route, Switch, withRouter } from 'react-router-dom';
 import { CreateSandboxModal } from 'app/components/CreateNewSandbox/CreateSandbox/CreateSandboxModal';
+import { useInitializeExperimentStore } from '@codesandbox/ab';
+import {
+  getExperimentUserId,
+  AB_TESTING_URL,
+} from '@codesandbox/common/lib/config/env';
 
 import { ErrorBoundary } from './common/ErrorBoundary';
 import { Modals } from './common/Modals';
@@ -34,8 +39,8 @@ const DuplicateAccount = Loadable(() =>
 
 const routeDebugger = _debug('cs:app:router');
 
-const SignInAuth = Loadable(
-  () => import(/* webpackChunkName: 'page-sign-in' */ './SignInAuth')
+const SignInAuth = Loadable(() =>
+  import(/* webpackChunkName: 'page-sign-in' */ './SignInAuth')
 );
 const SignIn = Loadable(() =>
   import(/* webpackChunkName: 'page-sign-in' */ './SignIn').then(module => ({
@@ -47,11 +52,11 @@ const Live = Loadable(() =>
     default: module.Live,
   }))
 );
-const VercelSignIn = Loadable(
-  () => import(/* webpackChunkName: 'page-vercel' */ './VercelAuth')
+const VercelSignIn = Loadable(() =>
+  import(/* webpackChunkName: 'page-vercel' */ './VercelAuth')
 );
-const PreviewAuth = Loadable(
-  () => import(/* webpackChunkName: 'page-vercel' */ './PreviewAuth')
+const PreviewAuth = Loadable(() =>
+  import(/* webpackChunkName: 'page-vercel' */ './PreviewAuth')
 );
 const NotFound = Loadable(() =>
   import(/* webpackChunkName: 'page-not-found' */ './common/NotFound').then(
@@ -135,8 +140,17 @@ const Boundary = withRouter(ErrorBoundary);
 const RoutesComponent: React.FC = () => {
   const { appUnmounted } = useActions();
   const { modals, activeTeamInfo } = useAppState();
+  const { analytics } = useEffects();
 
   useEffect(() => () => appUnmounted(), [appUnmounted]);
+
+  useInitializeExperimentStore(
+    AB_TESTING_URL,
+    getExperimentUserId,
+    async (key, value) => {
+      await analytics.identify(key, value);
+    }
+  );
 
   return (
     <Container>

--- a/packages/common/src/config/env.ts
+++ b/packages/common/src/config/env.ts
@@ -1,11 +1,27 @@
 // Grab NODE_ENV and REACT_APP_* environment variables and prepare them to be
 // injected into the application via DefinePlugin in Webpack configuration.
+import uuid from 'uuid';
 import getHost from '../utils/host';
 
 const REACT_APP = /^REACT_APP_/i;
 const NODE_ENV = JSON.stringify(process.env.NODE_ENV || 'development');
 const LOCAL_SERVER = Boolean(JSON.stringify(process.env.LOCAL_SERVER));
 const STAGING_API = Boolean(JSON.stringify(process.env.STAGING_API));
+
+export const AB_TESTING_URL = 'https://ab-testing.codesandbox.workers.dev';
+
+export const getExperimentUserId = () => {
+  const KEY_NAME = 'csb-ab-user-id';
+
+  let userId = localStorage.getItem(KEY_NAME);
+
+  if (!userId) {
+    userId = uuid.v4();
+    localStorage.setItem(KEY_NAME, userId);
+  }
+
+  return userId;
+};
 
 export default Object.keys(process.env)
   .filter(key => REACT_APP.test(key))

--- a/packages/homepage/gatsby-browser.js
+++ b/packages/homepage/gatsby-browser.js
@@ -1,4 +1,9 @@
-const { trackPageview } = require('@codesandbox/common/lib/utils/analytics');
+const { initializeExperimentStore } = require('@codesandbox/ab');
+const {
+  AB_TESTING_URL,
+  getExperimentUserId,
+} = require('@codesandbox/common/lib/config/env');
+const analytics = require('@codesandbox/common/lib/utils/analytics');
 
 exports.onClientEntry = () => {
   (function addDocSearch() {
@@ -9,8 +14,19 @@ exports.onClientEntry = () => {
     link.setAttribute(`href`, path);
     document.head.appendChild(link);
   })();
+
+  /**
+   * AB framework
+   */
+  initializeExperimentStore(
+    AB_TESTING_URL,
+    getExperimentUserId,
+    async (key, value) => {
+      await analytics.identify(key, value);
+    }
+  );
 };
 
 exports.onRouteUpdate = () => {
-  trackPageview();
+  analytics.trackPageview();
 };

--- a/packages/homepage/package.json
+++ b/packages/homepage/package.json
@@ -28,6 +28,7 @@
   ],
   "dependencies": {
     "@babel/preset-flow": "^7.0.0",
+    "@codesandbox/ab": "^1.0.2",
     "@codesandbox/common": "^1.0.8",
     "@juggle/resize-observer": "^2.5.0",
     "@react-hook/mouse-position": "^1.0.3",

--- a/packages/homepage/package.json
+++ b/packages/homepage/package.json
@@ -28,7 +28,7 @@
   ],
   "dependencies": {
     "@babel/preset-flow": "^7.0.0",
-    "@codesandbox/ab": "^1.0.2",
+    "@codesandbox/ab": "^1.0.4",
     "@codesandbox/common": "^1.0.8",
     "@juggle/resize-observer": "^2.5.0",
     "@react-hook/mouse-position": "^1.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1185,6 +1185,13 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
+"@codesandbox/ab@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@codesandbox/ab/-/ab-1.0.2.tgz#2d27b3faaf799c6d392a8f743471cd2a4b283a5c"
+  integrity sha512-24FaThfIx2Bb6EmaliuTDMLB6aCQzP4kKEV8vvKUPiaqBBiWyn2Y690AQsVFveEyXEehHxFc5kqFbtcGcm3XMA==
+  dependencies:
+    react "^16.9.0"
+
 "@csstools/convert-colors@^1.4.0":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@csstools/convert-colors/-/convert-colors-1.4.0.tgz#ad495dc41b12e75d588c6db8b9834f08fa131eb7"
@@ -12928,7 +12935,7 @@ esprima@^4.0.0, esprima@^4.0.1, esprima@~4.0.0:
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
 
-esquery@1.0.1, esquery@^1.0.0, esquery@^1.0.1:
+esquery@^1.0.0, esquery@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.0.1.tgz#406c51658b1f5991a5f9b62b1dc25b00e3e5c708"
   integrity sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1185,10 +1185,10 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@codesandbox/ab@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@codesandbox/ab/-/ab-1.0.2.tgz#2d27b3faaf799c6d392a8f743471cd2a4b283a5c"
-  integrity sha512-24FaThfIx2Bb6EmaliuTDMLB6aCQzP4kKEV8vvKUPiaqBBiWyn2Y690AQsVFveEyXEehHxFc5kqFbtcGcm3XMA==
+"@codesandbox/ab@^1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@codesandbox/ab/-/ab-1.0.4.tgz#b2f6761368cc036bb849b83aaf9772f14a24f11b"
+  integrity sha512-qxkG9uBxofUMTam/hFkUC3/iJ2cOGbiOCEOC6noUrWpO7FubcRaDjd19W7AhWZyw7d/WTZ3SR6TQIQUu9xuPgA==
   dependencies:
     react "^16.9.0"
 
@@ -12935,7 +12935,7 @@ esprima@^4.0.0, esprima@^4.0.1, esprima@~4.0.0:
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
 
-esquery@^1.0.0, esquery@^1.0.1:
+esquery@1.0.1, esquery@^1.0.0, esquery@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.0.1.tgz#406c51658b1f5991a5f9b62b1dc25b00e3e5c708"
   integrity sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==


### PR DESCRIPTION
This introduces the implementation of the AB framework across the apps (homepage and editor) in order to use the same user-id in both environments and it also persists the id from an anonymous user to a logged-in status.

We're going to ship an **A/A** test so that we'll able to make sure that Amplitude is getting the right values in the production, so then we'll be able to release a new one (A/B)

---

It also takes the opportunity to release a redesign for the sign-in banner at the very top in the editor, which is part of the next experiment.