### PR TITLE
Show loading state in `client/login` if authToken is null

### DIFF
--- a/packages/app/src/app/pages/Client/Prompt/index.tsx
+++ b/packages/app/src/app/pages/Client/Prompt/index.tsx
@@ -10,7 +10,7 @@ import { Buttons, Container } from './elements';
 import Logo from '../../../logo.svg';
 
 export const Prompt: FunctionComponent = () => {
-  const { authToken, error, isLoadingCLI, user } = useAppState();
+  const { authToken, error, user } = useAppState();
 
   const [deepLink, setDeepLink] = useState('');
 
@@ -70,7 +70,7 @@ export const Prompt: FunctionComponent = () => {
     );
   }
 
-  if (isLoadingCLI) {
+  if (!authToken) {
     return (
       <Container>
         <img


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

When a user signs into CodeSandbox via Google or GitHub and they land on `https://codesandbox.io/client/login`, the deeplink of the button contains a `null` nonce causing the authentication in play.js to fail.

## What is the new behavior?

This PR changes the logic slightly so the loading state is visible based on whether `authClient` is null or not. 

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Open play.js
2. Tap on "Sign in"
3. In Safari "Sign in" with a Google/GitHub account.
4. Once the web authentication has finished quickly tap on "Open on play.js"
5. As a result play.js prompts an error letting the user know that the sign in process didn't succeed.

## Checklist

- [x] Testing
- [x] Ready to be merged
