### PR TITLE
fix: Data uri binary files

### DIFF
--- a/packages/app/src/sandbox/eval/transpilers/base64/index.ts
+++ b/packages/app/src/sandbox/eval/transpilers/base64/index.ts
@@ -1,5 +1,7 @@
-import { Transpiler, LoaderContext, TranspilerResult } from 'sandpack-core';
+import { Transpiler, LoaderContext } from 'sandpack-core';
 import { extname } from 'path';
+import { isUrl } from '@codesandbox/common/lib/utils/is-url';
+
 // @ts-ignore
 import mimeTypes from './mimes.json';
 
@@ -8,33 +10,43 @@ function getMimeType(filePath: string): string | null | undefined {
   return mimeTypes[extension];
 }
 
+async function createDataUri(blob: Blob): Promise<string> {
+  return new Promise<string>((resolve, reject) => {
+    const reader = new FileReader();
+
+    reader.readAsDataURL(blob);
+
+    reader.onloadend = () => {
+      const base64data = reader.result;
+      resolve(base64data.toString());
+    };
+
+    reader.onerror = err => {
+      reject(err);
+    };
+  });
+}
+
 class Base64Transpiler extends Transpiler {
   constructor() {
     super('base64-loader');
   }
 
-  doTranspilation(code: string, loaderContext: LoaderContext) {
-    const blob: Blob =
-      typeof code === 'string'
-        ? new Blob([code], { type: getMimeType(loaderContext.path) })
-        : code;
+  async doTranspilation(code: string, loaderContext: LoaderContext) {
+    let uri: string = '#';
+    if (typeof code === 'string' && isUrl(code)) {
+      uri = code;
+    } else {
+      const blob: Blob =
+        typeof code === 'string'
+          ? new Blob([code], { type: getMimeType(loaderContext.path) })
+          : code;
+      uri = await createDataUri(blob);
+    }
 
-    return new Promise<TranspilerResult>((resolve, reject) => {
-      const reader = new FileReader();
-
-      reader.readAsDataURL(blob);
-
-      reader.onloadend = () => {
-        const base64data = reader.result;
-        resolve({
-          transpiledCode: `module.exports = "${base64data.toString()}"`,
-        });
-      };
-
-      reader.onerror = err => {
-        reject(err);
-      };
-    });
+    return {
+      transpiledCode: `module.exports = "${uri}"`,
+    };
   }
 }
 

--- a/packages/common/src/utils/is-url.ts
+++ b/packages/common/src/utils/is-url.ts
@@ -1,4 +1,4 @@
-const URL_RE = /https?:\/\/.+/;
+const URL_RE = /^https?:\/\/.+/;
 
 export function isUrl(url: string) {
   return URL_RE.test(url);


### PR DESCRIPTION
## What kind of change does this PR introduce?

Binary files should simply return the uri, no need to base64 encode it especially not encoding the uri
