### PR TITLE
fix(sandpack): manager id might undefined while consuming cache

### DIFF
--- a/packages/sandpack-core/src/cache.ts
+++ b/packages/sandpack-core/src/cache.ts
@@ -187,7 +187,7 @@ export function ignoreNextCache() {
   }
 }
 
-export async function consumeCache(manager: Manager) {
+export async function consumeCache(manager?: Manager) {
   try {
     const shouldIgnoreCache =
       localStorage.getItem('ignoreCache') ||
@@ -197,6 +197,8 @@ export async function consumeCache(manager: Manager) {
 
       return false;
     }
+
+    if (!manager || !manager.id) return false;
 
     const cacheData = (window as any).__SANDBOX_DATA__;
     const localData: ManagerCache | undefined = await localforage.getItem(


### PR DESCRIPTION
The error `undefined used as a key, but it is not a string.` has been solved in Sandpack. For some reason, the `manager` and its `id` might be `undefined` while sandpack is consuming the cache. To be honest, I'm not sure what this really means, or if this will be introducing any bug, but definitely, it wasn't working in the first place, plus it was polluting the console with warnings.