### PR TITLE
feat(dashboard): analytics

### DIFF
--- a/packages/app/src/app/overmind/namespaces/dashboard/types.ts
+++ b/packages/app/src/app/overmind/namespaces/dashboard/types.ts
@@ -10,7 +10,6 @@ export type PageTypes =
   | 'synced-sandboxes'
   | 'my-contributions'
   | 'repositories'
-  | 'repository-branches'
   | 'shared'
   | 'liked'
   | 'always-on'

--- a/packages/app/src/app/pages/Dashboard/Components/Branch/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Branch/index.tsx
@@ -8,7 +8,7 @@ import { useSelection } from '../Selection';
 import { BranchCard } from './BranchCard';
 import { BranchListItem } from './BranchListItem';
 
-const mapBranchEventToPageType: Partial<Record<PageTypes, string>> = {
+const MAP_BRANCH_EVENT_TO_PAGE_TYPE: Partial<Record<PageTypes, string>> = {
   'my-contributions':
     'Dashboard - Open Contribution Branch from My Contributions',
   repositories: 'Dashboard - Open Branch from Repository',
@@ -35,10 +35,7 @@ export const Branch: React.FC<BranchProps> = ({ branch, page }) => {
   };
 
   const handleClick = () => {
-    trackImprovedDashboardEvent(mapBranchEventToPageType[page], {
-      codesandbox: 'V1',
-      event_source: 'UI',
-    });
+    trackImprovedDashboardEvent(MAP_BRANCH_EVENT_TO_PAGE_TYPE[page]);
   };
 
   const selected = selectedIds.includes(branch.id);

--- a/packages/app/src/app/pages/Dashboard/Components/Branch/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Branch/index.tsx
@@ -1,5 +1,5 @@
-import track from '@codesandbox/common/lib/utils/analytics';
 import { v2BranchUrl } from '@codesandbox/common/lib/utils/url-generator';
+import { trackImprovedDashboardEvent } from '@codesandbox/common/lib/utils/analytics';
 import { useAppState } from 'app/overmind';
 import { PageTypes } from 'app/overmind/namespaces/dashboard/types';
 import React from 'react';
@@ -35,7 +35,7 @@ export const Branch: React.FC<BranchProps> = ({ branch, page }) => {
   };
 
   const handleClick = () => {
-    track(mapBranchEventToPageType[page], {
+    trackImprovedDashboardEvent(mapBranchEventToPageType[page], {
       codesandbox: 'V1',
       event_source: 'UI',
     });

--- a/packages/app/src/app/pages/Dashboard/Components/Branch/types.ts
+++ b/packages/app/src/app/pages/Dashboard/Components/Branch/types.ts
@@ -4,5 +4,6 @@ export type BranchProps = {
   branch: Branch;
   branchUrl: string;
   onContextMenu: (evt: React.MouseEvent) => void;
+  onClick: (evt: React.MouseEvent) => void;
   selected: boolean;
 };

--- a/packages/app/src/app/pages/Dashboard/Components/Repository/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Repository/index.tsx
@@ -12,7 +12,7 @@ import {
 import { css } from '@styled-system/css';
 import { useAppState } from 'app/overmind';
 import { useHistory } from 'react-router-dom';
-import track from '@codesandbox/common/lib/utils/analytics';
+import { trackImprovedDashboardEvent } from '@codesandbox/common/lib/utils/analytics';
 import { DashboardRepository } from '../../types';
 
 export const Repository: React.FC<DashboardRepository> = ({ repository }) => {
@@ -28,10 +28,7 @@ export const Repository: React.FC<DashboardRepository> = ({ repository }) => {
 
   // TODO: replace with double click action when/if implemeting the context menu
   const handleClick = (e: React.MouseEvent | React.KeyboardEvent) => {
-    track('Dashboard - Open Repository', {
-      codesandbox: 'V1',
-      event_source: 'UI',
-    });
+    trackImprovedDashboardEvent('Dashboard - Open Repository');
     const url = `/dashboard/repositories/github/${providerRepository.owner}/${providerRepository.name}`;
     if (e.ctrlKey || e.metaKey) {
       window.open(url, '_blank');

--- a/packages/app/src/app/pages/Dashboard/Components/Repository/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Repository/index.tsx
@@ -12,6 +12,7 @@ import {
 import { css } from '@styled-system/css';
 import { useAppState } from 'app/overmind';
 import { useHistory } from 'react-router-dom';
+import track from '@codesandbox/common/lib/utils/analytics';
 import { DashboardRepository } from '../../types';
 
 export const Repository: React.FC<DashboardRepository> = ({ repository }) => {
@@ -27,7 +28,10 @@ export const Repository: React.FC<DashboardRepository> = ({ repository }) => {
 
   // TODO: replace with double click action when/if implemeting the context menu
   const handleClick = (e: React.MouseEvent | React.KeyboardEvent) => {
-    // TODO: add analytics
+    track('Dashboard - Open Repository', {
+      codesandbox: 'V1',
+      event_source: 'UI',
+    });
     const url = `/dashboard/repositories/github/${providerRepository.owner}/${providerRepository.name}`;
     if (e.ctrlKey || e.metaKey) {
       window.open(url, '_blank');

--- a/packages/app/src/app/pages/Dashboard/Components/Sandbox/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Sandbox/index.tsx
@@ -172,7 +172,9 @@ const GenericSandbox = ({ isScrolling, item, page }: GenericSandboxProps) => {
       return;
     }
 
-    const sandboxEvent = !autoFork ? mapSandboxEventToPageType[page] : null;
+    const sandboxAnalyticsEvent = !autoFork
+      ? mapSandboxEventToPageType[page]
+      : null;
 
     // Templates in Home should fork, everything else opens
     if (event.ctrlKey || event.metaKey) {
@@ -186,7 +188,9 @@ const GenericSandbox = ({ isScrolling, item, page }: GenericSandboxProps) => {
           openInNewWindow: true,
         });
       } else {
-        trackImprovedDashboardEvent(sandboxEvent);
+        if (sandboxAnalyticsEvent) {
+          trackImprovedDashboardEvent(sandboxAnalyticsEvent);
+        }
         window.open(url, '_blank');
       }
     } else if (autoFork) {
@@ -194,7 +198,9 @@ const GenericSandbox = ({ isScrolling, item, page }: GenericSandboxProps) => {
         sandboxId: sandbox.id,
       });
     } else {
-      trackImprovedDashboardEvent(sandboxEvent);
+      if (sandboxAnalyticsEvent) {
+        trackImprovedDashboardEvent(sandboxAnalyticsEvent);
+      }
       history.push(url);
     }
   };

--- a/packages/app/src/app/pages/Dashboard/Components/Sandbox/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Sandbox/index.tsx
@@ -7,7 +7,9 @@ import { zonedTimeToUtc } from 'date-fns-tz';
 import { useActions, useAppState } from 'app/overmind';
 import { sandboxUrl } from '@codesandbox/common/lib/utils/url-generator';
 import { ESC } from '@codesandbox/common/lib/utils/keycodes';
-import track from '@codesandbox/common/lib/utils/analytics';
+import track, {
+  trackImprovedDashboardEvent,
+} from '@codesandbox/common/lib/utils/analytics';
 import { Icon } from '@codesandbox/components';
 import { formatNumber } from '@codesandbox/components/lib/components/Stats';
 import { SandboxCard, SkeletonCard } from './SandboxCard';
@@ -184,10 +186,7 @@ const GenericSandbox = ({ isScrolling, item, page }: GenericSandboxProps) => {
           openInNewWindow: true,
         });
       } else {
-        track(sandboxEvent, {
-          codesandbox: 'V1',
-          event_source: 'UI',
-        });
+        trackImprovedDashboardEvent(sandboxEvent);
         window.open(url, '_blank');
       }
     } else if (autoFork) {
@@ -195,10 +194,7 @@ const GenericSandbox = ({ isScrolling, item, page }: GenericSandboxProps) => {
         sandboxId: sandbox.id,
       });
     } else {
-      track(sandboxEvent, {
-        codesandbox: 'V1',
-        event_source: 'UI',
-      });
+      trackImprovedDashboardEvent(sandboxEvent);
       history.push(url);
     }
   };

--- a/packages/app/src/app/pages/Dashboard/Components/Sandbox/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Sandbox/index.tsx
@@ -20,7 +20,7 @@ import { DashboardSandbox, DashboardTemplate, PageTypes } from '../../types';
 import { SandboxItemComponentProps } from './types';
 import { useDrag } from '../../utils/dnd';
 
-const mapSandboxEventToPageType: Partial<Record<PageTypes, string>> = {
+const MAP_SANDBOX_EVENT_TO_PAGE_TYPE: Partial<Record<PageTypes, string>> = {
   recent: 'Dashboard - Open Sandbox from Recent',
   drafts: 'Dashboard - Open Sandbox from My Drafts',
   sandboxes: 'Dashboard - Open Sandbox from Sandboxes',
@@ -173,7 +173,7 @@ const GenericSandbox = ({ isScrolling, item, page }: GenericSandboxProps) => {
     }
 
     const sandboxAnalyticsEvent = !autoFork
-      ? mapSandboxEventToPageType[page]
+      ? MAP_SANDBOX_EVENT_TO_PAGE_TYPE[page]
       : null;
 
     // Templates in Home should fork, everything else opens

--- a/packages/app/src/app/pages/Dashboard/Components/VariableGrid/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/VariableGrid/index.tsx
@@ -139,7 +139,7 @@ const ComponentForTypes: IComponentForTypes = {
   'community-sandbox': React.memo(props => (
     <CommunitySandbox item={props.item} isScrolling={props.isScrolling} />
   )),
-  branch: ({ item }) => <Branch {...item} />,
+  branch: ({ item, page }) => <Branch page={page} {...item} />,
   repository: ({ item }) => <Repository {...item} />,
 };
 

--- a/packages/app/src/app/pages/Dashboard/Sidebar/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Sidebar/index.tsx
@@ -405,9 +405,13 @@ const MAP_SIDEBAR_ITEM_EVENT_TO_PAGE_TYPE: Partial<Record<
   repositories: 'Dashboard - View Repositories',
   drafts: 'Dashboard - View Drafts',
   templates: 'Dashboard - View Templates',
+  sandboxes: 'Dashboard - View Sandboxes',
+  'always-on': 'Dashboard - View Always-On',
   'synced-sandboxes': 'Dashboard - View Synced Sandboxes',
   archive: 'Dashboard - View Archive',
-  sandboxes: 'Dashboard - View Sandboxes',
+  discover: 'Dashboard - View Discover',
+  shared: 'Dashboard - View Shared',
+  liked: 'Dashboard - View Liked',
 };
 
 interface RowItemProps {

--- a/packages/app/src/app/pages/Dashboard/Sidebar/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Sidebar/index.tsx
@@ -396,7 +396,10 @@ const isSamePath = (
   return false;
 };
 
-const mapSidebarItemEventToPageType: Partial<Record<PageTypes, string>> = {
+const MAP_SIDEBAR_ITEM_EVENT_TO_PAGE_TYPE: Partial<Record<
+  PageTypes,
+  string
+>> = {
   recent: 'Dashboard - View Recent',
   'my-contributions': 'Dashboard - View My Contributions',
   repositories: 'Dashboard - View Repositories',
@@ -526,10 +529,10 @@ const RowItem: React.FC<RowItemProps> = ({
               }
             },
             onClick: () => {
-              const event = mapSidebarItemEventToPageType[page];
+              const event = MAP_SIDEBAR_ITEM_EVENT_TO_PAGE_TYPE[page];
               if (event) {
                 trackImprovedDashboardEvent(
-                  mapSidebarItemEventToPageType[page]
+                  MAP_SIDEBAR_ITEM_EVENT_TO_PAGE_TYPE[page]
                 );
               }
 
@@ -743,9 +746,11 @@ const NestableRowItem: React.FC<NestableRowItemProps> = ({
         <Link
           to={folderUrl}
           onClick={() => {
-            const event = mapSidebarItemEventToPageType[page];
+            const event = MAP_SIDEBAR_ITEM_EVENT_TO_PAGE_TYPE[page];
             if (event) {
-              trackImprovedDashboardEvent(mapSidebarItemEventToPageType[page]);
+              trackImprovedDashboardEvent(
+                MAP_SIDEBAR_ITEM_EVENT_TO_PAGE_TYPE[page]
+              );
             }
             history.push(folderUrl);
             return false;

--- a/packages/app/src/app/pages/Dashboard/Sidebar/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Sidebar/index.tsx
@@ -234,6 +234,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
           <NestableRowItem
             name="Sandboxes"
             path={dashboardUrls.sandboxes('/', activeTeam)}
+            page="sandboxes"
             folderPath="/"
             folders={[
               ...folders,
@@ -393,6 +394,17 @@ const isSamePath = (
   return false;
 };
 
+const mapSidebarItemEventToPageType: Partial<Record<PageTypes, string>> = {
+  recent: 'Dashboard - View Recent',
+  'my-contributions': 'Dashboard - View My Contributions',
+  repositories: 'Dashboard - View Repositories',
+  drafts: 'Dashboard - View Drafts',
+  templates: 'Dashboard - View Templates',
+  'synced-sandboxes': 'Dashboard - View Synced Sandboxes',
+  archive: 'Dashboard - View Archive',
+  sandboxes: 'Dashboard - View Sandboxes',
+};
+
 interface RowItemProps {
   name: string;
   path: string;
@@ -404,7 +416,6 @@ interface RowItemProps {
   badge?: boolean;
   nestingLevel?: number;
 }
-
 const RowItem: React.FC<RowItemProps> = ({
   name,
   path,
@@ -512,6 +523,17 @@ const RowItem: React.FC<RowItemProps> = ({
                 history.push(linkTo, { focus: 'FIRST_ITEM' });
               }
             },
+            onClick: () => {
+              const event = mapSidebarItemEventToPageType[page];
+              if (event) {
+                track(mapSidebarItemEventToPageType[page], {
+                  codesandbox: 'V1',
+                  event_source: 'UI',
+                });
+              }
+
+              return false;
+            },
           }}
         >
           <Stack
@@ -543,12 +565,14 @@ interface NestableRowItemProps {
   name: string;
   folderPath: string;
   path: string;
+  page: PageTypes;
   folders: DashboardBaseFolder[];
 }
 
 const NestableRowItem: React.FC<NestableRowItemProps> = ({
   name,
   path,
+  page,
   folderPath,
   folders,
 }) => {
@@ -717,7 +741,17 @@ const NestableRowItem: React.FC<NestableRowItemProps> = ({
       >
         <Link
           to={folderUrl}
-          onClick={() => history.push(folderUrl)}
+          onClick={() => {
+            const event = mapSidebarItemEventToPageType[page];
+            if (event) {
+              track(mapSidebarItemEventToPageType[page], {
+                codesandbox: 'V1',
+                event_source: 'UI',
+              });
+            }
+            history.push(folderUrl);
+            return false;
+          }}
           onContextMenu={onContextMenu}
           onKeyDown={event => {
             if (event.keyCode === ENTER && !isRenaming && !isNewFolder) {
@@ -811,6 +845,7 @@ const NestableRowItem: React.FC<NestableRowItemProps> = ({
               .sort(a => 1)
               .map(folder => (
                 <NestableRowItem
+                  page={page}
                   key={folder.path}
                   name={folder.name}
                   path={dashboardUrls.sandboxes(folder.path, state.activeTeam)}

--- a/packages/app/src/app/pages/Dashboard/Sidebar/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Sidebar/index.tsx
@@ -6,7 +6,9 @@ import { useAppState, useActions } from 'app/overmind';
 import { motion, AnimatePresence } from 'framer-motion';
 import { dashboard as dashboardUrls } from '@codesandbox/common/lib/utils/url-generator';
 import { ESC, ENTER } from '@codesandbox/common/lib/utils/keycodes';
-import track from '@codesandbox/common/lib/utils/analytics';
+import track, {
+  trackImprovedDashboardEvent,
+} from '@codesandbox/common/lib/utils/analytics';
 import { SkeletonTextBlock } from 'app/pages/Sandbox/Editor/Skeleton/elements';
 import {
   Element,
@@ -526,10 +528,9 @@ const RowItem: React.FC<RowItemProps> = ({
             onClick: () => {
               const event = mapSidebarItemEventToPageType[page];
               if (event) {
-                track(mapSidebarItemEventToPageType[page], {
-                  codesandbox: 'V1',
-                  event_source: 'UI',
-                });
+                trackImprovedDashboardEvent(
+                  mapSidebarItemEventToPageType[page]
+                );
               }
 
               return false;
@@ -744,10 +745,7 @@ const NestableRowItem: React.FC<NestableRowItemProps> = ({
           onClick={() => {
             const event = mapSidebarItemEventToPageType[page];
             if (event) {
-              track(mapSidebarItemEventToPageType[page], {
-                codesandbox: 'V1',
-                event_source: 'UI',
-              });
+              trackImprovedDashboardEvent(mapSidebarItemEventToPageType[page]);
             }
             history.push(folderUrl);
             return false;

--- a/packages/common/src/utils/analytics/index.ts
+++ b/packages/common/src/utils/analytics/index.ts
@@ -113,7 +113,18 @@ export function trackWithCooldown(
   track(event, data);
 }
 
-export default function track(eventName, secondArg: Object = {}) {
+export function trackImprovedDashboardEvent(
+  eventName: string,
+  extraInfo: Object = {}
+) {
+  track(eventName, {
+    ...extraInfo,
+    codesandbox: 'V1',
+    event_source: 'UI',
+  });
+}
+
+export default function track(eventName: string, secondArg: Object = {}) {
   if (!DO_NOT_TRACK_ENABLED && isAllowedEvent(eventName, secondArg)) {
     const data = {
       ...secondArg,


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

Closes XTD-96
Closes XTD-97

## What kind of change does this PR introduce?

<!-- Is it a Bug fix, feature, docs update, ... -->

Adds new analytics events to the dashboard.

## What is the new behavior?

<!-- if this is a feature change -->

- Dashboard - Open Contribution Branch from My Contributions
- Dashboard - Open Branch from Repository
- Dashboard - Open Branch from Recent
- Dashboard - Open Repository
- Dashboard - Open Sandbox from Recent
- Dashboard - Open Sandbox from My Drafts (not in the events table)
- Dashboard - Open Sandbox from Sandboxes (not in the events table)
- Dashboard - View Recent
- Dashboard - View My Contributions
- Dashboard - View Repositories
- Dashboard - View Drafts
- Dashboard - View Templates
- Dashboard - View Synced Sandboxes
- Dashboard - View Archive
- Dashboard - View Sandboxes

It sunsets one event:
- Dashboard - Recent sandbox opened (source: 'Home', dashboardVersion: 2)