### PR TITLE
fix: sse sandboxes ENDPOINT

### DIFF
--- a/packages/common/src/config/env.ts
+++ b/packages/common/src/config/env.ts
@@ -44,7 +44,7 @@ export default Object.keys(process.env)
       'process.env.NODE_ENV': NODE_ENV,
       'process.env.CSB': Boolean(process.env.CSB || false),
       'process.env.ENDPOINT': JSON.stringify(
-        process.env.ENDPOINT || 'codesandbox.io'
+        process.env.ENDPOINT || 'https://codesandbox.io'
       ),
       'process.env.STAGING_API': STAGING_API,
       'process.env.CODESANDBOX_HOST': JSON.stringify(getHost()),


### PR DESCRIPTION
We never set the `ENDPOINT`, so I never thought it would break anything. But apparently it's used in places, even though we never set it. The problem is that there was not a protocol introduced as part of the `ENDPOINT`. 

Fixes #6892