### PR TITLE
Have client provide default github auth scope

### DIFF
--- a/packages/app/src/app/overmind/internalActions.ts
+++ b/packages/app/src/app/overmind/internalActions.ts
@@ -186,6 +186,8 @@ export const runProviderAuth = (
   if (provider === 'github') {
     if (useExtraScopes) {
       authPath.searchParams.set('scope', 'user:email,repo,workflow');
+    } else {
+      authPath.searchParams.set('scope', 'user:email');
     }
   }
 


### PR DESCRIPTION
Today's login issues were caused by missing default scopes for the GH signin.

We are working on fixing this on the backend, but as an extra safeguard, we should make sure that the client passes at least the lowest default scope too.