### PR TITLE
feat(embed): wording experiment iteration 2 - open and fork

### DIFF
--- a/packages/app/src/embed/components/Actions/index.js
+++ b/packages/app/src/embed/components/Actions/index.js
@@ -3,7 +3,6 @@ import Tooltip from '@codesandbox/common/lib/components/Tooltip';
 import { sandboxUrl } from '@codesandbox/common/lib/utils/url-generator';
 import { ExperimentValues, useExperimentResult } from '@codesandbox/ab';
 
-import Logo from '../../logo.svg';
 
 import {
   Container,
@@ -27,7 +26,7 @@ export function GlobalActions({
   previewVisible,
   initialPath,
 }) {
-  const experimentPromise = useExperimentResult('embed-open-wording');
+  const experimentPromise = useExperimentResult('embed-open-wording-iteration2');
   const [openWordingB, setOpenWordingB] = useState(false);
 
   useEffect(() => {
@@ -102,24 +101,7 @@ export function GlobalActions({
               : `${sandboxUrl(sandbox)}?from-embed`
           }
         >
-          {openWordingB ? (
-            <>
-              <img
-                src={Logo}
-                width="32"
-                alt="CodeSandbox Logo"
-                style={{
-                  paddingRight: '8px',
-                  width: '18px',
-                  top: '-1px',
-                  position: 'relative',
-                }}
-              />
-              Edit Sandbox
-            </>
-          ) : (
-            'Open Sandbox'
-          )}
+          {openWordingB ? 'Open and Fork' : 'Open Sandbox'}
         </Button>
       )}
     </Container>


### PR DESCRIPTION
| A | B |
| - | - |
| ![Screenshot 2021-07-21 at 11 27 54](https://user-images.githubusercontent.com/4838076/126474544-bb7657e4-4ab1-48f3-a0a1-97f973b0460c.png) | ![image](https://user-images.githubusercontent.com/540472/129922818-b83634da-7dfb-45ab-bee8-85ab04519e85.png) |

As per https://linear.app/codesandbox/issue/GRO-37/embed-cta-iteration-2-open-and-fork

Experiment to test out the Open and Fork wording for the CTA button in embeds
