### PR TITLE
experimental(dashboard): star repo feature

### DIFF
--- a/packages/app/src/app/overmind/namespaces/dashboard/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/dashboard/actions.ts
@@ -2035,3 +2035,48 @@ export const getRepositoryByDetails = async (
     );
   }
 };
+
+export const getStarredRepos = ({ state, effects }: Context) => {
+  const { dashboard, activeTeam } = state;
+
+  const persistedStarredRepos = effects.browser.storage.get(
+    `CSB/EXPERIMENTAL_STARRED/${activeTeam}`
+  ) as Array<{ owner: string; name: string }>;
+
+  dashboard.starredRepos = persistedStarredRepos ?? [];
+};
+
+export const starRepo = (
+  { state, effects }: Context,
+  { owner, name }: { owner: string; name: string }
+) => {
+  const { dashboard, activeTeam } = state;
+
+  const existingRepo = dashboard.starredRepos.find(
+    repo => repo.owner === owner && repo.name === name
+  );
+  if (existingRepo) {
+    return;
+  }
+
+  dashboard.starredRepos.push({ owner, name });
+  effects.browser.storage.set(
+    `CSB/EXPERIMENTAL_STARRED/${activeTeam}`,
+    dashboard.starredRepos
+  );
+};
+
+export const unstarRepo = (
+  { state, effects }: Context,
+  { owner, name }: { owner: string; name: string }
+) => {
+  const { dashboard, activeTeam } = state;
+
+  dashboard.starredRepos = dashboard.starredRepos.filter(
+    repo => repo.owner !== owner || repo.name !== name
+  );
+  effects.browser.storage.set(
+    `CSB/EXPERIMENTAL_STARRED/${activeTeam}`,
+    dashboard.starredRepos
+  );
+};

--- a/packages/app/src/app/overmind/namespaces/dashboard/state.ts
+++ b/packages/app/src/app/overmind/namespaces/dashboard/state.ts
@@ -68,6 +68,7 @@ export type State = {
   contributions: Branch[] | null;
   /** v2 repositories (formerly projects) */
   repositories: Repository[] | null;
+  starredRepos: Array<{ owner: string; name: string }>;
 };
 
 export const DEFAULT_DASHBOARD_SANDBOXES: DashboardSandboxStructure = {
@@ -182,4 +183,5 @@ export const state: State = {
   ),
   contributions: null,
   repositories: null,
+  starredRepos: [],
 };

--- a/packages/app/src/app/pages/Dashboard/Components/Header/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Header/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import { useAppState, useActions } from 'app/overmind';
 import { Stack, Text, Button, Icon } from '@codesandbox/components';
@@ -51,7 +51,7 @@ export const Header = ({
   selectedRepo,
 }: Props) => {
   const location = useLocation();
-  const { modals } = useActions();
+  const { modals, dashboard: dashboardActions } = useActions();
   const { dashboard } = useAppState();
 
   const repositoriesListPage =
@@ -60,6 +60,17 @@ export const Header = ({
   const repositoryBranchesPage = location.pathname.includes(
     '/repositories/github'
   );
+
+  const [experimentalMode] = useState(() => {
+    return window.localStorage.getItem('CSB_DEBUG') === 'ENABLED';
+  });
+
+  const selectedRepoIsStarred =
+    selectedRepo &&
+    dashboard.starredRepos.some(
+      repo =>
+        repo.owner === selectedRepo.owner && repo.name === selectedRepo.name
+    );
 
   return (
     <Stack
@@ -126,6 +137,33 @@ export const Header = ({
               css={css({ paddingRight: 2 })}
             />
             Import repo
+          </Button>
+        )}
+
+        {repositoryBranchesPage && selectedRepo && experimentalMode && (
+          <Button
+            css={css({
+              fontSize: 2,
+              color: 'mutedForeground',
+              padding: 0,
+              width: 'auto',
+            })}
+            onClick={() => {
+              if (selectedRepoIsStarred) {
+                dashboardActions.unstarRepo(selectedRepo);
+              } else {
+                dashboardActions.starRepo(selectedRepo);
+              }
+            }}
+            variant="link"
+          >
+            <Icon
+              name="star"
+              size={20}
+              title="Star repo"
+              css={css({ paddingRight: 2 })}
+            />
+            {selectedRepoIsStarred ? 'Unstar' : 'Star'}
           </Button>
         )}
 

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Repositories/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Repositories/index.tsx
@@ -134,6 +134,7 @@ export const RepositoriesPage = () => {
           </Text>
         )}
       </Notification>
+
       <VariableGrid page={pageType} items={itemsToShow} />
     </SelectionProvider>
   );

--- a/packages/app/src/app/pages/Dashboard/Sidebar/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Sidebar/index.tsx
@@ -67,6 +67,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
 
   React.useEffect(() => {
     actions.dashboard.getAllFolders();
+    actions.dashboard.getStarredRepos();
   }, [actions.dashboard, state.activeTeam]);
 
   React.useEffect(() => {
@@ -223,6 +224,18 @@ export const Sidebar: React.FC<SidebarProps> = ({
             path={dashboardUrls.repositories(activeTeam)}
             icon="repository"
           />
+          {dashboard.starredRepos.map(repo => (
+            <RowItem
+              name={repo.name}
+              page="repositories"
+              path={dashboardUrls.repository(repo)}
+              icon="star"
+              nestingLevel={1}
+              style={{
+                whiteSpace: 'nowrap',
+              }}
+            />
+          ))}
           <Element marginTop={4} />
           <Element paddingX={7} paddingY={2}>
             <Text


### PR DESCRIPTION
Not on the roadmap yet and **not supported by the backend**, but I really felt the need to have this feature while working in the dashboard. It relies on **localStorage** to persist the starred repos per team.

All the functionality is dependent on the value of `CSB_DEBUG` being set to `ENABLED`, similar with how the devtools appears for the v2 editor. v1 does not have the same feature flag system as v2, but it would be nice to add maybe?

* adds star/unstar in the context menu
* adds star/unstar for the repo page header (when showing the branches)
* shows the starred repos in the sidebar, under `All repositories`
* starred repos are reset everytime you change the workspace

![Screenshot 2022-10-10 at 12 05 13](https://user-images.githubusercontent.com/9945366/194832609-cb4ee328-909a-4348-b1bc-2676141b38e0.png)
![Screenshot 2022-10-10 at 12 05 22](https://user-images.githubusercontent.com/9945366/194832618-acfe2bb6-d0d1-43e3-a871-9a930fd1e427.png)
![Screenshot 2022-10-10 at 12 05 36](https://user-images.githubusercontent.com/9945366/194832627-548685d4-099d-4bca-9bfd-98ca8dbcc8f8.png)

Why merge this?
* we can use it internally for convenience
* it gives us time to think about the UX of the feature for when we offer it for all users