### PR TITLE
fix: one-click sandbox create and proper redirect to v2 editor

### DIFF
--- a/packages/app/src/app/components/CreateNewSandbox/CreateSandbox/CreateSandbox.tsx
+++ b/packages/app/src/app/components/CreateNewSandbox/CreateSandbox/CreateSandbox.tsx
@@ -151,7 +151,7 @@ export const CreateSandbox: React.FC<CreateSandboxProps> = ({
   >('initial');
   // ❗️ We could combine viewState with selectedTemplate
   // and selectedRepo to limit the amount of states.
-  const [selectedTemplate, setSelectedTemplate] = useState<TemplateFragment>();
+  const [selectedTemplate] = useState<TemplateFragment>();
   const [selectedRepo, setSelectedRepo] = useState<GithubRepoToImport>();
   const [searchQuery, setSearchQuery] = useState<string>('');
 
@@ -180,8 +180,11 @@ export const CreateSandbox: React.FC<CreateSandboxProps> = ({
   };
 
   const selectTemplate = (template: TemplateFragment) => {
-    setSelectedTemplate(template);
-    setViewState('fromTemplate');
+    createFromTemplate(template, {});
+
+    // Temporarily disable the second screen until we have more functionality on it
+    // setSelectedTemplate(template);
+    // setViewState('fromTemplate');
   };
 
   const selectGithubRepo = (repo: GithubRepoToImport) => {

--- a/packages/app/src/app/components/CreateNewSandbox/CreateSandbox/types.ts
+++ b/packages/app/src/app/components/CreateNewSandbox/CreateSandbox/types.ts
@@ -3,7 +3,7 @@ import { TemplateFragment } from 'app/graphql/types';
 export type CreateSandboxParams = {
   name?: string;
   githubOwner?: string;
-  createRepo: boolean;
+  createRepo?: boolean;
 };
 
 export interface TemplateInfo {

--- a/packages/app/src/app/overmind/effects/router.ts
+++ b/packages/app/src/app/overmind/effects/router.ts
@@ -36,6 +36,8 @@ export default new (class RouterEffect {
 
     if (openInNewWindow) {
       window.open(url, '_blank');
+    } else if (v2) {
+      window.location.href = url;
     } else {
       history.push(url);
     }


### PR DESCRIPTION
Closes XTD-240: Proper redirect for v2 sandboxes after fork
Closes XTD-241: Disable second screen for create from template (temporarily)