### PR TITLE
feat: add tracking for always-on

### DIFF
--- a/packages/app/src/app/pages/Dashboard/Content/routes/AlwaysOn/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/AlwaysOn/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Helmet } from 'react-helmet';
 import { Stack, Button, Text, Icon } from '@codesandbox/components';
+import track from '@codesandbox/common/lib/utils/analytics';
 import css from '@styled-system/css';
 import { useAppState, useActions } from 'app/overmind';
 import { sandboxesTypes } from 'app/overmind/namespaces/dashboard/types';
@@ -26,6 +27,10 @@ export const AlwaysOn = () => {
     getPage(sandboxesTypes.ALWAYS_ON);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeTeam]);
+
+  React.useEffect(() => {
+    track('Sidebar - See Always-on');
+  }, []);
 
   const items: DashboardGridItem[] = sandboxes.ALWAYS_ON
     ? sandboxes.ALWAYS_ON.map(sandbox => ({

--- a/packages/app/src/app/pages/Sandbox/Editor/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/index.tsx
@@ -2,6 +2,7 @@ import Fullscreen from '@codesandbox/common/lib/components/flex/Fullscreen';
 import getTemplateDefinition from '@codesandbox/common/lib/templates';
 import codesandbox from '@codesandbox/common/lib/themes/codesandbox.json';
 import VERSION from '@codesandbox/common/lib/version';
+import track from '@codesandbox/common/lib/utils/analytics';
 import {
   ThemeProvider as ComponentsThemeProvider,
   Element,
@@ -100,6 +101,12 @@ export const Editor = ({ showNewSandboxModal }: EditorTypes) => {
   const { statusBar } = state.editor;
 
   const templateDef = sandbox && getTemplateDefinition(sandbox.template);
+
+  React.useEffect(() => {
+    if (sandbox && sandbox.alwaysOn) {
+      track('Editor - Load Always-on');
+    }
+  }, []);
 
   const getTopOffset = () => {
     if (state.preferences.settings.zenMode) {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Closes XTD-23

## What is the new behavior?

Adds two tracking events for always-on sandboxes, one for when the dashboard section of always-on is loaded and one for when an always-on sandbox is loaded