### PR TITLE
fix: improve sass compile speed by preloading files

### DIFF
--- a/packages/sandpack-core/src/npm/dynamic/fetch-protocols/npm-registry.ts
+++ b/packages/sandpack-core/src/npm/dynamic/fetch-protocols/npm-registry.ts
@@ -1,4 +1,5 @@
 import { satisfies, valid } from 'semver';
+import { Module } from '../../../types/module';
 import { FetchProtocol, Meta } from '../fetch-npm-module';
 import { fetchWithRetries } from './utils';
 import { TarStore } from './utils/tar-store';
@@ -233,6 +234,17 @@ export class NpmRegistryFetcher implements FetchProtocol {
       versionInfo.dist.tarball
     );
     return this.tarStore.meta(name, tarball, this.getRequestInit());
+  }
+
+  public async massFiles(name: string, version: string): Promise<Module[]> {
+    const versionInfo = await this.getVersionInfo(name, version);
+
+    const tarball = this.getTarballUrl(
+      name,
+      versionInfo.version,
+      versionInfo.dist.tarball
+    );
+    return this.tarStore.massFiles(name, tarball, this.getRequestInit());
   }
 
   public condition = (name: string, version: string): boolean => {

--- a/packages/sandpack-core/src/npm/dynamic/resolve-dependency.ts
+++ b/packages/sandpack-core/src/npm/dynamic/resolve-dependency.ts
@@ -2,7 +2,10 @@ import minimatch from 'minimatch';
 import * as semver from 'semver';
 
 import { ILambdaResponse } from '../merge-dependency';
-import { downloadDependency } from './fetch-npm-module';
+import {
+  downloadAllDependencyFiles,
+  downloadDependency,
+} from './fetch-npm-module';
 import { IParsedResolution } from './resolutions';
 
 export async function getPackageJSON(dep: string, version: string) {
@@ -143,6 +146,15 @@ export async function resolveDependencyInfo(
       content: packageJSONCode,
     },
   };
+
+  const allFiles = await downloadAllDependencyFiles(dep, version);
+  if (allFiles) {
+    allFiles.forEach(file => {
+      response.contents[`/node_modules/${dep}${file.path}`] = {
+        content: file.code,
+      };
+    });
+  }
 
   await Promise.all(
     Object.keys(response.dependencyDependencies).map(async packageName => {


### PR DESCRIPTION
This should improve the speed of loading sass by preloading all files in the worker.