### PR TITLE
Use semver for remote transient deps

### DIFF
--- a/packages/sandpack-core/src/npm/dynamic/fetch-npm-module.ts
+++ b/packages/sandpack-core/src/npm/dynamic/fetch-npm-module.ts
@@ -14,6 +14,7 @@ import { DEFAULT_EXTENSIONS } from '../../utils/extensions';
 export type Meta = {
   [path: string]: true;
 };
+
 type Metas = {
   [dependencyAndVersion: string]: Promise<Meta>;
 };
@@ -63,12 +64,12 @@ const resolveNPMAlias = (name: string, version: string): string[] => {
   return [parts[1]!, parts[2]!];
 };
 
-async function getMeta(
+function getMeta(
   name: string,
   packageJSONPath: string | null,
   version: string,
   useFallback = false
-) {
+): Promise<Meta> {
   const [depName, depVersion] = resolveNPMAlias(name, version);
   const nameWithoutAlias = depName.replace(ALIAS_REGEX, '');
   const id = `${packageJSONPath || depName}@${depVersion}`;
@@ -87,7 +88,7 @@ async function getMeta(
   return metas[id];
 }
 
-export async function downloadDependency(
+export function downloadDependency(
   name: string,
   version: string,
   path: string

--- a/packages/sandpack-core/src/npm/dynamic/resolve-dependency.ts
+++ b/packages/sandpack-core/src/npm/dynamic/resolve-dependency.ts
@@ -149,8 +149,10 @@ export async function resolveDependencyInfo(
       let packageVersion =
         response.dependencyDependencies[packageName].resolved;
 
-      if (response.dependencyDependencies[packageName].semver.match(IS_ALIAS)) {
-        packageVersion = response.dependencyDependencies[packageName].semver;
+      // If the package is a remote module or is an alias we use the semver as the version for fetching
+      const pkgSemver = response.dependencyDependencies[packageName].semver;
+      if (pkgSemver && (pkgSemver.match(IS_ALIAS) || pkgSemver.includes('/'))) {
+        packageVersion = pkgSemver;
       }
 
       const pkgJson = await getPackageJSON(packageName, packageVersion);


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?

<!-- Is it a Bug fix, feature, docs update, ... -->

Fixes a bug with transient dependencies that are urls to globs/git repos/...

See https://codesandbox.io/s/summer-glade-ztrpm for an example

Bug report https://twitter.com/acdlite/status/1427001781012373505

## What is the current behavior?

<!-- You can also link to an open issue here -->

We always try to fetch the version from unpkg for transient deps

## What is the new behavior?

<!-- if this is a feature change -->

We check if the transient dep is remote and fetch from remote source instead

