### PR TITLE
extend socket jwt ttl timeout

### DIFF
--- a/packages/app/src/app/overmind/effects/deployment/githubPages.ts
+++ b/packages/app/src/app/overmind/effects/deployment/githubPages.ts
@@ -26,11 +26,11 @@ export default (() => {
       if (!_jwtToken) {
         try {
           const token = await _options.provideJwtToken();
+          // Token expires after 10 minutes, we cache the token for 8 minutes.
+          const timeout = 1000 * 60 * 8;
           setTimeout(() => {
-            // Token expires after 10 seconds, for safety we actually cache the token
-            // for 5 seconds
             _jwtToken = undefined;
-          }, 5000);
+          }, timeout);
           return token;
         } catch (e) {
           _jwtToken = undefined;

--- a/packages/app/src/app/overmind/effects/deployment/netlify.ts
+++ b/packages/app/src/app/overmind/effects/deployment/netlify.ts
@@ -28,11 +28,11 @@ export default (() => {
       if (!_jwtToken) {
         try {
           const token = await _options.provideJwtToken();
+          // Token expires after 10 minutes, we cache the token for 8 minutes.
+          const timeout = 1000 * 60 * 8;
           setTimeout(() => {
-            // Token expires after 10 seconds, for safety we actually cache the token
-            // for 5 seconds
             _jwtToken = undefined;
-          }, 5000);
+          }, timeout);
           return token;
         } catch (e) {
           _jwtToken = undefined;

--- a/packages/app/src/app/overmind/effects/live/index.ts
+++ b/packages/app/src/app/overmind/effects/live/index.ts
@@ -157,11 +157,11 @@ class Live {
           return Promise.reject(e);
         })
         .then(jwt => {
+          // Token expires after 10 minutes, we cache the token for 8 minutes.
+          const timeout = 1000 * 60 * 8;
           setTimeout(() => {
-            // Token expires after 10 seconds, for safety we actually cache the token
-            // for 5 seconds
             this.jwtPromise = undefined;
-          }, 5000);
+          }, timeout);
 
           return jwt;
         });


### PR DESCRIPTION
To improve server deploys, we're extending the socket jwt ttl on the server side, but
we need to also extend how long we cache it on the frontend, or all this is pointless.

[Note: requires the server changes to be deployed first!!]

## What kind of change does this PR introduce?

Extend how long we cache JWTs for to improve server deploys

## What is the current behavior?

Everyone reconnects at the same time and the DB doesn't like that

## What is the new behavior?

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Extend TTL
2. Restart server
3. Beautiful smooth reconnect

## Checklist

- [ ] Documentation
- [x] Testing
- [ ] Ready to be merged <- no! requires server deploy
- [ ] Added myself to contributors table
