### PR TITLE
Improve less file manager to download missing dependencies and use regex properly

### DIFF
--- a/packages/app/src/sandbox/eval/transpilers/less/file-manager.ts
+++ b/packages/app/src/sandbox/eval/transpilers/less/file-manager.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 
-const PKG_IMPORT_RE = /^~?([@A-Za-z].*)/;
+const PKG_IMPORT_RE = /^~?([@A-Za-z\-_].*)/;
 
 /* eslint-disable no-unused-vars */
 /* eslint-disable func-names */
@@ -32,7 +32,7 @@ export default function (loaderContext, files) {
 
         const file = files[filepath];
         if (!file) {
-          const matches = PKG_IMPORT_RE.match(importName[0]);
+          const matches = importName.match(PKG_IMPORT_RE);
           if (matches && matches[1]) {
             return this.loadFile(
               `/node_modules/${matches[1]}`,

--- a/packages/app/src/sandbox/eval/transpilers/less/file-manager.ts
+++ b/packages/app/src/sandbox/eval/transpilers/less/file-manager.ts
@@ -55,6 +55,10 @@ export default function (ctx: ILessLoaderContext) {
         let contents = ctx.files[filepath];
         if (contents == null) {
           try {
+            if (importName[0] === '~') {
+              throw new Error('Skip resolution, it is a node_module');
+            }
+
             const resolvedModule = await resolveAsyncModule(filepath, ctx);
             contents = resolvedModule.code;
             ctx.files[filepath] = contents;

--- a/packages/app/src/sandbox/eval/transpilers/less/less-worker.ts
+++ b/packages/app/src/sandbox/eval/transpilers/less/less-worker.ts
@@ -5,12 +5,19 @@ import FileManager from './file-manager';
 
 const childHandler = new ChildHandler('less-worker');
 
+export interface LessLibrary {
+  render: (code: string, opts: Record<string, any>) => Promise<{ css: string }>;
+}
+
+// @ts-ignore
 self.less = {
   env: 'development',
 };
 
 // Stub window for less....
+// @ts-ignore
 self.window = self;
+// @ts-ignore
 self.window.document = {
   currentScript: { async: true },
   createElement: () => ({ appendChild: () => {} }),
@@ -23,10 +30,6 @@ self.window.document = {
 self.importScripts(
   `${process.env.CODESANDBOX_HOST || ''}/static/js/less.min.js`
 );
-
-declare var less: {
-  render: (code: string) => Promise<string>,
-};
 
 async function workerCompile(opts) {
   const { code, path, files } = opts;
@@ -44,7 +47,9 @@ async function workerCompile(opts) {
   const cleanCode = code.replace(/^\n$/gm, '');
 
   // register a custom importer callback
-  const { css } = await less.render(cleanCode, {
+  // @ts-ignore
+  const lessLibrary: LessLibrary = less;
+  const { css } = await lessLibrary.render(cleanCode, {
     filename: path,
     plugins: [FileManager(context, files)],
   });


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?

- Fix less regex for node_modules
- Try to fetch module if it's not in mem-fs

Fixes #6295
