### PR TITLE
Allow undoing account deletion

### DIFF
--- a/packages/app/src/app/graphql/types.ts
+++ b/packages/app/src/app/graphql/types.ts
@@ -137,6 +137,7 @@ export type CurrentUser = {
   collaboratorSandboxes: Array<Sandbox>;
   collection: Maybe<Collection>;
   collections: Array<Collection>;
+  deletionRequested: Scalars['Boolean'];
   email: Scalars['String'];
   /** Get enabled feature flags for all teams user is in */
   featureFlags: Array<FeatureFlag>;
@@ -901,7 +902,7 @@ export type RootQueryType = {
   album: Maybe<Album>;
   albums: Array<Album>;
   curatedAlbums: Array<Album>;
-  /** Get all feature flags  */
+  /** Get all feature flags */
   featureFlags: Array<FeatureFlag>;
   /** Get git repo and related sandboxes */
   git: Maybe<Git>;

--- a/packages/app/src/app/graphql/types.ts
+++ b/packages/app/src/app/graphql/types.ts
@@ -2297,6 +2297,14 @@ export type DeleteCurrentUserMutation = {
   __typename?: 'RootMutationType';
 } & Pick<RootMutationType, 'deleteCurrentUser'>;
 
+export type CancelDeleteCurrentUserMutationVariables = Exact<{
+  [key: string]: never;
+}>;
+
+export type CancelDeleteCurrentUserMutation = {
+  __typename?: 'RootMutationType';
+} & Pick<RootMutationType, 'cancelDeleteCurrentUser'>;
+
 export type UpdateSubscriptionBillingIntervalMutationVariables = Exact<{
   teamId: Scalars['UUID4'];
   subscriptionId: Scalars['UUID4'];

--- a/packages/app/src/app/overmind/effects/gql/dashboard/mutations.ts
+++ b/packages/app/src/app/overmind/effects/gql/dashboard/mutations.ts
@@ -63,6 +63,8 @@ import {
   SetDefaultTeamMemberAuthorizationMutationVariables,
   DeleteCurrentUserMutation,
   DeleteCurrentUserMutationVariables,
+  CancelDeleteCurrentUserMutation,
+  CancelDeleteCurrentUserMutationVariables,
   UpdateSubscriptionBillingIntervalMutation,
   UpdateSubscriptionBillingIntervalMutationVariables,
   PreviewUpdateSubscriptionBillingIntervalMutation,
@@ -543,6 +545,15 @@ export const deleteAccount: Query<
 > = gql`
   mutation deleteCurrentUser {
     deleteCurrentUser
+  }
+`;
+
+export const undoDeleteAccount: Query<
+  CancelDeleteCurrentUserMutation,
+  CancelDeleteCurrentUserMutationVariables
+> = gql`
+  mutation cancelDeleteCurrentUser {
+    cancelDeleteCurrentUser
   }
 `;
 

--- a/packages/app/src/app/overmind/namespaces/dashboard/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/dashboard/actions.ts
@@ -1811,6 +1811,20 @@ export const setDefaultTeamMemberAuthorization = async (
 export const requestAccountClosing = ({ state }: Context) => {
   state.currentModal = 'accountClosing';
 };
+export const undoRequestAccountClosing = ({ state }: Context) => {
+  state.currentModal = 'undoAccountClosing';
+};
+
+export const undoDeleteAccount = async ({ state, effects }: Context) => {
+  try {
+    await effects.gql.mutations.undoDeleteAccount({});
+    state.currentModal = 'undoDeleteConfirmation';
+  } catch {
+    effects.notificationToast.error(
+      'There was a problem undoing your account deletion. Please email us at support@codesandbox.io'
+    );
+  }
+};
 
 export const deleteAccount = async ({ state, effects }: Context) => {
   try {

--- a/packages/app/src/app/overmind/namespaces/dashboard/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/dashboard/actions.ts
@@ -1819,6 +1819,9 @@ export const undoDeleteAccount = async ({ state, effects }: Context) => {
   try {
     await effects.gql.mutations.undoDeleteAccount({});
     state.currentModal = 'undoDeleteConfirmation';
+    if (state.user) {
+      state.user.deletionRequested = false;
+    }
   } catch {
     effects.notificationToast.error(
       'There was a problem undoing your account deletion. Please email us at support@codesandbox.io'

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Settings/UserSettings/WorkspaceSettings.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Settings/UserSettings/WorkspaceSettings.tsx
@@ -206,10 +206,16 @@ export const WorkspaceSettings = () => {
                     padding: 0,
                   })}
                   onClick={() => {
-                    actions.dashboard.requestAccountClosing();
+                    if (user.deletionRequested) {
+                      actions.dashboard.undoRequestAccountClosing();
+                    } else {
+                      actions.dashboard.requestAccountClosing();
+                    }
                   }}
                 >
-                  Request Account Deletion
+                  {user.deletionRequested
+                    ? 'Undo Account Deletion'
+                    : 'Request Account Deletion'}
                 </Button>
                 <Stack justify="flex-start" gap={1}>
                   <Button
@@ -301,10 +307,16 @@ export const WorkspaceSettings = () => {
                   padding: 0,
                 })}
                 onClick={() => {
-                  actions.dashboard.requestAccountClosing();
+                  if (user.deletionRequested) {
+                    actions.dashboard.undoRequestAccountClosing();
+                  } else {
+                    actions.dashboard.requestAccountClosing();
+                  }
                 }}
               >
-                Request Account Deletion
+                {user.deletionRequested
+                  ? 'Undo Account Deletion'
+                  : 'Request Account Deletion'}
               </Button>
             </Stack>
           </Stack>

--- a/packages/app/src/app/pages/common/Modals/UndoAccountDeletion/UndoDeletedConfirmation.tsx
+++ b/packages/app/src/app/pages/common/Modals/UndoAccountDeletion/UndoDeletedConfirmation.tsx
@@ -1,0 +1,22 @@
+import { useActions } from 'app/overmind';
+import React, { FunctionComponent } from 'react';
+import { Alert } from '../Common/Alert';
+
+export const UndoAccountDeletionConfirmationModal: FunctionComponent = () => {
+  const { modalClosed } = useActions();
+  return (
+    <Alert
+      title="Request for account deletion undone"
+      description={
+        <>
+          Thanks for sticking around. <br />
+          Your account will not be deleted! <br />
+        </>
+      }
+      onPrimaryAction={async () => {
+        modalClosed();
+      }}
+      confirmMessage="Close"
+    />
+  );
+};

--- a/packages/app/src/app/pages/common/Modals/UndoAccountDeletion/index.tsx
+++ b/packages/app/src/app/pages/common/Modals/UndoAccountDeletion/index.tsx
@@ -1,0 +1,24 @@
+import { useActions } from 'app/overmind';
+import React, { FunctionComponent, useState } from 'react';
+import { Alert } from '../Common/Alert';
+
+export const UndoAccountDeletionModal: FunctionComponent = () => {
+  const { modalClosed, dashboard } = useActions();
+
+  const [loading, setLoading] = useState(false);
+
+  return (
+    <Alert
+      title="Undo Account Deletion"
+      description="Would you like to keep your account?"
+      onCancel={modalClosed}
+      onPrimaryAction={async () => {
+        setLoading(true);
+        await dashboard.undoDeleteAccount();
+        setLoading(false);
+      }}
+      confirmMessage={loading ? 'Loading' : 'Confirm'}
+      type="primary"
+    />
+  );
+};

--- a/packages/app/src/app/pages/common/Modals/index.tsx
+++ b/packages/app/src/app/pages/common/Modals/index.tsx
@@ -40,6 +40,8 @@ import { MinimumPrivacyModal } from './MinimumPrivacyModal';
 import { GenericAlertModal } from './GenericAlertModal';
 import { AccountDeletionModal } from './AccountDeletion';
 import { AccountDeletionConfirmationModal } from './AccountDeletion/DeletedConfirmation';
+import { UndoAccountDeletionModal } from './UndoAccountDeletion';
+import { UndoAccountDeletionConfirmationModal } from './UndoAccountDeletion/UndoDeletedConfirmation';
 import { NotFoundBranchModal } from './NotFoundBranchModal';
 import { GithubPagesLogs } from './GithubPagesLogs';
 import { CropThumbnail } from './CropThumbnail';
@@ -170,8 +172,16 @@ const modals = {
     Component: AccountDeletionModal,
     width: 450,
   },
+  undoAccountClosing: {
+    Component: UndoAccountDeletionModal,
+    width: 450,
+  },
   deleteConfirmation: {
     Component: AccountDeletionConfirmationModal,
+    width: 450,
+  },
+  undoDeleteConfirmation: {
+    Component: UndoAccountDeletionConfirmationModal,
     width: 450,
   },
   notFoundBranchModal: {

--- a/packages/common/src/types/index.ts
+++ b/packages/common/src/types/index.ts
@@ -141,6 +141,7 @@ export type CurrentUser = {
     } | null;
   };
   sendSurvey: boolean;
+  deletionRequested: boolean;
 };
 
 export type CustomTemplate = {


### PR DESCRIPTION
Co-authored-by: JamesACS <james@codesandbox.io>

## What kind of change does this PR introduce?

Users can now undo their request for account deletion without emailing us 🎉 

TO DO (but I am only a poor backend dev so I need help)
- [x] Update `user.deletionRequested` to `false` after the cancellation was successful
- [x] Maybe update my linter/formatter in case anything is wrong there.

## What is the current behavior?

<!-- You can also link to an open issue here -->

## What is the new behavior?

<!-- if this is a feature change -->

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Step A
2. Step B
3. Step C

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Testing <!-- We can only merge the PR if this is checked -->
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
