### PR TITLE
fix: text-overflow for folders in sidebar

### DIFF
--- a/packages/app/src/app/components/CreateNewSandbox/CreateSandbox/CreateSandbox.tsx
+++ b/packages/app/src/app/components/CreateNewSandbox/CreateSandbox/CreateSandbox.tsx
@@ -45,7 +45,7 @@ const QUICK_START_IDS = [
   'k8dsq1', // blank v2
   'fxis37', // next v2
   'prp60l', // remix v2
-  '6xxu1m', // nuxt (TODO: move it to v2 and make it official)
+  '6xxu1m', // nuxt v2
   'vue',
   'svelte',
   'angular',

--- a/packages/app/src/app/pages/Dashboard/Sidebar/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Sidebar/index.tsx
@@ -760,6 +760,7 @@ const NestableRowItem: React.FC<NestableRowItemProps> = ({
       >
         <Link
           to={folderUrl}
+          title={name}
           onClick={() => {
             const event = MAP_SIDEBAR_ITEM_EVENT_TO_PAGE_TYPE[page];
             if (event) {
@@ -815,13 +816,14 @@ const NestableRowItem: React.FC<NestableRowItemProps> = ({
               paddingLeft: 0,
               paddingRight: 0,
               marginRight: '0',
+              width: '96%',
             }}
           >
             <Stack
               justify="center"
               align="center"
               css={{
-                width: 24,
+                padding: '0 4px',
                 marginRight: '8px',
               }}
             >


### PR DESCRIPTION
Focused on the text-overflow which is more problematic for the release, left the animation and other details for later on.