### PR TITLE
fix(dashboard): Button is actually an anchor

### DIFF
--- a/packages/app/src/app/pages/Dashboard/Components/EmptyScreen/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/EmptyScreen/index.tsx
@@ -209,6 +209,7 @@ export const EmptyScreen: React.FC<EmptyScreenProps> = ({
                   </Stack>
                 </Button>
                 <Button
+                  as="a"
                   variant="link"
                   css={css({
                     height: 'auto',


### PR DESCRIPTION
Rendered a `button` because of a missing `as` prop. This fixes it.

<img width="1091" alt="image" src="https://user-images.githubusercontent.com/7533849/194332048-bd7fa747-b191-416b-90ce-8aee95926f29.png">
