### PR TITLE
feat(new-style): Update context menu and grid max width

### DIFF
--- a/packages/app/src/app/pages/Dashboard/Components/VariableGrid/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/VariableGrid/index.tsx
@@ -36,10 +36,10 @@ import { CreateFolder } from '../Folder/CreateFolder';
 import { Branch } from '../Branch';
 import { Repository } from '../Repository';
 
-export const GRID_MAX_WIDTH = 1900;
-export const MAX_COLUMN_COUNT = 6;
+export const GRID_MAX_WIDTH = 3840;
+export const MAX_COLUMN_COUNT = 10;
 export const GUTTER = 16;
-const ITEM_MIN_WIDTH = 280;
+const ITEM_MIN_WIDTH = 260;
 const ITEM_HEIGHT_GRID = 240;
 const ITEM_HEIGHT_LIST = 64;
 const HEADER_HEIGHT = 64;

--- a/packages/components/src/components/Menu/index.tsx
+++ b/packages/components/src/components/Menu/index.tsx
@@ -34,6 +34,9 @@ export const MenuStyles = createGlobalStyle(
       fontFamily: 'Inter, sans-serif',
       fontWeight: 400,
     },
+    '[data-reach-menu] > div': {
+      borderRadius: 4,
+    },
     '[data-reach-menu][hidden],[data-reach-menu-popover][hidden]': {
       display: 'none',
     },

--- a/packages/components/src/utils/polyfill-theme.ts
+++ b/packages/components/src/utils/polyfill-theme.ts
@@ -207,7 +207,7 @@ const polyfillTheme = vsCodeTheme => {
       border: uiColors.sideBar.border,
     },
     menuList: {
-      background: designLanguage.colorsV2.black[400],
+      background: designLanguage.colorsV2.black[500],
       foreground: designLanguage.colorsV2.gray[500],
       border: designLanguage.colorsV2.black[100],
       hoverBackground: designLanguage.colorsV2.black[100],


### PR DESCRIPTION
## About

- New styles for the context menu following the new editor
- Increase the max width of the container to show more columns in large screens


## Changes

<img width="1435" alt="Screen Shot 2022-10-03 at 20 00 06" src="https://user-images.githubusercontent.com/1891339/193700719-72d2b57e-4d20-4eb5-82e5-74b914887683.png">
<img width="1439" alt="Screen Shot 2022-10-03 at 20 00 02" src="https://user-images.githubusercontent.com/1891339/193700722-ac46d2f3-5f4f-443f-b6e6-ca4c26116ab0.png">
