### PR TITLE
fix: Fix a bunch of race conditions and replace fs with gensync equivalent

### DIFF
--- a/packages/app/src/sandbox/eval/transpilers/babel/worker/dynamic-download.ts
+++ b/packages/app/src/sandbox/eval/transpilers/babel/worker/dynamic-download.ts
@@ -114,7 +114,7 @@ function downloadRequires(
             filename: currentPath,
             extensions: ['.js', '.json'],
             moduleDirectory: ['node_modules'],
-            packageFilter: packageFilter(),
+            packageFilter,
           });
         } catch (err) {
           await downloadFromError({

--- a/packages/app/src/sandbox/eval/transpilers/babel/worker/evaluate.js
+++ b/packages/app/src/sandbox/eval/transpilers/babel/worker/evaluate.js
@@ -136,7 +136,7 @@ export default function evaluate(
         filename: path,
         extensions: ['.js', '.json'],
         moduleDirectory: ['node_modules'],
-        packageFilter: packageFilter(),
+        packageFilter,
       });
 
     cachedPaths[dirName][requirePath] = resolvedPath;
@@ -210,7 +210,7 @@ export function evaluateFromPath(
     filename: currentPath,
     extensions: ['.js', '.json'],
     moduleDirectory: ['node_modules'],
-    packageFilter: packageFilter(),
+    packageFilter,
   });
 
   const code = fs.readFileSync(resolvedPath).toString();

--- a/packages/app/src/sandbox/eval/transpilers/babel/worker/utils/resolvePatch.ts
+++ b/packages/app/src/sandbox/eval/transpilers/babel/worker/utils/resolvePatch.ts
@@ -9,8 +9,7 @@ export function patchedResolve() {
   const handler = {
     get(target, prop) {
       if (prop === 'sync') {
-        return (p, options) =>
-          target.sync(p, { ...options, packageFilter: packageFilter() });
+        return (p, options) => target.sync(p, { ...options, packageFilter });
       }
 
       return target[prop];

--- a/packages/app/src/sandbox/eval/transpilers/vue/v2/css-loader/get-modules.ts
+++ b/packages/app/src/sandbox/eval/transpilers/vue/v2/css-loader/get-modules.ts
@@ -24,7 +24,7 @@ export default async (code: string, loaderContext: LoaderContext) => {
     }
   );
 
-  await depPromises;
+  await Promise.all(depPromises);
 
   return {
     css: injectableSource,

--- a/packages/app/src/sandbox/eval/transpilers/vue/v2/index.ts
+++ b/packages/app/src/sandbox/eval/transpilers/vue/v2/index.ts
@@ -9,14 +9,12 @@ class VueTranspiler extends Transpiler {
     super('vue-loader');
   }
 
-  doTranspilation(code: string, loaderContext: LoaderContext) {
-    return import(/* webpackChunkName: 'vue-loader' */ './loader').then(
-      loader => {
-        const transpiledCode = loader.default(code, loaderContext);
-
-        return Promise.resolve({ transpiledCode });
-      }
+  async doTranspilation(code: string, loaderContext: LoaderContext) {
+    const loader = await import(
+      /* webpackChunkName: 'vue-loader' */ './loader'
     );
+    const transpiledCode = await loader.default(code, loaderContext);
+    return { transpiledCode };
   }
 }
 

--- a/packages/app/src/sandbox/eval/transpilers/vue/v2/loader.js
+++ b/packages/app/src/sandbox/eval/transpilers/vue/v2/loader.js
@@ -37,16 +37,8 @@ const rewriterInjectRE = /\b(css(?:-loader)?(?:\?[^!]+)?)(?:!|$)/;
 
 export default async function (content: string, loaderContext: LoaderContext) {
   const dependencyPromises = [];
-  const addDependency = (
-    depPath: string,
-    options?: {
-      isAbsolute?: boolean,
-      isEntry?: boolean,
-    }
-  ) => {
-    const p = loaderContext.addDependency(depPath, options);
-    dependencyPromises.push(p);
-    return p;
+  const addDependency = (p: string) => {
+    dependencyPromises.push(loaderContext.addDependency(p, options));
   };
 
   // Emit the vue-hot-reload-api so it's available in the sandbox

--- a/packages/app/src/sandbox/eval/transpilers/vue/v2/loader.js
+++ b/packages/app/src/sandbox/eval/transpilers/vue/v2/loader.js
@@ -50,7 +50,7 @@ export default async function (content: string, loaderContext: LoaderContext) {
     false
   );
 
-  const { path, _module } = loaderContext;
+  const path = loaderContext.path;
   const query = loaderContext.options;
   const options = {
     // Always disable esModule as sandpack is CommonJS
@@ -60,7 +60,7 @@ export default async function (content: string, loaderContext: LoaderContext) {
   };
 
   const rawRequest = getRawRequest(loaderContext);
-  const filePath = _module.module.path;
+  const filePath = loaderContext._module.module.path;
   const fileName = basename(filePath);
 
   const sourceRoot = dirname(path);

--- a/packages/app/src/sandbox/eval/transpilers/vue/v2/style-compiler/loader.ts
+++ b/packages/app/src/sandbox/eval/transpilers/vue/v2/style-compiler/loader.ts
@@ -103,16 +103,17 @@ export default async function (
     };
   }
 
-  // Explcitly give undefined if code is null, otherwise postcss crashses
+  // Explicitly give undefined if code is null, otherwise postcss crashses
   const postcssResult = await postcss(plugins).process(code || '', options);
 
   if (postcssResult.messages) {
     const messages = postcssResult.messages as any[];
     await Promise.all(
-      messages.map(async m => {
+      messages.map(m => {
         if (m.type === 'dependency') {
-          await loaderContext.addDependency(m.file);
+          return loaderContext.addDependency(m.file);
         }
+        return Promise.resolve();
       })
     );
   }

--- a/packages/app/src/sandbox/eval/transpilers/vue/v2/style-loader/index.ts
+++ b/packages/app/src/sandbox/eval/transpilers/vue/v2/style-loader/index.ts
@@ -7,10 +7,10 @@ class VueStyleLoader extends Transpiler {
     super('vue-style-loader');
   }
 
-  doTranspilation(content: string, loaderContext: LoaderContext) {
-    const transpiledCode = loader(content, loaderContext);
+  async doTranspilation(content: string, loaderContext: LoaderContext) {
+    const transpiledCode = await loader(content, loaderContext);
 
-    return Promise.resolve({ transpiledCode });
+    return { transpiledCode };
   }
 }
 

--- a/packages/app/src/sandbox/eval/transpilers/vue/v2/style-loader/loader.js
+++ b/packages/app/src/sandbox/eval/transpilers/vue/v2/style-loader/loader.js
@@ -9,11 +9,10 @@ import loaderUtils from 'sandpack-core/lib/transpiler/utils/loader-utils';
 import addStylesClientRaw from '!raw-loader!./addStylesClient';
 import listToStylesRaw from '!raw-loader!./listToStyles';
 
-
 const addStylesClientPath = '/node_modules/vue-style-loader/addStylesClient.js';
 const listToStylesPath = '/node_modules/vue-style-loader/listToStyles.js';
 
-export default function(content: string, loaderContext) {
+export default async function (content: string, loaderContext) {
   const isServer = false;
   const isProduction = false;
 
@@ -40,7 +39,7 @@ export default function(content: string, loaderContext) {
   );
 
   const id = JSON.stringify(hash(request));
-  loaderContext.addDependency(JSON.parse(request));
+  await loaderContext.addDependency(JSON.parse(request));
 
   const shared = [
     '// style-loader: Adds some css to the DOM by adding a <style> tag',

--- a/packages/app/src/sandbox/eval/transpilers/vue/v2/template-compiler/index.ts
+++ b/packages/app/src/sandbox/eval/transpilers/vue/v2/template-compiler/index.ts
@@ -5,14 +5,12 @@ class VueTemplateTranspiler extends Transpiler {
     super('vue-template-compiler');
   }
 
-  doTranspilation(code: string, loaderContext: LoaderContext) {
-    return import(
+  async doTranspilation(code: string, loaderContext: LoaderContext) {
+    const loader = await import(
       /* webpackChunkName: 'vue-template-compiler' */ './loader'
-    ).then(loader => {
-      const transpiledCode = loader.default(code, loaderContext);
-
-      return Promise.resolve({ transpiledCode });
-    });
+    );
+    const transpiledCode = await loader.default(code, loaderContext);
+    return { transpiledCode };
   }
 }
 

--- a/packages/app/src/sandbox/eval/transpilers/vue/v2/template-compiler/loader.ts
+++ b/packages/app/src/sandbox/eval/transpilers/vue/v2/template-compiler/loader.ts
@@ -11,7 +11,10 @@ import transformRequire from './modules/transform-require';
 import transformSrcset from './modules/transform-srcset';
 
 const hotReloadAPIPath = '!noop-loader!/node_modules/vue-hot-reload-api.js';
-export default async function (html: string, loaderContext: LoaderContext) {
+export default async function (
+  html: string,
+  loaderContext: LoaderContext
+): Promise<string> {
   loaderContext.emitModule(
     hotReloadAPIPath,
     vueHotReloadAPIRaw,

--- a/packages/app/src/sandbox/eval/transpilers/vue/v2/template-compiler/loader.ts
+++ b/packages/app/src/sandbox/eval/transpilers/vue/v2/template-compiler/loader.ts
@@ -11,7 +11,7 @@ import transformRequire from './modules/transform-require';
 import transformSrcset from './modules/transform-srcset';
 
 const hotReloadAPIPath = '!noop-loader!/node_modules/vue-hot-reload-api.js';
-export default function (html: string, loaderContext: LoaderContext) {
+export default async function (html: string, loaderContext: LoaderContext) {
   loaderContext.emitModule(
     hotReloadAPIPath,
     vueHotReloadAPIRaw,
@@ -24,8 +24,13 @@ export default function (html: string, loaderContext: LoaderContext) {
   const vueOptions = options.vueOptions || {};
   const needsHotReload = true;
 
+  const depPromises = [];
+  const addDependency = (p: string) => {
+    depPromises.push(loaderContext.addDependency(p));
+  };
+
   const defaultModules = [
-    transformRequire(options.transformRequire, loaderContext),
+    transformRequire(options.transformRequire, addDependency),
     transformSrcset(),
   ];
   const userModules = vueOptions.compilerModules || options.compilerModules;
@@ -113,6 +118,8 @@ export default function (html: string, loaderContext: LoaderContext) {
       '  }\n' +
       '}';
   }
+
+  await Promise.all(depPromises);
 
   return code;
 }

--- a/packages/app/src/sandbox/eval/transpilers/vue/v2/template-compiler/modules/transform-require.js
+++ b/packages/app/src/sandbox/eval/transpilers/vue/v2/template-compiler/modules/transform-require.js
@@ -7,34 +7,34 @@ var defaultOptions = {
   image: 'xlink:href',
 };
 
-export default (userOptions, loaderContext: LoaderContext) => {
+export default async (userOptions, addDependency) => {
   var options = userOptions
     ? { ...defaultOptions, userOptions }
     : defaultOptions;
 
   return {
     postTransformNode: node => {
-      transform(node, options, loaderContext);
+      transform(node, options, addDependency);
     },
   };
 };
 
-function transform(node, options, loaderContext: LoaderContext) {
+function transform(node, options, addDependency) {
   for (var tag in options) {
     if (node.tag === tag && node.attrs) {
       var attributes = options[tag];
       if (typeof attributes === 'string') {
-        node.attrs.some(attr => rewrite(attr, attributes, loaderContext));
+        node.attrs.some(attr => rewrite(attr, attributes, addDependency));
       } else if (Array.isArray(attributes)) {
         attributes.forEach(item =>
-          node.attrs.some(attr => rewrite(attr, item, loaderContext))
+          node.attrs.some(attr => rewrite(attr, item, addDependency))
         );
       }
     }
   }
 }
 
-function rewrite(attr, name, loaderContext: LoaderContext) {
+function rewrite(attr, name, addDependency) {
   if (attr.name === name) {
     var value = attr.value;
     var isStatic =
@@ -51,7 +51,7 @@ function rewrite(attr, name, loaderContext: LoaderContext) {
       attr.value = `require(${value})`;
 
       const rawDependency = value.slice(1).slice(0, -1);
-      loaderContext.addDependency(rawDependency);
+      addDependency(rawDependency);
     }
     return true;
   }

--- a/packages/app/src/sandbox/eval/transpilers/vue/v2/template-compiler/modules/transform-require.js
+++ b/packages/app/src/sandbox/eval/transpilers/vue/v2/template-compiler/modules/transform-require.js
@@ -7,7 +7,7 @@ var defaultOptions = {
   image: 'xlink:href',
 };
 
-export default async (userOptions, addDependency) => {
+export default (userOptions, addDependency) => {
   var options = userOptions
     ? { ...defaultOptions, userOptions }
     : defaultOptions;

--- a/packages/app/src/sandbox/eval/utils/resolve-utils.ts
+++ b/packages/app/src/sandbox/eval/utils/resolve-utils.ts
@@ -1,9 +1,6 @@
 import { PackageJSON } from '@codesandbox/common/lib/types';
 
-export const packageFilter = (isFile: (p: string) => boolean = () => true) => (
-  p: PackageJSON,
-  pkgLocation: string
-) => {
+export const packageFilter = (p: PackageJSON) => {
   if (p.module) {
     p.main = p.module;
   }

--- a/packages/sandpack-core/src/manager.ts
+++ b/packages/sandpack-core/src/manager.ts
@@ -1,6 +1,6 @@
 import { flattenDeep, uniq, values } from 'lodash-es';
 import { Protocol } from 'codesandbox-api';
-import resolve from 'browser-resolve';
+import { default as bresolve } from 'browser-resolve';
 import fs from 'fs';
 import gensync from 'gensync';
 
@@ -814,9 +814,10 @@ export default class Manager implements IEvaluator {
 
       try {
         resolvedPath = await new Promise((resolvePromise, rejectPromise) => {
-          resolve(
+          bresolve(
             shimmedPath,
             {
+              // @ts-ignore
               filename: parentPath,
               extensions: defaultExtensions.map(ext => '.' + ext),
               isFile: this.isFile.errback,
@@ -969,7 +970,8 @@ export default class Manager implements IEvaluator {
       }
 
       try {
-        resolvedPath = resolve.sync(shimmedPath, {
+        resolvedPath = bresolve.sync(shimmedPath, {
+          // @ts-ignore
           filename: parentPath,
           extensions: defaultExtensions.map(ext => '.' + ext),
           isFile: this.isFileSync,

--- a/packages/sandpack-core/src/manager.ts
+++ b/packages/sandpack-core/src/manager.ts
@@ -821,7 +821,7 @@ export default class Manager implements IEvaluator {
               extensions: defaultExtensions.map(ext => '.' + ext),
               isFile: this.isFile.errback,
               readFile: this.readFile.errback,
-              packageFilter: packageFilter(),
+              packageFilter,
               moduleDirectory: this.getModuleDirectories(),
             },
             (err: Error | undefined, foundPath: string) => {
@@ -974,7 +974,7 @@ export default class Manager implements IEvaluator {
           extensions: defaultExtensions.map(ext => '.' + ext),
           isFile: this.isFileSync,
           readFileSync: this.readFileSync,
-          packageFilter: packageFilter(),
+          packageFilter,
           moduleDirectory: this.getModuleDirectories(),
         });
         endMeasure(measureKey, { silent: true, lastTime: measureStartTime });

--- a/packages/sandpack-core/src/manager.ts
+++ b/packages/sandpack-core/src/manager.ts
@@ -860,7 +860,6 @@ export default class Manager implements IEvaluator {
           }
         }
       } catch (err) {
-        console.error(err);
         if (
           this.cachedPaths[dirredPath] &&
           this.cachedPaths[dirredPath][path]
@@ -996,7 +995,6 @@ export default class Manager implements IEvaluator {
           throw new Error(`Could not find '${resolvedPath}' in local files.`);
         }
       } catch (e) {
-        console.error(e);
         // MAKE SURE TO SYNC THIS WITH ASYNC VERSION
         if (
           this.cachedPaths[dirredPath] &&

--- a/packages/sandpack-core/src/manager.ts
+++ b/packages/sandpack-core/src/manager.ts
@@ -364,10 +364,15 @@ export default class Manager implements IEvaluator {
       return Promise.resolve(content);
     } catch (err) {
       if (this.fileResolver) {
-        return this.fileResolver.readFile(p).then(code => {
-          this.addModule({ path: p, code });
-          return code;
-        });
+        return this.fileResolver
+          .readFile(p)
+          .then(code => {
+            this.addModule({ path: p, code });
+            return code;
+          })
+          .catch(() => {
+            throw err;
+          });
       }
 
       return Promise.reject(err);
@@ -855,6 +860,7 @@ export default class Manager implements IEvaluator {
           }
         }
       } catch (err) {
+        console.error(err);
         if (
           this.cachedPaths[dirredPath] &&
           this.cachedPaths[dirredPath][path]
@@ -990,6 +996,7 @@ export default class Manager implements IEvaluator {
           throw new Error(`Could not find '${resolvedPath}' in local files.`);
         }
       } catch (e) {
+        console.error(e);
         // MAKE SURE TO SYNC THIS WITH ASYNC VERSION
         if (
           this.cachedPaths[dirredPath] &&

--- a/packages/sandpack-core/src/npm/dynamic/fetch-npm-module.ts
+++ b/packages/sandpack-core/src/npm/dynamic/fetch-npm-module.ts
@@ -3,7 +3,7 @@ import resolve from 'browser-resolve';
 import DependencyNotFoundError from 'sandbox-hooks/errors/dependency-not-found-error';
 
 import { Module } from '../../types/module';
-import Manager, { ReadFileCallback } from '../../manager';
+import Manager from '../../manager';
 
 import { getFetchProtocol } from './fetch-protocols';
 import { getDependencyName } from '../../utils/get-dependency-name';
@@ -156,18 +156,14 @@ function resolvePath(
       {
         filename: currentPath,
         extensions: defaultExtensions.map(ext => '.' + ext),
-        packageFilter: packageFilter(isFile),
+        packageFilter,
         moduleDirectory: [
           'node_modules',
           manager.envVariables.NODE_PATH,
         ].filter(Boolean),
         isFile,
         // @ts-ignore
-        readFile: async (
-          p: string,
-          c: ReadFileCallback,
-          cb: ReadFileCallback
-        ) => {
+        readFile: async (p: string, c, cb) => {
           const callback = cb || c;
 
           try {

--- a/packages/sandpack-core/src/utils/resolve-utils.ts
+++ b/packages/sandpack-core/src/utils/resolve-utils.ts
@@ -1,6 +1,6 @@
 import { PackageJSON } from '@codesandbox/common/lib/types';
 
-export const packageFilter = () => (p: PackageJSON) => {
+export const packageFilter = (p: PackageJSON) => {
   if (p.module) {
     p.main = p.module;
   }

--- a/packages/sandpack-core/src/utils/resolve-utils.ts
+++ b/packages/sandpack-core/src/utils/resolve-utils.ts
@@ -1,9 +1,6 @@
 import { PackageJSON } from '@codesandbox/common/lib/types';
 
-export const packageFilter = (isFile: (p: string) => boolean = () => true) => (
-  p: PackageJSON,
-  pkgLocation: string
-) => {
+export const packageFilter = () => (p: PackageJSON) => {
   if (p.module) {
     p.main = p.module;
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12975,7 +12975,7 @@ esprima@^4.0.0, esprima@^4.0.1, esprima@~4.0.0:
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
 
-esquery@^1.0.0, esquery@^1.0.1:
+esquery@1.0.1, esquery@^1.0.0, esquery@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.0.1.tgz#406c51658b1f5991a5f9b62b1dc25b00e3e5c708"
   integrity sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==


### PR DESCRIPTION
## What kind of change does this PR introduce?

More preparation work to replace the resolver, this PR resolves a bunch of "hidden" race conditions in the vue 2 transpiler and replaces the readFile and isFile utils with their gensync equivalent

This should be the last PR before the big one to replace the resolver
