### PR TITLE
Allow-downloads in iframes

### DIFF
--- a/packages/common/src/components/Preview/index.tsx
+++ b/packages/common/src/components/Preview/index.tsx
@@ -631,7 +631,7 @@ class BasePreview extends React.PureComponent<Props, State> {
                 <StyledFrame
                   key="PREVIEW"
                   allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
-                  sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
+                  sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts allow-downloads"
                   src={this.state.url}
                   ref={this.setIframeElement}
                   title={getSandboxName(sandbox)}


### PR DESCRIPTION
Accidentally reverted `allow-downloads` iframe feature in this [commit](https://github.com/codesandbox/codesandbox-client/commit/bb8176517289179b8375896870b37f0cb8c71cb6) that was introduced [here](https://github.com/codesandbox/codesandbox-client/pull/5163).

Activating it again.

