### PR TITLE
Fix issues with jspm and loader import syntax conflicts

### DIFF
--- a/packages/sandpack-core/src/transpiled-module/utils/query-path.test.ts
+++ b/packages/sandpack-core/src/transpiled-module/utils/query-path.test.ts
@@ -13,9 +13,19 @@ describe('Split query from path', () => {
       modulePath: './test.js',
       queryPath: 'url-loader!test',
     });
+    expect(
+      splitQueryFromPath('url-loader!test!some-dependency/test.js')
+    ).toEqual({
+      modulePath: 'some-dependency/test.js',
+      queryPath: 'url-loader!test',
+    });
+    expect(splitQueryFromPath('url-loader!test!another-dependency')).toEqual({
+      modulePath: 'another-dependency',
+      queryPath: 'url-loader!test',
+    });
   });
 
-  it('Should not extract `!` is it is part of a url or filepath', () => {
+  it('Should not extract `!` if it is part of a url or filepath', () => {
     expect(splitQueryFromPath('./test.js!cjs')).toEqual({
       modulePath: './test.js!cjs',
       queryPath: '',
@@ -24,6 +34,13 @@ describe('Split query from path', () => {
     expect(splitQueryFromPath('/npm:shopify-buy@2.11.0!cjs')).toEqual({
       modulePath: '/npm:shopify-buy@2.11.0!cjs',
       queryPath: '',
+    });
+
+    expect(
+      splitQueryFromPath('test-loader!/npm:shopify-buy@2.11.0!cjs')
+    ).toEqual({
+      modulePath: '/npm:shopify-buy@2.11.0!cjs',
+      queryPath: 'test-loader',
     });
   });
 });

--- a/packages/sandpack-core/src/transpiled-module/utils/query-path.test.ts
+++ b/packages/sandpack-core/src/transpiled-module/utils/query-path.test.ts
@@ -1,10 +1,29 @@
 import { splitQueryFromPath } from './query-path';
 
-it('can convert a query from the path', () => {
-  const path = './App.vue?vue&template=test';
+describe('Split query from path', () => {
+  it('Can extract regular query parameters', () => {
+    expect(splitQueryFromPath('./App.vue?vue&template=test')).toEqual({
+      modulePath: './App.vue',
+      queryPath: '?vue&template=test',
+    });
+  });
 
-  expect(splitQueryFromPath(path)).toEqual({
-    modulePath: './App.vue',
-    queryPath: '?vue&template=test',
+  it('Can extract special `!` params', () => {
+    expect(splitQueryFromPath('url-loader!test!./test.js')).toEqual({
+      modulePath: './test.js',
+      queryPath: 'url-loader!test',
+    });
+  });
+
+  it('Should not extract `!` is it is part of a url or filepath', () => {
+    expect(splitQueryFromPath('./test.js!cjs')).toEqual({
+      modulePath: './test.js!cjs',
+      queryPath: '',
+    });
+
+    expect(splitQueryFromPath('/npm:shopify-buy@2.11.0!cjs')).toEqual({
+      modulePath: '/npm:shopify-buy@2.11.0!cjs',
+      queryPath: '',
+    });
   });
 });

--- a/packages/sandpack-core/src/transpiled-module/utils/query-path.ts
+++ b/packages/sandpack-core/src/transpiled-module/utils/query-path.ts
@@ -1,7 +1,9 @@
+import { isUrl } from '@codesandbox/common/lib/utils/is-url';
+
 export const splitQueryFromPath = (
   path: string
 ): { queryPath: string; modulePath: string } => {
-  if (path.includes('!')) {
+  if (path.includes('!') && !/^\.?\/.*/.test(path) && !isUrl(path)) {
     const queryPath = path.split('!');
     const modulePath = queryPath.pop()!;
 

--- a/packages/sandpack-core/src/transpiled-module/utils/query-path.ts
+++ b/packages/sandpack-core/src/transpiled-module/utils/query-path.ts
@@ -1,14 +1,26 @@
 import { isUrl } from '@codesandbox/common/lib/utils/is-url';
 
+const isFilePath = (path: string): boolean =>
+  /^\.?\/.*/.test(path) || isUrl(path);
+
 export const splitQueryFromPath = (
   path: string
 ): { queryPath: string; modulePath: string } => {
-  if (path.includes('!') && !/^\.?\/.*/.test(path) && !isUrl(path)) {
-    const queryPath = path.split('!');
-    const modulePath = queryPath.pop()!;
+  if (path.includes('!') && !isFilePath(path)) {
+    const parts = path.split('!');
 
+    let modulePathIndex: number = [...parts]
+      .reverse()
+      .findIndex(v => isFilePath(v));
+    if (modulePathIndex < 0) {
+      modulePathIndex = parts.length - 1;
+    } else {
+      modulePathIndex = parts.length - modulePathIndex - 1;
+    }
+
+    const modulePath = parts.splice(modulePathIndex).join('!')!;
     return {
-      queryPath: queryPath.join('!'),
+      queryPath: parts.join('!'),
       modulePath,
     };
   }


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?

<!-- Is it a Bug fix, feature, docs update, ... -->

Currently loading the module `https://jspm.dev/npm:shopify-buy@2.11.0!cjs` fails due to it having an explanation mark, which we also use to specify loaders in imports...

Should we consider replacing this `!` with something else like `|>` or something, to make it more explicit and less likely we conflict with an actual character someone might use?

## What is the current behavior?

<!-- You can also link to an open issue here -->

Throws an error

## What is the new behavior?

<!-- if this is a feature change -->

Does not throw an error
