### PR TITLE
feat: add context menu for branch cards

### DIFF
--- a/packages/app/src/app/components/SandboxList/DeleteSandboxButton/index.tsx
+++ b/packages/app/src/app/components/SandboxList/DeleteSandboxButton/index.tsx
@@ -13,7 +13,7 @@ export const DeleteSandboxButton: FunctionComponent<Props> = ({ id }) => {
   const { deleteSandboxClicked } = useActions().profile;
 
   return (
-    <Tooltip content="Delete Sandbox">
+    <Tooltip content="Archive Sandbox">
       <Button onClick={() => deleteSandboxClicked(id)}>
         <DeleteIcon />
       </Button>

--- a/packages/app/src/app/pages/Dashboard/Components/Branch/BranchCard.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Branch/BranchCard.tsx
@@ -10,9 +10,9 @@ import { css } from '@styled-system/css';
 import { BranchProps } from './types';
 
 export const BranchCard: React.FC<BranchProps> = ({
-  onClick,
   onContextMenu,
   branch,
+  branchUrl,
   selected,
   ...props
 }) => {
@@ -22,9 +22,9 @@ export const BranchCard: React.FC<BranchProps> = ({
 
   return (
     <Stack
+      as="a"
       aria-label={ariaLabel}
       css={css({
-        cursor: 'pointer', // TODO: revisit cursor.
         position: 'relative',
         overflow: 'hidden',
         height: 240,
@@ -35,6 +35,7 @@ export const BranchCard: React.FC<BranchProps> = ({
         backgroundColor: selected ? 'card.backgroundHover' : 'card.background',
         transition: 'background ease-in-out',
         transitionDuration: theme => theme.speeds[2],
+        textDecoration: 'none',
         outline: 'none',
         ':hover': {
           backgroundColor: 'card.backgroundHover',
@@ -44,12 +45,8 @@ export const BranchCard: React.FC<BranchProps> = ({
         },
       })}
       direction="vertical"
-      onClick={onClick}
+      href={branchUrl}
       onContextMenu={onContextMenu}
-      onKeyDown={e => e.key === 'Enter' && onClick(e)}
-      tabIndex={0}
-      // TODO: refine semantics when/if the context menu gets implemented.
-      role="link"
       {...props}
     >
       <Stack
@@ -92,7 +89,10 @@ export const BranchCard: React.FC<BranchProps> = ({
             name="more"
             size={9}
             title="Branch actions"
-            onClick={() => ({})}
+            onClick={evt => {
+              evt.stopPropagation();
+              onContextMenu(evt);
+            }}
           />
         </Stack>
         <Stack gap={2}>

--- a/packages/app/src/app/pages/Dashboard/Components/Branch/BranchCard.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Branch/BranchCard.tsx
@@ -9,7 +9,13 @@ import {
 import { css } from '@styled-system/css';
 import { BranchProps } from './types';
 
-export const BranchCard: React.FC<BranchProps> = ({ onClick, branch }) => {
+export const BranchCard: React.FC<BranchProps> = ({
+  onClick,
+  onContextMenu,
+  branch,
+  selected,
+  ...props
+}) => {
   const { name: branchName, project, contribution } = branch;
   const { repository } = project;
   const ariaLabel = `Open branch ${branchName} from ${repository.name} by ${repository.owner} in the editor`;
@@ -24,8 +30,9 @@ export const BranchCard: React.FC<BranchProps> = ({ onClick, branch }) => {
         height: 240,
         width: '100%',
         borderRadius: '4px',
-        border: '1px solid transparent',
-        backgroundColor: 'card.background',
+        border: '1px solid',
+        borderColor: selected ? 'focusBorder' : 'transparent',
+        backgroundColor: selected ? 'card.backgroundHover' : 'card.background',
         transition: 'background ease-in-out',
         transitionDuration: theme => theme.speeds[2],
         outline: 'none',
@@ -38,10 +45,12 @@ export const BranchCard: React.FC<BranchProps> = ({ onClick, branch }) => {
       })}
       direction="vertical"
       onClick={onClick}
+      onContextMenu={onContextMenu}
       onKeyDown={e => e.key === 'Enter' && onClick(e)}
       tabIndex={0}
       // TODO: refine semantics when/if the context menu gets implemented.
       role="link"
+      {...props}
     >
       <Stack
         css={css({

--- a/packages/app/src/app/pages/Dashboard/Components/Branch/BranchListItem.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Branch/BranchListItem.tsx
@@ -13,13 +13,17 @@ import {
 import css from '@styled-system/css';
 import { BranchProps } from './types';
 
-export const BranchListItem = ({ branch, onClick }: BranchProps) => {
+export const BranchListItem = ({
+  branch,
+  branchUrl,
+  onContextMenu,
+}: BranchProps) => {
   const { name: branchName, project, contribution } = branch;
   const { repository } = project;
   return (
     <ListAction
       align="center"
-      onClick={onClick}
+      onContextMenu={onContextMenu}
       css={css({
         paddingX: 0,
         height: 64,
@@ -29,49 +33,63 @@ export const BranchListItem = ({ branch, onClick }: BranchProps) => {
         backgroundColor: 'transparent',
         color: 'inherit',
         ':hover, :focus, :focus-within': {
-          cursor: 'default',
           backgroundColor: 'list.hoverBackground',
         },
       })}
     >
-      <Grid css={{ width: 'calc(100% - 26px - 8px)' }} columnGap={2}>
-        <Column
-          span={[12, 7, 7]}
-          css={{
-            display: 'block',
-            overflow: 'hidden',
-            paddingBottom: 4,
-            paddingTop: 4,
-          }}
-        >
-          <Stack gap={4} align="center" marginLeft={2}>
-            {contribution ? (
-              <Icon color="#EDFFA5" name="contribution" size={16} />
-            ) : (
-              <Icon name="branch" size={16} />
-            )}
+      <Element
+        as="a"
+        css={{
+          display: 'flex',
+          alignItems: 'center',
+          height: '100%',
+          width: '100%',
+          textDecoration: 'none',
+        }}
+        href={branchUrl}
+      >
+        <Grid css={{ width: 'calc(100% - 26px - 8px)' }} columnGap={2}>
+          <Column
+            span={[12, 7, 7]}
+            css={{
+              display: 'block',
+              overflow: 'hidden',
+              paddingBottom: 4,
+              paddingTop: 4,
+            }}
+          >
+            <Stack gap={4} align="center" marginLeft={2}>
+              {contribution ? (
+                <Icon color="#EDFFA5" name="contribution" size={16} />
+              ) : (
+                <Icon name="branch" size={16} />
+              )}
 
-            <Element css={{ overflow: 'hidden' }}>
-              <Tooltip label={branchName}>
-                <Text size={3} weight="medium" maxWidth="100%">
-                  {branchName}
-                </Text>
-              </Tooltip>
-            </Element>
-          </Stack>
-        </Column>
-        <Column span={[0, 3, 3]} as={Stack} align="center">
-          <Text size={3} variant="muted" maxWidth="100%">
-            {repository.owner}/{repository.name}
-          </Text>
-        </Column>
-      </Grid>
-      <IconButton
-        name="more"
-        size={9}
-        title="Branch actions"
-        onClick={() => ({})}
-      />
+              <Element css={{ overflow: 'hidden' }}>
+                <Tooltip label={branchName}>
+                  <Text size={3} weight="medium" maxWidth="100%">
+                    {branchName}
+                  </Text>
+                </Tooltip>
+              </Element>
+            </Stack>
+          </Column>
+          <Column span={[0, 3, 3]} as={Stack} align="center">
+            <Text size={3} variant="muted" maxWidth="100%">
+              {repository.owner}/{repository.name}
+            </Text>
+          </Column>
+        </Grid>
+        <IconButton
+          name="more"
+          size={9}
+          title="Branch actions"
+          onClick={evt => {
+            evt.stopPropagation();
+            onContextMenu(evt);
+          }}
+        />
+      </Element>
     </ListAction>
   );
 };

--- a/packages/app/src/app/pages/Dashboard/Components/Branch/BranchListItem.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Branch/BranchListItem.tsx
@@ -23,7 +23,6 @@ export const BranchListItem = ({
   return (
     <ListAction
       align="center"
-      onContextMenu={onContextMenu}
       css={css({
         paddingX: 0,
         height: 64,
@@ -47,6 +46,7 @@ export const BranchListItem = ({
           textDecoration: 'none',
         }}
         href={branchUrl}
+        onContextMenu={onContextMenu}
       >
         <Grid css={{ width: 'calc(100% - 26px - 8px)' }} columnGap={2}>
           <Column

--- a/packages/app/src/app/pages/Dashboard/Components/Branch/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Branch/index.tsx
@@ -3,6 +3,7 @@ import { useAppState } from 'app/overmind';
 import React from 'react';
 import { useHistory } from 'react-router-dom';
 import { DashboardBranch } from '../../types';
+import { useSelection } from '../Selection';
 import { BranchCard } from './BranchCard';
 import { BranchListItem } from './BranchListItem';
 
@@ -11,6 +12,7 @@ export const Branch: React.FC<DashboardBranch> = ({ branch }) => {
     dashboard: { viewMode },
   } = useAppState();
   const history = useHistory();
+  const { selectedIds, onRightClick, onMenuEvent } = useSelection();
   const { name, project } = branch;
 
   const url = v2BranchUrl({ name, project });
@@ -24,9 +26,21 @@ export const Branch: React.FC<DashboardBranch> = ({ branch }) => {
     }
   };
 
+  const handleContextMenu = event => {
+    event.preventDefault();
+
+    if (event.type === 'contextmenu') onRightClick(event, branch.id);
+    else onMenuEvent(event, branch.id);
+  };
+
+  const selected = selectedIds.includes(branch.id);
+
   const props = {
     branch,
     onClick: handleClick,
+    onContextMenu: handleContextMenu,
+    'data-selection-id': branch.id,
+    selected,
   };
 
   return {

--- a/packages/app/src/app/pages/Dashboard/Components/Branch/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Branch/index.tsx
@@ -28,8 +28,11 @@ export const Branch: React.FC<DashboardBranch> = ({ branch }) => {
     branch,
     branchUrl,
     onContextMenu: handleContextMenu,
-    // 'data-selection-id': branch.id,
     selected,
+    /**
+     * If we ever need selection for branch entries, `data-selection-id` must be set
+     * 'data-selection-id': branch.id,
+     */
   };
 
   return {

--- a/packages/app/src/app/pages/Dashboard/Components/Branch/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Branch/index.tsx
@@ -1,7 +1,6 @@
 import { v2BranchUrl } from '@codesandbox/common/lib/utils/url-generator';
 import { useAppState } from 'app/overmind';
 import React from 'react';
-import { useHistory } from 'react-router-dom';
 import { DashboardBranch } from '../../types';
 import { useSelection } from '../Selection';
 import { BranchCard } from './BranchCard';
@@ -11,20 +10,10 @@ export const Branch: React.FC<DashboardBranch> = ({ branch }) => {
   const {
     dashboard: { viewMode },
   } = useAppState();
-  const history = useHistory();
   const { selectedIds, onRightClick, onMenuEvent } = useSelection();
   const { name, project } = branch;
 
-  const url = v2BranchUrl({ name, project });
-
-  const handleClick = (e: React.MouseEvent | React.KeyboardEvent) => {
-    // TODO: add analytics
-    if (e.metaKey) {
-      window.open(url, '_blank');
-    } else {
-      history.push(url);
-    }
-  };
+  const branchUrl = v2BranchUrl({ name, project });
 
   const handleContextMenu = event => {
     event.preventDefault();
@@ -37,9 +26,9 @@ export const Branch: React.FC<DashboardBranch> = ({ branch }) => {
 
   const props = {
     branch,
-    onClick: handleClick,
+    branchUrl,
     onContextMenu: handleContextMenu,
-    'data-selection-id': branch.id,
+    // 'data-selection-id': branch.id,
     selected,
   };
 

--- a/packages/app/src/app/pages/Dashboard/Components/Branch/types.ts
+++ b/packages/app/src/app/pages/Dashboard/Components/Branch/types.ts
@@ -2,7 +2,7 @@ import { BranchFragment as Branch } from 'app/graphql/types';
 
 export type BranchProps = {
   branch: Branch;
-  onClick: (e: React.MouseEvent | React.KeyboardEvent) => void;
+  branchUrl: string;
   onContextMenu: (evt: React.MouseEvent) => void;
   selected: boolean;
 };

--- a/packages/app/src/app/pages/Dashboard/Components/Branch/types.ts
+++ b/packages/app/src/app/pages/Dashboard/Components/Branch/types.ts
@@ -3,4 +3,6 @@ import { BranchFragment as Branch } from 'app/graphql/types';
 export type BranchProps = {
   branch: Branch;
   onClick: (e: React.MouseEvent | React.KeyboardEvent) => void;
+  onContextMenu: (evt: React.MouseEvent) => void;
+  selected: boolean;
 };

--- a/packages/app/src/app/pages/Dashboard/Components/Sandbox/SandboxListItem.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Sandbox/SandboxListItem.tsx
@@ -45,11 +45,6 @@ export const SandboxListItem = ({
 }: SandboxItemComponentProps) => (
   <ListAction
     align="center"
-    onClick={onClick}
-    onDoubleClick={onDoubleClick}
-    onBlur={onBlur}
-    onContextMenu={onContextMenu}
-    {...props}
     css={css({
       paddingX: 0,
       opacity,
@@ -65,118 +60,140 @@ export const SandboxListItem = ({
       },
     })}
   >
-    <Grid css={{ width: 'calc(100% - 26px - 8px)' }} columnGap={2}>
-      <Column
-        span={[12, 7, 7]}
-        css={{
-          display: 'block',
-          overflow: 'hidden',
-          paddingBottom: 4,
-          paddingTop: 4,
-        }}
-      >
-        <Stack gap={4} align="center" marginLeft={2}>
-          <Stack
-            as="div"
-            ref={thumbnailRef}
-            justify="center"
-            align="center"
-            css={css({
-              borderRadius: 'small',
-              height: 32,
-              width: 32,
-              backgroundSize: 'cover',
-              backgroundPosition: 'center center',
-              backgroundRepeat: 'no-repeat',
-              border: '1px solid',
-              borderColor: 'grays.500',
-              backgroundColor: 'grays.700',
-              flexShrink: 0,
-              position: 'relative',
-              svg: {
-                filter: 'grayscale(1)',
-                opacity: 0.1,
-              },
-            })}
-            style={{
-              [screenshotUrl
-                ? 'backgroundImage'
-                : null]: `url(${screenshotUrl})`,
-            }}
-          >
-            {alwaysOn && (
-              <Tooltip label="Always-On">
-                <span
-                  css={css({
-                    backgroundColor: 'green',
-                    width: 3,
-                    height: 3,
-                    position: 'absolute',
-                    right: '-6px',
-                    bottom: '-4px',
-                    borderRadius: '50%',
-                  })}
-                />
-              </Tooltip>
-            )}
-            {screenshotUrl ? null : <TemplateIcon width="16" height="16" />}
+    <Element
+      css={css({
+        display: 'flex',
+        alignItems: 'center',
+        width: '100%',
+        height: '100%',
+      })}
+      onClick={onClick}
+      onDoubleClick={onDoubleClick}
+      onBlur={onBlur}
+      onContextMenu={onContextMenu}
+      {...props}
+    >
+      <Grid css={{ width: 'calc(100% - 26px - 8px)' }} columnGap={2}>
+        <Column
+          span={[12, 7, 7]}
+          css={{
+            display: 'block',
+            overflow: 'hidden',
+            paddingBottom: 4,
+            paddingTop: 4,
+          }}
+        >
+          <Stack gap={4} align="center" marginLeft={2}>
+            <Stack
+              as="div"
+              ref={thumbnailRef}
+              justify="center"
+              align="center"
+              css={css({
+                borderRadius: 'small',
+                height: 32,
+                width: 32,
+                backgroundSize: 'cover',
+                backgroundPosition: 'center center',
+                backgroundRepeat: 'no-repeat',
+                border: '1px solid',
+                borderColor: 'grays.500',
+                backgroundColor: 'grays.700',
+                flexShrink: 0,
+                position: 'relative',
+                svg: {
+                  filter: 'grayscale(1)',
+                  opacity: 0.1,
+                },
+              })}
+              style={{
+                [screenshotUrl
+                  ? 'backgroundImage'
+                  : null]: `url(${screenshotUrl})`,
+              }}
+            >
+              {alwaysOn && (
+                <Tooltip label="Always-On">
+                  <span
+                    css={css({
+                      backgroundColor: 'green',
+                      width: 3,
+                      height: 3,
+                      position: 'absolute',
+                      right: '-6px',
+                      bottom: '-4px',
+                      borderRadius: '50%',
+                    })}
+                  />
+                </Tooltip>
+              )}
+              {screenshotUrl ? null : <TemplateIcon width="16" height="16" />}
+            </Stack>
+            <Element css={{ overflow: 'hidden' }}>
+              {editing ? (
+                <form onSubmit={onSubmit}>
+                  <Input
+                    autoFocus
+                    value={newTitle}
+                    onChange={onChange}
+                    onKeyDown={onInputKeyDown}
+                    onBlur={onInputBlur}
+                  />
+                </form>
+              ) : (
+                <Tooltip label={sandboxTitle}>
+                  <Stack gap={1} align="center">
+                    <PrivacyIcon />
+                    <Text size={3} weight="medium" maxWidth="100%">
+                      {sandboxTitle}
+                    </Text>
+                  </Stack>
+                </Tooltip>
+              )}
+            </Element>
           </Stack>
-          <Element css={{ overflow: 'hidden' }}>
-            {editing ? (
-              <form onSubmit={onSubmit}>
-                <Input
-                  autoFocus
-                  value={newTitle}
-                  onChange={onChange}
-                  onKeyDown={onInputKeyDown}
-                  onBlur={onInputBlur}
-                />
-              </form>
-            ) : (
-              <Tooltip label={sandboxTitle}>
-                <Stack gap={1} align="center">
-                  <PrivacyIcon />
-                  <Text size={3} weight="medium" maxWidth="100%">
-                    {sandboxTitle}
-                  </Text>
-                </Stack>
-              </Tooltip>
-            )}
-          </Element>
-        </Stack>
-      </Column>
-      <Column span={[0, 3, 3]} as={Stack} align="center">
-        {sandbox.removedAt ? (
+        </Column>
+        <Column span={[0, 3, 3]} as={Stack} align="center">
+          {sandbox.removedAt ? (
+            <Text
+              size={3}
+              variant={selected ? 'body' : 'muted'}
+              maxWidth="100%"
+            >
+              <Text css={css({ display: ['none', 'none', 'inline'] })}>
+                Deleted
+              </Text>{' '}
+              {formatDistanceToNow(
+                new Date(sandbox.removedAt.replace(/ /g, 'T'))
+              )}{' '}
+              ago
+            </Text>
+          ) : (
+            <Text
+              size={3}
+              variant={selected ? 'body' : 'muted'}
+              maxWidth="100%"
+            >
+              <Text css={css({ display: ['none', 'none', 'inline'] })}>
+                Updated
+              </Text>{' '}
+              {lastUpdated}
+            </Text>
+          )}
+        </Column>
+        <Column span={[0, 2, 2]} as={Stack} align="center">
           <Text size={3} variant={selected ? 'body' : 'muted'} maxWidth="100%">
-            <Text css={css({ display: ['none', 'none', 'inline'] })}>
-              Deleted
-            </Text>{' '}
-            {formatDistanceToNow(
-              new Date(sandbox.removedAt.replace(/ /g, 'T'))
-            )}{' '}
-            ago
+            {sandboxLocation}
           </Text>
-        ) : (
-          <Text size={3} variant={selected ? 'body' : 'muted'} maxWidth="100%">
-            <Text css={css({ display: ['none', 'none', 'inline'] })}>
-              Updated
-            </Text>{' '}
-            {lastUpdated}
-          </Text>
-        )}
-      </Column>
-      <Column span={[0, 2, 2]} as={Stack} align="center">
-        <Text size={3} variant={selected ? 'body' : 'muted'} maxWidth="100%">
-          {sandboxLocation}
-        </Text>
-      </Column>
-    </Grid>
-    <IconButton
-      name="more"
-      size={9}
-      title="Sandbox actions"
-      onClick={onContextMenu}
-    />
+        </Column>
+      </Grid>
+      <IconButton
+        name="more"
+        size={9}
+        title="Sandbox actions"
+        onClick={onContextMenu}
+      />
+    </Element>
   </ListAction>
 );
 

--- a/packages/app/src/app/pages/Dashboard/Components/Sandbox/SandboxListItem.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Sandbox/SandboxListItem.tsx
@@ -161,7 +161,7 @@ export const SandboxListItem = ({
               maxWidth="100%"
             >
               <Text css={css({ display: ['none', 'none', 'inline'] })}>
-                Deleted
+                Archived
               </Text>{' '}
               {formatDistanceToNow(
                 new Date(sandbox.removedAt.replace(/ /g, 'T'))

--- a/packages/app/src/app/pages/Dashboard/Components/Sandbox/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Sandbox/index.tsx
@@ -231,19 +231,33 @@ const GenericSandbox = ({ isScrolling, item, page }: GenericSandboxProps) => {
     onSubmit();
   }, [onSubmit]);
 
-  const interactionProps = {
-    tabIndex: 0, // make div focusable
-    style: {
-      outline: 'none',
-    }, // we handle outline with border
-    selected,
-    onClick,
-    onMouseDown,
-    onDoubleClick,
-    onContextMenu,
-    onBlur,
-    'data-selection-id': sandbox.id,
-  };
+  const interactionProps =
+    page === 'recent'
+      ? {
+          selected,
+          as: 'a',
+          href: url,
+          style: {
+            outline: 'none',
+            textDecoration: 'none',
+          },
+          onBlur,
+          onContextMenu,
+        }
+      : {
+          tabIndex: 0, // make div focusable
+          style: {
+            outline: 'none',
+          }, // we handle outline with border
+          selected,
+          onClick,
+          onMouseDown,
+          onDoubleClick,
+          onContextMenu,
+          onBlur,
+          // Recent page does not support selection
+          'data-selection-id': sandbox.id,
+        };
 
   const sandboxProps = {
     autoFork,

--- a/packages/app/src/app/pages/Dashboard/Components/Sandbox/types.ts
+++ b/packages/app/src/app/pages/Dashboard/Components/Sandbox/types.ts
@@ -18,8 +18,8 @@ export interface SandboxItemComponentProps {
 
   isScrolling: boolean;
   selected: boolean;
-  onClick: (evt: React.MouseEvent) => void;
-  onDoubleClick: (evt: React.MouseEvent) => void;
+  onClick?: (evt: React.MouseEvent) => void;
+  onDoubleClick?: (evt: React.MouseEvent) => void;
   onBlur: (evt: React.FocusEvent) => void;
   onContextMenu: (evt: React.MouseEvent) => void;
 

--- a/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenu.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenu.tsx
@@ -8,6 +8,7 @@ import {
   DashboardNewMasterBranch,
   DashboardCommunitySandbox,
   PageTypes,
+  DashboardBranch,
 } from '../../types';
 import {
   MultiMenu,
@@ -18,6 +19,7 @@ import {
   ContainerMenu,
   CommunitySandboxMenu,
 } from './ContextMenus';
+import { BranchMenu } from './ContextMenus/BranchMenu';
 
 interface IMenuProps {
   visible: boolean;
@@ -36,6 +38,7 @@ interface IContextMenuProps extends IMenuProps {
   sandboxes: Array<DashboardSandbox | DashboardTemplate>;
   folders: Array<DashboardFolder>;
   repos?: Array<DashboardRepo>;
+  branches: Array<DashboardBranch>;
   setRenaming: null | ((value: boolean) => void);
   createNewFolder: () => void;
   createNewSandbox: (() => void) | null;
@@ -49,6 +52,7 @@ export const ContextMenu: React.FC<IContextMenuProps> = ({
   selectedIds,
   sandboxes,
   folders,
+  branches,
   repos,
   setRenaming,
   createNewFolder,
@@ -64,6 +68,7 @@ export const ContextMenu: React.FC<IContextMenuProps> = ({
     | DashboardRepo
     | DashboardNewMasterBranch
     | DashboardCommunitySandbox
+    | DashboardBranch
   > = selectedIds.map(id => {
     if (id.startsWith('/')) {
       if (repos && repos.length) {
@@ -86,6 +91,12 @@ export const ContextMenu: React.FC<IContextMenuProps> = ({
       const folder = folders.find(f => f.path === id);
       return { type: 'folder', ...folder };
     }
+
+    const branch = branches.find(b => b.branch.id === id);
+    if (branch) {
+      return branch;
+    }
+
     const sandbox = sandboxes.find(s => s.sandbox.id === id);
     return sandbox;
   });
@@ -100,6 +111,8 @@ export const ContextMenu: React.FC<IContextMenuProps> = ({
         createNewFolder={createNewFolder}
       />
     );
+  } else if (selectedItems[0].type === 'branch') {
+    menu = <BranchMenu />;
   } else if (selectedItems.length > 1) {
     menu = <MultiMenu page={page} selectedItems={selectedItems} />;
   } else if (

--- a/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenu.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenu.tsx
@@ -112,7 +112,7 @@ export const ContextMenu: React.FC<IContextMenuProps> = ({
       />
     );
   } else if (selectedItems[0].type === 'branch') {
-    menu = <BranchMenu />;
+    menu = <BranchMenu branch={selectedItems[0].branch} />;
   } else if (selectedItems.length > 1) {
     menu = <MultiMenu page={page} selectedItems={selectedItems} />;
   } else if (

--- a/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenu.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenu.tsx
@@ -114,7 +114,19 @@ export const ContextMenu: React.FC<IContextMenuProps> = ({
   } else if (selectedItems[0].type === 'branch') {
     menu = <BranchMenu branch={selectedItems[0].branch} />;
   } else if (selectedItems.length > 1) {
-    menu = <MultiMenu page={page} selectedItems={selectedItems} />;
+    menu = (
+      <MultiMenu
+        page={page}
+        selectedItems={
+          selectedItems as Array<
+            | DashboardFolder
+            | DashboardSandbox
+            | DashboardTemplate
+            | DashboardCommunitySandbox
+          >
+        }
+      />
+    );
   } else if (
     selectedItems[0] &&
     (selectedItems[0].type === 'sandbox' ||

--- a/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenus/BranchMenu.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenus/BranchMenu.tsx
@@ -1,12 +1,28 @@
 import React from 'react';
 import { Menu } from '@codesandbox/components';
+import { BranchFragment as Branch } from 'app/graphql/types';
+import {
+  githubRepoUrl,
+  v2BranchUrl,
+} from '@codesandbox/common/lib/utils/url-generator';
+import { useHistory } from 'react-router-dom';
 import { Context, MenuItem } from '../ContextMenu';
 
-// type BranchMenuProps = {
-//   branch: DashboardBranch;
-// };
-export const BranchMenu = () => {
+type BranchMenuProps = {
+  branch: Branch;
+};
+export const BranchMenu: React.FC<BranchMenuProps> = ({ branch }) => {
   const { visible, setVisibility, position } = React.useContext(Context);
+  const history = useHistory();
+
+  const { name, project, contribution } = branch;
+  const branchUrl = v2BranchUrl({ name, project });
+  const githubUrl = githubRepoUrl({
+    branch: name,
+    repo: project.repository.name,
+    username: project.repository.owner,
+    path: '',
+  });
 
   return (
     <Menu.ContextMenu
@@ -15,10 +31,28 @@ export const BranchMenu = () => {
       position={position}
       style={{ width: 120 }}
     >
-      <MenuItem onSelect={() => alert('github')}>Open on GitHub</MenuItem>
-      <MenuItem onSelect={() => alert('code')}>Open on VS Code</MenuItem>
+      <MenuItem onSelect={() => history.push(branchUrl)}>Open branch</MenuItem>
+      <MenuItem onSelect={() => window.open(branchUrl, '_blank')}>
+        Open branch in a new tab
+      </MenuItem>
+      {!contribution && (
+        <MenuItem onSelect={() => window.open(githubUrl, '_blank')}>
+          Open on GitHub
+        </MenuItem>
+      )}
+      <MenuItem
+        onSelect={() => {
+          /* TODO: Decide if we bring the functionality from v2 */
+        }}
+      >
+        Open in VS Code
+      </MenuItem>
       <Menu.Divider />
-      <MenuItem onSelect={() => alert('remove')}>
+      <MenuItem
+        onSelect={() => {
+          /* TODO: Implement remove branch */
+        }}
+      >
         Remove from CodeSandbox
       </MenuItem>
     </Menu.ContextMenu>

--- a/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenus/BranchMenu.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenus/BranchMenu.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { Menu } from '@codesandbox/components';
+import { Context, MenuItem } from '../ContextMenu';
+
+// type BranchMenuProps = {
+//   branch: DashboardBranch;
+// };
+export const BranchMenu = () => {
+  const { visible, setVisibility, position } = React.useContext(Context);
+
+  return (
+    <Menu.ContextMenu
+      visible={visible}
+      setVisibility={setVisibility}
+      position={position}
+      style={{ width: 120 }}
+    >
+      <MenuItem onSelect={() => alert('github')}>Open on GitHub</MenuItem>
+      <MenuItem onSelect={() => alert('code')}>Open on VS Code</MenuItem>
+      <Menu.Divider />
+      <MenuItem onSelect={() => alert('remove')}>
+        Remove from CodeSandbox
+      </MenuItem>
+    </Menu.ContextMenu>
+  );
+};

--- a/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenus/BranchMenu.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenus/BranchMenu.tsx
@@ -40,13 +40,6 @@ export const BranchMenu: React.FC<BranchMenuProps> = ({ branch }) => {
           Open on GitHub
         </MenuItem>
       )}
-      <MenuItem
-        onSelect={() => {
-          /* TODO: Decide if we bring the functionality from v2 */
-        }}
-      >
-        Open in VS Code
-      </MenuItem>
       <Menu.Divider />
       <MenuItem
         onSelect={() => {

--- a/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenus/FolderMenu.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenus/FolderMenu.tsx
@@ -54,7 +54,7 @@ export const FolderMenu = ({ folder, setRenaming }: FolderMenuProps) => {
           });
         }}
       >
-        Delete folder
+        Archive folder
       </MenuItem>
     </Menu.ContextMenu>
   );

--- a/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenus/SandboxMenu.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenus/SandboxMenu.tsx
@@ -392,7 +392,7 @@ export const SandboxMenu: React.FC<SandboxMenuProps> = ({
                 setVisibility(false);
               }}
             >
-              Delete Template
+              Archive Template
             </MenuItem>
           ) : (
             <MenuItem
@@ -403,7 +403,7 @@ export const SandboxMenu: React.FC<SandboxMenuProps> = ({
                 setVisibility(false);
               }}
             >
-              Delete Sandbox
+              Archive Sandbox
             </MenuItem>
           )}
         </>

--- a/packages/app/src/app/pages/Dashboard/Components/Selection/DragPreview.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Selection/DragPreview.tsx
@@ -69,7 +69,12 @@ export const DragPreview: React.FC<DragPreviewProps> = React.memo(
               };
             }
 
-            const sandbox = sandboxes.find(s => s.sandbox.id === id)!.sandbox;
+            const dashboardEntry = sandboxes.find(s => s.sandbox.id === id);
+            if (!dashboardEntry?.sandbox) {
+              return null;
+            }
+
+            const sandbox = dashboardEntry.sandbox;
 
             let screenshotUrl = sandbox.screenshotUrl;
             // We set a fallback thumbnail in the API which is used for
@@ -91,6 +96,7 @@ export const DragPreview: React.FC<DragPreviewProps> = React.memo(
               Icon: TemplateIcon,
             };
           })
+          .filter(Boolean)
           .slice(0, 4),
       [folders, sandboxes, selectedIds, selectionItems]
     );

--- a/packages/app/src/app/pages/Dashboard/Components/Selection/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Selection/index.tsx
@@ -27,6 +27,7 @@ import {
   DashboardRepo,
   DashboardCommunitySandbox,
   PageTypes,
+  DashboardBranch,
 } from '../../types';
 import { DndDropType } from '../../utils/dnd';
 
@@ -104,16 +105,19 @@ export const SelectionProvider: React.FC<SelectionProviderProps> = ({
       item.type === 'template' ||
       item.type === 'folder' ||
       item.type === 'repo' ||
-      item.type === 'community-sandbox'
+      item.type === 'community-sandbox' ||
+      item.type === 'branch'
   ) as Array<
     | DashboardSandbox
     | DashboardTemplate
     | DashboardFolder
     | DashboardRepo
     | DashboardCommunitySandbox
+    | DashboardBranch
   >;
 
   const selectionItems = possibleItems.map(item => {
+    if (item.type === 'branch') return item.branch.id;
     if (item.type === 'folder') return item.path;
     if (item.type === 'repo') return item.name;
     return item.sandbox.id;
@@ -128,6 +132,9 @@ export const SelectionProvider: React.FC<SelectionProviderProps> = ({
       item.type === 'template' ||
       item.type === 'community-sandbox'
   ) as Array<DashboardSandbox | DashboardTemplate>;
+  const branches = (items || []).filter(
+    item => item.type === 'branch'
+  ) as DashboardBranch[];
 
   const [selectedIds, setSelectedIds] = React.useState<string[]>([]);
   const actions = useActions();
@@ -635,7 +642,7 @@ export const SelectionProvider: React.FC<SelectionProviderProps> = ({
             position: 'absolute',
             background: '#6CC7F640', // blues.300 with 25% opacity
             border: '1px solid',
-            borderColor: 'blues.600',
+            borderColor: 'focusBorder',
             pointerEvents: 'none', // disable selection
           })}
           style={{
@@ -662,6 +669,7 @@ export const SelectionProvider: React.FC<SelectionProviderProps> = ({
         selectedIds={selectedIds}
         sandboxes={sandboxes || []}
         folders={folders || []}
+        branches={branches || []}
         setRenaming={setRenaming}
         page={page}
         createNewFolder={createNewFolder}

--- a/packages/app/src/app/pages/Dashboard/Sidebar/ContextMenu.tsx
+++ b/packages/app/src/app/pages/Dashboard/Sidebar/ContextMenu.tsx
@@ -88,7 +88,7 @@ export const ContextMenu: React.FC<ContextMenuProps> = ({
             });
           }}
         >
-          Delete folder
+          Archive folder
         </MenuItem>
       </>
     );

--- a/packages/app/src/app/pages/Profile/ContextMenu.tsx
+++ b/packages/app/src/app/pages/Profile/ContextMenu.tsx
@@ -149,7 +149,7 @@ export const ContextMenu = () => {
           </Menu.Item>
           <Menu.Divider />
           <Menu.Item onSelect={() => deleteSandboxClicked(sandboxId)}>
-            Delete sandbox
+            Archive sandbox
           </Menu.Item>
         </>
       )}

--- a/packages/app/src/app/pages/common/Modals/DeleteProfileSandboxModal/index.tsx
+++ b/packages/app/src/app/pages/common/Modals/DeleteProfileSandboxModal/index.tsx
@@ -10,11 +10,11 @@ export const DeleteProfileSandboxModal: FunctionComponent = () => {
 
   return (
     <Alert
-      title="Delete Sandbox"
-      description="Are you sure you want to delete this sandbox?"
+      title="Archive Sandbox"
+      description="Are you sure you want to archive this sandbox?"
       onCancel={modalClosed}
       onPrimaryAction={sandboxDeleted}
-      confirmMessage="Delete"
+      confirmMessage="Archive"
       type="danger"
     />
   );

--- a/packages/app/src/app/pages/common/Modals/DeleteSandboxModal/index.tsx
+++ b/packages/app/src/app/pages/common/Modals/DeleteSandboxModal/index.tsx
@@ -10,11 +10,11 @@ export const DeleteSandboxModal: FunctionComponent = () => {
 
   return (
     <Alert
-      title="Delete Sandbox"
-      description="Are you sure you want to delete this sandbox?"
+      title="Archive Sandbox"
+      description="Are you sure you want to archive this sandbox?"
       onCancel={modalClosed}
       onPrimaryAction={sandboxDeleted}
-      confirmMessage="Delete"
+      confirmMessage="Archive"
       type="danger"
     />
   );

--- a/packages/app/src/app/pages/common/Modals/MoveSandboxFolderModal/DirectoryPicker/SandboxesItem/FolderEntry/index.tsx
+++ b/packages/app/src/app/pages/common/Modals/MoveSandboxFolderModal/DirectoryPicker/SandboxesItem/FolderEntry/index.tsx
@@ -164,7 +164,7 @@ class FolderEntry extends React.Component<Props, State> {
             },
           },
           {
-            title: 'Delete Folder',
+            title: 'Archive Folder',
             icon: TrashIcon,
             color: theme.red.darken(0.2)(),
             action: () => {


### PR DESCRIPTION
this is pointing to #6925, as I started with some facelift work and continued on the same source to implement the context menu.

It was a bit awkward, because context menus are tied to the selection. Added a context menu component for branches that works for regular and for contribution branches.

![image](https://user-images.githubusercontent.com/9945366/192245024-9eef1d6e-dde0-4a40-b82a-496df3d2473a.png)

Also modified the sandbox card/list view for the recent page to support direct link instead of select on click and open on double click

![image](https://user-images.githubusercontent.com/9945366/192245189-73411a58-2008-4f30-bd6d-6585a12647b0.png)

Will create two follow-up linear tasks:
* Implement context menu for repos
* Implement branch removal via the context menu (felt too much for this PR which was already big)
