### PR TITLE
feat: more context menu options for branch/repo

### DIFF
--- a/packages/app/src/app/pages/Dashboard/Components/Header/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Header/index.tsx
@@ -141,7 +141,6 @@ export const Header = ({
                 alignItems: 'center',
                 textDecoration: 'none',
                 fontSize: 2,
-                padding: 2,
                 color: 'mutedForeground',
                 width: 'auto',
                 transition: `color ease-in`,

--- a/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenus/BranchMenu.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenus/BranchMenu.tsx
@@ -4,7 +4,9 @@ import { BranchFragment as Branch } from 'app/graphql/types';
 import {
   githubRepoUrl,
   v2BranchUrl,
+  dashboard,
 } from '@codesandbox/common/lib/utils/url-generator';
+import { useHistory } from 'react-router-dom';
 import { Context, MenuItem } from '../ContextMenu';
 
 type BranchMenuProps = {
@@ -15,12 +17,19 @@ export const BranchMenu: React.FC<BranchMenuProps> = ({ branch }) => {
 
   const { name, project, contribution } = branch;
   const branchUrl = v2BranchUrl({ name, project });
+
+  const { name: repoName, owner } = project.repository;
+
   const githubUrl = githubRepoUrl({
     branch: name,
-    repo: project.repository.name,
-    username: project.repository.owner,
+    repo: repoName,
+    username: owner,
     path: '',
   });
+
+  const repoUrl = dashboard.repository({ owner, name: repoName });
+
+  const history = useHistory();
 
   return (
     <Menu.ContextMenu
@@ -44,6 +53,9 @@ export const BranchMenu: React.FC<BranchMenuProps> = ({ branch }) => {
           Open on GitHub
         </MenuItem>
       )}
+      <MenuItem onSelect={() => history.push(repoUrl)}>
+        Open repository
+      </MenuItem>
       {/* TODO: Implement remove branch <Menu.Divider />
       <Menu.Divider />
       <MenuItem

--- a/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenus/MultiItemMenu.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenus/MultiItemMenu.tsx
@@ -220,7 +220,7 @@ export const MultiMenu = ({ selectedItems, page }: IMultiMenuProps) => {
     ? [{ label: 'Export Items', fn: exportItems }]
     : [];
 
-  const DELETE = { label: 'Delete Items', fn: deleteItems };
+  const DELETE = { label: 'Archive Items', fn: deleteItems };
   const RECOVER = {
     label: 'Recover Sandboxes',
     fn: () => {

--- a/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenus/RepositoryMenu.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenus/RepositoryMenu.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import { Menu } from '@codesandbox/components';
 import { ProjectFragment as Repository } from 'app/graphql/types';
-import { dashboard } from '@codesandbox/common/lib/utils/url-generator';
+import {
+  dashboard,
+  v2DraftBranchUrl,
+} from '@codesandbox/common/lib/utils/url-generator';
 import { useHistory } from 'react-router-dom';
 import { Context, MenuItem } from '../ContextMenu';
 
@@ -19,6 +22,11 @@ export const RepositoryMenu: React.FC<RepositoryMenuProps> = ({
     owner: providerRepository.owner,
     name: providerRepository.name,
   });
+  const branchFromDefaultUrl = v2DraftBranchUrl(
+    providerRepository.owner,
+    providerRepository.name
+  );
+
   const githubUrl = `https://github.com/${providerRepository.owner}/${providerRepository.name}`;
 
   return (
@@ -36,6 +44,10 @@ export const RepositoryMenu: React.FC<RepositoryMenuProps> = ({
       </MenuItem>
       <MenuItem onSelect={() => window.open(githubUrl, '_blank')}>
         Open on GitHub
+      </MenuItem>
+      <Menu.Divider />
+      <MenuItem onSelect={() => window.open(branchFromDefaultUrl, '_blank')}>
+        Create branch
       </MenuItem>
 
       {/* TODO: Implement remove repository


### PR DESCRIPTION
Add option to create branch from default on a repository card

![image](https://user-images.githubusercontent.com/9945366/194551924-2b6b3417-9eb9-41e7-ad7f-b42b644d5154.png)

Add link to repository overview on branch card

![image](https://user-images.githubusercontent.com/9945366/194552151-78601515-a83c-416f-a718-5f5557fcb801.png)

While there I fixed two issues noticed in yesterday's QA session:
* A small height jump when going to the list view for branches
* A wrong copy text on the multiselect context menu