### PR TITLE
feat(dashboard): add context menu to repositories

### DIFF
--- a/packages/app/src/app/pages/Dashboard/Components/Repository/RepositoryCard.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Repository/RepositoryCard.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { Icon, IconButton, Stack, Text } from '@codesandbox/components';
+import { css } from '@styled-system/css';
+import { RepositoryProps } from './types';
+
+export const RepositoryCard: React.FC<RepositoryProps> = ({
+  labels,
+  repository,
+  selected,
+  onContextMenu,
+  ...props
+}) => {
+  return (
+    <Stack
+      as="a"
+      aria-label={labels.repository}
+      css={css({
+        cursor: 'pointer', // TODO: revisit cursor.
+        position: 'relative',
+        overflow: 'hidden',
+        height: 240,
+        width: '100%',
+        borderRadius: '4px',
+        border: '1px solid',
+        borderColor: selected ? 'focusBorder' : 'transparent',
+        backgroundColor: selected ? 'card.backgroundHover' : 'card.background',
+        transition: 'background ease-in-out',
+        paddingRight: 8,
+        paddingLeft: 8,
+        paddingTop: 4,
+        paddingBottom: 4,
+        outline: 'none',
+        transitionDuration: theme => theme.speeds[2],
+        textDecoration: 'none',
+        ':hover': {
+          backgroundColor: 'card.backgroundHover',
+        },
+        ':focus-visible': {
+          borderColor: 'focusBorder',
+        },
+      })}
+      direction="vertical"
+      gap={4}
+      href={repository.url}
+      onContextMenu={onContextMenu}
+      {...props}
+    >
+      <IconButton
+        css={css({
+          marginLeft: 'auto',
+          marginRight: 0,
+        })}
+        name="more"
+        size={9}
+        title="Repository actions"
+        onClick={evt => {
+          evt.stopPropagation();
+          onContextMenu(evt);
+        }}
+      />
+
+      <Stack align="center" direction="vertical" gap={6}>
+        <Icon color="#999" name="repository" size={24} />{' '}
+        <Stack align="center" direction="vertical" gap={2}>
+          <Text
+            css={css({
+              color: '#E5E5E5',
+              textAlign: 'center',
+              minHeight: 42,
+            })}
+            size={16}
+          >
+            {repository.owner}/{repository.name}
+          </Text>
+          <Text
+            css={css({
+              color: '#808080',
+              textAlign: 'center',
+            })}
+            size={13}
+          >
+            {labels.branches}
+          </Text>
+        </Stack>
+      </Stack>
+    </Stack>
+  );
+};

--- a/packages/app/src/app/pages/Dashboard/Components/Repository/RepositoryListItem.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Repository/RepositoryListItem.tsx
@@ -15,6 +15,7 @@ import { RepositoryProps } from './types';
 export const RepositoryListItem: React.FC<RepositoryProps> = ({
   labels,
   repository,
+  selected,
   onContextMenu,
   ...props
 }) => {
@@ -27,10 +28,11 @@ export const RepositoryListItem: React.FC<RepositoryProps> = ({
         borderBottom: '1px solid',
         borderBottomColor: 'grays.600',
         overflow: 'hidden',
-        backgroundColor: 'transparent',
-        color: 'inherit',
+        backgroundColor: selected ? 'purpleOpaque' : 'transparent',
+        color: selected ? 'white' : 'inherit',
         ':hover, :focus, :focus-within': {
-          backgroundColor: 'list.hoverBackground',
+          cursor: 'default',
+          backgroundColor: selected ? 'purpleOpaque' : 'list.hoverBackground',
         },
       })}
     >

