### PR TITLE
Make sure we use jsdelivr for resolving absolute versions

### DIFF
--- a/packages/common/src/utils/dependencies.ts
+++ b/packages/common/src/utils/dependencies.ts
@@ -58,8 +58,8 @@ export async function getLatestVersion(
     // If it is not an absolute version (e.g. a tag like `next`), we don't want to fetch
     // using JSDelivr, because JSDelivr caches the response for a long time. Because of this,
     // when a tag updates to a new version, people won't see that update for a long time.
-    // Unpkg does handle this nicely, but is less stable. So we default to JSDelivr, but
-    // for tags we use unpkg.
+    // Instead, we download all possible versions from JSDelivr, and we check those versions
+    // to see what's the maximum satisfying version. The API call is cached for only 10s.
     try {
       const allVersions = await fetchAllVersions(dep);
       return maxSatisfying(allVersions.versions, version);

--- a/packages/common/src/utils/dependencies.ts
+++ b/packages/common/src/utils/dependencies.ts
@@ -62,7 +62,10 @@ export async function getLatestVersion(
     // to see what's the maximum satisfying version. The API call is cached for only 10s.
     try {
       const allVersions = await fetchAllVersions(dep);
-      return maxSatisfying(allVersions.versions, version);
+      return (
+        allVersions.tags[version] ||
+        maxSatisfying(allVersions.versions, version)
+      );
     } catch (e) {
       return fetchJsdelivr();
     }


### PR DESCRIPTION
Unpkg can sometimes take over 30s to load the version, which results in the bundler being _really_ slow. JSDelivr is more reliable for these kinds of things.