### PR TITLE
Feat/live tracking

### DIFF
--- a/packages/app/src/app/overmind/namespaces/live/liveMessageOperators.ts
+++ b/packages/app/src/app/overmind/namespaces/live/liveMessageOperators.ts
@@ -146,6 +146,8 @@ export const onUserEntered = (
     return;
   }
 
+  effects.analytics.track('Editor - Joined the live session');
+
   const users = camelizeKeys(data.users);
 
   state.live.roomInfo.users = users as LiveUser[];
@@ -195,6 +197,8 @@ export const onUserLeft = (
   if (!state.live.roomInfo) {
     return;
   }
+
+  effects.analytics.track('Editor - Left the live session');
 
   if (!state.live.notificationsHidden) {
     const { users } = state.live.roomInfo;

--- a/packages/app/src/app/overmind/namespaces/live/liveMessageOperators.ts
+++ b/packages/app/src/app/overmind/namespaces/live/liveMessageOperators.ts
@@ -146,7 +146,7 @@ export const onUserEntered = (
     return;
   }
 
-  effects.analytics.track('Editor - Joined the live session');
+  effects.analytics.track('Editor - Someone joined the live session');
 
   const users = camelizeKeys(data.users);
 
@@ -198,7 +198,7 @@ export const onUserLeft = (
     return;
   }
 
-  effects.analytics.track('Editor - Left the live session');
+  effects.analytics.track('Editor - Someone left the live session');
 
   if (!state.live.notificationsHidden) {
     const { users } = state.live.roomInfo;

--- a/packages/app/src/app/pages/Sandbox/Editor/Header/CollaboratorHeads/CollaboratorHeads.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Header/CollaboratorHeads/CollaboratorHeads.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from 'react';
+import React, { FunctionComponent, useEffect } from 'react';
 import css from '@styled-system/css';
 import { AnimatePresence, motion } from 'framer-motion';
 import { sortBy } from 'lodash-es';
@@ -6,7 +6,7 @@ import Tooltip, {
   SingletonTooltip,
 } from '@codesandbox/common/lib/components/Tooltip';
 import { TippyProps } from '@tippy.js/react';
-import { useAppState, useActions } from 'app/overmind';
+import { useAppState, useActions, useEffects } from 'app/overmind';
 import { Stack, Avatar, Text, Menu, Link } from '@codesandbox/components';
 import { LiveUser } from '@codesandbox/common/lib/types';
 
@@ -106,6 +106,8 @@ const CollaboratorHead = (props: ICollaboratorHeadProps) => (
 export const CollaboratorHeads: FunctionComponent = () => {
   const state = useAppState();
   const actions = useActions();
+  const effects = useEffects();
+
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const liveUsers = state.live.roomInfo?.users || [];
 
@@ -146,6 +148,12 @@ export const CollaboratorHeads: FunctionComponent = () => {
 
   const firstLiveUsers = orderedLiveUsers.slice(0, USER_OVERFLOW_LIMIT);
   const restLiveUsers = orderedLiveUsers.slice(USER_OVERFLOW_LIMIT);
+
+  useEffect(() => {
+    effects.analytics.track('Editor - Amount of live users', {
+      amount: orderedLiveUsers.length,
+    });
+  }, [orderedLiveUsers.length, effects]);
 
   // It doesn't make sense to show a "More" button for live users if there's
   // only one in it.


### PR DESCRIPTION
This introduces three new events that aims to track the live sessions in the client

- Editor - Someone joined the live session
- Editor - Someone left the live session
- Editor - Amount of live users

![Screenshot 2021-06-21 at 11 04 48](https://user-images.githubusercontent.com/4838076/122747637-382db380-d283-11eb-9a79-39f88c92ae3a.png)
