### PR TITLE
Reduce retry count for jsdelivr if it fails to load

### DIFF
--- a/packages/sandpack-core/src/npm/dynamic/fetch-protocols/utils.ts
+++ b/packages/sandpack-core/src/npm/dynamic/fetch-protocols/utils.ts
@@ -2,7 +2,7 @@ import delay from '@codesandbox/common/lib/utils/delay';
 
 export async function fetchWithRetries(
   url: string,
-  retries = 6,
+  retries = 2,
   requestInit?: RequestInit
 ): Promise<Response> {
   const doFetch = () =>


### PR DESCRIPTION
When JSDelivr fails (which I think it did more often recently), sandboxes take ages to load. This reduces the try count, because knowing JSDelivr, if it fails twice, it will most probably fail 3rd, 4th etc...