### PR TITLE
Tweaks to copy as ESModule url context menu item

### DIFF
--- a/packages/app/src/app/components/ContextMenu/elements.ts
+++ b/packages/app/src/app/components/ContextMenu/elements.ts
@@ -74,3 +74,18 @@ export const ItemContainer = styled.div`
     margin-bottom: 0;
   }
 `;
+
+export const Badge = styled.p`
+  margin: 0 0 0 4px;
+  border-radius: 2px;
+  background-color: ${opts => opts.theme.colors.blues[700]};
+  color: ${opts => opts.theme.colors.white};
+  width: ${opts => opts.theme.sizes[7]}px;
+  height: ${opts => opts.theme.sizes[3]}px;
+  text-align: center;
+  line-height: 1.4;
+  font-size: ${opts => opts.theme.fontSizes[1]}px;
+  font-weight: ${opts => opts.theme.fontWeights.medium};
+  position: relative;
+  top: -1px;
+`;

--- a/packages/app/src/app/components/ContextMenu/index.tsx
+++ b/packages/app/src/app/components/ContextMenu/index.tsx
@@ -4,7 +4,7 @@ import Portal from '@codesandbox/common/lib/components/Portal';
 
 import { ENTER } from '@codesandbox/common/lib/utils/keycodes';
 
-import { Container, Item, ItemContainer } from './elements';
+import { Container, Item, ItemContainer, Badge } from './elements';
 
 type OnContextMenu = (event: React.MouseEvent) => void;
 
@@ -13,6 +13,7 @@ interface ItemType {
   title: string;
   icon?: React.ElementType;
   action: () => boolean | void;
+  isNewFeature?: boolean;
 }
 
 export type ContextMenuItemType = ItemType | ItemType[];
@@ -192,6 +193,7 @@ export class ContextMenu extends React.PureComponent<Props, State> {
         >
           {item.icon && <item.icon />}
           {item.title}
+          {item.isNewFeature && <Badge>New</Badge>}
         </Item>
       );
     };

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Explorer/Files/DirectoryEntry/DirectoryChildren/ModuleEntry.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Explorer/Files/DirectoryEntry/DirectoryChildren/ModuleEntry.tsx
@@ -70,7 +70,7 @@ export const ModuleEntry: React.FC<IModuleEntryProps> = React.memo(
     const handleCopyESModuleUrl = useCallback(() => {
       const esmoduleUrl = new URL(
         module.path.substr(1),
-        `https://esmodule-cdn.fly.dev/${currentSandbox.id}/fs/`
+        `https://esm-cdn-preview.codesandbox.io/${currentSandbox.id}/fs/`
       );
       esmoduleUrl.searchParams.set(
         'mtime',

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Explorer/Files/DirectoryEntry/DirectoryChildren/ModuleEntry.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Explorer/Files/DirectoryEntry/DirectoryChildren/ModuleEntry.tsx
@@ -3,9 +3,11 @@ import { notificationState } from '@codesandbox/common/lib/utils/notifications';
 import { NotificationStatus } from '@codesandbox/notifications';
 import { useAppState, useEffects } from 'app/overmind';
 import { getType } from 'app/utils/get-type.ts';
-import React from 'react';
+import React, { useCallback, useMemo } from 'react';
 
 import { Entry } from '../Entry';
+
+const ESM_EXTENSIONS = ['ts', 'tsx', 'js', 'jsx'];
 
 interface IModuleEntryProps {
   module: Module;
@@ -55,13 +57,17 @@ export const ModuleEntry: React.FC<IModuleEntryProps> = React.memo(
 
     const isNotSynced = module.savedCode && module.code !== module.savedCode;
 
-    const showESModuleItem: boolean = !!(
-      module &&
-      module.path &&
-      currentSandbox.template === 'esm-react'
-    );
+    const showESModuleItem: boolean = useMemo(() => {
+      if (!module.path || currentSandbox.template !== 'esm-react') {
+        return false;
+      }
 
-    const handleCopyESModuleUrl = React.useCallback(() => {
+      const modulePathParts = module.path.split('.');
+      const extname = modulePathParts[modulePathParts.length - 1];
+      return ESM_EXTENSIONS.includes(extname);
+    }, [module.path, currentSandbox.template]);
+
+    const handleCopyESModuleUrl = useCallback(() => {
       const esmoduleUrl = new URL(
         module.path.substr(1),
         `https://esmodule-cdn.fly.dev/${currentSandbox.id}/fs/`

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Explorer/Files/DirectoryEntry/Entry/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Explorer/Files/DirectoryEntry/Entry/index.tsx
@@ -178,6 +178,7 @@ const EntryComponent: React.FC<IEntryProps> = ({
         title: 'Copy as ESModule URL',
         action: copyESModuleURL,
         icon: AddFileIcon, // TODO: Figure out what the actual icon is
+        isNewFeature: true,
       },
       deleteEntry && {
         title: 'Delete',


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?

<!-- Is it a Bug fix, feature, docs update, ... -->

Implements some final touches to the esmodule url context menu item.

- Only show the item for ts, tsx, js and jsx
- Use the new codesandbox hostname
- Add the new badge

![Screen Shot 2021-07-12 at 14 20 42](https://user-images.githubusercontent.com/2175521/125286808-81ba6d00-e31c-11eb-8233-f6dbd97517e6.png)

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
