### PR TITLE
Fix(dashboard): Use react router links

### DIFF
--- a/packages/app/src/app/pages/Dashboard/Components/Repository/RepositoryCard.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Repository/RepositoryCard.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { Icon, IconButton, Stack, Text } from '@codesandbox/components';
+import { Link } from 'react-router-dom';
 import { css } from '@styled-system/css';
+import { Icon, IconButton, Stack, Text } from '@codesandbox/components';
 import { RepositoryProps } from './types';
 
 export const RepositoryCard: React.FC<RepositoryProps> = ({
@@ -12,7 +13,7 @@ export const RepositoryCard: React.FC<RepositoryProps> = ({
 }) => {
   return (
     <Stack
-      as="a"
+      as={Link}
       aria-label={labels.repository}
       css={css({
         cursor: 'pointer', // TODO: revisit cursor.
@@ -41,7 +42,7 @@ export const RepositoryCard: React.FC<RepositoryProps> = ({
       })}
       direction="vertical"
       gap={4}
-      href={repository.url}
+      to={repository.url}
       onContextMenu={onContextMenu}
       {...props}
     >

--- a/packages/app/src/app/pages/Dashboard/Components/Repository/RepositoryListItem.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Repository/RepositoryListItem.tsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
+import { css } from '@styled-system/css';
 import {
   Element,
   Column,
@@ -9,7 +11,6 @@ import {
   Stack,
   Text,
 } from '@codesandbox/components';
-import { css } from '@styled-system/css';
 import { RepositoryProps } from './types';
 
 export const RepositoryListItem: React.FC<RepositoryProps> = ({
@@ -38,7 +39,7 @@ export const RepositoryListItem: React.FC<RepositoryProps> = ({
     >
       <Element
         aria-label={labels.repository}
-        as="a"
+        as={Link}
         css={{
           display: 'flex',
           alignItems: 'center',
@@ -46,7 +47,7 @@ export const RepositoryListItem: React.FC<RepositoryProps> = ({
           width: '100%',
           textDecoration: 'none',
         }}
-        href={repository.url}
+        to={repository.url}
         onContextMenu={onContextMenu}
         {...props}
       >

--- a/packages/app/src/app/pages/Dashboard/Components/Sandbox/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Sandbox/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useLocation, useHistory } from 'react-router-dom';
+import { useLocation, useHistory, Link } from 'react-router-dom';
 import { getEmptyImage } from 'react-dnd-html5-backend';
 import formatDistanceStrict from 'date-fns/formatDistanceStrict';
 import { zonedTimeToUtc } from 'date-fns-tz';
@@ -246,8 +246,8 @@ const GenericSandbox = ({ isScrolling, item, page }: GenericSandboxProps) => {
     page === 'recent'
       ? {
           selected,
-          as: 'a',
-          href: url,
+          as: Link,
+          to: url,
           style: {
             outline: 'none',
             textDecoration: 'none',


### PR DESCRIPTION
Makes sure the navigation is added to history and is only rendering routes and not reloading the whole page.

Closes XTD-229

## Video

Video shows no refresh:

https://user-images.githubusercontent.com/7533849/194079444-f0474483-37f4-4376-9a9c-4b15cd5d8458.mov

