### PR TITLE
feat(ab experiment): change trigger to show sign-in ads in the editor

### DIFF
--- a/packages/app/src/app/overmind/namespaces/editor/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/editor/actions.ts
@@ -78,10 +78,7 @@ export const persistCursorToUrl = debounce(
     // and all the browsers do too.
     if (newUrl) {
       effects.router.replace(
-        newUrl
-          .toString()
-          .replace(/%2F/g, '/')
-          .replace('%3A', ':')
+        newUrl.toString().replace(/%2F/g, '/').replace('%3A', ':')
       );
     }
   },
@@ -546,6 +543,10 @@ export const codeChanged = (
   }
 ) => {
   effects.analytics.trackOnce('Change Code');
+
+  if (!state.user) {
+    state.editor.changeCounter++;
+  }
 
   if (!state.editor.currentSandbox) {
     return;

--- a/packages/app/src/app/overmind/namespaces/editor/state.ts
+++ b/packages/app/src/app/overmind/namespaces/editor/state.ts
@@ -27,6 +27,7 @@ import { mainModule as getMainModule } from '../../utils/main-module';
 import { parseConfigurations } from '../../utils/parse-configurations';
 
 type State = {
+  changeCounter: number;
   /**
    * Never use this! It doesn't reflect the id of the current sandbox. Use editor.currentSandbox.id instead.
    */
@@ -88,6 +89,7 @@ type State = {
 };
 
 export const state: State = {
+  changeCounter: 0,
   hasLoadedInitialModule: false,
   sandboxes: {},
   currentId: null,

--- a/packages/app/src/app/pages/Sandbox/Editor/Header/SignInAd.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Header/SignInAd.tsx
@@ -11,7 +11,9 @@ export const SignInBanner = () => {
   const { signInClicked } = useActions();
   const [show, setShow] = useState(false);
 
-  const experimentPromise = useExperimentResult('editor-signin-banner-trigger');
+  const experimentPromise = useExperimentResult(
+    'editor-signin-banner-trigger-real'
+  );
   const [bannerTriggerOnce, setBannerTriggerOnce] = useState(false);
 
   useEffect(() => {

--- a/packages/app/src/app/pages/Sandbox/Editor/Header/SignInAd.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Header/SignInAd.tsx
@@ -1,12 +1,13 @@
 import React, { useEffect, useState } from 'react';
 import css from '@styled-system/css';
 import { Stack, Text, Button } from '@codesandbox/components';
-import { useActions } from 'app/overmind';
+import { useActions, useAppState } from 'app/overmind';
 import track from '@codesandbox/common/lib/utils/analytics';
 import { motion, AnimatePresence } from 'framer-motion';
 import { ExperimentValues, useExperimentResult } from '@codesandbox/ab';
 
 export const SignInBanner = () => {
+  const state = useAppState();
   const { signInClicked } = useActions();
   const [show, setShow] = useState(false);
 
@@ -16,6 +17,11 @@ export const SignInBanner = () => {
   useEffect(() => {
     let timer: number | undefined;
 
+    const showBanner = () => {
+      setShow(true);
+      setBannerTriggerOnce(true);
+    };
+
     /**
      * Experiment
      */
@@ -24,30 +30,24 @@ export const SignInBanner = () => {
        * A
        */
       if (experiment === ExperimentValues.A && bannerTriggerOnce === false) {
-        timer = window.setTimeout(() => {
-          setShow(true);
-          setBannerTriggerOnce(true);
-          // 3 minutes
-        }, 180000);
+        timer = window.setTimeout(showBanner, 180000);
+        // 3 minutes
       } else if (
         /**
          * B
          */
         experiment === ExperimentValues.B &&
+        state.editor.changeCounter === 3 &&
         bannerTriggerOnce === false
       ) {
-        timer = window.setTimeout(() => {
-          setShow(true);
-          setBannerTriggerOnce(true);
-          // 3 minutes
-        }, 180000);
+        showBanner();
       }
     });
 
     return () => {
       clearTimeout(timer);
     };
-  }, [experimentPromise, bannerTriggerOnce]);
+  }, [state.editor.changeCounter, experimentPromise, bannerTriggerOnce]);
 
   return (
     <AnimatePresence>


### PR DESCRIPTION
Let's run our first experiement! 🚀 

---

This changes the trigger to show the sign-in ads on top of editor for anonymous users:
- A version: keep the same, runs after 3 minutos;
- B version: run after 3 changes in the editor;