### PR TITLE
update stale bot

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -11,25 +11,26 @@ jobs:
       - uses: actions/stale@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          stale-issue-message:
-            'This issue has automatically been marked stale because there has
-            been no activity in a while. Please leave a comment if the issue has
-            not been resolved, or if it is not stale for any other reason. After
-            2 weeks, this issue will automatically be closed, unless a comment
-            is made or the stale label is removed.'
+          stale-issue-message: 'This issue has automatically been marked stale
+            because there has been no activity in a while. It will automatically
+            be closed in 2 weeks.
+
+            If this issue should not be closed please leave a comment, or use
+            the `no-stale` label'
           stale-issue-label: 'stale'
           exempt-issue-label: '💥 Crash Report,To Be Fixed,no-stale'
           close-issue-message:
             "This issue has been automatically closed because there wasn't any
             activity after the previous notice or the stale label wasn't
             removed."
-          stale-pr-message:
-            'This PR has automatically been marked stale because there has been
-            no activity in a while. Please leave a comment if the issue has not
-            been resolved, or if it is not stale for any other reason. After 2
-            weeks, this issue will automatically be closed, unless a comment is
-            made or the stale label is removed.'
+          stale-pr-message: 'This PR has automatically been marked stale because
+            there has been no activity in a while. It will automatically be
+            closed in 2 weeks.
+
+            If this PR should not be closed please leave a comment, add a
+            commit, or use the `no-stale` label'
           stale-pr-label: 'stale'
+          exempt-pr-labels: 'no-stale'
           close-pr-message:
             "This PR has been automatically closed because there wasn't any
             activity after the previous notice or the stale label wasn't


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?

Community update

## What is the current behavior?

Issues go stale after 90 days, but that can get frustrating for issues that are still relevant.

## What is the new behavior?

Update the stale-bot messaging to highlight that the `no-stale` label can be used to prevent state-bot from running.
