### PR TITLE
fix: show better message when exporting to GitHub

### DIFF
--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/GitHub/CreateRepo.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/GitHub/CreateRepo.tsx
@@ -50,7 +50,7 @@ export const CreateRepo = () => {
           >
             open the GitHub import
           </Link>
-          . This will open the GitHub repo in the more powerful{' '}
+          . This will open the GitHub repo in the new{' '}
           <a
             href="https://projects.codesandbox.io"
             rel="noreferrer"

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/GitHub/CreateRepo.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/GitHub/CreateRepo.tsx
@@ -40,7 +40,7 @@ export const CreateRepo = () => {
       defaultOpen={!currentSandbox.originalGit}
     >
       <Element paddingX={2}>
-        <Text variant="muted" marginBottom={4} block>
+        <Text variant="muted" marginBottom={2} block>
           Export the content of this sandbox to a new GitHub repository,
           allowing you to commit changes made on CodeSandbox to GitHub. If you
           want to rather import an existing repository,{' '}
@@ -50,9 +50,12 @@ export const CreateRepo = () => {
           >
             open the GitHub import
           </Link>
-          . This will open the GitHub repo in the new{' '}
+          .
+        </Text>
+        <Text variant="muted" marginBottom={4} block>
+          This will open the GitHub repo in the new{' '}
           <a
-            href="https://projects.codesandbox.io"
+            href="https://projects.codesandbox.io?utm_source=editor"
             rel="noreferrer"
             target="_blank"
           >

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/GitHub/CreateRepo.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/GitHub/CreateRepo.tsx
@@ -50,7 +50,15 @@ export const CreateRepo = () => {
           >
             open the GitHub import
           </Link>
-          .
+          . This will open the GitHub repo in the more powerful{' '}
+          <a
+            href="https://projects.codesandbox.io"
+            rel="noreferrer"
+            target="_blank"
+          >
+            CodeSandbox (Projects) editor
+          </a>{' '}
+          which is built for GitHub repos.
         </Text>
         {!isAllModulesSynced && (
           <Text marginBottom={2} block variant="danger">


### PR DESCRIPTION
<img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.light.svg#gh-dark-mode-only" /><img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.svg#gh-light-mode-only" />&nbsp; Open in CodeSandbox <a href="https://codesandbox.io/p/github/codesandbox/codesandbox-client/draft/peaceful-cache?workspace=%7B%22gitSidebarPanel%22:%22PR%22,%22sidebarPanel%22:%22GIT%22%7D">Web Editor</a> | <a href="https://codesandbox.io/p/vscode?owner=codesandbox&repo=codesandbox-client&branch=draft/peaceful-cache">VS Code</a>

<!-- open-in-codesandbox:complete -->


