### PR TITLE
feat(embed): wording experiment

### DIFF
--- a/packages/app/src/embed/components/Actions/index.js
+++ b/packages/app/src/embed/components/Actions/index.js
@@ -1,6 +1,9 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import Tooltip from '@codesandbox/common/lib/components/Tooltip';
 import { sandboxUrl } from '@codesandbox/common/lib/utils/url-generator';
+import { ExperimentValues, useExperimentResult } from '@codesandbox/ab';
+
+import Logo from '../../logo.svg';
 
 import {
   Container,
@@ -24,6 +27,26 @@ export function GlobalActions({
   previewVisible,
   initialPath,
 }) {
+  const experimentPromise = useExperimentResult('embed-open-wording');
+  const [openWordingB, setOpenWordingB] = useState(false);
+
+  useEffect(() => {
+    /* Wait for the API */
+    experimentPromise.then(experiment => {
+      if (experiment === ExperimentValues.A) {
+        /**
+         * A
+         */
+        setOpenWordingB(false);
+      } else if (experiment === ExperimentValues.B) {
+        /**
+         * B
+         */
+        setOpenWordingB(true);
+      }
+    });
+  }, [experimentPromise]);
+
   const smallTouchScreenButton = previewVisible ? (
     <Button onClick={openEditor}>View Source</Button>
   ) : (
@@ -79,7 +102,24 @@ export function GlobalActions({
               : `${sandboxUrl(sandbox)}?from-embed`
           }
         >
-          Open Sandbox
+          {openWordingB ? (
+            <>
+              <img
+                src={Logo}
+                width="32"
+                alt="CodeSandbox Logo"
+                style={{
+                  paddingRight: '8px',
+                  width: '18px',
+                  top: '-1px',
+                  position: 'relative',
+                }}
+              />
+              Edit Sandbox
+            </>
+          ) : (
+            'Open Sandbox'
+          )}
         </Button>
       )}
     </Container>

--- a/packages/app/src/embed/index.js
+++ b/packages/app/src/embed/index.js
@@ -4,8 +4,24 @@ import { render } from 'react-dom';
 import requirePolyfills from '@codesandbox/common/lib/load-dynamic-polyfills';
 import 'normalize.css';
 import '@codesandbox/common/lib/global.css';
-import track, { identifyOnce } from '@codesandbox/common/lib/utils/analytics';
+import track, {
+  identifyOnce,
+  identify,
+} from '@codesandbox/common/lib/utils/analytics';
+import { initializeExperimentStore } from '@codesandbox/ab';
+import {
+  getExperimentUserId,
+  AB_TESTING_URL,
+} from '@codesandbox/common/lib/config/env';
 import App from './components/App';
+
+initializeExperimentStore(
+  AB_TESTING_URL,
+  getExperimentUserId,
+  async (key, value) => {
+    await identify(key, value);
+  }
+);
 
 try {
   // If this value is not set, set it to false

--- a/packages/app/src/embed/logo.svg
+++ b/packages/app/src/embed/logo.svg
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 17.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="1024px"
+	 height="1024px" viewBox="0 0 1024 1024" enable-background="new 0 0 1024 1024" xml:space="preserve">
+    <g id="Layer_1">
+      <polyline
+        fill="#FFFFFF"
+        points="719.001,851 719.001,639.848 902,533.802 902,745.267 719.001,851"
+      />
+      <polyline
+        fill="#FFFFFF"
+        points="302.082,643.438 122.167,539.135 122.167,747.741 302.082,852.573 302.082,643.438"
+      />
+      <polyline
+        fill="#FFFFFF"
+        points="511.982,275.795 694.939,169.633 512.06,63 328.436,169.987 511.982,275.795"
+      />
+    </g>
+    <g id="Layer_2">
+      <polyline
+        fill="none"
+        stroke="#FFFFFF"
+        stroke-width="80"
+        stroke-miterlimit="10"
+        points="899,287.833 509,513 509,963"
+      />
+      <line
+        fill="none"
+        stroke="#FFFFFF"
+        stroke-width="80"
+        stroke-miterlimit="10"
+        x1="122.167"
+        y1="289"
+        x2="511.5"
+        y2="513"
+      />
+      <polygon
+        fill="none"
+        stroke="#FFFFFF"
+        stroke-width="80"
+        stroke-miterlimit="10"
+        points="121,739.083 510.917,963.042 901,738.333 901,288 511,62 121,289"
+      />
+    </g>
+</svg>


### PR DESCRIPTION
Related to GRO-11

| A | B |
| - | - |
| ![Screenshot 2021-07-21 at 11 27 54](https://user-images.githubusercontent.com/4838076/126474544-bb7657e4-4ab1-48f3-a0a1-97f973b0460c.png) | ![Screenshot 2021-07-21 at 11 28 25](https://user-images.githubusercontent.com/4838076/126474616-50d1446c-c95e-4ebe-9ab7-cb3d3b633764.png) |



It implements the AB framework in the embed application, and then it also introduces a new experiment to test different wording in the embed call to action.
- `embed-open-wording`: @tromika is this name correctly? 
- @tromika could you please create this experiment in the production mode, with the proper description? 