### PR TITLE
fix(sandpack): Rewrite import.meta to $csb__import_meta

### DIFF
--- a/packages/app/src/sandbox/eval/transpilers/babel/ast/__snapshots__/rewrite-meta.test.ts.snap
+++ b/packages/app/src/sandbox/eval/transpilers/babel/ast/__snapshots__/rewrite-meta.test.ts.snap
@@ -1,0 +1,16 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Rewrite import.meta Can detect and rewrite import.meta to $csb__import_meta 1`] = `
+"\\"use strict\\";
+var $csb__import_meta = {
+  url: \\"https://csb.io/index.js\\"
+};
+const a = $csb__import_meta.url;
+"
+`;
+
+exports[`Rewrite import.meta Should not add a global $csb__import_meta when there is no need for it 1`] = `
+"\\"use strict\\";
+const a = \\"hello\\";
+"
+`;

--- a/packages/app/src/sandbox/eval/transpilers/babel/ast/collect-dependencies.ts
+++ b/packages/app/src/sandbox/eval/transpilers/babel/ast/collect-dependencies.ts
@@ -1,13 +1,14 @@
 import { walk } from 'estree-walker';
 
 import { ESTreeAST } from './utils';
+import { Syntax as n } from './syntax';
 
 export function collectDependenciesFromAST(ast: ESTreeAST): Array<string> {
   const deps: Set<string> = new Set();
   walk(ast.program, {
     enter(node) {
       // @ts-ignore
-      if (node.type === 'CallExpression' && node.callee.name === 'require') {
+      if (node.type === n.CallExpression && node.callee.name === 'require') {
         // @ts-ignore
         if (node.arguments.length && node.arguments[0].value) {
           // @ts-ignore

--- a/packages/app/src/sandbox/eval/transpilers/babel/ast/rewrite-meta.test.ts
+++ b/packages/app/src/sandbox/eval/transpilers/babel/ast/rewrite-meta.test.ts
@@ -1,0 +1,24 @@
+import { rewriteImportMeta } from './rewrite-meta';
+import { generateCode, parseModule } from './utils';
+
+describe('Rewrite import.meta', () => {
+  it('Can detect and rewrite import.meta to $csb__import_meta', () => {
+    const code = `const a = import.meta.url;`;
+    const ast = parseModule(code);
+    rewriteImportMeta(ast, {
+      url: 'https://csb.io/index.js',
+    });
+    const result = generateCode(ast);
+    expect(result).toMatchSnapshot();
+  });
+
+  it('Should not add a global $csb__import_meta when there is no need for it', () => {
+    const code = `const a = "hello";`;
+    const ast = parseModule(code);
+    rewriteImportMeta(ast, {
+      url: 'https://csb.io/index.js',
+    });
+    const result = generateCode(ast);
+    expect(result).toMatchSnapshot();
+  });
+});

--- a/packages/app/src/sandbox/eval/transpilers/babel/ast/rewrite-meta.ts
+++ b/packages/app/src/sandbox/eval/transpilers/babel/ast/rewrite-meta.ts
@@ -1,0 +1,72 @@
+// This code is written to be performant, that's why we opted to ignore these linting issues
+/* eslint-disable no-loop-func, no-continue */
+import * as meriyah from 'meriyah';
+import { walk } from 'estree-walker';
+
+import { Syntax as n } from './syntax';
+import { ESTreeAST } from './utils';
+
+export interface IESModuleMeta {
+  url: string;
+}
+
+const CSB_IMPORT_META_NAME = '$csb__import_meta';
+export function rewriteImportMeta(ast: ESTreeAST, meta: IESModuleMeta): void {
+  let hasImportMeta = false;
+  walk(ast.program, {
+    enter(node: meriyah.ESTree.MemberExpression) {
+      if (node.type === n.MemberExpression) {
+        if (
+          node.object.type === n.MetaProperty &&
+          node.object.meta.name === 'import'
+        ) {
+          node.object = {
+            type: n.Identifier,
+            name: CSB_IMPORT_META_NAME,
+          };
+
+          hasImportMeta = true;
+
+          this.skip();
+        }
+      }
+    },
+  });
+
+  if (hasImportMeta) {
+    ast.program.body.unshift({
+      type: n.VariableDeclaration,
+      kind: 'var',
+      declarations: [
+        {
+          type: n.VariableDeclarator,
+          id: {
+            type: n.Identifier,
+            name: CSB_IMPORT_META_NAME,
+          },
+          init: {
+            type: n.ObjectExpression,
+            properties: [
+              {
+                type: n.Property,
+                kind: 'init',
+                computed: false,
+                shorthand: false,
+                method: false,
+                key: {
+                  type: n.Identifier,
+                  name: 'url',
+                },
+                value: {
+                  type: n.Literal,
+                  value: meta.url,
+                  raw: JSON.stringify(meta.url),
+                },
+              },
+            ],
+          },
+        },
+      ],
+    });
+  }
+}


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?

<!-- Is it a Bug fix, feature, docs update, ... -->

Before this PR we didn't touch import.meta which resulted in errors as `import.meta` is only allowed in ESModules.

## What is the current behavior?

<!-- You can also link to an open issue here -->

We don't do anything with import.meta resulting in errors.

## What is the new behavior?

<!-- if this is a feature change -->

Now sandpack replaces `import.meta` with `$csb__import_meta` which we insert as a module-scoped variable if `import.meta` is used.

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

Wrote some basic unit tests and tried out this failing sandbox https://codesandbox.io/s/quizzical-cerf-2ph7r?file=/src/index.tsx

Closes CSB-858

