### PR TITLE
Fix exports failing when they include an extension

### DIFF
--- a/packages/sandpack-core/src/resolver/fixture/node_modules/@zendesk/laika/esm/laika.js
+++ b/packages/sandpack-core/src/resolver/fixture/node_modules/@zendesk/laika/esm/laika.js
@@ -1,0 +1,1 @@
+export const LAIKA = 'laika';

--- a/packages/sandpack-core/src/resolver/fixture/node_modules/@zendesk/laika/package.json
+++ b/packages/sandpack-core/src/resolver/fixture/node_modules/@zendesk/laika/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@zendesk/laika",
+  "version": "1.0.0",
+  "exports": {
+    ".": {
+      "import": "./esm/main.js",
+      "require": "./cjs/main.js"
+    },
+    "./*": {
+      "import": "./esm/*.js",
+      "require": "./cjs/*.js"
+    },
+    "./cjs": {
+      "require": "./cjs/main.js"
+    },
+    "./cjs/*": {
+      "require": "./cjs/*.js"
+    },
+    "./esm/*": {
+      "import": "./esm/*.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "main": "cjs/main.js",
+  "module": "esm/main.js",
+  "source": "src/main.ts"
+}

--- a/packages/sandpack-core/src/resolver/resolver.test.ts
+++ b/packages/sandpack-core/src/resolver/resolver.test.ts
@@ -371,6 +371,7 @@ describe('resolve', () => {
     });
 
     it('should alias package.exports globs', () => {
+      // Test path normalization as well
       const resolved = resolveSync('package-exports///components/a', {
         filename: '/foo.js',
         extensions: ['.ts', '.tsx', '.js', '.jsx'],
@@ -380,6 +381,16 @@ describe('resolve', () => {
       expect(resolved).toBe(
         '/node_modules/package-exports/src/components/a.js'
       );
+    });
+
+    it('should alias package.exports subdirectory globs', () => {
+      const resolved = resolveSync('@zendesk/laika/esm/laika', {
+        filename: '/index.tsx',
+        extensions: ['.ts', '.tsx', '.js', '.jsx'],
+        isFile,
+        readFile,
+      });
+      expect(resolved).toBe('/node_modules/@zendesk/laika/esm/laika.js');
     });
 
     it('should alias package.exports object globs', () => {

--- a/packages/sandpack-core/src/resolver/resolver.ts
+++ b/packages/sandpack-core/src/resolver/resolver.ts
@@ -240,7 +240,7 @@ function loadAlias(pkgJson: IFoundPackageJSON, filename: string): string {
     relativeFilepath = aliasedPath;
 
     // Simply check to ensure we don't infinitely alias files due to a misconfiguration of a package/user
-    if (count > 10) {
+    if (count > 5) {
       throw new Error('Could not resolve file due to a cyclic alias');
     }
     count++;
@@ -260,6 +260,12 @@ function loadAlias(pkgJson: IFoundPackageJSON, filename: string): string {
       if (re.test(relativeFilepath)) {
         const val = aliases[aliasKey];
         aliasedPath = relativeFilepath.replace(re, val);
+        if (aliasedPath.startsWith(relativeFilepath)) {
+          const newAddition = aliasedPath.substr(relativeFilepath.length);
+          if (relativeFilepath.endsWith(newAddition)) {
+            aliasedPath = relativeFilepath;
+          }
+        }
         break;
       }
     }
@@ -357,7 +363,7 @@ function* expandFile(
 ): Generator<any, string | null, any> {
   const pkg = yield* findPackageJSON(filepath, opts);
 
-  if (expandCount > 15) {
+  if (expandCount > 5) {
     throw new Error('Cyclic alias detected');
   }
 

--- a/packages/sandpack-core/src/resolver/resolver.ts
+++ b/packages/sandpack-core/src/resolver/resolver.ts
@@ -262,7 +262,10 @@ function loadAlias(pkgJson: IFoundPackageJSON, filename: string): string {
         aliasedPath = relativeFilepath.replace(re, val);
         if (aliasedPath.startsWith(relativeFilepath)) {
           const newAddition = aliasedPath.substr(relativeFilepath.length);
-          if (relativeFilepath.endsWith(newAddition)) {
+          if (
+            !newAddition.includes('/') &&
+            relativeFilepath.endsWith(newAddition)
+          ) {
             aliasedPath = relativeFilepath;
           }
         }


### PR DESCRIPTION
# Pull Request

Currently if an exports field contains an extension we keep adding the extension resulting in a path with the same extension multiple times... this PR fixes that by checking if the new addition to the string was the same as the end of the string.

It's not perfect but not sure how else to fix this without largely refactoring the resolver again...

Closes #6279 