### PR TITLE
feat(preview): attach document event

### DIFF
--- a/packages/app/src/sandbox/compile.ts
+++ b/packages/app/src/sandbox/compile.ts
@@ -794,6 +794,13 @@ async function compile(opts: CompileOptions) {
         }
       }
     }, 600);
+
+    /**
+     * For tracking purpose
+     */
+    document.addEventListener('click', () => {
+      dispatch({ type: 'document-focus' });
+    });
   } catch (e) {
     // eslint-disable-next-line no-console
     console.log('Error in sandbox:');

--- a/packages/common/src/components/Preview/index.tsx
+++ b/packages/common/src/components/Preview/index.tsx
@@ -13,7 +13,7 @@ import { getModulePath } from '../../sandbox/modules';
 import getTemplate from '../../templates';
 import { generateFileFromSandbox } from '../../templates/configuration/package-json';
 import { Module, NpmRegistry, Sandbox } from '../../types';
-import track from '../../utils/analytics';
+import track, { trackWithCooldown } from '../../utils/analytics';
 import { getSandboxName } from '../../utils/get-sandbox-name';
 import { frameUrl, host } from '../../utils/url-generator';
 import { Container, Loading, StyledFrame } from './elements';
@@ -361,6 +361,10 @@ class BasePreview extends React.PureComponent<Props, State> {
           }
           case 'done': {
             this.setState({ showScreenshot: false });
+            break;
+          }
+          case 'document-focus': {
+            trackWithCooldown('Browser focus', 30 * 1000);
             break;
           }
           default: {

--- a/packages/common/src/utils/analytics/index.ts
+++ b/packages/common/src/utils/analytics/index.ts
@@ -53,11 +53,7 @@ export async function setAnonymousId() {
     let anonymousUid = localStorage.getItem(ANONYMOUS_UID_KEY);
 
     if (!anonymousUid) {
-      anonymousUid = String(
-        Math.random()
-          .toString(36)
-          .substring(2)
-      );
+      anonymousUid = String(Math.random().toString(36).substring(2));
 
       localStorage.setItem(ANONYMOUS_UID_KEY, anonymousUid);
     }
@@ -103,6 +99,23 @@ export function setGroup(name: string, value: string | string[]) {
   if (!DO_NOT_TRACK_ENABLED) {
     amplitude.setGroup(name, value);
   }
+}
+
+const trackedEventsByTime: Record<string, number> = {};
+export function trackWithCooldown(
+  event: string,
+  cooldown: number,
+  data: any = {}
+) {
+  const now = Date.now();
+  if (trackedEventsByTime[event]) {
+    if (now - trackedEventsByTime[event] <= cooldown) {
+      return;
+    }
+  }
+
+  trackedEventsByTime[event] = now;
+  track(event, data);
 }
 
 export default function track(eventName, secondArg: Object = {}) {


### PR DESCRIPTION
This change aims to track when the user interacts with the preview, which will improve the session metric and how the user spends their time in the code editor. So in order to make this work, I needed to find out a way to back and forth message from the iframe to the main application, **as it is not possible to attach a listener to an iframe.**

