### PR TITLE
feat(dashboard): Implement notifications

### DIFF
--- a/packages/app/src/app/pages/Dashboard/Components/Notification/Notification.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Notification/Notification.tsx
@@ -1,0 +1,67 @@
+import React, { useState } from 'react';
+import { css } from 'styled-components';
+import { useEffects } from 'app/overmind';
+import { Element, Text, IconButton, Stack } from '@codesandbox/components';
+
+import { PageTypes } from '../../types';
+import { GUTTER, GRID_MAX_WIDTH } from '../VariableGrid';
+import { NotificationIndicator } from './NotificationIndicator';
+
+interface NotificationProps {
+  children: React.ReactNode;
+  pageType: PageTypes;
+}
+
+export const Notification = ({ children, pageType }: NotificationProps) => {
+  const [isShown, setIsShown] = useState(true);
+  const { browser } = useEffects();
+
+  const dismissNotification = () => {
+    // Get previously dismissed notifications
+    const prevDismissedNotifications = browser.storage.get(
+      'notificationDismissed'
+    ) as object;
+
+    // Add notification to dismissed
+    browser.storage.set('notificationDismissed', {
+      ...prevDismissedNotifications,
+      [pageType]: true,
+    });
+
+    setIsShown(false);
+  };
+
+  if (isShown)
+    return (
+      <Element
+        paddingX={4}
+        paddingY={2}
+        marginTop={8}
+        css={{
+          width: `calc(100% - ${2 * GUTTER}px)`,
+          maxWidth: GRID_MAX_WIDTH - 2 * GUTTER,
+          marginLeft: 'auto',
+          marginRight: 'auto',
+          backgroundColor: 'rgba(255, 255, 255, 0.1)',
+        }}
+      >
+        <Stack gap={4} align="center">
+          <NotificationIndicator />
+          <Text size={12} variant="muted" css={css({ lineHeight: '16px' })}>
+            {children}
+          </Text>
+          <Element
+            css={{ flexGrow: 1, display: 'flex', justifyContent: 'flex-end' }}
+          >
+            <IconButton
+              name="cross"
+              title="Dismiss notification"
+              onClick={dismissNotification}
+            />
+          </Element>
+        </Stack>
+      </Element>
+    );
+
+  return null;
+};

--- a/packages/app/src/app/pages/Dashboard/Components/Notification/Notification.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Notification/Notification.tsx
@@ -13,8 +13,10 @@ interface NotificationProps {
 }
 
 export const Notification = ({ children, pageType }: NotificationProps) => {
-  const [isShown, setIsShown] = useState(true);
   const { browser } = useEffects();
+  const [isShown, setIsShown] = useState(() => {
+    return !browser.storage.get('notificationDismissed')?.[pageType];
+  });
 
   const dismissNotification = () => {
     // Get previously dismissed notifications

--- a/packages/app/src/app/pages/Dashboard/Components/Notification/Notification.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Notification/Notification.tsx
@@ -43,6 +43,7 @@ export const Notification = ({ children, pageType }: NotificationProps) => {
           marginLeft: 'auto',
           marginRight: 'auto',
           backgroundColor: 'rgba(255, 255, 255, 0.1)',
+          borderRadius: '4px',
         }}
       >
         <Stack gap={4} align="center">

--- a/packages/app/src/app/pages/Dashboard/Components/Notification/NotificationIndicator.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Notification/NotificationIndicator.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Element } from '@codesandbox/components';
+
+export const NotificationIndicator = () => (
+  <Element
+    css={{
+      width: 5,
+      height: 5,
+      backgroundColor: '#EDFFA5',
+      borderRadius: '100%',
+    }}
+  />
+);

--- a/packages/app/src/app/pages/Dashboard/Components/Notification/NotificationIndicator.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Notification/NotificationIndicator.tsx
@@ -8,6 +8,7 @@ export const NotificationIndicator = () => (
       height: 5,
       backgroundColor: '#EDFFA5',
       borderRadius: '100%',
+      flexShrink: 0,
     }}
   />
 );

