### PR TITLE
fix(create-modal): add fallback for teaminfo null when loading

### DIFF
--- a/packages/app/src/app/components/CreateSandbox/CreateSandbox.tsx
+++ b/packages/app/src/app/components/CreateSandbox/CreateSandbox.tsx
@@ -426,7 +426,7 @@ export const CreateSandbox: React.FC<CreateSandboxProps> = ({
                     <Panel tab={tabState} id="team-templates">
                       <TemplateCategoryList
                         title={`${
-                          isUser ? 'My' : activeTeamInfo.name
+                          isUser ? 'My' : activeTeamInfo?.name || 'Team'
                         } templates`}
                         templates={teamTemplates}
                         onSelectTemplate={template => {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes #7005

Add null check when reading active team, as it could still be loading the team info.

## What is the current behavior?

When team info is still loading (or failed) and the create new modal is opened, it tries to read the team name of `null`. This crashes the application.

## What is the new behavior?

Fallback to "Team templates" until team name is accessible.

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Go to the dashboard
2. Select a team
3. Click the "New" button top right
4. Confirm that application doesn't crash

## Checklist

- [x] Ready to be merged