### PR TITLE
fix: don't add file extensions to resolved filepaths

### DIFF
--- a/packages/app/src/sandbox/eval/presets/custom/index.ts
+++ b/packages/app/src/sandbox/eval/presets/custom/index.ts
@@ -17,7 +17,8 @@ async function registerTranspilers(
   const savedTranspilers = {};
   const configModule = await manager.resolveTranspiledModule(
     '/.codesandbox/template.json',
-    '/'
+    '/',
+    []
   );
   configModule.setIsEntry(true);
 
@@ -45,7 +46,8 @@ async function registerTranspilers(
 
           const tModule = await manager.resolveTranspiledModule(
             t,
-            '/.codesandbox/template.json'
+            '/.codesandbox/template.json',
+            []
           );
 
           if (tModule.shouldTranspile()) {

--- a/packages/app/src/sandbox/eval/presets/vue-cli/index.ts
+++ b/packages/app/src/sandbox/eval/presets/vue-cli/index.ts
@@ -45,7 +45,8 @@ export default function initialize() {
         try {
           const tModule = await manager.resolveTranspiledModule(
             '@vue/babel-plugin-jsx',
-            '/package.json'
+            '/package.json',
+            []
           );
           await tModule.transpile(manager);
         } catch (e) {

--- a/packages/sandpack-core/src/npm/dynamic/fetch-npm-module.ts
+++ b/packages/sandpack-core/src/npm/dynamic/fetch-npm-module.ts
@@ -171,7 +171,7 @@ function resolvePath(
           const callback = cb || c;
 
           try {
-            const tModule = await manager.resolveTranspiledModule(p, '/');
+            const tModule = await manager.resolveTranspiledModule(p, '/', []);
             tModule.initiators.add(currentTModule);
             currentTModule.dependencies.add(tModule);
             return callback(null, tModule.module.code);
@@ -192,7 +192,6 @@ function resolvePath(
             const subDepVersionVersionInfo = await getDependencyVersion(
               currentTModule,
               manager,
-              defaultExtensions,
               depName
             );
 
@@ -253,7 +252,6 @@ type DependencyVersionResult =
 async function getDependencyVersion(
   currentTModule: TranspiledModule,
   manager: Manager,
-  defaultExtensions: string[] = DEFAULT_EXTENSIONS,
   dependencyName: string
 ): Promise<DependencyVersionResult | null> {
   const { manifest } = manager;
@@ -263,7 +261,7 @@ async function getDependencyVersion(
       pathUtils.join(dependencyName, 'package.json'),
       currentTModule,
       manager,
-      defaultExtensions
+      []
     );
 
     // If the dependency is in the root we get it from the manifest, as the manifest
@@ -346,6 +344,7 @@ export default async function fetchModule(
   defaultExtensions: Array<string> = DEFAULT_EXTENSIONS
 ): Promise<Module> {
   const currentPath = currentTModule.module.path;
+
   // Get the last part of the path as dependency name for paths like
   // instantsearch.js/node_modules/lodash/sum.js
   // In this case we want to get the lodash dependency info
@@ -356,7 +355,6 @@ export default async function fetchModule(
   const versionInfo = await getDependencyVersion(
     currentTModule,
     manager,
-    defaultExtensions,
     dependencyName
   );
 


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?

<!-- Is it a Bug fix, feature, docs update, ... -->

Currently we call `manager.resolveTranspiledModule` in `fetchNPMModule#resolvePath`, but we forgot to skip the ignored extensions which adds unnecessary lookup times/latency and might actually cause issues like #6046 

#6046 was actually a pretty nice edge-case, apparently the packaged used has a `package.json.js` file 🤯  , see https://unpkg.com/browse/vue-instantsearch@4.0.0-beta.1/dist/vue3/es/package.json.js

Fixes #6046

Closes CSB-998

## What is the current behavior?

<!-- You can also link to an open issue here -->

Tries different file extensions for fully resolved filepaths

## What is the new behavior?

<!-- if this is a feature change -->

Does not try different file extensions if filepath is already fully resolved
