### PR TITLE
Add `allow-pointer-lock` to preview iframe

### DIFF
--- a/packages/app/src/app/pages/common/Modals/ShareModal/getCode.ts
+++ b/packages/app/src/app/pages/common/Modals/ShareModal/getCode.ts
@@ -72,7 +72,7 @@ export const getIframeScript = (sandbox, mainModule, state, height) =>
      style="width:100%; height:${height}px; border:0; border-radius: 4px; overflow:hidden;"
      title="${escapeHtml(getSandboxName(sandbox))}"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
-     sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts allow-pointer-lock"
+     sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
    ></iframe>`;
 
 // eslint-disable-next-line

--- a/packages/app/src/app/pages/common/Modals/ShareModal/getCode.ts
+++ b/packages/app/src/app/pages/common/Modals/ShareModal/getCode.ts
@@ -72,7 +72,7 @@ export const getIframeScript = (sandbox, mainModule, state, height) =>
      style="width:100%; height:${height}px; border:0; border-radius: 4px; overflow:hidden;"
      title="${escapeHtml(getSandboxName(sandbox))}"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
-     sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
+     sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts allow-pointer-lock"
    ></iframe>`;
 
 // eslint-disable-next-line

--- a/packages/common/src/components/Preview/index.tsx
+++ b/packages/common/src/components/Preview/index.tsx
@@ -631,7 +631,7 @@ class BasePreview extends React.PureComponent<Props, State> {
                 <StyledFrame
                   key="PREVIEW"
                   allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
-                  sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts allow-downloads"
+                  sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts allow-downloads allow-pointer-lock"
                   src={this.state.url}
                   ref={this.setIframeElement}
                   title={getSandboxName(sandbox)}


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?

Bug fix
Closes #6399 
<!-- Is it a Bug fix, feature, docs update, ... -->

## What is the current behavior?

The pointer lock API can't be used in the preview iframe.

<!-- You can also link to an open issue here -->

## What is the new behavior?

Allow users to create sandboxes that depend on the pointer being used as a control input, as is done in the React Three Fiber demo.

<!-- if this is a feature change -->

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Nothing yet.

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] ~~Documentation~~
- [ ] ~~Testing <!-- We can only merge the PR if this is checked -->~~
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] ~~Added myself to contributors table~~
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