--- a/packages/app/src/app/pages/Dashboard/Components/Repository/RepositoryListItem.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Repository/RepositoryListItem.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import {
+  Element,
+  Column,
+  Grid,
+  Icon,
+  IconButton,
+  ListAction,
+  Stack,
+  Text,
+} from '@codesandbox/components';
+import { css } from '@styled-system/css';
+import { RepositoryProps } from './types';
+
+export const RepositoryListItem: React.FC<RepositoryProps> = ({
+  labels,
+  repository,
+  onContextMenu,
+  ...props
+}) => {
+  return (
+    <ListAction
+      align="center"
+      css={css({
+        paddingX: 0,
+        height: 64,
+        borderBottom: '1px solid',
+        borderBottomColor: 'grays.600',
+        overflow: 'hidden',
+        backgroundColor: 'transparent',
+        color: 'inherit',
+        ':hover, :focus, :focus-within': {
+          backgroundColor: 'list.hoverBackground',
+        },
+      })}
+    >
+      <Element
+        aria-label={labels.repository}
+        as="a"
+        css={{
+          display: 'flex',
+          alignItems: 'center',
+          height: '100%',
+          width: '100%',
+          textDecoration: 'none',
+        }}
+        href={repository.url}
+        onContextMenu={onContextMenu}
+        {...props}
+      >
+        <Grid css={{ width: 'calc(100% - 26px - 8px)' }}>
+          <Column
+            span={[12, 5, 5]}
+            css={{
+              display: 'block',
+              overflow: 'hidden',
+              paddingBottom: 4,
+              paddingTop: 4,
+            }}
+          >
+            <Stack gap={4} align="center" marginLeft={2}>
+              <Icon color="#999" name="repository" size={16} width="32px" />
+              <Element css={{ overflow: 'hidden' }}>
+                <Text size={3} weight="medium" maxWidth="100%">
+                  {repository.owner}/{repository.name}
+                </Text>
+              </Element>
+            </Stack>
+          </Column>
+          <Column span={[0, 4, 4]} as={Stack} align="center">
+            <Text size={3} variant="muted" maxWidth="100%">
+              {labels.branches}
+            </Text>
+          </Column>
+        </Grid>
+        <IconButton
+          name="more"
+          size={9}
+          title="Repository actions"
+          onClick={evt => {
+            evt.stopPropagation();
+            onContextMenu(evt);
+          }}
+        />
+      </Element>
+    </ListAction>
+  );
+};

--- a/packages/app/src/app/pages/Dashboard/Components/Repository/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Repository/index.tsx
@@ -1,173 +1,55 @@
 import React from 'react';
-import {
-  Element,
-  Column,
-  Grid,
-  Icon,
-  IconButton,
-  ListAction,
-  Stack,
-  Text,
-} from '@codesandbox/components';
-import { css } from '@styled-system/css';
 import { useAppState } from 'app/overmind';
-import { useHistory } from 'react-router-dom';
 import { trackImprovedDashboardEvent } from '@codesandbox/common/lib/utils/analytics';
+import { dashboard } from '@codesandbox/common/lib/utils/url-generator';
 import { DashboardRepository } from '../../types';
