### PR TITLE
fix(vscode): remove open effect on mount

### DIFF
--- a/packages/app/src/app/pages/VSCodeAuth/Prompt/index.tsx
+++ b/packages/app/src/app/pages/VSCodeAuth/Prompt/index.tsx
@@ -92,9 +92,6 @@ export const Prompt: FunctionComponent = () => {
     });
   }, [vscodeUrl, authToken]);
 
-  // Attempt to open VS Code when the page mounts.
-  useEffect(() => openInVsCode(), [openInVsCode]);
-
   if (error) {
     return (
       <Container>


### PR DESCRIPTION
<img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.light.svg#gh-dark-mode-only" /><img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.svg#gh-light-mode-only" />&nbsp; Open in CodeSandbox <a href="https://codesandbox.io/p/github/codesandbox/codesandbox-client/fix/vscode-remove-open-effect?workspace=%7B%22gitSidebarPanel%22:%22PR%22,%22sidebarPanel%22:%22GIT%22%7D">Web Editor</a> | <a href="https://codesandbox.io/p/vscode?owner=codesandbox&repo=codesandbox-client&branch=fix/vscode-remove-open-effect">VS Code</a>

<!-- open-in-codesandbox:complete -->


A follow-up to #6836.

## Changes

- Removes the `useEffect` that'd open the VS Code on component's mount.

## Motivation

We don't have the on mount logic in the previous implementation and it looks like I've migrated it incorrectly. You need explicitly click on the "Open in Visual Studio Code" button for the login to happen, just as the text above the button suggests. 