### PR TITLE
fix: filter recent branches by teamId

### DIFF
--- a/packages/app/src/app/graphql/types.ts
+++ b/packages/app/src/app/graphql/types.ts
@@ -240,8 +240,9 @@ export type CurrentUserNotificationsArgs = {
 };
 
 export type CurrentUserRecentBranchesArgs = {
-  contribution?: Maybe<Scalars['Boolean']>;
+  contribution: Maybe<Scalars['Boolean']>;
   limit?: Maybe<Scalars['Int']>;
+  teamId: Maybe<Scalars['UUID4']>;
 };
 
 export type CurrentUserRecentProjectsArgs = {
@@ -579,6 +580,8 @@ export type ProSubscription = {
   paymentProvider: Maybe<SubscriptionPaymentProvider>;
   quantity: Maybe<Scalars['Int']>;
   status: SubscriptionStatus;
+  trialEnd: Maybe<Scalars['DateTime']>;
+  trialStart: Maybe<Scalars['DateTime']>;
   type: SubscriptionType;
   unitPrice: Maybe<Scalars['Int']>;
   updateBillingUrl: Maybe<Scalars['String']>;
@@ -1341,8 +1344,10 @@ export type Sandbox = {
   isFrozen: Scalars['Boolean'];
   isSse: Maybe<Scalars['Boolean']>;
   isV2: Scalars['Boolean'];
+  /** Depending on the context, this may be the last access of the current user or the aggregate last access for all users */
+  lastAccessedAt: Scalars['DateTime'];
   likeCount: Scalars['Int'];
-  /** If the sandbox has been forked from a git sandbox this will be set */
+  /** If the sandbox has been made into a git sandbox, then this will be set */
   originalGit: Maybe<Git>;
   permissions: Maybe<SandboxProtectionSettings>;
   /** If a PR has been opened on the sandbox, this will be set to the PR number */
@@ -1503,12 +1508,15 @@ export type Template = {
   __typename?: 'Template';
   bookmarked: Maybe<Array<Maybe<Bookmarked>>>;
   color: Maybe<Scalars['String']>;
+  /** @deprecated This field is deprecated and will always be null. Query sandbox > description instead */
   description: Maybe<Scalars['String']>;
   iconUrl: Maybe<Scalars['String']>;
   id: Maybe<Scalars['UUID4']>;
   insertedAt: Maybe<Scalars['String']>;
+  official: Scalars['Boolean'];
   published: Maybe<Scalars['Boolean']>;
   sandbox: Maybe<Sandbox>;
+  /** @deprecated This field is deprecated and will always be null. Query sandbox > title instead */
   title: Maybe<Scalars['String']>;
   updatedAt: Maybe<Scalars['String']>;
 };
@@ -3087,6 +3095,7 @@ export type RecentlyAccessedSandboxesQuery = {
 
 export type RecentlyAccessedBranchesQueryVariables = Exact<{
   limit: Scalars['Int'];
+  teamId: Maybe<Scalars['UUID4']>;
 }>;
 
 export type RecentlyAccessedBranchesQuery = { __typename?: 'RootQueryType' } & {

--- a/packages/app/src/app/overmind/effects/gql/dashboard/queries.ts
+++ b/packages/app/src/app/overmind/effects/gql/dashboard/queries.ts
@@ -336,9 +336,9 @@ export const recentlyAccessedBranches: Query<
   RecentlyAccessedBranchesQuery,
   RecentlyAccessedBranchesQueryVariables
 > = gql`
-  query RecentlyAccessedBranches($limit: Int!) {
+  query RecentlyAccessedBranches($limit: Int!, $teamId: UUID4) {
     me {
-      recentBranches(limit: $limit) {
+      recentBranches(limit: $limit, teamId: $teamId) {
         ...branch
       }
     }

--- a/packages/app/src/app/overmind/namespaces/dashboard/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/dashboard/actions.ts
@@ -593,6 +593,7 @@ export const getStartPageSandboxes = async ({ state, effects }: Context) => {
 
     const branchesResult = await effects.gql.queries.recentlyAccessedBranches({
       limit: 12,
+      teamId: state.activeTeam,
     });
 
     dashboard.sandboxes.RECENT_SANDBOXES =


### PR DESCRIPTION
Recent branches were not filtered by teamId, so they would show up on all the teams.

Ready for review, but not for merging, as it relies on a filter present only on staging atm.