### PR TITLE
fix: Use map for transpilers, this resolves an issue with transpilers dissapearing

### DIFF
--- a/packages/app/integration-tests/tests/utils.js
+++ b/packages/app/integration-tests/tests/utils.js
@@ -1,5 +1,4 @@
 export const SECOND = 1000;
-const SANDBOXES_REPO = 'codesandbox/integration-sandboxes';
 
 export function pageLoaded(page) {
   return new Promise(resolve =>
@@ -12,7 +11,7 @@ export function pageLoaded(page) {
 }
 
 function sandboxUrl(sandboxId) {
-  return `http://localhost:3000/#github/${SANDBOXES_REPO}/tree/master/${sandboxId}`;
+  return `http://localhost:3000/#github/codesandbox/integration-sandboxes/tree/master/${sandboxId}`;
 }
 
 export function loadSandbox(page, sandboxId, timeout) {

--- a/packages/sandpack-core/src/manager.ts
+++ b/packages/sandpack-core/src/manager.ts
@@ -1443,7 +1443,7 @@ export default class Manager implements IEvaluator {
 
   dispose() {
     if (this.preset) {
-      this.preset.transpilers.forEach(t => {
+      this.preset.getTranspilers().forEach(t => {
         if (t.dispose) {
           t.dispose();
         }
@@ -1481,11 +1481,13 @@ export default class Manager implements IEvaluator {
     const info: TranspilerContext = {};
 
     const data = await Promise.all(
-      Array.from(this.preset.transpilers).map(t =>
-        t
-          .getTranspilerContext(this)
-          .then(context => ({ name: t.name, data: context }))
-      )
+      this.preset
+        .getTranspilers()
+        .map(t =>
+          t
+            .getTranspilerContext(this)
+            .then(context => ({ name: t.name, data: context }))
+        )
     );
 
     data.forEach(t => {

--- a/packages/sandpack-core/src/preset/preset.ts
+++ b/packages/sandpack-core/src/preset/preset.ts
@@ -42,10 +42,10 @@ type LoaderDefinition = {
  */
 export class Preset {
   public experimentalEsmSupport = false;
+  private _transpilers: Map<string, Transpiler>;
 
   loaders: Array<LoaderDefinition>;
 
-  transpilers: Set<Transpiler>;
   name: string;
   ignoredExtensions: Array<string>;
   htmlDisabled: boolean;
@@ -98,7 +98,7 @@ export class Preset {
     } = {}
   ) {
     this.loaders = [];
-    this.transpilers = new Set();
+    this._transpilers = new Map();
     this.name = name;
 
     this.hasDotEnv = hasDotEnv || false;
@@ -115,8 +115,23 @@ export class Preset {
     this.htmlDisabled = htmlDisabled || false;
 
     this.postTranspilers.forEach(transpiler => {
-      this.transpilers.add(transpiler.transpiler);
+      this.addTranspiler(transpiler.transpiler);
     });
+  }
+
+  private addTranspiler(t: Transpiler) {
+    // TODO: Should this overwrite or skip?
+    // if (this._transpilers.has(t.name)) {}
+
+    this._transpilers.set(t.name, t);
+  }
+
+  getTranspiler(name: string): Transpiler | undefined {
+    return this._transpilers.get(name);
+  }
+
+  getTranspilers(): Transpiler[] {
+    return Array.from(this._transpilers.values());
   }
 
   setAdditionalAliases = (aliases: { [path: string]: string }) => {
@@ -129,7 +144,7 @@ export class Preset {
   };
 
   resetTranspilers = () => {
-    this.transpilers.clear();
+    this._transpilers.clear();
     this.loaders.length = 0;
   };
 
@@ -201,7 +216,7 @@ export class Preset {
       this.loaders.push(transpilerObject);
     }
 
-    transpilers.forEach(t => this.transpilers.add(t.transpiler));
+    transpilers.forEach(t => this.addTranspiler(t.transpiler));
 
     return this.loaders;
   }
@@ -225,20 +240,18 @@ export class Preset {
       : [];
 
     // Remove "" values
-    const transpilerNames = query.split('!').filter(x => x);
+    const transpilerNames = query.split('!').filter(Boolean);
 
     const extraTranspilers = transpilerNames
       .map(loaderName => loaderName.split('?'))
       .filter(([name]) => !!name)
       .map(([name, options]) => {
-        let transpiler = Array.from(this.transpilers).find(
-          t => t.name === name
-        );
+        let transpiler = this.getTranspiler(name);
 
         if (!transpiler) {
           const webpackLoader = new WebpackTranspiler(name, evaluator);
           // If the loader is not installed, we try to run the webpack loader.
-          this.transpilers.add(webpackLoader);
+          this.addTranspiler(webpackLoader);
           transpiler = webpackLoader;
         }
 

--- a/packages/sandpack-core/src/preset/preset.ts
+++ b/packages/sandpack-core/src/preset/preset.ts
@@ -121,7 +121,7 @@ export class Preset {
 
   private addTranspiler(t: Transpiler) {
     // TODO: Should this overwrite or skip?
-    // if (this._transpilers.has(t.name)) {}
+    if (this._transpilers.has(t.name)) return;
 
     this._transpilers.set(t.name, t);
   }


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?

This PR changes the logic of transpilers in a preset to use a (private) map so we ensure full control over when and how transpilers are registered.

The good thing is that this de-duplicates duplicate transpiler registrations so should speedup code execution as well.

For some reason this fixed a case where transpilers dissapear, still not sure how this is even possible?

Fixes #6105