--- a/packages/app/src/app/pages/Dashboard/Content/routes/MyContributions/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/MyContributions/index.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import { Helmet } from 'react-helmet';
 import { useParams } from 'react-router-dom';
-import { useAppState, useActions } from 'app/overmind';
+import { useAppState, useActions, useEffects } from 'app/overmind';
 import { Header } from 'app/pages/Dashboard/Components/Header';
 import { VariableGrid } from 'app/pages/Dashboard/Components/VariableGrid';
 import { DashboardGridItem, PageTypes } from 'app/pages/Dashboard/types';
 import { SelectionProvider } from 'app/pages/Dashboard/Components/Selection';
+import { Notification } from 'app/pages/Dashboard/Components/Notification/Notification';
 
 export const MyContributionsPage = () => {
   const params = useParams<{ path: string }>();
@@ -15,12 +16,17 @@ export const MyContributionsPage = () => {
     activeTeam,
     dashboard: { contributions },
   } = useAppState();
+  const { browser } = useEffects();
 
   React.useEffect(() => {
     actions.dashboard.getContributionBranches();
   }, [actions.dashboard]);
 
   const pageType: PageTypes = 'my-contributions';
+
+  const isNotificationDismissed = browser.storage.get(
+    'notificationDismissed'
+  )?.[pageType];
 
   const itemsToShow = (): DashboardGridItem[] => {
     if (contributions === null) {
@@ -51,6 +57,13 @@ export const MyContributionsPage = () => {
         showFilters={Boolean(param)}
         showSortOptions={Boolean(param)}
       />
+      {!isNotificationDismissed ? (
+        <Notification pageType={pageType}>
+          {itemsToShow().length === 0
+            ? 'Introducing contribution branches: the easiest way of contributing to open source.'
+            : 'Your contribution branches now live here, so you can manage your contributions easily.'}
+        </Notification>
+      ) : null}
       <VariableGrid page={pageType} items={itemsToShow()} />
     </SelectionProvider>
   );

--- a/packages/app/src/app/pages/Dashboard/Content/routes/MyContributions/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/MyContributions/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Helmet } from 'react-helmet';
 import { useParams } from 'react-router-dom';
-import { useAppState, useActions, useEffects } from 'app/overmind';
+import { useAppState, useActions } from 'app/overmind';
 import { Header } from 'app/pages/Dashboard/Components/Header';
 import { VariableGrid } from 'app/pages/Dashboard/Components/VariableGrid';
 import { DashboardGridItem, PageTypes } from 'app/pages/Dashboard/types';
@@ -16,7 +16,6 @@ export const MyContributionsPage = () => {
     activeTeam,
     dashboard: { contributions },
   } = useAppState();
-  const { browser } = useEffects();
 
   React.useEffect(() => {
     actions.dashboard.getContributionBranches();
@@ -24,11 +23,7 @@ export const MyContributionsPage = () => {
 
   const pageType: PageTypes = 'my-contributions';
 
-  const isNotificationDismissed = browser.storage.get(
-    'notificationDismissed'
-  )?.[pageType];
-
-  const itemsToShow = (): DashboardGridItem[] => {
+  const getItemsToShow = (): DashboardGridItem[] => {
     if (contributions === null) {
       return [{ type: 'skeleton-row' }, { type: 'skeleton-row' }];
     }
@@ -39,11 +34,13 @@ export const MyContributionsPage = () => {
     }));
   };
 
+  const itemsToShow = getItemsToShow();
+
   return (
     <SelectionProvider
       page={pageType}
       activeTeamId={activeTeam}
-      items={itemsToShow()}
+      items={itemsToShow}
     >
       <Helmet>
         <title>{param || 'Dashboard'} - CodeSandbox</title>
@@ -57,14 +54,12 @@ export const MyContributionsPage = () => {
         showFilters={Boolean(param)}
         showSortOptions={Boolean(param)}
       />
-      {!isNotificationDismissed ? (
-        <Notification pageType={pageType}>
-          {itemsToShow().length === 0
-            ? 'Introducing contribution branches: the easiest way of contributing to open source.'
-            : 'Your contribution branches now live here, so you can manage your contributions easily.'}
-        </Notification>
-      ) : null}
-      <VariableGrid page={pageType} items={itemsToShow()} />
+      <Notification pageType={pageType}>
+        {itemsToShow.length === 0
+          ? 'Introducing contribution branches: the easiest way of contributing to open source.'
+          : 'Your contribution branches now live here, so you can manage your contributions easily.'}
+      </Notification>
+      <VariableGrid page={pageType} items={itemsToShow} />
     </SelectionProvider>
   );
 };

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Repositories/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Repositories/index.tsx
@@ -7,6 +7,7 @@ import { VariableGrid } from 'app/pages/Dashboard/Components/VariableGrid';
 import { DashboardGridItem, PageTypes } from 'app/pages/Dashboard/types';
 import { SelectionProvider } from 'app/pages/Dashboard/Components/Selection';
 import { Notification } from 'app/pages/Dashboard/Components/Notification/Notification';
+import { Text } from '@codesandbox/components';
 
 export const RepositoriesPage = () => {
   const params = useParams<{ path: string }>();
@@ -93,9 +94,21 @@ export const RepositoriesPage = () => {
         nestedPageType={pageType}
       />
       <Notification pageType={pageType}>
-        {itemsToShow.length === 0
-          ? 'CodeSandbox Projects is now Repositories: an improved git workflow powered by the cloud. '
-          : 'Your CodeSandbox Projects repositories now live here. Repository sandboxes are now listed under Synced sandboxes. You can find your contribution branches on My contributions inside your personal team.'}
+        {itemsToShow.length === 0 ? (
+          <Text>
+            CodeSandbox Projects is now Repositories: an improved git workflow
+            powered by the cloud.
+          </Text>
+        ) : (
+          <Text>
+            Your CodeSandbox Projects repositories now live here. Repository
+            sandboxes are now listed under{' '}
+            <Text css={{ color: '#fff' }}>Synced sandboxes</Text>. You can find
+            your contribution branches on{' '}
+            <Text css={{ color: '#fff' }}>My contributions</Text> inside your
+            personal team.
+          </Text>
+        )}
       </Notification>
       <VariableGrid page={pageType} items={itemsToShow} />
     </SelectionProvider>

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Repositories/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Repositories/index.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import { Helmet } from 'react-helmet';
 import { useParams } from 'react-router-dom';
-import { useAppState, useActions } from 'app/overmind';
+import { useAppState, useActions, useEffects } from 'app/overmind';
 import { Header } from 'app/pages/Dashboard/Components/Header';
 import { VariableGrid } from 'app/pages/Dashboard/Components/VariableGrid';
 import { DashboardGridItem, PageTypes } from 'app/pages/Dashboard/types';
 import { SelectionProvider } from 'app/pages/Dashboard/Components/Selection';
+import { Notification } from 'app/pages/Dashboard/Components/Notification/Notification';
 
 export const RepositoriesPage = () => {
   const params = useParams<{ path: string }>();
@@ -15,6 +16,7 @@ export const RepositoriesPage = () => {
     activeTeam,
     dashboard: { repositories },
   } = useAppState();
+  const { browser } = useEffects();
   const pathRef = React.useRef<string>(null);
 
   React.useEffect(() => {
@@ -45,6 +47,10 @@ export const RepositoriesPage = () => {
   }, [path]);
 
   const pageType: PageTypes = 'repositories';
+
+  const isNotificationDismissed = browser.storage.get(
+    'notificationDismissed'
+  )?.[pageType];
 
   const itemsToShow = (): DashboardGridItem[] => {
     if (repositories === null) {
@@ -89,6 +95,13 @@ export const RepositoriesPage = () => {
         showBetaBadge
         nestedPageType={pageType}
       />
+      {!isNotificationDismissed ? (
+        <Notification pageType={pageType}>
+          {itemsToShow().length === 0
+            ? 'CodeSandbox Projects is now Repositories: an improved git workflow powered by the cloud. '
+            : 'Your CodeSandbox Projects repositories now live here. Repository sandboxes are now listed under Synced sandboxes. You can find your contribution branches on My contributions inside your personal team.'}
+        </Notification>
+      ) : null}
       <VariableGrid page={pageType} items={itemsToShow()} />
     </SelectionProvider>
   );

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Repositories/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Repositories/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Helmet } from 'react-helmet';
 import { useParams } from 'react-router-dom';
-import { useAppState, useActions, useEffects } from 'app/overmind';
+import { useAppState, useActions } from 'app/overmind';
 import { Header } from 'app/pages/Dashboard/Components/Header';
 import { VariableGrid } from 'app/pages/Dashboard/Components/VariableGrid';
 import { DashboardGridItem, PageTypes } from 'app/pages/Dashboard/types';
@@ -16,7 +16,6 @@ export const RepositoriesPage = () => {
     activeTeam,
     dashboard: { repositories },
   } = useAppState();
-  const { browser } = useEffects();
   const pathRef = React.useRef<string>(null);
 
   React.useEffect(() => {
@@ -48,11 +47,7 @@ export const RepositoriesPage = () => {
 
   const pageType: PageTypes = 'repositories';
 
-  const isNotificationDismissed = browser.storage.get(
-    'notificationDismissed'
-  )?.[pageType];
-
-  const itemsToShow = (): DashboardGridItem[] => {
+  const getItemsToShow = (): DashboardGridItem[] => {
     if (repositories === null) {
       return [{ type: 'skeleton-row' }, { type: 'skeleton-row' }];
     }
@@ -79,11 +74,13 @@ export const RepositoriesPage = () => {
     }));
   };
 
+  const itemsToShow = getItemsToShow();
+
   return (
     <SelectionProvider
       page={pageType}
       activeTeamId={activeTeam}
-      items={itemsToShow()}
+      items={itemsToShow}
     >
       <Helmet>
         <title>{path || 'Dashboard'} - CodeSandbox</title>
@@ -95,14 +92,12 @@ export const RepositoriesPage = () => {
         showBetaBadge
         nestedPageType={pageType}
       />
-      {!isNotificationDismissed ? (
-        <Notification pageType={pageType}>
-          {itemsToShow().length === 0
-            ? 'CodeSandbox Projects is now Repositories: an improved git workflow powered by the cloud. '
-            : 'Your CodeSandbox Projects repositories now live here. Repository sandboxes are now listed under Synced sandboxes. You can find your contribution branches on My contributions inside your personal team.'}
-        </Notification>
-      ) : null}
-      <VariableGrid page={pageType} items={itemsToShow()} />
+      <Notification pageType={pageType}>
+        {itemsToShow.length === 0
+          ? 'CodeSandbox Projects is now Repositories: an improved git workflow powered by the cloud. '
+          : 'Your CodeSandbox Projects repositories now live here. Repository sandboxes are now listed under Synced sandboxes. You can find your contribution branches on My contributions inside your personal team.'}
+      </Notification>
+      <VariableGrid page={pageType} items={itemsToShow} />
     </SelectionProvider>
   );
 };

--- a/packages/app/src/app/pages/Dashboard/Content/routes/SyncedSandboxes/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/SyncedSandboxes/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Helmet } from 'react-helmet';
 import { useParams } from 'react-router-dom';
-import { useAppState, useActions, useEffects } from 'app/overmind';
+import { useAppState, useActions } from 'app/overmind';
 import { Header } from 'app/pages/Dashboard/Components/Header';
 import { VariableGrid } from 'app/pages/Dashboard/Components/VariableGrid';
 import {
@@ -24,7 +24,6 @@ export const SyncedSandboxesPage = () => {
     activeTeam,
     dashboard: { sandboxes },
   } = useAppState();
-  const { browser } = useEffects();
 
   React.useEffect(() => {
     const path = home ? null : param;
@@ -34,7 +33,7 @@ export const SyncedSandboxesPage = () => {
   const activeSandboxes =
     (sandboxes.REPOS && Object.values(sandboxes.REPOS)) || [];
 
-  const itemsToShow = (): DashboardGridItem[] => {
+  const getItemsToShow = (): DashboardGridItem[] => {
     if (sandboxes.REPOS === null) {
       return [{ type: 'skeleton-row' }, { type: 'skeleton-row' }];
     }
@@ -60,7 +59,9 @@ export const SyncedSandboxesPage = () => {
     return [{ type: 'skeleton-row' }, { type: 'skeleton-row' }];
   };
 
-  const possibleTemplates = itemsToShow()
+  const itemsToShow = getItemsToShow();
+
+  const possibleTemplates = itemsToShow
     .filter((s: DashboardRepoSandbox) => s.sandbox)
     .map((s: DashboardRepoSandbox) => s.sandbox);
 
@@ -71,15 +72,11 @@ export const SyncedSandboxesPage = () => {
 
   const pageType: PageTypes = 'synced-sandboxes';
 
-  const isNotificationDismissed = browser.storage.get(
-    'notificationDismissed'
-  )?.[pageType];
-
   return (
     <SelectionProvider
       page={pageType}
       activeTeamId={activeTeam}
-      items={itemsToShow()}
+      items={itemsToShow}
     >
       <Helmet>
         <title>{param || 'Dashboard'} - CodeSandbox</title>
@@ -93,13 +90,11 @@ export const SyncedSandboxesPage = () => {
         showSortOptions={Boolean(param)}
         nestedPageType={pageType}
       />
-      {!isNotificationDismissed ? (
-        <Notification pageType={pageType}>
-          Repository sandboxes are now called Synced sandboxes. New imported
-          repositories will be listed under All repositories.
-        </Notification>
-      ) : null}
-      <VariableGrid page={pageType} items={itemsToShow()} />
+      <Notification pageType={pageType}>
+        Repository sandboxes are now called Synced sandboxes. New imported
+        repositories will be listed under All repositories.
+      </Notification>
+      <VariableGrid page={pageType} items={itemsToShow} />
     </SelectionProvider>
   );
 };

--- a/packages/app/src/app/pages/Dashboard/Content/routes/SyncedSandboxes/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/SyncedSandboxes/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Helmet } from 'react-helmet';
 import { useParams } from 'react-router-dom';
-import { useAppState, useActions } from 'app/overmind';
+import { useAppState, useActions, useEffects } from 'app/overmind';
 import { Header } from 'app/pages/Dashboard/Components/Header';
 import { VariableGrid } from 'app/pages/Dashboard/Components/VariableGrid';
 import {
@@ -10,6 +10,7 @@ import {
   PageTypes,
 } from 'app/pages/Dashboard/types';
 import { SelectionProvider } from 'app/pages/Dashboard/Components/Selection';
+import { Notification } from 'app/pages/Dashboard/Components/Notification/Notification';
 import { getPossibleTemplates } from '../../utils';
 import { useFilteredItems } from './useFilteredItems';
 
@@ -23,6 +24,7 @@ export const SyncedSandboxesPage = () => {
     activeTeam,
     dashboard: { sandboxes },
   } = useAppState();
+  const { browser } = useEffects();
 
   React.useEffect(() => {
     const path = home ? null : param;
@@ -69,6 +71,10 @@ export const SyncedSandboxesPage = () => {
 
   const pageType: PageTypes = 'synced-sandboxes';
 
+  const isNotificationDismissed = browser.storage.get(
+    'notificationDismissed'
+  )?.[pageType];
+
   return (
     <SelectionProvider
       page={pageType}
@@ -87,6 +93,12 @@ export const SyncedSandboxesPage = () => {
         showSortOptions={Boolean(param)}
         nestedPageType={pageType}
       />
+      {!isNotificationDismissed ? (
+        <Notification pageType={pageType}>
+          Repository sandboxes are now called Synced sandboxes. New imported
+          repositories will be listed under All repositories.
+        </Notification>
+      ) : null}
       <VariableGrid page={pageType} items={itemsToShow()} />
     </SelectionProvider>
   );

--- a/packages/app/src/app/pages/Dashboard/Content/routes/SyncedSandboxes/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/SyncedSandboxes/index.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Helmet } from 'react-helmet';
 import { useParams } from 'react-router-dom';
 import { useAppState, useActions } from 'app/overmind';
+import { Text } from '@codesandbox/components';
 import { Header } from 'app/pages/Dashboard/Components/Header';
 import { VariableGrid } from 'app/pages/Dashboard/Components/VariableGrid';
 import {
@@ -91,8 +92,10 @@ export const SyncedSandboxesPage = () => {
         nestedPageType={pageType}
       />
       <Notification pageType={pageType}>
-        Repository sandboxes are now called Synced sandboxes. New imported
-        repositories will be listed under All repositories.
+        Repository sandboxes are now called{' '}
+        <Text css={{ color: '#fff' }}>Synced sandboxes</Text>. New imported
+        repositories will be listed under{' '}
+        <Text css={{ color: '#fff' }}>All repositories</Text>.
       </Notification>
       <VariableGrid page={pageType} items={itemsToShow} />
     </SelectionProvider>

--- a/packages/app/src/app/pages/Dashboard/Sidebar/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Sidebar/index.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { Link as RouterLink, useLocation, useHistory } from 'react-router-dom';
 import { orderBy } from 'lodash-es';
 import { join, dirname } from 'path';
-import { useAppState, useActions } from 'app/overmind';
+import { useAppState, useActions, useEffects } from 'app/overmind';
 import { motion, AnimatePresence } from 'framer-motion';
 import { dashboard as dashboardUrls } from '@codesandbox/common/lib/utils/url-generator';
 import { ESC, ENTER } from '@codesandbox/common/lib/utils/keycodes';
@@ -32,6 +32,7 @@ import { DashboardBaseFolder, PageTypes } from '../types';
 import { Position } from '../Components/Selection';
 import { SIDEBAR_WIDTH, NEW_FOLDER_ID } from './constants';
 import { DragItemType, useDrop } from '../utils/dnd';
+import { NotificationIndicator } from '../Components/Notification/NotificationIndicator';
 
 const SidebarContext = React.createContext(null);
 
@@ -453,6 +454,16 @@ const RowItem: React.FC<RowItemProps> = ({
     accepts.push('sandbox');
   }
   if (!canNotAcceptFolders.includes(page)) accepts.push('folder');
+  const { browser } = useEffects();
+
+  const isPageWithNotification =
+    page === 'my-contributions' ||
+    page === 'repositories' ||
+    page === 'synced-sandboxes';
+
+  const isNotificationDismissed = browser.storage.get(
+    'notificationDismissed'
+  )?.[page];
 
   const usedPath = folderPath || path;
   const [{ canDrop, isOver, isDragging }, dropRef] = useDrop({
@@ -574,6 +585,18 @@ const RowItem: React.FC<RowItemProps> = ({
               <Badge>New</Badge>
             </Stack>
           )}
+
+          {isPageWithNotification && !isNotificationDismissed ? (
+            <Element
+              css={{
+                flexGrow: 1,
+                display: 'flex',
+                justifyContent: 'flex-end',
+              }}
+            >
+              <NotificationIndicator />
+            </Element>
+          ) : null}
         </Link>
       )}
     </SidebarListAction>


### PR DESCRIPTION
The only thing that we might want to update is the dismissal of the notifications and when the dots in the sidebar update. If we want to update the dots in the sidebar when a notification is dismissed, we need to keep track of the state higher up in the tree instead of just inside the notifications. Right now the notification indicator dots are gone when the routes change.

## Video

https://user-images.githubusercontent.com/7533849/194049924-10dba198-0778-4bcc-b531-f98a86c50681.mov

