### PR TITLE
fix(beta import): remove the tree keyword from url

### DIFF
--- a/packages/common/src/utils/url-generator.ts
+++ b/packages/common/src/utils/url-generator.ts
@@ -184,7 +184,10 @@ export const gitHubToSandboxUrl = (githubUrl: string) =>
   githubUrl.replace(gitHubPrefix, '/s/github').replace(dotGit, '');
 
 export const gitHubToSandboxBetaUrl = (githubUrl: string) =>
-  githubUrl.replace(gitHubPrefix, '/github').replace(dotGit, '');
+  githubUrl
+    .replace(gitHubPrefix, '/github')
+    .replace(dotGit, '')
+    .replace(/\/tree\//, '/');
 
 export const searchUrl = (query?: string) =>
   `/search${query ? `?query=${query}` : ''}`;


### PR DESCRIPTION
https://github.com/codesandbox/sandpack/tree/tree/main -> `github/codesandbox/tree/main`
https://github.com/codesandbox/sandpack/tree/main -> `github/codesandbox/main`