### PR TITLE
fix: Use prefetch for Babel instead of preload

### DIFF
--- a/packages/app/src/sandbox/startup.js
+++ b/packages/app/src/sandbox/startup.js
@@ -9,16 +9,16 @@ import { isStandalone } from 'codesandbox-api';
 
 import { BABEL7_VERSION } from './eval/transpilers/babel/babel-version';
 
-function preloadJs(url) {
-  // Preload the babel script too
+// Prefetch file as it's not used quickly enough to use preload without warnings
+function prefetchScript(url) {
   const preloadLink = document.createElement('link');
   preloadLink.href = url;
-  preloadLink.rel = 'preload';
+  preloadLink.rel = 'prefetch';
   preloadLink.as = 'script';
   document.head.appendChild(preloadLink);
 }
 
-preloadJs(
+prefetchScript(
   `${
     process.env.CODESANDBOX_HOST || ''
   }/static/js/babel.${BABEL7_VERSION}.min.js`


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?

<!-- Is it a Bug fix, feature, docs update, ... -->

Currently we're preloading Babel, but this throws a warning in chrome as we don't always use this script within a couple seconds, sometimes it's only used on a hot reload or not at all.

## What is the current behavior?

<!-- You can also link to an open issue here -->

Throws a warning

## What is the new behavior?

<!-- if this is a feature change -->

No more warning

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
