### PR TITLE
fix: proper window.location redirects for cloud sandboxes and branches

### DIFF
--- a/packages/app/src/app/pages/Dashboard/Components/Sandbox/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Sandbox/index.tsx
@@ -198,7 +198,11 @@ const GenericSandbox = ({ isScrolling, item, page }: GenericSandboxProps) => {
       if (sandboxAnalyticsEvent) {
         trackImprovedDashboardEvent(sandboxAnalyticsEvent);
       }
-      history.push(url);
+      if (sandbox.isV2) {
+        window.location.href = url;
+      } else {
+        history.push(url);
+      }
     }
   };
 

--- a/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenus/BranchMenu.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenus/BranchMenu.tsx
@@ -5,7 +5,6 @@ import {
   githubRepoUrl,
   v2BranchUrl,
 } from '@codesandbox/common/lib/utils/url-generator';
-import { useHistory } from 'react-router-dom';
 import { Context, MenuItem } from '../ContextMenu';
 
 type BranchMenuProps = {
@@ -13,7 +12,6 @@ type BranchMenuProps = {
 };
 export const BranchMenu: React.FC<BranchMenuProps> = ({ branch }) => {
   const { visible, setVisibility, position } = React.useContext(Context);
-  const history = useHistory();
 
   const { name, project, contribution } = branch;
   const branchUrl = v2BranchUrl({ name, project });
@@ -31,7 +29,13 @@ export const BranchMenu: React.FC<BranchMenuProps> = ({ branch }) => {
       position={position}
       style={{ width: 120 }}
     >
-      <MenuItem onSelect={() => history.push(branchUrl)}>Open branch</MenuItem>
+      <MenuItem
+        onSelect={() => {
+          window.location.href = branchUrl;
+        }}
+      >
+        Open branch
+      </MenuItem>
       <MenuItem onSelect={() => window.open(branchUrl, '_blank')}>
         Open branch in a new tab
       </MenuItem>

--- a/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenus/SandboxMenu.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenus/SandboxMenu.tsx
@@ -127,7 +127,17 @@ export const SandboxMenu: React.FC<SandboxMenuProps> = ({
           Fork Template
         </MenuItem>
       ) : null}
-      <MenuItem onSelect={() => history.push(url)}>Open {label}</MenuItem>
+      <MenuItem
+        onSelect={() => {
+          if (sandbox.isV2) {
+            window.location.href = url;
+          } else {
+            history.push(url);
+          }
+        }}
+      >
+        Open {label}
+      </MenuItem>
       <MenuItem
         onSelect={() => {
           window.open(`https://codesandbox.io${url}`, '_blank');


### PR DESCRIPTION
Fixes redirects from v1 dashboard to v2 editor (branches and cloud sandboxes) Missed this in the initial QA session