### PR TITLE
feat(dashboard): improve repositories loading

### DIFF
--- a/packages/app/src/app/graphql/types.ts
+++ b/packages/app/src/app/graphql/types.ts
@@ -3209,6 +3209,7 @@ export type ContributionBranchesQuery = { __typename?: 'RootQueryType' } & {
 
 export type RepositoriesByTeamQueryVariables = Exact<{
   teamId: Scalars['UUID4'];
+  syncData: Maybe<Scalars['Boolean']>;
 }>;
 
 export type RepositoriesByTeamQuery = { __typename?: 'RootQueryType' } & {

--- a/packages/app/src/app/graphql/types.ts
+++ b/packages/app/src/app/graphql/types.ts
@@ -3224,6 +3224,15 @@ export type RepositoriesByTeamQuery = { __typename?: 'RootQueryType' } & {
   >;
 };
 
+export type RepositoryByDetailsQueryVariables = Exact<{
+  owner: Scalars['String'];
+  name: Scalars['String'];
+}>;
+
+export type RepositoryByDetailsQuery = { __typename?: 'RootQueryType' } & {
+  project: Maybe<{ __typename?: 'Project' } & ProjectFragment>;
+};
+
 export type RecentNotificationFragment = { __typename?: 'Notification' } & Pick<
   Notification,
   'id' | 'type' | 'data' | 'insertedAt' | 'read'

--- a/packages/app/src/app/overmind/effects/gql/dashboard/queries.ts
+++ b/packages/app/src/app/overmind/effects/gql/dashboard/queries.ts
@@ -51,6 +51,8 @@ import {
   ContributionBranchesQueryVariables,
   RepositoriesByTeamQuery,
   RepositoriesByTeamQueryVariables,
+  RepositoryByDetailsQuery,
+  RepositoryByDetailsQueryVariables,
 } from 'app/graphql/types';
 import { gql, Query } from 'overmind-graphql';
 
@@ -499,6 +501,19 @@ export const getRepositoriesByTeam: Query<
           ...project
         }
       }
+    }
+  }
+  ${projectFragment}
+  ${branchFragment}
+`;
+
+export const getRepositoryByDetails: Query<
+  RepositoryByDetailsQuery,
+  RepositoryByDetailsQueryVariables
+> = gql`
+  query RepositoryByDetails($owner: String!, $name: String!) {
+    project(gitProvider: GITHUB, owner: $owner, repo: $name) {
+      ...project
     }
   }
   ${projectFragment}

