### PR TITLE
Facelift: Change CTA text on Header

### DIFF
--- a/packages/app/src/app/pages/Dashboard/Header/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Header/index.tsx
@@ -79,19 +79,13 @@ export const Header: React.FC<HeaderProps> = React.memo(
         <Stack align="center" gap={2}>
           <Button
             variant="primary"
-            css={css({ width: 'auto', paddingX: 3 })}
+            css={css({ width: 'auto', paddingX: 4 })}
             disabled={activeWorkspaceAuthorization === 'READ'}
             onClick={() => {
               openCreateSandboxModal({});
             }}
           >
-            <Icon
-              name="plus"
-              size={20}
-              title="Create new"
-              css={css({ paddingRight: 2 })}
-            />
-            New
+            Create
           </Button>
 
           {user && <Notifications />}

--- a/packages/app/src/app/pages/Sandbox/Editor/Header/Actions.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Header/Actions.tsx
@@ -1,5 +1,5 @@
 import Tooltip from '@codesandbox/common/lib/components/Tooltip';
-import { Avatar, Button, Icon, Stack } from '@codesandbox/components';
+import { Avatar, Button, Stack } from '@codesandbox/components';
 import css from '@styled-system/css';
 import { useAppState, useActions } from 'app/overmind';
 import { UserMenu } from 'app/pages/common/UserMenu';
@@ -197,7 +197,7 @@ export const Actions = () => {
 
       <Button
         variant="secondary"
-        css={css({ paddingX: 3 })}
+        css={css({ paddingX: 4 })}
         onClick={() => {
           if (!user) {
             signInClicked({ onCancel: () => openCreateSandboxModal({}) });
@@ -207,13 +207,7 @@ export const Actions = () => {
         }}
         disabled={activeWorkspaceAuthorization === 'READ'}
       >
-        <Icon
-          name="plus"
-          size={20}
-          title="Create new"
-          css={css({ paddingRight: 2 })}
-        />
-        New
+        Create
       </Button>
 
       {hasLogIn && <Notifications />}


### PR DESCRIPTION
Change text of CTA on Dash and Editor header to '`Create`' 
(`Create` does not clash with the `New` cards in the grid)

(before)
<img width="445" alt="Screen Shot 2022-10-05 at 11 06 34" src="https://user-images.githubusercontent.com/93996574/194098919-1393f0f2-eea2-4eb3-ad7f-df4587d24c77.png">

(after)
<img width="352" alt="Screen Shot 2022-10-05 at 11 06 48" src="https://user-images.githubusercontent.com/93996574/194098948-3975e210-667d-4a3d-bb47-adc12199a7aa.png">
