### PR TITLE
Allow the '$' sign in folders and files

### DIFF
--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/Files/DirectoryEntry/validateTitle.js
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/Files/DirectoryEntry/validateTitle.js
@@ -4,7 +4,7 @@ export const validateTitle = (id, title, siblings = []) => {
     // It has whitespaces
     return 'Title cannot have whitespaces';
   }
-  if (/[!@#$%^&*(),?":{}|<>]/g.test(title)) {
+  if (/[!@#%^&*(),?":{}|<>]/g.test(title)) {
     return 'Title cannot have special characters';
   }
 

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Explorer/Files/DirectoryEntry/validateTitle.js
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Explorer/Files/DirectoryEntry/validateTitle.js
@@ -4,7 +4,7 @@ export const validateTitle = (id, title, siblings = []) => {
     // It has whitespaces
     return 'Title cannot have whitespaces';
   }
-  if (/[!@#$%^&*(),?":{}|<>]/g.test(title)) {
+  if (/[!@#%^&*(),?":{}|<>]/g.test(title)) {
     return 'Title cannot have special characters';
   }
 


### PR DESCRIPTION
This removes the client side validation of the $ in files and folders,
which was not needed anyway.
