### PR TITLE
Change section names on sidebar

### DIFF
--- a/packages/app/src/app/pages/Dashboard/Components/Breadcrumbs/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Breadcrumbs/index.tsx
@@ -24,7 +24,7 @@ export const Breadcrumbs: React.FC<BreadcrumbProps> = ({
     }[nestedPageType];
   } else if (albumId) link = dashboard.discover(activeTeam);
 
-  let prefix = 'Sandboxes';
+  let prefix = 'All sandboxes';
   if (nestedPageType) {
     prefix = {
       'synced-sandboxes': 'Synced sandboxes',

--- a/packages/app/src/app/pages/Dashboard/Sidebar/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Sidebar/index.tsx
@@ -234,7 +234,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
             icon="star"
           />
           <NestableRowItem
-            name="Sandboxes"
+            name="All sandboxes"
             path={dashboardUrls.sandboxes('/', activeTeam)}
             page="sandboxes"
             folderPath="/"
@@ -254,7 +254,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
             />
           )}
           <RowItem
-            name="Synced Sandboxes"
+            name="Synced"
             page="synced-sandboxes"
             path={dashboardUrls.syncedSandboxes(activeTeam)}
             icon="sync"


### PR DESCRIPTION
Change name of sections `Sandboxes` and `Synced Sandboxes` on sidebar and internal page

(before)
<img width="128" alt="Screen Shot 2022-10-03 at 15 43 26" src="https://user-images.githubusercontent.com/93996574/193654247-863ff38f-3840-4adc-9f3c-8134da2e6862.png">


(after
<img width="111" alt="Screen Shot 2022-10-03 at 15 41 11" src="https://user-images.githubusercontent.com/93996574/193653989-9cf4922a-f23c-4401-834e-6b63fe33a2ed.png">
)