### PR TITLE
fix: fixes a split markdown link

### DIFF
--- a/packages/homepage/content/seo/react/index.md
+++ b/packages/homepage/content/seo/react/index.md
@@ -280,5 +280,5 @@ other libraries to build a full-stack app and keeping up with a fast development
 pace.
 
 To learn more about React, we recommend checking out our
-[React c](https://codesandbox.io/s/new)[ode samples](https://codesandbox.io/s/new)
+[React code samples](https://codesandbox.io/examples/package/react)
 and [React’s own documentation](https://reactjs.org/docs/getting-started.html).


### PR DESCRIPTION
The React code samples  link was split in two links [React c][ode samples] and it was wrongly (I hope) linked to a new project start page

<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?

it is a Bug fix for the bottom links

## What is the current behavior?

Esthetically wrong linked and I think with the wrong link too.

## What is the new behavior?

One link to the react examples


## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation N/A
- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
