### PR TITLE
fix(contextmenu): check if selected item is undefined

### DIFF
--- a/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenu.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenu.tsx
@@ -116,7 +116,8 @@ export const ContextMenu: React.FC<IContextMenuProps> = ({
   });
 
   let menu: React.ReactNode;
-  if (selectedItems.length === 0) {
+
+  if (selectedItems.length === 0 || selectedItems[0] === undefined) {
     if (['repositories', 'my-contributions', 'synced-sandboxes'].includes(page))
       return null;
     menu = (


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes #7004 

## What is the current behavior?

When the context menu for an item in the dashboard is opened without somehow having an item selected, we create an array of selected items with an `undefined` value inside. This happens because non of the `if` statements are true and [the final `find` in the `map` function](https://github.com/codesandbox/codesandbox-client/pull/7007/files#diff-0c91eff0484478676cabb97d7c836696ec2bf811f5352d63730af0c697240414R114) creating the array returns `undefined`. We later [check for `selectedItems[0].type`](https://github.com/codesandbox/codesandbox-client/pull/7007/files#diff-0c91eff0484478676cabb97d7c836696ec2bf811f5352d63730af0c697240414R129), which fails when it's `undefined` resulting in a crash.

## What is the new behavior?

When item is `undefined` we check this first, before moving to the next if statement trying to read `type`.

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

See #7004

## Checklist

- [x] Ready to be merged