### PR TITLE
fix: remove drafts test from all sandboxes

### DIFF
--- a/packages/app/src/app/pages/Dashboard/Components/Sandbox/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Sandbox/index.tsx
@@ -30,7 +30,7 @@ interface GenericSandboxProps {
   item: DashboardSandbox | DashboardTemplate;
 }
 
-function getFolderName(item: GenericSandboxProps['item']): string {
+function getFolderName(item: GenericSandboxProps['item']): string | undefined {
   if (item.type === 'template') {
     const { sandbox } = item;
     if (sandbox.team) {
@@ -48,7 +48,7 @@ function getFolderName(item: GenericSandboxProps['item']): string {
 
   if (sandbox.collection) {
     if (sandbox.collection.path === '/' && !sandbox.teamId) {
-      return 'Drafts';
+      return undefined;
     }
 
     return sandbox.collection.path.split('/').pop();

--- a/packages/app/src/app/pages/Dashboard/Components/Sandbox/types.ts
+++ b/packages/app/src/app/pages/Dashboard/Components/Sandbox/types.ts
@@ -5,7 +5,7 @@ export interface SandboxItemComponentProps {
   autoFork?: boolean;
   sandbox: DashboardSandbox['sandbox'] | DashboardTemplate['sandbox'];
   sandboxTitle: string;
-  sandboxLocation: string;
+  sandboxLocation?: string;
   lastUpdated: string;
   viewCount: number | string;
   TemplateIcon: React.FC<{


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?

Updates dashboard sandbox cards

## What is the current behavior?

Sandboxes that are not drafts, but unsorted still received a `Drafts` label

## What is the new behavior?

The `Drafts` label is removed from sandboxes under "All Sandboxes"

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Tested viewing "My drafts"
2. Tested viewing "All Sandboxes"
3. Tested viewing folders inside "All Sandboxes"
4. Tested search

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
