### PR TITLE
lint: disable no-undef for TS files

### DIFF
--- a/packages/app/src/app/overmind/effects/vscode/LinterWorker/index.js
+++ b/packages/app/src/app/overmind/effects/vscode/LinterWorker/index.js
@@ -376,6 +376,11 @@ const TYPESCRIPT_PARSER_OPTIONS = {
     // note you must disable the base rule as it can report incorrect errors
     'no-use-before-define': 'off',
     '@typescript-eslint/no-use-before-define': 'error',
+    /**
+     * Off because this gives false positive errors when using global namspace types like `JSX.*`
+     * @link https://github.com/typescript-eslint/typescript-eslint/blob/master/docs/getting-started/linting/FAQ.md#i-get-errors-from-the-no-undef-rule-about-global-variables-not-being-defined-even-though-there-are-no-typescript-errors
+     */
+    'no-undef': 'off',
   },
 };
 

--- a/packages/app/src/app/overmind/effects/vscode/LinterWorker/index.js
+++ b/packages/app/src/app/overmind/effects/vscode/LinterWorker/index.js
@@ -377,7 +377,7 @@ const TYPESCRIPT_PARSER_OPTIONS = {
     'no-use-before-define': 'off',
     '@typescript-eslint/no-use-before-define': 'error',
     /**
-     * Off because this gives false positive errors when using global namspace types like `JSX.*`
+     * Off because this gives false positive errors when using global namespace types like `JSX.*`
      * @link https://github.com/typescript-eslint/typescript-eslint/blob/master/docs/getting-started/linting/FAQ.md#i-get-errors-from-the-no-undef-rule-about-global-variables-not-being-defined-even-though-there-are-no-typescript-errors
      */
     'no-undef': 'off',


### PR DESCRIPTION
Resolves https://github.com/codesandbox/codesandbox-client/issues/3401#issuecomment-812929720

[Reference](https://github.com/typescript-eslint/typescript-eslint/blob/master/docs/getting-started/linting/FAQ.md#i-get-errors-from-the-no-undef-rule-about-global-variables-not-being-defined-even-though-there-are-no-typescript-errors)