### PR TITLE
feat(homepage): start coding wording experiment

### DIFF
--- a/packages/homepage/src/screens/home/hero/Content.js
+++ b/packages/homepage/src/screens/home/hero/Content.js
@@ -12,7 +12,7 @@ import html from '../../../assets/icons/home-html.svg';
 import more from '../../../assets/icons/home-more.svg';
 
 const Content = () => {
-  const experimentPromise = useExperimentResult('hp-cta-iteration-1');
+  const experimentPromise = useExperimentResult('hp-cta-iteration-2');
   const [freeWordingA, setFreeWordingA] = useState(false);
 
   useEffect(() => {
@@ -86,7 +86,7 @@ const Content = () => {
           }}
           href="/s"
         >
-          {freeWordingA ? 'Create Sandbox, it’s free' : 'Create Sandbox →'}
+          {freeWordingA ? 'Create Sandbox, it’s free' : '</> Start coding for free'}
         </Button>
       </motion.div>
     </>

--- a/packages/homepage/src/screens/home/hero/Content.js
+++ b/packages/homepage/src/screens/home/hero/Content.js
@@ -86,7 +86,13 @@ const Content = () => {
           }}
           href="/s"
         >
-          {freeWordingA ? 'Create Sandbox, it’s free' : '</> Start coding for free'}
+          {freeWordingA ? (
+            'Create Sandbox, it’s free'
+          ) : (
+            <>
+              <strong>{'</>'}</strong> Start coding for free
+            </>
+          )}
         </Button>
       </motion.div>
     </>


### PR DESCRIPTION
| A | B |
| - | - |
| ![image](https://user-images.githubusercontent.com/540472/127684919-b0434fb6-10fa-4897-b692-0e8c1ab591ab.png) | ![image](https://user-images.githubusercontent.com/540472/130437197-613f0774-cd60-4ffc-9745-0c084dfdf120.png) |

As per https://linear.app/codesandbox/issue/GRO-38/cta-variants-on-the-homepage-iteration-2-start-coding, let's start an experiment to test the start coding wording in the middle CTA on the homepage.