### PR TITLE
ui(create-modal): polish card sizes and overflow

### DIFF
--- a/packages/app/src/app/components/CreateNewSandbox/CreateSandbox/CreateSandbox.tsx
+++ b/packages/app/src/app/components/CreateNewSandbox/CreateSandbox/CreateSandbox.tsx
@@ -85,6 +85,8 @@ export const CreateSandbox: React.FC<CreateSandboxProps> = ({
   const defaultSelectedTab =
     initialTab || isSyncedSandboxesPage ? 'import' : 'quickstart';
   const isUser = user?.username === activeTeamInfo?.name;
+  const mediaQuery = window.matchMedia('screen and (max-width: 950px)');
+  const mobileScreenSize = mediaQuery.matches;
 
   /**
    * Checking for user because user is undefined when landing on /s/, even though
@@ -134,7 +136,7 @@ export const CreateSandbox: React.FC<CreateSandboxProps> = ({
     teamTemplatesData.state === 'ready' ? teamTemplatesData.teamTemplates : [];
 
   const tabState = useTabState({
-    orientation: 'vertical',
+    orientation: mobileScreenSize ? 'horizontal' : 'vertical',
     selectedId: defaultSelectedTab,
   });
 
@@ -168,9 +170,6 @@ export const CreateSandbox: React.FC<CreateSandboxProps> = ({
 
     actions.modals.newSandboxModal.close();
   };
-
-  const mediaQuery = window.matchMedia('screen and (max-width: 950px)');
-  const mobileScreenSize = mediaQuery.matches;
 
   const selectTemplate = (template: TemplateFragment) => {
     setSelectedTemplate(template);

--- a/packages/app/src/app/components/CreateNewSandbox/CreateSandbox/CreateSandbox.tsx
+++ b/packages/app/src/app/components/CreateNewSandbox/CreateSandbox/CreateSandbox.tsx
@@ -177,7 +177,15 @@ export const CreateSandbox: React.FC<CreateSandboxProps> = ({
   return (
     <ThemeProvider>
       <Container>
-        <Stack gap={4} align="center" css={{ width: '100%', padding: '24px' }}>
+        <Stack
+          gap={4}
+          align="center"
+          css={{
+            width: '100%',
+            padding: '24px',
+            '@media screen and (max-width: 950px)': { padding: '16px' },
+          }}
+        >
           <HeaderInformation>
             {viewState === 'initial' ? (
               <Text size={4} variant="muted">

--- a/packages/app/src/app/components/CreateNewSandbox/CreateSandbox/CreateSandbox.tsx
+++ b/packages/app/src/app/components/CreateNewSandbox/CreateSandbox/CreateSandbox.tsx
@@ -169,6 +169,9 @@ export const CreateSandbox: React.FC<CreateSandboxProps> = ({
     actions.modals.newSandboxModal.close();
   };
 
+  const mediaQuery = window.matchMedia('screen and (max-width: 950px)');
+  const mobileScreenSize = mediaQuery.matches;
+
   const selectTemplate = (template: TemplateFragment) => {
     setSelectedTemplate(template);
     setViewState('fromTemplate');
@@ -182,8 +185,7 @@ export const CreateSandbox: React.FC<CreateSandboxProps> = ({
           align="center"
           css={{
             width: '100%',
-            padding: '24px',
-            '@media screen and (max-width: 950px)': { padding: '16px' },
+            padding: mobileScreenSize ? '16px' : '24px',
           }}
         >
           <HeaderInformation>
@@ -281,7 +283,7 @@ export const CreateSandbox: React.FC<CreateSandboxProps> = ({
                       ))
                     : null}
 
-                  {essentialState.state === 'loading' ? (
+                  {!mobileScreenSize && essentialState.state === 'loading' ? (
                     <Stack direction="vertical" css={{ marginTop: 6 }} gap={5}>
                       <SkeletonText css={{ width: 100 }} />
                       <SkeletonText css={{ width: 90 }} />

--- a/packages/app/src/app/components/CreateNewSandbox/CreateSandbox/FromTemplate.tsx
+++ b/packages/app/src/app/components/CreateNewSandbox/CreateSandbox/FromTemplate.tsx
@@ -9,7 +9,7 @@ import {
   Text,
 } from '@codesandbox/components';
 
-import { StyledInput, StyledLabel, StyledSelect } from './elements';
+import { StyledInput, StyledSelect } from './elements';
 import { CloudBetaBadge } from '../../CloudBetaBadge';
 import { CreateSandboxParams } from './types';
 
@@ -29,7 +29,10 @@ export const FromTemplate: React.FC<FromTemplateProps> = ({
   // TODO: Set generated name as default value if we can / need
   // otherwise tell the user if empty we generate a name
   const [sandboxName, setSandboxName] = useState<string>();
-  const [createRepo, setCreateRepo] = useState<boolean>(false);
+
+  const createRepo = false;
+  // TODO: Enable when checkbox is active again
+  // const [createRepo, setCreateRepo] = useState<boolean>(false);
   const [selectedTeam, setSelectedTeam] = useState<string>(activeTeam);
 
   return (
@@ -94,24 +97,22 @@ export const FromTemplate: React.FC<FromTemplateProps> = ({
 
           <Checkbox
             id="sb-repo"
-            onChange={e => {
-              setCreateRepo(e.target.checked);
-            }}
+            disabled
             checked={createRepo}
             label={
-              <StyledLabel
+              <Text
                 css={{
                   fontSize: 13,
                   display: 'block',
                   marginTop: 2,
                   marginLeft: 4,
+                  color: '#999999',
+                  lineHeight: '16px',
                 }}
-                htmlFor="sb-repo"
               >
-                Create git repository
-              </StyledLabel>
+                Create git repository (coming soon)
+              </Text>
             }
-            disabled={!hasLogIn || !user || !dashboard.teams}
           />
 
           {createRepo ? (

--- a/packages/app/src/app/components/CreateNewSandbox/CreateSandbox/SearchBox/elements.ts
+++ b/packages/app/src/app/components/CreateNewSandbox/CreateSandbox/SearchBox/elements.ts
@@ -45,6 +45,10 @@ export const SearchElement = styled.input`
   &:-ms-input-placeholder {
     color: #757575;
   }
+
+  @media screen and (max-width: 370px) {
+    width: auto;
+  }
 `;
 
 export const InputWrapper = styled.div`

--- a/packages/app/src/app/components/CreateNewSandbox/CreateSandbox/TemplateCard.tsx
+++ b/packages/app/src/app/components/CreateNewSandbox/CreateSandbox/TemplateCard.tsx
@@ -26,7 +26,11 @@ export const TemplateCard = ({
   const teamName = template.sandbox?.collection?.team?.name;
 
   return (
-    <TemplateButton type="button" onClick={() => onSelectTemplate(template)}>
+    <TemplateButton
+      title={sandboxTitle}
+      type="button"
+      onClick={() => onSelectTemplate(template)}
+    >
       <Stack css={{ height: '100%' }} direction="vertical" gap={4}>
         <Stack
           css={{ justifyContent: 'space-between', alignItems: 'flex-start' }}
@@ -42,6 +46,7 @@ export const TemplateCard = ({
               fontWeight: 500,
               textOverflow: 'ellipsis',
               overflow: 'hidden',
+              whiteSpace: 'nowrap',
             }}
           >
             {sandboxTitle}

--- a/packages/app/src/app/components/CreateNewSandbox/CreateSandbox/TemplateCategoryList.tsx
+++ b/packages/app/src/app/components/CreateNewSandbox/CreateSandbox/TemplateCategoryList.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 import track from '@codesandbox/common/lib/utils/analytics';
 import { Text, Stack } from '@codesandbox/components';
+import { css } from '@styled-system/css';
 
 import { TemplateFragment } from 'app/graphql/types';
 import { TemplateCard } from './TemplateCard';
@@ -26,7 +27,15 @@ export const TemplateCategoryList = ({
 
   return (
     <Stack direction="vertical" css={{ height: '100%' }} gap={6}>
-      <Stack css={{ alignItems: 'center' }} gap={2}>
+      <Stack
+        css={css({
+          alignItems: 'center',
+          '@media screen and (max-width: 950px)': {
+            display: 'none',
+          },
+        })}
+        gap={2}
+      >
         <Text
           as="h2"
           size={4}

--- a/packages/app/src/app/components/CreateNewSandbox/CreateSandbox/elements.ts
+++ b/packages/app/src/app/components/CreateNewSandbox/CreateSandbox/elements.ts
@@ -3,10 +3,9 @@ import { Tab as BaseTab, TabList, TabPanel } from 'reakit/Tab';
 import { Button, Select } from '@codesandbox/components';
 
 export const Container = styled.div`
-  // TODO: Proper height, width and responsive styles
   min-width: 870px;
-  max-width: 1200px;
-  height: 550px;
+  max-width: 950px;
+  height: 500px;
   overflow: hidden;
   border-radius: 4px;
   background-color: #151515;
@@ -38,7 +37,7 @@ export const ModalBody = styled.div`
 `;
 
 export const ModalSidebar = styled.div`
-  width: 224px;
+  width: 176px;
   flex-shrink: 0;
   padding: 0px 24px 24px;
   overflow: auto;
@@ -54,7 +53,7 @@ export const Tabs = styled(TabList)`
   flex-direction: column;
 
   // TODO: Mobile styles
-  @media screen and (max-width: 800px) {
+  @media screen and (max-width: 950px) {
     display: none;
   }
 `;
@@ -163,7 +162,7 @@ export const TemplateButton = styled.button`
   background: #1d1d1d;
   border: 1px solid transparent;
   text-align: left;
-  padding: 24px;
+  padding: 16px;
   border-radius: 2px;
   color: #e5e5e5;
   transition: background ${props => props.theme.speeds[2]} ease-out;

--- a/packages/app/src/app/components/CreateNewSandbox/CreateSandbox/elements.ts
+++ b/packages/app/src/app/components/CreateNewSandbox/CreateSandbox/elements.ts
@@ -215,9 +215,3 @@ export const StyledSelect = styled(Select)`
   height: 48px;
   padding-left: 44px !important;
 `;
-
-export const StyledLabel = styled.label`
-  color: #999999;
-  font-size: 12px;
-  line-height: 16px;
-`;

--- a/packages/app/src/app/components/CreateNewSandbox/CreateSandbox/elements.ts
+++ b/packages/app/src/app/components/CreateNewSandbox/CreateSandbox/elements.ts
@@ -1,10 +1,8 @@
 import styled, { css } from 'styled-components';
 import { Tab as BaseTab, TabList, TabPanel } from 'reakit/Tab';
-import { Button, Select } from '@codesandbox/components';
+import { Select } from '@codesandbox/components';
 
 export const Container = styled.div`
-  min-width: 870px;
-  max-width: 950px;
   height: 500px;
   overflow: hidden;
   border-radius: 4px;
@@ -12,18 +10,6 @@ export const Container = styled.div`
   color: #e5e5e5;
   display: flex;
   flex-direction: column;
-
-  @media screen and (max-width: 800px) {
-    max-width: 100%;
-    margin: auto;
-    min-width: auto;
-    height: 100vh;
-    border-radius: 0;
-
-    div[role='tabpanel'] {
-      padding-bottom: 40px;
-    }
-  }
 `;
 
 export const HeaderInformation = styled.div`
@@ -34,6 +20,11 @@ export const ModalBody = styled.div`
   display: flex;
   flex: 1;
   overflow: hidden;
+
+  @media screen and (max-width: 950px) {
+    flex-direction: column;
+    gap: 16px;
+  }
 `;
 
 export const ModalSidebar = styled.div`
@@ -41,42 +32,29 @@ export const ModalSidebar = styled.div`
   flex-shrink: 0;
   padding: 0px 24px 24px;
   overflow: auto;
+
+  @media screen and (max-width: 950px) {
+    width: auto;
+    padding: 8px 8px 0;
+  }
 `;
 
 export const ModalContent = styled.div`
   flex-grow: 1;
   padding: 0 24px;
+  overflow: auto;
+
+  @media screen and (max-width: 950px) {
+    padding: 0 16px;
+  }
 `;
 
 export const Tabs = styled(TabList)`
   display: flex;
   flex-direction: column;
 
-  // TODO: Mobile styles
   @media screen and (max-width: 950px) {
-    display: none;
-  }
-`;
-
-export const DashboardButton = styled(Button).attrs({
-  variant: 'secondary',
-})`
-  margin-top: 16px;
-  justify-content: flex-start;
-  height: 32px;
-  color: #999999;
-
-  > div {
-    width: 24px;
-    height: 24px;
-  }
-
-  :hover:not(:disabled) {
-    background: transparent;
-    color: white;
-    path {
-      fill: white;
-    }
+    flex-direction: row;
   }
 `;
 
@@ -92,6 +70,7 @@ export const Tab = styled(BaseTab)`
   font-size: 12px;
   line-height: 16px;
   cursor: pointer;
+  white-space: nowrap;
 
   &[aria-selected='true'],
   :hover {
@@ -101,16 +80,17 @@ export const Tab = styled(BaseTab)`
   &:focus {
     outline: none;
   }
+
+  @media screen and (max-width: 950px) {
+    margin-bottom: 0;
+    padding: 8px;
+  }
 `;
 
 export const TabContent = styled(TabPanel)`
   width: 100%;
   height: 100%;
   outline: none;
-
-  @media screen and (max-width: 800px) {
-    max-height: 100%;
-  }
 `;
 
 export const Header = styled.header`
@@ -122,40 +102,6 @@ export const Header = styled.header`
   border-bottom: 1px solid #242424;
   font-size: 19px;
   line-height: 24px;
-
-  @media screen and (max-width: 800px) {
-    display: none;
-  }
-`;
-
-export const Legend = styled.span`
-  color: #757575;
-  font-size: 16px;
-  line-height: 19px;
-`;
-
-export const Grid = styled.div<{ columnCount: number }>`
-  display: grid;
-  margin: 0 1.5rem;
-  grid-template-columns: repeat(${props => props.columnCount}, 1fr);
-  gap: 1rem;
-`;
-
-export const MobileTabs = styled.div`
-  display: none;
-  @media screen and (max-width: 800px) {
-    display: flex;
-    border: 1px solid #242424;
-    z-index: 2147483647;
-
-    button {
-      color: #757575;
-
-      &.active {
-        color: inherit;
-      }
-    }
-  }
 `;
 
 export const TemplateButton = styled.button`
@@ -183,6 +129,14 @@ export const TemplateGrid = styled.div`
   gap: 8px 10px;
   overflow: auto;
   padding-bottom: 8px;
+
+  @media screen and (max-width: 756px) {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  @media screen and (max-width: 485px) {
+    grid-template-columns: 1fr;
+  }
 `;
 
 export const inputStyles = css`

--- a/packages/app/src/app/components/Modal/index.js
+++ b/packages/app/src/app/components/Modal/index.js
@@ -19,6 +19,7 @@ const GlobalStyles = createGlobalStyle`
   opacity: 0;
   transform: scale(0.9) translateY(5px);
   overflow-y: hidden;
+  width: 950px; 
 }
 
 .ReactModal__Overlay {

--- a/packages/app/src/app/components/Modal/index.js
+++ b/packages/app/src/app/components/Modal/index.js
@@ -20,6 +20,16 @@ const GlobalStyles = createGlobalStyle`
   transform: scale(0.9) translateY(5px);
   overflow-y: hidden;
   width: 950px; 
+  
+  @media screen and (max-width: 950px) {
+    width: 95%;
+  }
+  
+  @media screen and (max-width: 756px) {
+    width: 100%;
+    border: 0;
+    border-radius: 0;
+  }
 }
 
 .ReactModal__Overlay {

--- a/packages/components/src/components/Checkbox/index.tsx
+++ b/packages/components/src/components/Checkbox/index.tsx
@@ -75,6 +75,7 @@ export const Checkbox: FunctionComponent<ICheckboxProps> = ({
   checked,
   id,
   label,
+  disabled,
   ...props
 }) => {
   const inputId = useId(id);
@@ -85,9 +86,14 @@ export const Checkbox: FunctionComponent<ICheckboxProps> = ({
         id={inputId}
         name={inputId}
         type="checkbox"
+        disabled={disabled}
         {...props}
       />
-      <Label as="label" htmlFor={inputId}>
+      <Label
+        css={disabled ? { opacity: 0.6, cursor: 'not-allowed' } : {}}
+        as="label"
+        htmlFor={inputId}
+      >
         {label}
       </Label>
     </Element>


### PR DESCRIPTION
* Mobile view
* Modal window sized according to the design (but need to look into the weird max-width set on react-modal
* Template cards padding reduced
* Text overflow handled and title added for tooltip info

Tested responsive design on different screen sizes

https://user-images.githubusercontent.com/9945366/193804177-9ca43119-a4da-4e7f-ac50-56a42e1f7b02.mov


