### PR TITLE
Facelift: Extra type review

### DIFF
--- a/packages/app/src/app/pages/Dashboard/Components/Breadcrumbs/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Breadcrumbs/index.tsx
@@ -33,7 +33,7 @@ export const Breadcrumbs: React.FC<BreadcrumbProps> = ({
   } else if (albumId) prefix = 'Discover';
 
   return (
-    <Text marginBottom={1} marginTop={-2} block weight="regular" size={6} >
+    <Text marginBottom={1} marginTop={-2} block weight="regular" size={6} paddingRight={4} >
       <Link
         to={link}
         as={LinkBase}

--- a/packages/app/src/app/pages/Dashboard/Components/Breadcrumbs/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Breadcrumbs/index.tsx
@@ -33,7 +33,7 @@ export const Breadcrumbs: React.FC<BreadcrumbProps> = ({
   } else if (albumId) prefix = 'Discover';
 
   return (
-    <Text marginBottom={1} block weight="regular" size={6}>
+    <Text marginBottom={1} marginTop={-2} block weight="regular" size={6} >
       <Link
         to={link}
         as={LinkBase}

--- a/packages/app/src/app/pages/Dashboard/Components/Header/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Header/index.tsx
@@ -104,13 +104,7 @@ export const Header = ({
                 width: 'auto',
               })}
             >
-              <Icon
-                name="plus"
-                size={20}
-                title="New"
-                css={css({ paddingRight: 2 })}
-              />
-              Import Repo
+              + Import Repo
             </Button>
           )}
 

--- a/packages/app/src/app/pages/Dashboard/Components/Header/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Header/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useLocation } from 'react-router-dom';
 import { useAppState, useActions } from 'app/overmind';
-import { Stack, Text, Button } from '@codesandbox/components';
+import { Stack, Text, Button, Icon } from '@codesandbox/components';
 import css from '@styled-system/css';
 import { Breadcrumbs, BreadcrumbProps } from '../Breadcrumbs';
 import { FilterOptions } from '../Filters/FilterOptions';
@@ -60,7 +60,7 @@ export const Header = ({
       })}
     >
       {title ? (
-        <Text marginBottom={1} block weight="regular" size={6}>
+        <Text marginBottom={1} marginTop={-2} block weight="regular" size={6} >
           {title}
         </Text>
       ) : (
@@ -83,7 +83,13 @@ export const Header = ({
               width: 'auto',
             })}
           >
-            + New Folder
+            <Icon
+              name="plus"
+              size={20}
+              title="New"
+              css={css({ paddingRight: 2 })}
+            />
+        New Folder
           </Button>
         )}
         {location.pathname.includes('/repositories') &&
@@ -98,7 +104,13 @@ export const Header = ({
                 width: 'auto',
               })}
             >
-              + Import Repo
+              <Icon
+                name="plus"
+                size={20}
+                title="New"
+                css={css({ paddingRight: 2 })}
+              />
+              Import Repo
             </Button>
           )}
 

