### PR TITLE
Fix measure warnings

### DIFF
--- a/packages/common/src/utils/metrics.ts
+++ b/packages/common/src/utils/metrics.ts
@@ -17,12 +17,24 @@ if (typeof global.performance === 'undefined') {
   };
 }
 
-export function measure(key: MeasurementKey) {
+export function now(): number {
+  try {
+    return performance.now();
+  } catch (err) {
+    console.warn(err);
+    return 0;
+  }
+}
+
+export function measure(key: MeasurementKey): number {
   try {
     performance.mark(`${key}_start`);
-    runningMeasurements.set(key, performance.now());
+    const currentTime = now();
+    runningMeasurements.set(key, currentTime);
+    return currentTime;
   } catch (e) {
     console.warn(`Something went wrong while adding measure: ${e.message}`);
+    return 0;
   }
 }
 

--- a/packages/sandpack-core/src/manager.ts
+++ b/packages/sandpack-core/src/manager.ts
@@ -8,7 +8,7 @@ import { isUrl } from '@codesandbox/common/lib/utils/is-url';
 import _debug from '@codesandbox/common/lib/utils/debug';
 import { getGlobal } from '@codesandbox/common/lib/utils/global';
 import { ParsedConfigurationFiles } from '@codesandbox/common/lib/templates/template';
-import { measure, endMeasure } from '@codesandbox/common/lib/utils/metrics';
+import { endMeasure, now } from '@codesandbox/common/lib/utils/metrics';
 import DependencyNotFoundError from 'sandbox-hooks/errors/dependency-not-found-error';
 import ModuleNotFoundError from 'sandbox-hooks/errors/module-not-found-error';
 
@@ -788,8 +788,8 @@ export default class Manager implements IEvaluator {
     if (cachedPath && this.transpiledModules[cachedPath]) {
       resolvedPath = cachedPath;
     } else {
-      const measureKey = `resolve-async:${path}::${parentPath}::${query}::${Date.now()}`;
-      measure(measureKey);
+      const measureKey = `resolve-async:${path}::${parentPath}::${query}`;
+      const measureStartTime = now();
       const presetAliasedPath = this.getPresetAliasedPath(path);
 
       const aliasedPath = this.getAliasedDependencyPath(
@@ -825,7 +825,7 @@ export default class Manager implements IEvaluator {
           );
         });
 
-        endMeasure(measureKey, { silent: true });
+        endMeasure(measureKey, { silent: true, lastTime: measureStartTime });
 
         this.cachedPaths[dirredPath][path] = resolvedPath;
 
@@ -959,7 +959,7 @@ export default class Manager implements IEvaluator {
       resolvedPath = cachedPath;
     } else {
       const measureKey = `resolve-sync:${path}:${parentPath}`;
-      measure(measureKey);
+      const measureStartTime = now();
       const presetAliasedPath = this.getPresetAliasedPath(path);
 
       const aliasedPath = this.getAliasedDependencyPath(
@@ -983,7 +983,7 @@ export default class Manager implements IEvaluator {
           packageFilter: packageFilter(this.isFile),
           moduleDirectory: this.getModuleDirectories(),
         });
-        endMeasure(measureKey, { silent: true });
+        endMeasure(measureKey, { silent: true, lastTime: measureStartTime });
 
         this.cachedPaths[dirredPath][path] = resolvedPath;
 


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?

Gets rid of the resolver measure warnings and probably also fixes a memory leak as these measures are kept in memory if not resolved which can happen quite easily as there's no cleanup call
