### PR TITLE
fix(dashboard): prevent double click on editing

### DIFF
--- a/packages/app/src/app/pages/Dashboard/Components/Folder/FolderCard.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Folder/FolderCard.tsx
@@ -31,7 +31,7 @@ export const FolderCard: React.FC<FolderItemComponentProps> = ({
     direction="vertical"
     gap={2}
     onClick={onClick}
-    onDoubleClick={onDoubleClick}
+    onDoubleClick={editing ? undefined : onDoubleClick}
     onContextMenu={onContextMenu}
     {...props}
     css={css({

--- a/packages/app/src/app/pages/Dashboard/Components/Sandbox/SandboxCard.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Sandbox/SandboxCard.tsx
@@ -247,7 +247,7 @@ export const SandboxCard = ({
     <Stack
       direction="vertical"
       onClick={onClick}
-      onDoubleClick={onDoubleClick}
+      onDoubleClick={editing ? undefined : onDoubleClick}
       onBlur={onBlur}
       onContextMenu={onContextMenu}
       {...props}

--- a/packages/app/src/app/pages/Dashboard/Components/VariableGrid/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/VariableGrid/index.tsx
@@ -80,6 +80,7 @@ interface IComponentForTypes {
 const ComponentForTypes: IComponentForTypes = {
   sandbox: React.memo(props => (
     <Sandbox
+      key={props.item.name}
       page={props.page}
       item={props.item}
       isScrolling={props.isScrolling}
@@ -92,7 +93,7 @@ const ComponentForTypes: IComponentForTypes = {
       isScrolling={props.isScrolling}
     />
   )),
-  folder: props => <Folder {...props.item} />,
+  folder: props => <Folder key={props.item.name} {...props.item} />,
   repo: props => <Repo {...props.item} isScrolling={props.isScrolling} />,
   'new-folder': props => <CreateFolder {...props.item} />,
   'new-sandbox': () => <NewSandbox />,

--- a/packages/app/src/app/pages/Dashboard/Components/VariableGrid/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/VariableGrid/index.tsx
@@ -80,7 +80,7 @@ interface IComponentForTypes {
 const ComponentForTypes: IComponentForTypes = {
   sandbox: React.memo(props => (
     <Sandbox
-      key={props.item.name}
+      key={props.item.sandbox.id}
       page={props.page}
       item={props.item}
       isScrolling={props.isScrolling}

--- a/packages/app/src/app/pages/Profile/SandboxPicker/index.tsx
+++ b/packages/app/src/app/pages/Profile/SandboxPicker/index.tsx
@@ -114,7 +114,7 @@ export const SandboxPicker: React.FC<{ closeModal?: () => void }> = ({
             })}
           >
             {collectionsInPath.map(collection => (
-              <Column key={collection.path} data-column>
+              <Column key={`${collection.path}${collection.name}`} data-column>
                 <FolderCard
                   collection={collection}
                   onClick={() => setPath(collection.path)}


### PR DESCRIPTION
<img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.light.svg#gh-dark-mode-only" /><img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.svg#gh-light-mode-only" />&nbsp; Open in CodeSandbox <a href="https://codesandbox.io/p/github/codesandbox/codesandbox-client/SPT-81?workspace=%7B%22gitSidebarPanel%22:%22PR%22,%22sidebarPanel%22:%22GIT%22%7D">Web Editor</a> | <a href="https://codesandbox.io/p/vscode?owner=codesandbox&repo=codesandbox-client&branch=SPT-81">VS Code</a>

<!-- open-in-codesandbox:complete -->


https://user-images.githubusercontent.com/4838076/182361284-5c233797-579c-4e90-996f-9e8f28ed9ca3.mov


