### PR TITLE
Update references to renamed GitHub App

### DIFF
--- a/packages/homepage/content/articles/codesandbox-ci-embeds/index.md
+++ b/packages/homepage/content/articles/codesandbox-ci-embeds/index.md
@@ -39,7 +39,7 @@ like React, Babel, Framer, Material UI, and others. And it's proving to be a
 real time-saver.
 
 **Try it out for yourself by
-[installing the GitHub app](https://github.com/apps/codesandbox)**.
+[installing the GitHub app](https://github.com/apps/codesandbox-ci)**.
 
 https://twitter.com/mattgperry/status/1181863225756934144
 
@@ -92,7 +92,7 @@ maintainers new ways to reduce their support overhead and get more done.
 Available now, CodeSandbox CI makes it possible to test fixes without the need
 to clone, install, and check things locally. There’s more info about how to
 configure CodeSandbox CI in [our docs](/docs/ci), and you can get started by
-[installing the GitHub app](https://github.com/apps/codesandbox).
+[installing the GitHub app](https://github.com/apps/codesandbox-ci).
 
 ## Thanks
 

--- a/packages/homepage/content/docs/8-ci.md
+++ b/packages/homepage/content/docs/8-ci.md
@@ -8,7 +8,7 @@ description:
 
 ## What is CodeSandbox CI?
 
-CodeSandbox CI is a [GitHub app](https://github.com/apps/codesandbox) that you
+CodeSandbox CI is a [GitHub app](https://github.com/apps/codesandbox-ci) that you
 can install in your repository. The app is responsible for building your
 library. Whenever a Pull Request is opened it builds a version of the library
 from that PR. This is published to our registry, so you can immediately test the
@@ -35,7 +35,7 @@ A typical workflow might look like this:
 ## How do I set this up?
 
 For most libraries, the only thing you need to do is install this
-[GitHub App](https://github.com/apps/codesandbox). In some cases you might need
+[GitHub App](https://github.com/apps/codesandbox-ci). In some cases you might need
 to do some configuration, an example of this is for monorepos. You can configure
 your library by creating a file called `ci.json` in a folder called
 `.codesandbox` (`.codesandbox/ci.json`) in the root of your repo. An example PR

--- a/packages/homepage/content/features/ci/index.md
+++ b/packages/homepage/content/features/ci/index.md
@@ -4,7 +4,7 @@ description:
   A GitHub integration that auto-builds your library⁠ from pull requests.
 slug: ci
 ctaText: Install GitHub App
-ctaLink: https://github.com/apps/codesandbox
+ctaLink: https://github.com/apps/codesandbox-ci
 tweetText:
   This is going to save us so much time, and as a result I've just made a
   CodeSandbox reproduction mandatory for bug reports.


### PR DESCRIPTION


In preparation for renaming the existing GitHub App, this change fixes its URL.

Please wait to merge.