### PR TITLE
Facelift: Update margins and font-sizes on Upgrade to Pro page

### DIFF
--- a/packages/app/src/app/pages/Pro/upgrade.tsx
+++ b/packages/app/src/app/pages/Pro/upgrade.tsx
@@ -225,7 +225,7 @@ export const ProUpgrade = () => {
             padding: '24px 1em',
           })}
         >
-          <Element css={{ width: '100%' }}>
+          <Element css={{ width: '100%', paddingTop:'24px' }}>
             <Switcher
               workspaceType={workspaceType}
               workspaces={workspacesList}

--- a/packages/app/src/app/pages/Pro/upgrade/Switcher.tsx
+++ b/packages/app/src/app/pages/Pro/upgrade/Switcher.tsx
@@ -56,7 +56,7 @@ export const Switcher: React.FC<{
             name={activeTeamInfo.name}
           />
 
-          <Stack css={{ marginLeft: 24, marginTop: -6 }} direction="vertical">
+          <Stack css={{ marginLeft: 24}} direction="vertical">
             <WorkspaceName>
               <span>{activeTeamInfo.name}</span>
             </WorkspaceName>
@@ -148,12 +148,12 @@ export const Switcher: React.FC<{
                   justify="center"
                   align="center"
                   css={{
-                    border: '1px solid #C5C5C5',
                     width: 24,
                     height: 24,
+                    backgroundColor: '#252525',
                   }}
                 >
-                  <Icon name="plus" size={14} />
+                  <Icon name="plus" size={16} />
                 </Stack>
 
                 <Text size={4} css={{ marginLeft: 19 }}>
@@ -257,11 +257,6 @@ const WorkspaceName = styled.p`
   color: #e5e5e5;
 
   font-size: 24px;
-
-  @media (min-width: 720px) {
-    font-size: 32px;
-    line-height: 42px;
-  }
 
   & span::-moz-selection {
     -webkit-text-stroke: 1px #e5e5e5;

--- a/packages/app/src/app/pages/Pro/upgrade/elements.ts
+++ b/packages/app/src/app/pages/Pro/upgrade/elements.ts
@@ -21,7 +21,7 @@ export const PlanTitle = styled.h1`
   margin-top: 40px;
 
   @media (min-width: 720px) {
-    font-size: 48px;
+    font-size: 40px;
     line-height: 56px;
   }
 `;


### PR DESCRIPTION
Closes XTD-167

(before)
<img width="1280" alt="Screen Shot 2022-09-26 at 17 43 17" src="https://user-images.githubusercontent.com/93996574/192376167-5678e44b-a837-4282-8f4d-09c53631104d.png">

(after)
<img width="1279" alt="Screen Shot 2022-09-26 at 17 41 07" src="https://user-images.githubusercontent.com/93996574/192375964-652d00f9-546a-4ad5-b3f5-abfc6ab8084f.png">
