### PR TITLE
fix(sandpack): Manager typings should reflect that id can be undefined in case of react-sandpack

### DIFF
--- a/packages/app/src/sandbox/compile.ts
+++ b/packages/app/src/sandbox/compile.ts
@@ -777,13 +777,7 @@ async function compile(opts: CompileOptions) {
       type: 'success',
     });
 
-    saveCache(
-      sandboxId,
-      managerModuleToTranspile,
-      manager,
-      changedModuleCount,
-      firstLoad
-    );
+    saveCache(managerModuleToTranspile, manager, changedModuleCount, firstLoad);
 
     setTimeout(async () => {
       try {

--- a/packages/app/src/sandbox/compile.ts
+++ b/packages/app/src/sandbox/compile.ts
@@ -419,7 +419,7 @@ function overrideDocumentClose() {
 overrideDocumentClose();
 
 interface CompileOptions {
-  sandboxId: string;
+  sandboxId?: string | null;
   modules: { [path: string]: Module };
   customNpmRegistries?: NpmRegistry[];
   externalResources: string[];

--- a/packages/sandpack-core/src/cache.ts
+++ b/packages/sandpack-core/src/cache.ts
@@ -51,13 +51,12 @@ export function clearIndexedDBCache() {
 }
 
 export async function saveCache(
-  sandboxId: string,
   managerModuleToTranspile: any,
   manager: Manager,
   changes: number,
   firstRun: boolean
 ) {
-  if (!sandboxId) {
+  if (!manager.id) {
     return Promise.resolve(false);
   }
 
@@ -101,7 +100,7 @@ export async function saveCache(
     );
 
     return window
-      .fetch(`${host}/api/v1/sandboxes/${sandboxId}/cache`, {
+      .fetch(`${host}/api/v1/sandboxes/${manager.id}/cache`, {
         method: 'POST',
         body: JSON.stringify({
           version: manager.version,
@@ -188,6 +187,10 @@ export function ignoreNextCache() {
 }
 
 export async function consumeCache(manager: Manager) {
+  if (!manager.id) {
+    return false;
+  }
+
   try {
     const shouldIgnoreCache =
       localStorage.getItem('ignoreCache') ||

--- a/packages/sandpack-core/src/manager.ts
+++ b/packages/sandpack-core/src/manager.ts
@@ -179,7 +179,7 @@ export default class Manager implements IEvaluator {
   esmodules: Map<string, Promise<string>>;
 
   constructor(
-    id: string | null,
+    id: string | null | undefined,
     preset: Preset,
     modules: { [path: string]: Module },
     options: TManagerOptions,

--- a/packages/sandpack-core/src/manager.ts
+++ b/packages/sandpack-core/src/manager.ts
@@ -130,7 +130,7 @@ function triggerFileWatch(path: string, type: 'rename' | 'change') {
   }
 }
 export default class Manager implements IEvaluator {
-  id: string;
+  id?: string | null;
   transpiledModules: {
     [path: string]: {
       module: Module;
@@ -179,7 +179,7 @@ export default class Manager implements IEvaluator {
   esmodules: Map<string, Promise<string>>;
 
   constructor(
-    id: string,
+    id: string | null,
     preset: Preset,
     modules: { [path: string]: Module },
     options: TManagerOptions,
@@ -1457,6 +1457,9 @@ export default class Manager implements IEvaluator {
 
   deleteAPICache() {
     ignoreNextCache();
+    if (!this.id) {
+      return Promise.resolve();
+    }
     return deleteAPICache(this.id, this.version);
   }
 

--- a/packages/sandpack-core/src/transpiled-module/transpiled-module.ts
+++ b/packages/sandpack-core/src/transpiled-module/transpiled-module.ts
@@ -130,7 +130,7 @@ export type LoaderContext = {
   // Remaining loaders after current loader
   remainingRequests: string;
   template: string;
-  sandboxId: string | null;
+  sandboxId?: string | null;
   resourceQuery: string;
   getLoaderQuery: (module: Module) => string;
 };


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?

<!-- Is it a Bug fix, feature, docs update, ... -->

Currently the manager types suggest id is always defined, which is not the case for react-sandpack. This is a copy from #6021 but instead of only checking this in consumeCache this fixes the manager types to reflect what the state is in react-sandpack as there's some other places where this could cause issues.

Closes #6021 

## What is the current behavior?

<!-- You can also link to an open issue here -->

Manager has an id property that is typed as stirng

## What is the new behavior?

<!-- if this is a feature change -->

Manager has an id property that is typed as string, null or undefined

