### PR TITLE
fix: conflict between core-js and bfs-process

### DIFF
--- a/packages/app/src/app/overmind/state.ts
+++ b/packages/app/src/app/overmind/state.ts
@@ -69,7 +69,7 @@ type State = {
   sandboxesLimits?: {
     sandboxCount: number;
     sandboxLimit: number;
-  };
+  } | null;
 };
 
 export const state: State = {

--- a/packages/sandpack-core/src/runner/eval.ts
+++ b/packages/sandpack-core/src/runner/eval.ts
@@ -41,6 +41,7 @@ export default function (
   }
 
   // This is a hack to make core-js work...
+  // See https://github.com/codesandbox/codesandbox-client/pull/6136
   if (window.process.versions) {
     window.process.versions.v8 = '50.0';
   }

--- a/packages/sandpack-core/src/runner/eval.ts
+++ b/packages/sandpack-core/src/runner/eval.ts
@@ -5,6 +5,22 @@ const g = typeof window === 'undefined' ? self : window;
 
 const hasGlobalDeclaration = /^const global/m;
 
+const V8_VERSION = getV8Version();
+function getV8Version(): string {
+  const userAgent = navigator?.userAgent;
+  if (userAgent) {
+    let match = userAgent.match(/Edge\/(\d+)/);
+    // @ts-ignore
+    if (!match || match[1] >= 74) {
+      match = userAgent.match(/Chrome\/(\d+)/);
+      if (match) {
+        return match[1];
+      }
+    }
+  }
+  return '0';
+}
+
 /* eslint-disable no-unused-vars */
 export default function (
   code: string,
@@ -43,7 +59,7 @@ export default function (
   // This is a hack to make core-js work...
   // See https://github.com/codesandbox/codesandbox-client/pull/6136
   if (window.process.versions) {
-    window.process.versions.v8 = '50.0';
+    window.process.versions.v8 = V8_VERSION;
   }
 
   const allGlobalKeys = Object.keys(allGlobals);

--- a/packages/sandpack-core/src/runner/eval.ts
+++ b/packages/sandpack-core/src/runner/eval.ts
@@ -26,7 +26,7 @@ export default function (
     module,
     exports,
     process,
-    global,    
+    global,
     ...globals,
   };
 
@@ -38,6 +38,11 @@ export default function (
 
   if (hasGlobalDeclaration.test(code)) {
     delete allGlobals.global;
+  }
+
+  // This is a hack to make core-js work...
+  if (window.process.versions) {
+    window.process.versions.v8 = '50.0';
   }
 
   const allGlobalKeys = Object.keys(allGlobals);


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?

This PR fixes an issue with core-js and bfs-process conflicting.

We definitely need to have a look at how to prevent all the global scope poluting we (and mainly browser-fs) does though, as these bugs can be prevented pretty easily that way.

Also probably a good idea to revisit the eval code at some point as it also has some weird behaviour with core-js, specifically this line: https://github.com/zloirock/core-js/blob/master/packages/core-js/internals/global.js#L2 

Also this one for detecting v8 engine using the nodeJS path: https://github.com/zloirock/core-js/blob/master/packages/core-js/internals/engine-v8-version.js

Closes #5943 
