### PR TITLE
feat: move to recent on workspace change and reset state data

### DIFF
--- a/packages/app/src/app/overmind/actions.ts
+++ b/packages/app/src/app/overmind/actions.ts
@@ -516,7 +516,11 @@ export const setActiveTeam = async (
 
   state.activeTeam = id;
   effects.browser.storage.set(TEAM_ID_LOCAL_STORAGE, id);
-  state.dashboard.sandboxes = DEFAULT_DASHBOARD_SANDBOXES;
+
+  // reset dashboard data on team change
+  state.dashboard.sandboxes = { ...DEFAULT_DASHBOARD_SANDBOXES };
+  state.dashboard.repositories = null;
+  state.dashboard.contributions = null;
 
   actions.internal.replaceWorkspaceParameterInUrl();
 

--- a/packages/app/src/app/pages/Dashboard/Sidebar/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Sidebar/index.tsx
@@ -48,6 +48,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
   onSidebarToggle,
   ...props
 }) => {
+  const history = useHistory();
   const state = useAppState();
   const actions = useActions();
   const [activeAccount, setActiveAccount] = useState<{
@@ -55,7 +56,13 @@ export const Sidebar: React.FC<SidebarProps> = ({
     name: string;
     avatarUrl: string;
   } | null>(null);
-  const { dashboard, activeTeam, activeTeamInfo, user } = state;
+  const {
+    dashboard,
+    activeTeam,
+    activeTeamInfo,
+    user,
+    personalWorkspaceId,
+  } = state;
 
   React.useEffect(() => {
     actions.dashboard.getAllFolders();
@@ -65,7 +72,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
     if (state.activeTeam) {
       const team = dashboard.teams.find(({ id }) => id === state.activeTeam);
       if (team) {
-        const isPersonalWorkspace = team.id === state.personalWorkspaceId;
+        const isPersonalWorkspace = team.id === personalWorkspaceId;
         setActiveAccount({
           id: team.id,
           name: team.name,
@@ -152,6 +159,8 @@ export const Sidebar: React.FC<SidebarProps> = ({
                   actions.setActiveTeam({
                     id: workspace.id,
                   });
+
+                  history.replace(dashboardUrls.recent(workspace.id));
                 }}
                 activeAccount={activeAccount}
               />
@@ -199,12 +208,14 @@ export const Sidebar: React.FC<SidebarProps> = ({
               Repositories
             </Text>
           </Element>
-          <RowItem
-            name="My contributions"
-            page="my-contributions"
-            path={dashboardUrls.myContributions(activeTeam)}
-            icon="contribution"
-          />
+          {activeTeam === personalWorkspaceId && (
+            <RowItem
+              name="My contributions"
+              page="my-contributions"
+              path={dashboardUrls.myContributions(activeTeam)}
+              icon="contribution"
+            />
+          )}
           <RowItem
             name="All repositories"
             page="repositories"


### PR DESCRIPTION
Fixes the problem with data reset on changing the workspace. It also addresses the problem of figuring out something changed, since you are redirected to the `recent` page everytime you change the team/workspace.

Also, I removed `my contributions` link from the sidebar if you are in a team (Closes XTD-197)

NOTE: Recent page still shares the branch data between the teams, there's a pending request to the backend team to help us with that, so you might see the same items in the recent page while you switch