### PR TITLE
QA: Change 'Recent'page title and notification colors

### DIFF
--- a/packages/app/src/app/pages/Dashboard/Components/Notification/Notification.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Notification/Notification.tsx
@@ -50,7 +50,7 @@ export const Notification = ({ children, pageType }: NotificationProps) => {
       >
         <Stack gap={4} align="center">
           <NotificationIndicator />
-          <Text size={12} variant="muted" css={css({ lineHeight: '16px' })}>
+          <Text size={12} css={css({ lineHeight: '16px', color: '#C2C2C2' })}>
             {children}
           </Text>
           <Element

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Recent/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Recent/index.tsx
@@ -58,11 +58,7 @@ export const Recent = () => {
       <Helmet>
         <title>Dashboard - CodeSandbox</title>
       </Helmet>
-      <Header
-        title="Pick up where you left off"
-        activeTeam={activeTeam}
-        showViewOptions
-      />
+      <Header title="Recent" activeTeam={activeTeam} showViewOptions />
       <VariableGrid page={pageType} items={items} />
     </SelectionProvider>
   );

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Repositories/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Repositories/index.tsx
@@ -103,9 +103,9 @@ export const RepositoriesPage = () => {
           <Text>
             Your CodeSandbox Projects repositories now live here. Repository
             sandboxes are now listed under{' '}
-            <Text css={{ color: '#fff' }}>Synced sandboxes</Text>. You can find
-            your contribution branches on{' '}
-            <Text css={{ color: '#fff' }}>My contributions</Text> inside your
+            <Text css={{ color: '#EBEBEB' }}>Synced sandboxes</Text>. You can
+            find your contribution branches on{' '}
+            <Text css={{ color: '#EBEBEB' }}>My contributions</Text> inside your
             personal team.
           </Text>
         )}

--- a/packages/app/src/app/pages/Dashboard/Content/routes/SyncedSandboxes/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/SyncedSandboxes/index.tsx
@@ -93,9 +93,9 @@ export const SyncedSandboxesPage = () => {
       />
       <Notification pageType={pageType}>
         Repository sandboxes are now called{' '}
-        <Text css={{ color: '#fff' }}>Synced sandboxes</Text>. New imported
+        <Text css={{ color: '#EBEBEB' }}>Synced sandboxes</Text>. New imported
         repositories will be listed under{' '}
-        <Text css={{ color: '#fff' }}>All repositories</Text>.
+        <Text css={{ color: '#EBEBEB' }}>All repositories</Text>.
       </Notification>
       <VariableGrid page={pageType} items={itemsToShow} />
     </SelectionProvider>


### PR DESCRIPTION
1. Change Recent page title to `Recent`
2. Change notification text base and highlight color.
(before)
<img width="1174" alt="Screen Shot 2022-10-05 at 14 18 20" src="https://user-images.githubusercontent.com/93996574/194122033-d46edad0-dd68-4216-a9fc-98e82a6f91cc.png">

(after)
<img width="1178" alt="Screen Shot 2022-10-05 at 14 15 11" src="https://user-images.githubusercontent.com/93996574/194121529-56c7385c-07a4-4d27-872e-c970e8680b7d.png">