+import { RepositoryCard } from './RepositoryCard';
+import { RepositoryListItem } from './RepositoryListItem';
+import { RepositoryProps } from './types';
+import { useSelection } from '../Selection';
 
 export const Repository: React.FC<DashboardRepository> = ({ repository }) => {
   const { branches, repository: providerRepository } = repository;
   const {
+    activeTeam,
     dashboard: { viewMode },
   } = useAppState();
-  const ariaLabel = `View branches from repository ${providerRepository.name} by ${providerRepository.owner}`;
-  const branchesLabel = `${branches.length} ${
-    branches.length === 1 ? 'branch' : 'branches'
-  }`;
-  const history = useHistory();
+  const { selectedIds, onRightClick, onMenuEvent } = useSelection();
+  const repositoryId = `${providerRepository.owner}-${providerRepository.name}`;
+  const repositoryUrl = dashboard.repository({
+    owner: providerRepository.owner,
+    name: providerRepository.name,
+    teamId: activeTeam,
+  });
 
-  // TODO: replace with double click action when/if implemeting the context menu
-  const handleClick = (e: React.MouseEvent | React.KeyboardEvent) => {
-    trackImprovedDashboardEvent('Dashboard - Open Repository');
-    const url = `/dashboard/repositories/github/${providerRepository.owner}/${providerRepository.name}`;
-    if (e.ctrlKey || e.metaKey) {
-      window.open(url, '_blank');
-    } else {
-      history.push(url);
-    }
+  const handleContextMenu = (event: React.MouseEvent<HTMLDivElement>) => {
+    event.preventDefault();
+
+    if (event.type === 'contextmenu') onRightClick(event, repositoryId);
+    else onMenuEvent(event, repositoryId);
   };
 
-  if (viewMode === 'grid') {
-    return (
-      <Stack
-        aria-label={ariaLabel}
-        css={css({
-          cursor: 'pointer', // TODO: revisit cursor.
-          position: 'relative',
-          overflow: 'hidden',
-          height: 240,
-          width: '100%',
-          borderRadius: '4px',
-          border: '1px solid transparent',
-          backgroundColor: 'card.background',
-          transition: 'background ease-in-out',
-          paddingRight: 8,
-          paddingLeft: 8,
-          paddingTop: 4,
-          paddingBottom: 4,
-          outline: 'none',
+  const selected = selectedIds.includes(repositoryId);
 
-          transitionDuration: theme => theme.speeds[2],
-          ':hover': {
-            backgroundColor: 'card.backgroundHover',
-          },
-          ':focus-visible': {
-            borderColor: 'focusBorder',
-          },
-        })}
-        direction="vertical"
-        gap={4}
-        onClick={handleClick}
-        onKeyDown={e => e.key === 'Enter' && handleClick(e)}
-        // TODO: refine semantics when/if the context menu gets implemented.
-        role="link"
-        tabIndex={0}
-      >
-        <IconButton
-          css={css({
-            marginLeft: 'auto',
-            marginRight: 0,
-          })}
-          name="more"
-          size={9}
-          title="Branch actions"
-          onClick={() => ({})}
-        />
-        <Stack align="center" direction="vertical" gap={6}>
-          <Icon color="#999" name="repository" size={24} />
-          <Stack align="center" direction="vertical" gap={2}>
-            <Text
-              css={css({
-                color: '#E5E5E5',
-                textAlign: 'center',
-                minHeight: 42,
-              })}
-              size={16}
-            >
-              {providerRepository.owner}/{providerRepository.name}
-            </Text>
-            <Text
-              css={css({
-                color: '#808080',
-                textAlign: 'center',
-                paddingTop: 2,
-              })}
-              size={13}
-            >
-              {branchesLabel}
-            </Text>
-          </Stack>
-        </Stack>
-      </Stack>
-    );
-  }
+  const props: RepositoryProps = {
+    repository: {
+      owner: providerRepository.owner,
+      name: providerRepository.name,
+      url: repositoryUrl,
+    },
+    labels: {
+      repository: `View branches from repository ${providerRepository.name} by ${providerRepository.owner}`,
+      branches: `${branches.length} ${
+        branches.length === 1 ? 'branch' : 'branches'
+      }`,
+    },
+    selected,
+    onClick: () => trackImprovedDashboardEvent('Dashboard - Open Repository'),
+    onContextMenu: handleContextMenu,
+  };
 
-  if (viewMode === 'list') {
-    return (
-      <ListAction
-        align="center"
-        onClick={handleClick}
-        css={css({
-          paddingX: 0,
-          height: 64,
-          borderBottom: '1px solid',
-          borderBottomColor: 'grays.600',
-          overflow: 'hidden',
-          backgroundColor: 'transparent',
-          color: 'inherit',
-          ':hover, :focus, :focus-within': {
-            cursor: 'default',
-            backgroundColor: 'list.hoverBackground',
-          },
-        })}
-      >
-        <Grid css={{ width: 'calc(100% - 26px - 8px)' }}>
-          <Column
-            span={[12, 5, 5]}
-            css={{
-              display: 'block',
-              overflow: 'hidden',
-              paddingBottom: 4,
-              paddingTop: 4,
-            }}
-          >
-            <Stack gap={4} align="center" marginLeft={2}>
-              <Icon color="#999" name="repository" size={16} width="32px" />
-              <Element css={{ overflow: 'hidden' }}>
-                <Text size={3} weight="medium" maxWidth="100%">
-                  {providerRepository.owner}/{providerRepository.name}
-                </Text>
-              </Element>
-            </Stack>
-          </Column>
-          <Column span={[0, 4, 4]} as={Stack} align="center">
-            <Text size={3} variant="muted" maxWidth="100%">
-              {branchesLabel}
-            </Text>
-          </Column>
-        </Grid>
-        <IconButton
-          name="more"
-          size={9}
-          title="Branch actions"
-          onClick={() => ({})}
-        />
-      </ListAction>
-    );
-  }
-
-  /**
-   * Satisfy expected return from React.FC
-   */
-  return null;
+  return {
+    grid: <RepositoryCard {...props} />,
+    list: <RepositoryListItem {...props} />,
+  }[viewMode];
 };

--- a/packages/app/src/app/pages/Dashboard/Components/Repository/types.ts
+++ b/packages/app/src/app/pages/Dashboard/Components/Repository/types.ts
@@ -1,0 +1,14 @@
+import { ProjectFragment as Repository } from 'app/graphql/types';
+
+export type RepositoryProps = {
+  repository: Pick<Repository['repository'], 'owner' | 'name'> & {
+    url: string;
+  };
+  labels: {
+    branches: string;
+    repository: string;
+  };
+  onContextMenu: (evt: React.MouseEvent) => void;
+  onClick: (evt: React.MouseEvent) => void;
+  selected: boolean;
+};

--- a/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenu.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenu.tsx
@@ -9,6 +9,7 @@ import {
   DashboardCommunitySandbox,
   PageTypes,
   DashboardBranch,
+  DashboardRepository,
 } from '../../types';
 import {
   MultiMenu,
@@ -20,6 +21,7 @@ import {
   CommunitySandboxMenu,
 } from './ContextMenus';
 import { BranchMenu } from './ContextMenus/BranchMenu';
+import { RepositoryMenu } from './ContextMenus/RepositoryMenu';
 
 interface IMenuProps {
   visible: boolean;
@@ -39,6 +41,7 @@ interface IContextMenuProps extends IMenuProps {
   folders: Array<DashboardFolder>;
   repos?: Array<DashboardRepo>;
   branches: Array<DashboardBranch>;
+  repositories: Array<DashboardRepository>;
   setRenaming: null | ((value: boolean) => void);
   createNewFolder: () => void;
   createNewSandbox: (() => void) | null;
@@ -53,6 +56,7 @@ export const ContextMenu: React.FC<IContextMenuProps> = ({
   sandboxes,
   folders,
   branches,
+  repositories, // v2 repositories, formerly known as projects.
   repos,
   setRenaming,
   createNewFolder,
@@ -69,6 +73,7 @@ export const ContextMenu: React.FC<IContextMenuProps> = ({
     | DashboardNewMasterBranch
     | DashboardCommunitySandbox
     | DashboardBranch
+    | DashboardRepository
   > = selectedIds.map(id => {
     if (id.startsWith('/')) {
       if (repos && repos.length) {
@@ -97,6 +102,15 @@ export const ContextMenu: React.FC<IContextMenuProps> = ({
       return branch;
     }
 
+    const repository = repositories.find(r => {
+      const { repository: providerRepository } = r.repository;
+      const rId = `${providerRepository.owner}-${providerRepository.name}`;
+      return rId === id;
+    });
+    if (repository) {
+      return repository;
+    }
+
     const sandbox = sandboxes.find(s => s.sandbox.id === id);
     return sandbox;
   });
@@ -113,6 +127,8 @@ export const ContextMenu: React.FC<IContextMenuProps> = ({
     );
   } else if (selectedItems[0].type === 'branch') {
     menu = <BranchMenu branch={selectedItems[0].branch} />;
+  } else if (selectedItems[0].type === 'repository') {
+    menu = <RepositoryMenu repository={selectedItems[0].repository} />;
   } else if (selectedItems.length > 1) {
     menu = (
       <MultiMenu

--- a/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenus/RepositoryMenu.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenus/RepositoryMenu.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { Menu } from '@codesandbox/components';
+import { ProjectFragment as Repository } from 'app/graphql/types';
+import {
+  //   githubRepoUrl,
+  dashboard,
+} from '@codesandbox/common/lib/utils/url-generator';
+import { useHistory } from 'react-router-dom';
+import { Context, MenuItem } from '../ContextMenu';
+
+type RepositoryMenuProps = {
+  repository: Repository;
+};
+export const RepositoryMenu: React.FC<RepositoryMenuProps> = ({
+  repository,
+}) => {
+  const { visible, setVisibility, position } = React.useContext(Context);
+  const history = useHistory();
+
+  const { repository: providerRepository } = repository;
+  const repositoryUrl = dashboard.repository({
+    owner: providerRepository.owner,
+    name: providerRepository.name,
+  });
+  const githubUrl = `https://github.com/${providerRepository.owner}/${providerRepository.name}`;
+  //   TODO: fix this githubRepoUrl
+  //   const githubUrl = githubRepoUrl({
+  //     branch: ?
+  //     repo: providerRepository.name,
+  //     username: providerRepository.owner,
+  //     path: '',
+  //   });
+
+  return (
+    <Menu.ContextMenu
+      visible={visible}
+      setVisibility={setVisibility}
+      position={position}
+      style={{ width: 120 }}
+    >
+      <MenuItem onSelect={() => history.push(repositoryUrl)}>
+        Open repository
+      </MenuItem>
+      <MenuItem onSelect={() => window.open(repositoryUrl, '_blank')}>
+        Open repository in a new tab
+      </MenuItem>
+      <MenuItem onSelect={() => window.open(githubUrl, '_blank')}>
+        Open on GitHub
+      </MenuItem>
+
+      <Menu.Divider />
+      <MenuItem
+        onSelect={() => {
+          /* TODO: Implement remove repository */
+        }}
+      >
+        Remove from CodeSandbox
+      </MenuItem>
+    </Menu.ContextMenu>
+  );
+};

--- a/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenus/RepositoryMenu.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenus/RepositoryMenu.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import { Menu } from '@codesandbox/components';
 import { ProjectFragment as Repository } from 'app/graphql/types';
-import {
-  //   githubRepoUrl,
-  dashboard,
-} from '@codesandbox/common/lib/utils/url-generator';
+import { dashboard } from '@codesandbox/common/lib/utils/url-generator';
 import { useHistory } from 'react-router-dom';
 import { Context, MenuItem } from '../ContextMenu';
 
@@ -23,13 +20,6 @@ export const RepositoryMenu: React.FC<RepositoryMenuProps> = ({
     name: providerRepository.name,
   });
   const githubUrl = `https://github.com/${providerRepository.owner}/${providerRepository.name}`;
-  //   TODO: fix this githubRepoUrl
-  //   const githubUrl = githubRepoUrl({
-  //     branch: ?
-  //     repo: providerRepository.name,
-  //     username: providerRepository.owner,
-  //     path: '',
-  //   });
 
   return (
     <Menu.ContextMenu

--- a/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenus/index.ts
+++ b/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenus/index.ts
@@ -4,4 +4,5 @@ export { FolderMenu } from './FolderMenu';
 export { RepoMenu } from './RepoMenu';
 export { MasterMenu } from './MasterMenu';
 export { ContainerMenu } from './ContainerMenu';
+export { RepositoryMenu } from './RepositoryMenu';
 export { CommunitySandboxMenu } from './CommunitySandboxMenu';

--- a/packages/app/src/app/pages/Dashboard/Components/Selection/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Selection/index.tsx
@@ -28,6 +28,7 @@ import {
   DashboardCommunitySandbox,
   PageTypes,
   DashboardBranch,
+  DashboardRepository,
 } from '../../types';
 import { DndDropType } from '../../utils/dnd';
 
@@ -114,10 +115,15 @@ export const SelectionProvider: React.FC<SelectionProviderProps> = ({
     | DashboardRepo
     | DashboardCommunitySandbox
     | DashboardBranch
+    | DashboardRepository
   >;
 
   const selectionItems = possibleItems.map(item => {
     if (item.type === 'branch') return item.branch.id;
+    if (item.type === 'repository') {
+      const { repository: providerRepository } = item.repository;
+      return `${providerRepository.owner}-${providerRepository.name}`;
+    }
     if (item.type === 'folder') return item.path;
     if (item.type === 'repo') return item.name;
     return item.sandbox.id;
@@ -135,6 +141,9 @@ export const SelectionProvider: React.FC<SelectionProviderProps> = ({
   const branches = (items || []).filter(
     item => item.type === 'branch'
   ) as DashboardBranch[];
+  const repositories = (items || []).filter(
+    item => item.type === 'repository'
+  ) as DashboardRepository[];
 
   const [selectedIds, setSelectedIds] = React.useState<string[]>([]);
   const actions = useActions();
@@ -670,6 +679,7 @@ export const SelectionProvider: React.FC<SelectionProviderProps> = ({
         sandboxes={sandboxes || []}
         folders={folders || []}
         branches={branches || []}
+        repositories={repositories || []}
         setRenaming={setRenaming}
         page={page}
         createNewFolder={createNewFolder}

--- a/packages/common/src/utils/url-generator/dashboard.ts
+++ b/packages/common/src/utils/url-generator/dashboard.ts
@@ -31,6 +31,20 @@ export const myContributions = (teamId?: string | null) =>
 export const repositories = (teamId?: string | null) =>
   appendTeamIdQueryParam(`${DASHBOARD_URL_PREFIX}/repositories`, teamId);
 
+export const repository = ({
+  owner,
+  name,
+  teamId,
+}: {
+  owner: string;
+  name: string;
+  teamId?: string | null;
+}) =>
+  appendTeamIdQueryParam(
+    `${DASHBOARD_URL_PREFIX}/repositories/github/${owner}/${name}`,
+    teamId
+  );
+
 export const syncedSandboxes = (teamId?: string | null) =>
   appendTeamIdQueryParam(`${DASHBOARD_URL_PREFIX}/synced-sandboxes`, teamId);
 


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What is the new behavior?

<!-- if this is a feature change -->

Splits the Repository component into two elements: `RepositoryCard` and `RepositoryListItem`.
Adds the context menu to said elements.

|Repo card|
|:-:|
|<img width="384" alt="Screen Shot 2022-09-29 at 02 07 10" src="https://user-images.githubusercontent.com/24959348/192943697-22da80bd-9fc0-42b2-a96e-0a4373b8500a.png">|

|List item|
|:-:|
|<img width="882" alt="Screen Shot 2022-09-29 at 02 08 34" src="https://user-images.githubusercontent.com/24959348/192943883-63975f94-977d-42cb-94c5-d04d476326e2.png">|
