### PR TITLE
facelift: push bottom group down the sidebar

### DIFF
--- a/packages/app/src/app/pages/Dashboard/Sidebar/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Sidebar/index.tsx
@@ -126,14 +126,21 @@ export const Sidebar: React.FC<SidebarProps> = ({
           ...props.css,
         })}
       >
-        <List>
+        <List
+          css={css({
+            display: 'flex',
+            flexDirection: 'column',
+            height: '100%',
+            paddingBottom: 4,
+          })}
+        >
           <ListItem
             css={css({
               marginTop: 6,
               paddingLeft: 2,
               paddingRight: 0,
               borderRadius: 2,
-              height: 10,
+              minHeight: 10,
               backgroundColor: 'sideBar.hoverBackground',
             })}
           >
@@ -255,7 +262,12 @@ export const Sidebar: React.FC<SidebarProps> = ({
             path={dashboardUrls.archive(activeTeam)}
             icon="archive"
           />
-          <Element marginTop={8} />
+          <Element
+            marginTop={4}
+            css={css({
+              flex: 1, // This pushes the bottom links all the way down
+            })}
+          />
           <RowItem
             name="Discover"
             page="discover"
@@ -390,12 +402,14 @@ interface RowItemProps {
   folderPath?: string;
   style?: React.CSSProperties;
   badge?: boolean;
+  nestingLevel?: number;
 }
 
 const RowItem: React.FC<RowItemProps> = ({
   name,
   path,
   folderPath = path,
+  nestingLevel = 0,
   page,
   icon,
   setFoldersVisibility = null,
@@ -463,7 +477,7 @@ const RowItem: React.FC<RowItemProps> = ({
       css={css(
         merge(
           {
-            height: 10,
+            minHeight: nestingLevel ? 8 : 10,
             paddingX: 0,
             opacity: isDragging && !canDrop ? 0.25 : 1,
             color:
@@ -698,7 +712,7 @@ const NestableRowItem: React.FC<NestableRowItemProps> = ({
         folderPath={folderPath}
         page="sandboxes"
         icon="folder"
-        style={{ height: nestingLevel ? 8 : 10 }}
+        nestingLevel={nestingLevel}
         setFoldersVisibility={setFoldersVisibility}
       >
         <Link


### PR DESCRIPTION
Closes XTD-153

Added an element that pushes the last group all the way down (made the whole sidebar a vertical flex)

![Screenshot 2022-09-26 at 18 18 10](https://user-images.githubusercontent.com/9945366/192316846-6d3068cf-7574-400c-af2b-4636a879ed0f.png)

Works well when overflowing
![Screenshot 2022-09-26 at 18 18 26](https://user-images.githubusercontent.com/9945366/192316961-c0f57971-f361-4403-a4f8-7e4bb5b408a2.png)

