### PR TITLE
Facelift: Page header copy and type review

### DIFF
--- a/packages/app/src/app/pages/Dashboard/Components/Breadcrumbs/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Breadcrumbs/index.tsx
@@ -33,7 +33,7 @@ export const Breadcrumbs: React.FC<BreadcrumbProps> = ({
   } else if (albumId) prefix = 'Discover';
 
   return (
-    <Text marginBottom={1} block weight="bold" size={5}>
+    <Text marginBottom={1} block weight="regular" size={6}>
       <Link
         to={link}
         as={LinkBase}

--- a/packages/app/src/app/pages/Dashboard/Components/Header/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Header/index.tsx
@@ -60,7 +60,7 @@ export const Header = ({
       })}
     >
       {title ? (
-        <Text marginBottom={1} block weight="bold" size={5}>
+        <Text marginBottom={1} block weight="regular" size={6}>
           {title}
         </Text>
       ) : (

--- a/packages/app/src/app/pages/Dashboard/Components/Selection/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Selection/index.tsx
@@ -608,7 +608,7 @@ export const SelectionProvider: React.FC<SelectionProviderProps> = ({
         id="selection-container"
         onContextMenu={onContainerContextMenu}
         css={css({
-          paddingTop: 10,
+          paddingTop: 8,
           paddingBottom: 8,
           width: '100%',
           height: '100%',

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Liked/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Liked/index.tsx
@@ -35,7 +35,7 @@ export const Liked = () => {
         <title>Liked Sandboxes - CodeSandbox</title>
       </Helmet>
       <Header
-        title="Liked Sandboxes"
+        title="Liked sandboxes"
         activeTeam={activeTeam}
         templates={getPossibleTemplates(sandboxes.LIKED)}
         showViewOptions

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Shared/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Shared/index.tsx
@@ -35,7 +35,7 @@ export const Shared = () => {
         <title>Shared with Me - CodeSandbox</title>
       </Helmet>
       <Header
-        title="Sandboxes Shared with Me"
+        title="Sandboxes shared with me"
         activeTeam={activeTeam}
         templates={getPossibleTemplates(sandboxes.SHARED)}
         showViewOptions


### PR DESCRIPTION
Correct title copy 
Adjust font-size, font-weight 
Change padding-top of header title to align with improvements introduced by [PR #6919](https://github.com/codesandbox/codesandbox-client/pull/6919)

<img width="1025" alt="Screen Shot 2022-09-22 at 19 07 09" src="https://user-images.githubusercontent.com/93996574/191859933-e9a44fb5-8723-45d8-8a51-d9dec0ad5e5b.png">

