### PR TITLE
fix(dashboard): show empty state on repositories page

### DIFF
--- a/packages/app/src/app/pages/Dashboard/Content/routes/Repositories/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Repositories/index.tsx
@@ -91,7 +91,7 @@ export const RepositoriesPage = () => {
       repository,
     }));
 
-    if (viewMode === 'grid') {
+    if (viewMode === 'grid' && repoItems.length > 0) {
       repoItems.unshift({ type: 'import-repository' });
     }
 


### PR DESCRIPTION
To check this, open repositories page on the dashboard with a team with 0 repositories. To confirm that it still works with repositories check out the page with a team with repositories.