### PR TITLE
Facelift: Modals UI review on Dashboard

### DIFF
--- a/packages/app/src/app/components/Notifications/Content.tsx
+++ b/packages/app/src/app/components/Notifications/Content.tsx
@@ -112,12 +112,9 @@ export const NotificationsContent = props => {
   return (
     <Element
       css={css({
-        backgroundColor: 'sideBar.background',
+        backgroundColor: 'menuList.background',
         fontFamily: 'Inter',
         width: 321,
-        borderWidth: 1,
-        borderStyle: 'solid',
-        borderColor: 'sideBar.border',
       })}
       {...props}
     >
@@ -126,13 +123,11 @@ export const NotificationsContent = props => {
         css={css({
           display: 'grid',
           gridTemplateColumns: '1fr 60px',
-          borderWidth: 0,
-          borderBottomWidth: 1,
-          borderStyle: 'solid',
-          borderColor: 'sideBar.border',
         })}
       >
-        <Text weight="bold">Notifications</Text>
+        <Text weight="regular" size={4}>
+          Notifications
+        </Text>
         <Element>
           {userNotifications.notifications ? <Filters /> : null}
         </Element>

--- a/packages/app/src/app/pages/common/Modals/Common/Alert.tsx
+++ b/packages/app/src/app/pages/common/Modals/Common/Alert.tsx
@@ -33,7 +33,7 @@ export const Alert: FunctionComponent<Props> = ({
     {...props}
   >
     {title && (
-      <Text weight="bold" block size={6} paddingBottom={2}>
+      <Text weight="regular" block size={5} paddingBottom={4}>
         {title}
       </Text>
     )}

--- a/packages/app/src/app/pages/common/Modals/DeploymentModal/index.tsx
+++ b/packages/app/src/app/pages/common/Modals/DeploymentModal/index.tsx
@@ -35,7 +35,13 @@ export const DeploymentModal: FunctionComponent = () => {
     >
       {url ? (
         <Element marginBottom={4}>
-          <Text weight="bold" block size={4} align="center" paddingBottom={4}>
+          <Text
+            weight="regular"
+            block
+            size={4}
+            align="center"
+            paddingBottom={4}
+          >
             Deployed!
           </Text>
           <Link variant="muted" block size={3} align="center" href={url}>

--- a/packages/app/src/app/pages/common/Modals/MoveSandboxFolderModal/index.tsx
+++ b/packages/app/src/app/pages/common/Modals/MoveSandboxFolderModal/index.tsx
@@ -75,7 +75,7 @@ export const MoveSandboxFolderModal: FunctionComponent = () => {
           gap={6}
           direction="vertical"
         >
-          <Text size={6} weight="bold">
+          <Text size={6} weight="regular">
             Move {modals.moveSandboxModal.sandboxIds.length}{' '}
             {modals.moveSandboxModal.sandboxIds.length > 1 ? 'items' : 'item'}
           </Text>

--- a/packages/app/src/app/pages/common/Modals/PilotPaymentModal/index.tsx
+++ b/packages/app/src/app/pages/common/Modals/PilotPaymentModal/index.tsx
@@ -78,7 +78,7 @@ export const PilotPaymentModal: FunctionComponent = () => {
         })}
       >
         <Element>
-          <Text block marginBottom={6} size={4} weight="bold">
+          <Text block marginBottom={6} size={4} weight="regular">
             Payment Info
           </Text>
 

--- a/packages/app/src/app/pages/common/Modals/PreferencesModal/Appearance/index.tsx
+++ b/packages/app/src/app/pages/common/Modals/PreferencesModal/Appearance/index.tsx
@@ -8,7 +8,7 @@ import { EditorTheme } from './EditorTheme';
 
 export const Appearance: FunctionComponent = () => (
   <div>
-    <Text block marginBottom={6} size={4} weight="bold">
+    <Text block marginBottom={6} size={4} weight="regular">
       Appearance
     </Text>
 

--- a/packages/app/src/app/pages/common/Modals/PreferencesModal/CodeFormatting/index.tsx
+++ b/packages/app/src/app/pages/common/Modals/PreferencesModal/CodeFormatting/index.tsx
@@ -6,7 +6,7 @@ import { Prettier } from './Prettier';
 
 export const CodeFormatting: FunctionComponent = () => (
   <>
-    <Text block marginBottom={4} size={4} variant="muted" weight="bold">
+    <Text block marginBottom={4} size={4} variant="muted" weight="regular">
       Prettier Settings{' '}
       <a
         href="https://prettier.io/docs/en/options.html"

--- a/packages/app/src/app/pages/common/Modals/PreferencesModal/Editor/Editor.tsx
+++ b/packages/app/src/app/pages/common/Modals/PreferencesModal/Editor/Editor.tsx
@@ -8,7 +8,7 @@ import { VimModeSettings } from './VimModeSettings';
 
 export const Editor: React.FC = () => (
   <>
-    <Text block marginBottom={6} size={4} weight="bold">
+    <Text block marginBottom={6} size={4} weight="regular">
       Editor
     </Text>
 

--- a/packages/app/src/app/pages/common/Modals/PreferencesModal/Experiments/index.tsx
+++ b/packages/app/src/app/pages/common/Modals/PreferencesModal/Experiments/index.tsx
@@ -7,7 +7,7 @@ import { ContainerLSP } from './ContainerLSP';
 
 export const Experiments: FunctionComponent = () => (
   <>
-    <Text block marginBottom={6} size={4} weight="bold">
+    <Text block marginBottom={6} size={4} weight="regular">
       Experiments
     </Text>
 

--- a/packages/app/src/app/pages/common/Modals/PreferencesModal/Integrations/index.tsx
+++ b/packages/app/src/app/pages/common/Modals/PreferencesModal/Integrations/index.tsx
@@ -8,7 +8,7 @@ import { Container } from './elements';
 
 export const Integrations: FunctionComponent = () => (
   <div>
-    <Text block marginBottom={6} size={4} weight="bold">
+    <Text block marginBottom={6} size={4} weight="regular">
       Integrations
     </Text>
 

--- a/packages/app/src/app/pages/common/Modals/PreferencesModal/KeyMapping.tsx
+++ b/packages/app/src/app/pages/common/Modals/PreferencesModal/KeyMapping.tsx
@@ -5,7 +5,7 @@ import { VSCodePlaceholder } from './VSCodePlaceholder';
 
 export const KeyMapping: FunctionComponent = () => (
   <>
-    <Text block marginBottom={6} size={4} weight="bold">
+    <Text block marginBottom={6} size={4} weight="regular">
       Key Bindings
     </Text>
 

--- a/packages/app/src/app/pages/common/Modals/PreferencesModal/MailPreferences/index.tsx
+++ b/packages/app/src/app/pages/common/Modals/PreferencesModal/MailPreferences/index.tsx
@@ -17,7 +17,7 @@ export const MailPreferences: FunctionComponent = () => {
 
   return (
     <>
-      <Text block marginBottom={6} size={4} weight="bold">
+      <Text block marginBottom={6} size={4} weight="regular">
         Email me when...
       </Text>
 

--- a/packages/app/src/app/pages/common/Modals/PreferencesModal/PreferencesSync/index.tsx
+++ b/packages/app/src/app/pages/common/Modals/PreferencesModal/PreferencesSync/index.tsx
@@ -62,7 +62,7 @@ export const PreferencesSync: FunctionComponent = () => {
   return (
     <>
       <Stack justify="space-between" align="baseline">
-        <Text block marginBottom={6} size={4} weight="bold">
+        <Text block marginBottom={6} size={4} weight="regular">
           Preferences Profiles
         </Text>
         {settingsSync.settings?.length ? (

--- a/packages/app/src/app/pages/common/Modals/PreferencesModal/Preview/Preview.tsx
+++ b/packages/app/src/app/pages/common/Modals/PreferencesModal/Preview/Preview.tsx
@@ -21,7 +21,7 @@ export const Preview: React.FC = () => {
 
   return (
     <div>
-      <Text block marginBottom={6} size={4} weight="bold">
+      <Text block marginBottom={6} size={4} weight="regular">
         Preview
       </Text>
 

--- a/packages/app/src/app/pages/common/Modals/PreferencesModal/SideNavigation.tsx
+++ b/packages/app/src/app/pages/common/Modals/PreferencesModal/SideNavigation.tsx
@@ -17,23 +17,17 @@ export const SideNavigation: FunctionComponent<Props> = ({ menuItems }) => {
   const { itemIdChanged } = useActions().preferences;
 
   return (
-    <Element
-      css={css({
-        backgroundColor: 'sideBar.background',
-        borderWidth: 1,
-        borderRightStyle: 'solid',
-        borderColor: 'sideBar.border',
-        width: 244,
-      })}
-      paddingBottom={8}
-    >
+    <Element css={css({ width: 244 })} paddingBottom={8}>
       <Text
         block
         paddingBottom={6}
         paddingLeft={5}
         paddingTop={6}
         size={4}
-        weight="bold"
+        weight="regular"
+        css={css({
+          color: 'sideBarSectionHeader.foreground',
+        })}
       >
         Preferences
       </Text>
@@ -46,10 +40,13 @@ export const SideNavigation: FunctionComponent<Props> = ({ menuItems }) => {
               transition: '0.3s ease all',
               fontSize: 3,
               paddingX: 5,
-              paddingY: 2,
+              paddingY: 3,
               cursor: 'pointer',
               lineHeight: 1,
-              color: itemId === id ? 'list.hoverForeground' : 'mutedForeground',
+              color:
+                itemId === id
+                  ? 'list.hoverForeground'
+                  : 'sideBarSectionHeader.foreground',
               '&:hover': {
                 backgroundColor: 'list.hoverBackground',
                 color: 'list.hoverForeground',
@@ -58,7 +55,7 @@ export const SideNavigation: FunctionComponent<Props> = ({ menuItems }) => {
             key={title}
             onClick={() => itemIdChanged(id)}
           >
-            <Element marginRight={3}>
+            <Element marginRight={4}>
               <Icon />
             </Element>
 

--- a/packages/app/src/app/pages/common/Modals/PreferencesModal/SideNavigation.tsx
+++ b/packages/app/src/app/pages/common/Modals/PreferencesModal/SideNavigation.tsx
@@ -36,13 +36,22 @@ export const SideNavigation: FunctionComponent<Props> = ({ menuItems }) => {
         {menuItems.map(({ Icon, id, title }) => (
           <Stack
             align="center"
+            as="button"
             css={css({
-              transition: '0.3s ease all',
+              width: '100%',
+              appearance: 'none',
+              fontFamily: 'inherit',
+              textAlign: 'left',
+              background: 'transparent',
+              transition: 'all ease-in-out',
+              transitionDuration: theme => theme.speeds[2],
+              outline: 'none',
               fontSize: 3,
               paddingX: 5,
               paddingY: 3,
               cursor: 'pointer',
               lineHeight: 1,
+              border: '1px solid transparent',
               color:
                 itemId === id
                   ? 'list.hoverForeground'
@@ -50,6 +59,9 @@ export const SideNavigation: FunctionComponent<Props> = ({ menuItems }) => {
               '&:hover': {
                 backgroundColor: 'list.hoverBackground',
                 color: 'list.hoverForeground',
+              },
+              '&:focus-visible': {
+                borderColor: 'focusBorder',
               },
             })}
             key={title}

--- a/packages/app/src/app/pages/common/Modals/PreferencesModal/SideNavigation/elements.js
+++ b/packages/app/src/app/pages/common/Modals/PreferencesModal/SideNavigation/elements.js
@@ -26,7 +26,7 @@ export const Item = styled.div`
   top: ${props => props.top}px;
   left: 0;
   right: 0;
-  height: ${ITEM_HEIGHT + 2}px;
+  height: ${ITEM_HEIGHT - 2}px;
   line-height: ${ITEM_HEIGHT - 2}px;
   margin: 1px 1rem;
   padding: 0 1rem;

--- a/packages/app/src/app/pages/common/Modals/PreferencesModal/SideNavigation/elements.js
+++ b/packages/app/src/app/pages/common/Modals/PreferencesModal/SideNavigation/elements.js
@@ -26,7 +26,7 @@ export const Item = styled.div`
   top: ${props => props.top}px;
   left: 0;
   right: 0;
-  height: ${ITEM_HEIGHT - 2}px;
+  height: ${ITEM_HEIGHT + 2}px;
   line-height: ${ITEM_HEIGHT - 2}px;
   margin: 1px 1rem;
   padding: 0 1rem;

--- a/packages/app/src/app/pages/common/Modals/PreferencesModal/index.tsx
+++ b/packages/app/src/app/pages/common/Modals/PreferencesModal/index.tsx
@@ -110,6 +110,7 @@ export const PreferencesModal: FunctionComponent = () => {
           height: 482,
           width: '100%',
           padding: 6,
+          marginTop: 52,
           '*': { boxSizing: 'border-box' },
         })}
       >


### PR DESCRIPTION
IMPORTANT: Changes affect **only** the dashboard. 

**1. Adjust style of Notifications menu**

(before)
<img width="342" alt="Screen Shot 2022-09-28 at 18 38 44" src="https://user-images.githubusercontent.com/93996574/192893809-7137f8e0-a9b0-4e65-a4b7-c41104eadad0.png">

(after)
<img width="334" alt="image" src="https://user-images.githubusercontent.com/93996574/192893373-0aa2cfa1-6654-4e71-bc78-ee1971336a9d.png">


**2. Adjust style of Preferences modal**

(before)
<img width="923" alt="Screen Shot 2022-09-28 at 18 39 33" src="https://user-images.githubusercontent.com/93996574/192893830-5ec9cc9c-5781-47bb-8e91-f2e7e2712d81.png">

(after)
<img width="914" alt="Screen Shot 2022-09-28 at 18 37 51" src="https://user-images.githubusercontent.com/93996574/192893748-e8fac2e6-bfdb-4086-ae71-6e41c505c2fb.png">


**3. General modal type adjustment**

(before)
<img width="463" alt="image" src="https://user-images.githubusercontent.com/93996574/192893483-5707542a-1d00-49fe-8d4d-bd6d184a79e3.png">

(after)
<img width="464" alt="Screen Shot 2022-09-28 at 18 38 07" src="https://user-images.githubusercontent.com/93996574/192893776-3ab786b4-6940-4894-bc05-7d61324cd459.png">


Closes XTD-158.