--- a/packages/app/src/app/pages/Dashboard/Components/Selection/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Selection/index.tsx
@@ -608,7 +608,7 @@ export const SelectionProvider: React.FC<SelectionProviderProps> = ({
         id="selection-container"
         onContextMenu={onContainerContextMenu}
         css={css({
-          paddingTop: 8,
+          paddingTop: 10,
           paddingBottom: 8,
           width: '100%',
           height: '100%',

--- a/packages/app/src/app/pages/Dashboard/Components/VariableGrid/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/VariableGrid/index.tsx
@@ -107,7 +107,7 @@ const ComponentForTypes: IComponentForTypes = {
   'new-master-branch': props => <NewMasterSandbox {...props.item} />,
   header: ({ item }) => (
     <Stack justify="space-between" align="center">
-      <Text block weight="bold" css={css({ userSelect: 'none' })}>
+      <Text block weight="regular" css={css({ userSelect: 'none' })}>
         {item.title}
       </Text>
       {item.showMoreLink

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Discover/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Discover/index.tsx
@@ -9,6 +9,7 @@ import {
   Column,
   Link,
   Avatar,
+  Icon,
 } from '@codesandbox/components';
 import css from '@styled-system/css';
 import {
@@ -154,13 +155,13 @@ const Banner = () => (
     })}
   >
     <Stack direction="vertical" marginLeft={6} css={{ zIndex: 2 }}>
-      <Text size={4} marginBottom={2}>
+      <Text size={3}>
         {banner.label}
       </Text>
-      <Text size={9} weight="bold" marginBottom={1}>
+      <Text size={32} weight="regular" marginTop={2}>
         {banner.title}
       </Text>
-      <Text size={5} css={{ opacity: 0.5 }}>
+      <Text size={4} marginTop={2} css={{ opacity: 0.6 }}>
         {banner.subtitle}
       </Text>
     </Stack>
@@ -337,7 +338,7 @@ const Album: React.FC<AlbumTypes> = ({ album, showMore = false }) => {
   return (
     <Stack key={album.id} direction="vertical" gap={6}>
       <Stack justify="space-between" align="flex-end">
-        <Text size={6} weight="bold">
+        <Text size={5} weight="regular">
           {album.title}
         </Text>
         {showMore && (
@@ -429,7 +430,7 @@ const TrendingSandboxes = () => {
 
   return (
     <Stack direction="vertical" gap={6} css={css({ marginTop: '100px' })}>
-      <Text size={6} weight="bold">
+      <Text size={5} weight="regular">
         {trendingSandboxesAlbum.title}
       </Text>
 

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Discover/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Discover/index.tsx
@@ -9,7 +9,6 @@ import {
   Column,
   Link,
   Avatar,
-  Icon,
 } from '@codesandbox/components';
 import css from '@styled-system/css';
 import {
@@ -155,9 +154,7 @@ const Banner = () => (
     })}
   >
     <Stack direction="vertical" marginLeft={6} css={{ zIndex: 2 }}>
-      <Text size={3}>
-        {banner.label}
-      </Text>
+      <Text size={3}>{banner.label}</Text>
       <Text size={32} weight="regular" marginTop={2}>
         {banner.title}
       </Text>

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/TeamSettings.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/TeamSettings.tsx
@@ -35,7 +35,7 @@ export const TeamSettings = () => {
         css={css({
           height: 'calc(100vh - 140px)',
           overflowY: 'scroll',
-          paddingY: 10,
+          paddingY: 6,
         })}
       >
         <Stack
@@ -67,7 +67,7 @@ export const TeamSettings = () => {
               </RouterSwitch>
             </BrowserRouter>
           ) : (
-            <Text>Loading...</Text>
+            <Text css={css({color: 'sideBarSectionHeader.foreground'})}>Loading...</Text>
           )}
         </Stack>
       </Element>

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Settings/UserSettings/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Settings/UserSettings/index.tsx
@@ -26,7 +26,7 @@ export const UserSettings = () => {
         css={css({
           height: 'calc(100vh - 140px)',
           overflowY: 'scroll',
-          paddingY: 10,
+          paddingY: 6,
         })}
       >
         <Stack
@@ -54,7 +54,7 @@ export const UserSettings = () => {
               </Switch>
             </BrowserRouter>
           ) : (
-            <Text>Loading...</Text>
+            <Text css={css({color: 'sideBarSectionHeader.foreground'})} >Loading...</Text>
           )}
         </Stack>
       </Element>


### PR DESCRIPTION
- Adjust Page Header paddings
<img width="1280" alt="Screen Shot 2022-09-23 at 19 17 35" src="https://user-images.githubusercontent.com/93996574/192063995-a4282cdb-4a44-41a7-bbdb-ea10a0183c53.png">

- Adjust type size on Discover page
<img width="1279" alt="Screen Shot 2022-09-23 at 19 18 07" src="https://user-images.githubusercontent.com/93996574/192064062-6bf1de00-c981-4cfc-9449-d66720cd9093.png">


- Adjust type size on Archive page
<img width="1278" alt="Screen Shot 2022-09-23 at 19 17 12" src="https://user-images.githubusercontent.com/93996574/192063968-d4cbc37b-9d26-4db1-8049-1aa125a18c17.png">

- Add + icon to New Folder on the Sandboxes page
<img width="1280" alt="Screen Shot 2022-09-23 at 19 18 36" src="https://user-images.githubusercontent.com/93996574/192064119-be7719ed-5ec7-4667-85d4-24532f843973.png">


