### PR TITLE
fix(homepage): prevent video overflow

### DIFF
--- a/packages/homepage/src/screens/home/hero/elements.js
+++ b/packages/homepage/src/screens/home/hero/elements.js
@@ -2,7 +2,6 @@ import styled from 'styled-components';
 
 export const HeroWrapper = styled.div`
   padding: 10rem 0 5rem 0;
-  margin-bottom: 4rem;
 
   ${props => props.theme.breakpoints.md} {
     padding-top: 5rem;

--- a/packages/homepage/src/screens/home/video/index.js
+++ b/packages/homepage/src/screens/home/video/index.js
@@ -121,6 +121,7 @@ const Video = () => {
       transition={{ delay: 1, duration: 1, ease: 'easeOut' }}
       css={`
         overflow-x: ${active ? 'initial' : 'hidden'};
+        padding-top: 4rem;
       `}
     >
       <section

--- a/packages/homepage/src/screens/home/video/index.js
+++ b/packages/homepage/src/screens/home/video/index.js
@@ -120,7 +120,7 @@ const Video = () => {
       animate={{ opacity: 1, y: 0 }}
       transition={{ delay: 1, duration: 1, ease: 'easeOut' }}
       css={`
-        overflow-x: ${active ? 'initial' : 'hidden'};
+        overflow-x: hidden;
         padding-top: 4rem;
       `}
     >

--- a/packages/homepage/src/screens/home/video/index.js
+++ b/packages/homepage/src/screens/home/video/index.js
@@ -120,7 +120,7 @@ const Video = () => {
       animate={{ opacity: 1, y: 0 }}
       transition={{ delay: 1, duration: 1, ease: 'easeOut' }}
       css={`
-        overflow: active ? "hidden" : 'initial';
+        overflow-x: ${active ? 'initial' : 'hidden'};
       `}
     >
       <section


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?
Fixes #5980, a layout bug in the homepage.
<!-- Is it a Bug fix, feature, docs update, ... -->

## What is the current behavior?
There is an overflow-x in the initial load, when the video is "skewed", before animating into the view and playing.
<!-- You can also link to an open issue here -->

## What is the new behavior?
The overflow is fixed. There was a syntax error in the `overflow` property, it was missing brackets.
I added that and fixed the logic since it should be `hidden` when not active.

That caused a cut in the video element, so I replaced the `margin-bottom` on the `Hero` element with `padding-top` on the `motion.div`.
<!-- if this is a feature change -->

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Open homepage
2. If needed, resize the window so that the video doesn't animate on page load
3. Verify that there is an overflow-x in the homepage
4. Scroll down so that the video animates in and play
5. Verify the scroll is gone

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
