### PR TITLE
feat(sidebar): Sidebar overmind state

### DIFF
--- a/packages/app/src/app/graphql/types.ts
+++ b/packages/app/src/app/graphql/types.ts
@@ -580,6 +580,8 @@ export type ProSubscription = {
   paymentProvider: Maybe<SubscriptionPaymentProvider>;
   quantity: Maybe<Scalars['Int']>;
   status: SubscriptionStatus;
+  trialEnd: Maybe<Scalars['DateTime']>;
+  trialStart: Maybe<Scalars['DateTime']>;
   type: SubscriptionType;
   unitPrice: Maybe<Scalars['Int']>;
   updateBillingUrl: Maybe<Scalars['String']>;
@@ -3389,6 +3391,60 @@ export type RecentNotificationsQuery = { __typename?: 'RootQueryType' } & {
     { __typename?: 'CurrentUser' } & {
       notifications: Array<
         { __typename?: 'Notification' } & RecentNotificationFragment
+      >;
+    }
+  >;
+};
+
+export type SidebarSyncedSandboxFragmentFragment = {
+  __typename?: 'Sandbox';
+} & Pick<Sandbox, 'id'>;
+
+export type SidebarCollectionFragmentFragment = {
+  __typename?: 'Collection';
+} & Pick<Collection, 'id' | 'path'>;
+
+export type SidebarTemplateFragmentFragment = {
+  __typename?: 'Template';
+} & Pick<Template, 'id'>;
+
+export type PersonalSidebarDataQueryVariables = Exact<{ [key: string]: never }>;
+
+export type PersonalSidebarDataQuery = { __typename?: 'RootQueryType' } & {
+  me: Maybe<
+    { __typename?: 'CurrentUser' } & {
+      sandboxes: Array<
+        { __typename?: 'Sandbox' } & SidebarSyncedSandboxFragmentFragment
+      >;
+      collections: Array<
+        { __typename?: 'Collection' } & SidebarCollectionFragmentFragment
+      >;
+      templates: Array<
+        { __typename?: 'Template' } & SidebarTemplateFragmentFragment
+      >;
+    }
+  >;
+};
+
+export type TeamSidebarDataQueryVariables = Exact<{
+  id: Scalars['UUID4'];
+}>;
+
+export type TeamSidebarDataQuery = { __typename?: 'RootQueryType' } & {
+  me: Maybe<
+    { __typename?: 'CurrentUser' } & {
+      team: Maybe<
+        { __typename?: 'Team' } & {
+          sandboxes: Array<
+            { __typename?: 'Sandbox' } & SidebarSyncedSandboxFragmentFragment
+          >;
+          collections: Array<
+            { __typename?: 'Collection' } & SidebarCollectionFragmentFragment
+          >;
+          templates: Array<
+            { __typename?: 'Template' } & SidebarTemplateFragmentFragment
+          >;
+        }
       >;
     }
   >;

--- a/packages/app/src/app/graphql/types.ts
+++ b/packages/app/src/app/graphql/types.ts
@@ -3400,10 +3400,6 @@ export type SidebarSyncedSandboxFragmentFragment = {
   __typename?: 'Sandbox';
 } & Pick<Sandbox, 'id'>;
 
-export type SidebarCollectionFragmentFragment = {
-  __typename?: 'Collection';
-} & Pick<Collection, 'id' | 'path'>;
-
 export type SidebarTemplateFragmentFragment = {
   __typename?: 'Template';
 } & Pick<Template, 'id'>;
@@ -3415,9 +3411,6 @@ export type PersonalSidebarDataQuery = { __typename?: 'RootQueryType' } & {
     { __typename?: 'CurrentUser' } & {
       sandboxes: Array<
         { __typename?: 'Sandbox' } & SidebarSyncedSandboxFragmentFragment
-      >;
-      collections: Array<
-        { __typename?: 'Collection' } & SidebarCollectionFragmentFragment
       >;
       templates: Array<
         { __typename?: 'Template' } & SidebarTemplateFragmentFragment
@@ -3437,9 +3430,6 @@ export type TeamSidebarDataQuery = { __typename?: 'RootQueryType' } & {
         { __typename?: 'Team' } & {
           sandboxes: Array<
             { __typename?: 'Sandbox' } & SidebarSyncedSandboxFragmentFragment
-          >;
-          collections: Array<
-            { __typename?: 'Collection' } & SidebarCollectionFragmentFragment
           >;
           templates: Array<
             { __typename?: 'Template' } & SidebarTemplateFragmentFragment

--- a/packages/app/src/app/overmind/effects/gql/index.ts
+++ b/packages/app/src/app/overmind/effects/gql/index.ts
@@ -11,6 +11,8 @@ import * as teamsQueries from './teams/queries';
 import * as dashboardQueries from './dashboard/queries';
 import * as dashboardMutations from './dashboard/mutations';
 
+import * as sidebarQueries from './sidebar/queries';
+
 import * as notificationsQueries from './notifications/queries';
 import * as notificationsMutations from './notifications/mutations';
 
@@ -24,6 +26,7 @@ export default graphql({
     ...commentsQueries,
     ...teamsQueries,
     ...dashboardQueries,
+    ...sidebarQueries,
     ...notificationsQueries,
   },
   mutations: {

--- a/packages/app/src/app/overmind/effects/gql/sidebar/fragments.ts
+++ b/packages/app/src/app/overmind/effects/gql/sidebar/fragments.ts
@@ -6,13 +6,6 @@ export const sidebarSyncedSandboxFragment = gql`
   }
 `;
 
-export const sidebarCollectionFragment = gql`
-  fragment sidebarCollectionFragment on Collection {
-    id
-    path
-  }
-`;
-
 export const sidebarTemplateFragment = gql`
   fragment sidebarTemplateFragment on Template {
     id

--- a/packages/app/src/app/overmind/effects/gql/sidebar/fragments.ts
+++ b/packages/app/src/app/overmind/effects/gql/sidebar/fragments.ts
@@ -1,0 +1,20 @@
+import { gql } from 'overmind-graphql';
+
+export const sidebarSyncedSandboxFragment = gql`
+  fragment sidebarSyncedSandboxFragment on Sandbox {
+    id
+  }
+`;
+
+export const sidebarCollectionFragment = gql`
+  fragment sidebarCollectionFragment on Collection {
+    id
+    path
+  }
+`;
+
+export const sidebarTemplateFragment = gql`
+  fragment sidebarTemplateFragment on Template {
+    id
+  }
+`;

--- a/packages/app/src/app/overmind/effects/gql/sidebar/queries.ts
+++ b/packages/app/src/app/overmind/effects/gql/sidebar/queries.ts
@@ -7,7 +7,6 @@ import {
 } from 'app/graphql/types';
 
 import {
-  sidebarCollectionFragment,
   sidebarSyncedSandboxFragment,
   sidebarTemplateFragment,
 } from './fragments';
@@ -21,21 +20,14 @@ export const getPersonalSidebarData: Query<
       sandboxes(hasOriginalGit: true) {
         ...sidebarSyncedSandboxFragment
       }
-      collections {
-        ...sidebarCollectionFragment
-      }
       templates {
         ...sidebarTemplateFragment
       }
     }
   }
   ${sidebarSyncedSandboxFragment}
-  ${sidebarCollectionFragment}
   ${sidebarTemplateFragment}
 `;
-/**
- * 👆 fragments might actually be a bit too much for this
- */
 
 export const getTeamSidebarData: Query<
   TeamSidebarDataQuery,
@@ -47,9 +39,6 @@ export const getTeamSidebarData: Query<
         sandboxes(hasOriginalGit: true) {
           ...sidebarSyncedSandboxFragment
         }
-        collections {
-          ...sidebarCollectionFragment
-        }
         templates {
           ...sidebarTemplateFragment
         }
@@ -57,9 +46,5 @@ export const getTeamSidebarData: Query<
     }
   }
   ${sidebarSyncedSandboxFragment}
-  ${sidebarCollectionFragment}
   ${sidebarTemplateFragment}
 `;
-/**
- * 👆 fragments might actually be a bit too much for this
- */

--- a/packages/app/src/app/overmind/effects/gql/sidebar/queries.ts
+++ b/packages/app/src/app/overmind/effects/gql/sidebar/queries.ts
@@ -1,0 +1,65 @@
+import { gql, Query } from 'overmind-graphql';
+
+import {
+  PersonalSidebarDataQuery,
+  TeamSidebarDataQuery,
+  TeamSidebarDataQueryVariables,
+} from 'app/graphql/types';
+
+import {
+  sidebarCollectionFragment,
+  sidebarSyncedSandboxFragment,
+  sidebarTemplateFragment,
+} from './fragments';
+
+export const getPersonalSidebarData: Query<
+  PersonalSidebarDataQuery,
+  undefined
+> = gql`
+  query PersonalSidebarData {
+    me {
+      sandboxes(hasOriginalGit: true) {
+        ...sidebarSyncedSandboxFragment
+      }
+      collections {
+        ...sidebarCollectionFragment
+      }
+      templates {
+        ...sidebarTemplateFragment
+      }
+    }
+  }
+  ${sidebarSyncedSandboxFragment}
+  ${sidebarCollectionFragment}
+  ${sidebarTemplateFragment}
+`;
+/**
+ * 👆 fragments might actually be a bit too much for this
+ */
+
+export const getTeamSidebarData: Query<
+  TeamSidebarDataQuery,
+  TeamSidebarDataQueryVariables
+> = gql`
+  query TeamSidebarData($id: UUID4!) {
+    me {
+      team(id: $id) {
+        sandboxes(hasOriginalGit: true) {
+          ...sidebarSyncedSandboxFragment
+        }
+        collections {
+          ...sidebarCollectionFragment
+        }
+        templates {
+          ...sidebarTemplateFragment
+        }
+      }
+    }
+  }
+  ${sidebarSyncedSandboxFragment}
+  ${sidebarCollectionFragment}
+  ${sidebarTemplateFragment}
+`;
+/**
+ * 👆 fragments might actually be a bit too much for this
+ */

--- a/packages/app/src/app/overmind/index.ts
+++ b/packages/app/src/app/overmind/index.ts
@@ -13,6 +13,7 @@ import { createModals } from './factories';
 import * as modals from './modals';
 import * as comments from './namespaces/comments';
 import * as dashboard from './namespaces/dashboard';
+import * as sidebar from './namespaces/sidebar';
 import * as deployment from './namespaces/deployment';
 import * as editor from './namespaces/editor';
 import * as explore from './namespaces/explore';
@@ -43,6 +44,7 @@ export const config = merge(
     live,
     workspace,
     dashboard,
+    sidebar,
     deployment,
     files,
     git,

--- a/packages/app/src/app/overmind/namespaces/sidebar/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/sidebar/actions.ts
@@ -15,31 +15,33 @@ export const getSidebarData = async (
        */
       const {
         me: {
-          team: { sandboxes, ...restData },
+          team: { sandboxes, templates, collections },
         },
       } = await queries.getTeamSidebarData({ id: teamId });
 
+      const hasSyncedSandboxes = sandboxes?.length > 0;
+      const hasTemplates = templates?.length > 0;
+
       state.sidebar = {
-        /**
-         * Renaming sandboxes to syncedSandboxes
-         */
-        syncedSandboxes: sandboxes,
-        ...restData,
+        hasSyncedSandboxes,
+        hasTemplates,
+        collections,
       };
     } else {
       /**
        * Fetch data for the user
        */
       const {
-        me: { sandboxes, ...restData },
+        me: { sandboxes, templates, collections },
       } = await queries.getPersonalSidebarData();
 
+      const hasSyncedSandboxes = sandboxes?.length > 0;
+      const hasTemplates = templates?.length > 0;
+
       state.sidebar = {
-        /**
-         * Renaming sandboxes to syncedSandboxes
-         */
-        syncedSandboxes: sandboxes,
-        ...restData,
+        hasSyncedSandboxes,
+        hasTemplates,
+        collections,
       };
     }
   } catch {

--- a/packages/app/src/app/overmind/namespaces/sidebar/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/sidebar/actions.ts
@@ -1,0 +1,50 @@
+import { Context } from 'app/overmind';
+
+export const getSidebarData = async (
+  { state, effects }: Context,
+  teamId?: string
+) => {
+  const {
+    gql: { queries },
+  } = effects;
+
+  try {
+    if (teamId) {
+      /**
+       * Fetch data for the selected team
+       */
+      const {
+        me: {
+          team: { sandboxes, ...restData },
+        },
+      } = await queries.getTeamSidebarData({ id: teamId });
+
+      state.sidebar = {
+        /**
+         * Renaming sandboxes to syncedSandboxes
+         */
+        syncedSandboxes: sandboxes,
+        ...restData,
+      };
+    } else {
+      /**
+       * Fetch data for the user
+       */
+      const {
+        me: { sandboxes, ...restData },
+      } = await queries.getPersonalSidebarData();
+
+      state.sidebar = {
+        /**
+         * Renaming sandboxes to syncedSandboxes
+         */
+        syncedSandboxes: sandboxes,
+        ...restData,
+      };
+    }
+  } catch {
+    effects.notificationToast.error(
+      `There was a problem getting your data for the sidebar.`
+    );
+  }
+};

--- a/packages/app/src/app/overmind/namespaces/sidebar/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/sidebar/actions.ts
@@ -15,7 +15,7 @@ export const getSidebarData = async (
        */
       const {
         me: {
-          team: { sandboxes, templates, collections },
+          team: { sandboxes, templates },
         },
       } = await queries.getTeamSidebarData({ id: teamId });
 
@@ -25,14 +25,13 @@ export const getSidebarData = async (
       state.sidebar = {
         hasSyncedSandboxes,
         hasTemplates,
-        collections,
       };
     } else {
       /**
        * Fetch data for the user
        */
       const {
-        me: { sandboxes, templates, collections },
+        me: { sandboxes, templates },
       } = await queries.getPersonalSidebarData();
 
       const hasSyncedSandboxes = sandboxes?.length > 0;
@@ -41,7 +40,6 @@ export const getSidebarData = async (
       state.sidebar = {
         hasSyncedSandboxes,
         hasTemplates,
-        collections,
       };
     }
   } catch {

--- a/packages/app/src/app/overmind/namespaces/sidebar/index.ts
+++ b/packages/app/src/app/overmind/namespaces/sidebar/index.ts
@@ -1,0 +1,4 @@
+import * as actions from './actions';
+import { state } from './state';
+
+export { state, actions };

--- a/packages/app/src/app/overmind/namespaces/sidebar/state.ts
+++ b/packages/app/src/app/overmind/namespaces/sidebar/state.ts
@@ -1,8 +1,4 @@
-import type {
-  SidebarCollectionFragmentFragment,
-  SidebarSyncedSandboxFragmentFragment,
-  SidebarTemplateFragmentFragment,
-} from 'app/graphql/types';
+import type { SidebarCollectionFragmentFragment } from 'app/graphql/types';
 
 /**
  * SidebarState, required to be named just State. Can be an interface instead
@@ -11,16 +7,16 @@ import type {
  * ❗️ TODO: Add sidebar notification indicator state
  */
 export interface State {
-  syncedSandboxes: Array<SidebarSyncedSandboxFragmentFragment> | null;
+  hasSyncedSandboxes: boolean | null;
+  hasTemplates: boolean | null;
   collections: Array<SidebarCollectionFragmentFragment> | null;
-  templates: Array<SidebarTemplateFragmentFragment> | null;
 }
 
 /**
  * Default state for the sidebar
  */
 export const state: State = {
-  syncedSandboxes: null,
+  hasSyncedSandboxes: null,
+  hasTemplates: null,
   collections: null,
-  templates: null,
 };

--- a/packages/app/src/app/overmind/namespaces/sidebar/state.ts
+++ b/packages/app/src/app/overmind/namespaces/sidebar/state.ts
@@ -1,0 +1,26 @@
+import type {
+  SidebarCollectionFragmentFragment,
+  SidebarSyncedSandboxFragmentFragment,
+  SidebarTemplateFragmentFragment,
+} from 'app/graphql/types';
+
+/**
+ * SidebarState, required to be named just State. Can be an interface instead
+ * of a type though.
+ *
+ * ❗️ TODO: Add sidebar notification indicator state
+ */
+export interface State {
+  syncedSandboxes: Array<SidebarSyncedSandboxFragmentFragment> | null;
+  collections: Array<SidebarCollectionFragmentFragment> | null;
+  templates: Array<SidebarTemplateFragmentFragment> | null;
+}
+
+/**
+ * Default state for the sidebar
+ */
+export const state: State = {
+  syncedSandboxes: null,
+  collections: null,
+  templates: null,
+};

--- a/packages/app/src/app/overmind/namespaces/sidebar/state.ts
+++ b/packages/app/src/app/overmind/namespaces/sidebar/state.ts
@@ -1,5 +1,3 @@
-import type { SidebarCollectionFragmentFragment } from 'app/graphql/types';
-
 /**
  * SidebarState, required to be named just State. Can be an interface instead
  * of a type though.
@@ -9,7 +7,6 @@ import type { SidebarCollectionFragmentFragment } from 'app/graphql/types';
 export interface State {
   hasSyncedSandboxes: boolean | null;
   hasTemplates: boolean | null;
-  collections: Array<SidebarCollectionFragmentFragment> | null;
 }
 
 /**
@@ -18,5 +15,4 @@ export interface State {
 export const state: State = {
   hasSyncedSandboxes: null,
   hasTemplates: null,
-  collections: null,
 };

--- a/packages/app/src/app/pages/Dashboard/Sidebar/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Sidebar/index.tsx
@@ -248,7 +248,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
             icon="file"
           />
 
-          {state.sidebar.templates ? (
+          {state.sidebar.hasTemplates ? (
             <RowItem
               name="Templates"
               page="templates"
@@ -278,7 +278,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
             />
           )}
 
-          {state.sidebar.syncedSandboxes.length > 0 ? (
+          {state.sidebar.hasSyncedSandboxes ? (
             <RowItem
               name="Synced"
               page="synced-sandboxes"

--- a/packages/app/src/app/pages/Dashboard/Sidebar/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Sidebar/index.tsx
@@ -70,6 +70,12 @@ export const Sidebar: React.FC<SidebarProps> = ({
   }, [actions.dashboard, state.activeTeam]);
 
   React.useEffect(() => {
+    actions.sidebar.getSidebarData(
+      state.activeTeam !== personalWorkspaceId ? state.activeTeam : undefined
+    );
+  }, [state.activeTeam, personalWorkspaceId, actions.sidebar]);
+
+  React.useEffect(() => {
     if (state.activeTeam) {
       const team = dashboard.teams.find(({ id }) => id === state.activeTeam);
       if (team) {
@@ -84,6 +90,8 @@ export const Sidebar: React.FC<SidebarProps> = ({
     }
   }, [state.activeTeam, state.activeTeamInfo, dashboard.teams]);
 
+  // ❗️ TODO: Replace dashboard.allCollections this with state.sidebar.collections
+  // that way we can get rid of dashboard state and actions later.
   const folders =
     (dashboard.allCollections || []).filter(folder => folder.path !== '/') ||
     [];
@@ -239,12 +247,16 @@ export const Sidebar: React.FC<SidebarProps> = ({
             path={dashboardUrls.drafts(activeTeam)}
             icon="file"
           />
-          <RowItem
-            name="Templates"
-            page="templates"
-            path={dashboardUrls.templates(activeTeam)}
-            icon="star"
-          />
+
+          {state.sidebar.templates ? (
+            <RowItem
+              name="Templates"
+              page="templates"
+              path={dashboardUrls.templates(activeTeam)}
+              icon="star"
+            />
+          ) : null}
+
           <NestableRowItem
             name="All sandboxes"
             path={dashboardUrls.sandboxes('/', activeTeam)}
@@ -265,12 +277,16 @@ export const Sidebar: React.FC<SidebarProps> = ({
               icon="server"
             />
           )}
-          <RowItem
-            name="Synced"
-            page="synced-sandboxes"
-            path={dashboardUrls.syncedSandboxes(activeTeam)}
-            icon="sync"
-          />
+
+          {state.sidebar.syncedSandboxes.length > 0 ? (
+            <RowItem
+              name="Synced"
+              page="synced-sandboxes"
+              path={dashboardUrls.syncedSandboxes(activeTeam)}
+              icon="sync"
+            />
+          ) : null}
+
           <RowItem
             name="Archive"
             page="archive"

--- a/packages/app/src/app/pages/Dashboard/Sidebar/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Sidebar/index.tsx
@@ -66,10 +66,12 @@ export const Sidebar: React.FC<SidebarProps> = ({
   } = state;
 
   React.useEffect(() => {
+    // Used to fetch collections
     actions.dashboard.getAllFolders();
   }, [actions.dashboard, state.activeTeam]);
 
   React.useEffect(() => {
+    // Used to check for templates and synced sandboxes
     actions.sidebar.getSidebarData(
       state.activeTeam !== personalWorkspaceId ? state.activeTeam : undefined
     );
@@ -90,8 +92,6 @@ export const Sidebar: React.FC<SidebarProps> = ({
     }
   }, [state.activeTeam, state.activeTeamInfo, dashboard.teams]);
 
-  // ❗️ TODO: Replace dashboard.allCollections this with state.sidebar.collections
-  // that way we can get rid of dashboard state and actions later.
   const folders =
     (dashboard.allCollections || []).filter(folder => folder.path !== '/') ||
     [];

--- a/packages/app/src/app/pages/Pro/legacy-pages/WorkspacePlanSelection.tsx
+++ b/packages/app/src/app/pages/Pro/legacy-pages/WorkspacePlanSelection.tsx
@@ -538,7 +538,8 @@ const PlanCard: React.FC<{
   plan: Plan;
   billingInterval: Plan['billingInterval'];
   setBillingInterval: (billingInterval: Plan['billingInterval']) => void;
-  currentSubscription: ProSubscription | null;
+  // Omitting new trialEnd and trialStart
+  currentSubscription: Omit<ProSubscription, 'trialEnd' | 'trialStart'> | null;
 }> = ({ plan, billingInterval, setBillingInterval, currentSubscription }) => {
   const isSelected = plan.billingInterval === billingInterval;
   const isCurrent =

--- a/yarn.lock
+++ b/yarn.lock
@@ -13680,7 +13680,7 @@ esprima@^4.0.0, esprima@^4.0.1, esprima@~4.0.0:
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
 
-esquery@^1.0.0, esquery@^1.0.1:
+esquery@1.0.1, esquery@^1.0.0, esquery@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.0.1.tgz#406c51658b1f5991a5f9b62b1dc25b00e3e5c708"
   integrity sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==


### PR DESCRIPTION
### About

To make it easier to interact with the sidebar and conditionally render sidebar items using less data and requests we now have a separate sidebar state. In the future we will be able to use this for other things, e.g. showing sidebar notification indicators. In this PR we also conditionally render the Templates and Synced Sandboxes sidebar rows based on data.

### Linear

Closes XTD-198