--- a/packages/app/src/app/overmind/effects/gql/dashboard/queries.ts
+++ b/packages/app/src/app/overmind/effects/gql/dashboard/queries.ts
@@ -490,12 +490,12 @@ export const getRepositoriesByTeam: Query<
   RepositoriesByTeamQuery,
   RepositoriesByTeamQueryVariables
 > = gql`
-  query RepositoriesByTeam($teamId: UUID4!) {
+  query RepositoriesByTeam($teamId: UUID4!, $syncData: Boolean) {
     me {
       team(id: $teamId) {
         id
         name
-        projects {
+        projects(syncData: $syncData) {
           ...project
         }
       }

--- a/packages/app/src/app/overmind/namespaces/dashboard/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/dashboard/actions.ts
@@ -1972,15 +1972,35 @@ export const getRepositoriesByTeam = async ({ state, effects }: Context) => {
   try {
     dashboard.repositories = null;
 
-    const repositoriesData = await effects.gql.queries.getRepositoriesByTeam({
-      teamId: activeTeam,
-    });
-    const v2Repositories = repositoriesData?.me?.team?.projects;
-    if (!v2Repositories?.length) {
+    // First fetch data without syncing with GitHub
+    // to decrease waiting time.
+    const unsyncedRepositoriesData = await effects.gql.queries.getRepositoriesByTeam(
+      {
+        teamId: activeTeam,
+        syncData: false,
+      }
+    );
+    const unsyncedRepositories = unsyncedRepositoriesData?.me?.team?.projects;
+    if (!unsyncedRepositories?.length) {
       return;
     }
 
-    dashboard.repositories = v2Repositories;
+    dashboard.repositories = unsyncedRepositories;
+
+    // Then fetch data synced with GitHub to make sure
+    // what we show is up-to-date.
+    const syncedRepositoriesData = await effects.gql.queries.getRepositoriesByTeam(
+      {
+        teamId: activeTeam,
+        syncData: true,
+      }
+    );
+    const syncedRepositories = syncedRepositoriesData?.me?.team?.projects;
+    if (!syncedRepositories?.length) {
+      return;
+    }
+
+    dashboard.repositories = syncedRepositories;
   } catch (error) {
     effects.notificationToast.error(
       'There was a problem getting your open repositories'

--- a/packages/app/src/app/overmind/namespaces/dashboard/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/dashboard/actions.ts
@@ -2003,7 +2003,34 @@ export const getRepositoriesByTeam = async ({ state, effects }: Context) => {
     dashboard.repositories = syncedRepositories;
   } catch (error) {
     effects.notificationToast.error(
-      'There was a problem getting your open repositories'
+      'There was a problem getting your repositories'
+    );
+  }
+};
+
+// If the repository page is accessed directly, we can use this
+// to avoid fetching all repos.
+export const getRepositoryByDetails = async (
+  { state, effects }: Context,
+  { owner, name }: { owner: string; name: string }
+) => {
+  const { dashboard } = state;
+  try {
+    dashboard.repositories = null;
+
+    const repositoryData = await effects.gql.queries.getRepositoryByDetails({
+      owner,
+      name,
+    });
+    const repository = repositoryData?.project;
+    if (!repository) {
+      return;
+    }
+
+    dashboard.repositories = [repository];
+  } catch (error) {
+    effects.notificationToast.error(
+      `There was a problem getting repository ${name} from ${owner}`
     );
   }
 };

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Repositories/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Repositories/index.tsx
@@ -17,8 +17,18 @@ export const RepositoriesPage = () => {
   } = useAppState();
 
   React.useEffect(() => {
-    actions.dashboard.getRepositoriesByTeam();
-  }, [activeTeam, actions.dashboard]);
+    // If no repositories were fetched yet and the user tries
+    // to directly access a repository, we should fetch said
+    // repository only.
+    if (repositories === null) {
+      if (path) {
+        const [, owner, name] = path.split('/');
+        actions.dashboard.getRepositoryByDetails({ owner, name });
+      } else {
+        actions.dashboard.getRepositoriesByTeam();
+      }
+    }
+  }, [path]);
 
   const pageType: PageTypes = 'repositories';
 

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Repositories/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Repositories/index.tsx
@@ -15,6 +15,7 @@ export const RepositoriesPage = () => {
     activeTeam,
     dashboard: { repositories },
   } = useAppState();
+  const pathRef = React.useRef<string>(null);
 
   React.useEffect(() => {
     // If no repositories were fetched yet and the user tries
@@ -28,6 +29,19 @@ export const RepositoriesPage = () => {
         actions.dashboard.getRepositoriesByTeam();
       }
     }
+
+    // If the current view is the list of the repositories
+    // and the previous view was a repo and only that repo
+    // was fetched, get all repositories of that team.
+    if (
+      path === '' &&
+      pathRef.current?.startsWith('github') &&
+      repositories.length === 1
+    ) {
+      actions.dashboard.getRepositoriesByTeam();
+    }
+
+    pathRef.current = path;
   }, [path]);
 
   const pageType: PageTypes = 'repositories';


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?

<!-- Is it a Bug fix, feature, docs update, ... -->

Adds progressive loading to the repositories page. I've also added the behavior of fetching only the selected repo if the user accesses the page directly.

## What is the new behavior?

<!-- if this is a feature change -->

Decreases initial loading time for a team with almost 100 projects and around 2000 branches from nearly 14s to less than 5s.
|Now|Previously|
|:-:|:-:|
|![image](https://user-images.githubusercontent.com/24959348/192923913-1320e0f6-0222-4acf-8151-f453a884ad6b.png)|![image](https://user-images.githubusercontent.com/24959348/192923928-259aac3f-8106-4324-9436-6b33b57bb401.png)|
