### PR TITLE
fix: wildcard exports adding an extension should not break dir/index

### DIFF
--- a/packages/sandpack-core/src/resolver/resolver.test.ts
+++ b/packages/sandpack-core/src/resolver/resolver.test.ts
@@ -478,6 +478,18 @@ describe('resolve', () => {
         })
       ).toThrow();
     });
+
+    it('should not fail on wildcard *.js and folder references', () => {
+      const resolved = resolveSync('./test', {
+        filename: '/node_modules/package-exports/src/utils/path.js',
+        extensions: ['.ts', '.tsx', '.js', '.jsx'],
+        isFile,
+        readFile,
+      });
+      expect(resolved).toBe(
+        '/node_modules/package-exports/src/utils/test/index.js'
+      );
+    });
   });
 
   describe('normalize module specifier', () => {

--- a/packages/sandpack-core/src/resolver/resolver.ts
+++ b/packages/sandpack-core/src/resolver/resolver.ts
@@ -345,6 +345,19 @@ export const resolver = gensync<
   let foundFile = yield* expandFile(modulePath, opts);
   if (!foundFile) {
     foundFile = yield* expandFile(pathUtils.join(modulePath, 'index'), opts);
+
+    // In case alias adds an extension, we retry the entire resolution with an added /index
+    // This is mostly a hack I guess, but it works for now, so many edge-cases
+    if (!foundFile) {
+      try {
+        const parts = moduleSpecifier.split('/');
+        if (!parts.length || !parts[parts.length - 1].startsWith('index')) {
+          foundFile = yield* resolve(moduleSpecifier + '/index', opts);
+        }
+      } catch (err) {
+        // should throw ModuleNotFound for original specifier, not new one
+      }
+    }
   }
 
   if (!foundFile) {


### PR DESCRIPTION
## What kind of change does this PR introduce?

<!-- Is it a Bug fix, feature, docs update, ... -->

Fixes #6473 
Closes CSB-3611
