### PR TITLE
fix: GitHub scopes for Projects

### DIFF
--- a/packages/common/src/utils/url-generator.ts
+++ b/packages/common/src/utils/url-generator.ts
@@ -164,8 +164,7 @@ export const signInPageUrl = (redirectTo?: string) => {
 };
 
 export const signInUrl = (extraScopes: boolean = false) =>
-  '/auth/github' +
-  (extraScopes ? '?scope=user:email,public_repo,workflow' : '');
+  '/auth/github' + (extraScopes ? '?scope=user:email,repo,workflow' : '');
 export const signInVercelUrl = () => '/auth/vercel';
 
 export const profileUrl = (username: string) => `/u/${username}`;


### PR DESCRIPTION
<img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.light.svg#gh-dark-mode-only" /><img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.svg#gh-light-mode-only" />&nbsp; Open in CodeSandbox <a href="https://codesandbox.io/p/github/codesandbox/codesandbox-client/aj/fix-scopes?workspace=%7B%22gitSidebarPanel%22:%22PR%22,%22sidebarPanel%22:%22GIT%22%7D">Web Editor</a> | <a href="https://codesandbox.io/p/vscode?owner=codesandbox&repo=codesandbox-client&branch=aj/fix-scopes">VS Code</a>

<!-- open-in-codesandbox:complete -->


This PR adjusts the default GitHub scopes we ask for. Instead of `public_repo`, we ask for `repo`, which is required for Projects.

Note, this PR is dependent on codesandbox/codesandbox-server#934.