### PR TITLE
Update job application count in header navigation on main site

### DIFF
--- a/packages/homepage/src/components/Navigation/index.js
+++ b/packages/homepage/src/components/Navigation/index.js
@@ -141,7 +141,7 @@ const Navigation = () => {
 
                     <Jobs>
                       <Link to="/jobs" onMouseEnter={() => setOpenedNav(null)}>
-                        Jobs <Span>2</Span>
+                        Jobs <Span>3</Span>
                       </Link>
                     </Jobs>
                   </List>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Update job application count in header navigation on main site so it matches with the footer and current amount of roles available.

## What is the current behavior?

The old one says "2".

## What is the new behavior?

Now it's a "3".

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Just updated the number from "2" to "3", nothing too complex.

## Checklist

- [ ] Documentation (N\A)
- [x] Testing
- [x] Ready to be merged
- [ ] Added myself to contributors table