### PR TITLE
fix: hover interaction with more button

### DIFF
--- a/packages/app/src/app/components/CreateSandbox/CreateSandbox.tsx
+++ b/packages/app/src/app/components/CreateSandbox/CreateSandbox.tsx
@@ -220,10 +220,14 @@ export const CreateSandbox: React.FC<CreateSandboxProps> = ({
               // TODO: add aria-label based on title to IconButton?
               <IconButton
                 name="arrowDown"
+                variant="square"
                 size={16}
                 title="Back to overview"
                 css={{
                   transform: 'rotate(90deg)',
+                  '&:active:not(:disabled)': {
+                    transform: 'rotate(90deg)',
+                  },
                 }}
                 onClick={() => {
                   setViewState('initial');
@@ -255,6 +259,7 @@ export const CreateSandbox: React.FC<CreateSandboxProps> = ({
             // TODO: IconButton doesn't have aria label or visuallyhidden text (reads floating label too late)
             <IconButton
               name="cross"
+              variant="square"
               size={16}
               title="Close modal"
               onClick={() => actions.modals.newSandboxModal.close()}

--- a/packages/app/src/app/pages/Dashboard/Components/Branch/BranchCard.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Branch/BranchCard.tsx
@@ -90,10 +90,7 @@ export const BranchCard: React.FC<BranchProps> = ({
             </Text>
           </Tooltip>
           <IconButton
-            css={{
-              borderRadius: '2px',
-              cursor: 'default',
-            }}
+            variant="square"
             name="more"
             size={14}
             title="Branch actions"

--- a/packages/app/src/app/pages/Dashboard/Components/Branch/BranchCard.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Branch/BranchCard.tsx
@@ -40,6 +40,9 @@ export const BranchCard: React.FC<BranchProps> = ({
         ':hover': {
           backgroundColor: 'card.backgroundHover',
         },
+        ':has(button:hover)': {
+          backgroundColor: 'card.background',
+        },
         ':focus-visible': {
           borderColor: 'focusBorder',
         },
@@ -87,8 +90,12 @@ export const BranchCard: React.FC<BranchProps> = ({
             </Text>
           </Tooltip>
           <IconButton
+            css={{
+              borderRadius: '2px',
+              cursor: 'default',
+            }}
             name="more"
-            size={9}
+            size={14}
             title="Branch actions"
             onClick={evt => {
               evt.stopPropagation();

--- a/packages/app/src/app/pages/Dashboard/Components/Branch/BranchListItem.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Branch/BranchListItem.tsx
@@ -89,10 +89,7 @@ export const BranchListItem = ({
           </Column>
         </Grid>
         <IconButton
-          css={{
-            borderRadius: '2px',
-            cursor: 'default',
-          }}
+          variant="square"
           name="more"
           size={14}
           title="Branch actions"

--- a/packages/app/src/app/pages/Dashboard/Components/Branch/BranchListItem.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Branch/BranchListItem.tsx
@@ -34,6 +34,9 @@ export const BranchListItem = ({
         ':hover, :focus, :focus-within': {
           backgroundColor: 'list.hoverBackground',
         },
+        ':has(button:hover)': {
+          backgroundColor: 'transparent',
+        },
       })}
     >
       <Element
@@ -50,7 +53,7 @@ export const BranchListItem = ({
       >
         <Grid css={{ width: 'calc(100% - 26px - 8px)' }}>
           <Column
-           span={[12, 5, 5]}
+            span={[12, 5, 5]}
             css={{
               display: 'block',
               overflow: 'hidden',
@@ -60,7 +63,12 @@ export const BranchListItem = ({
           >
             <Stack gap={4} align="center" marginLeft={2}>
               {contribution ? (
-                <Icon color="#EDFFA5" name="contribution" size={16} width="32px" />
+                <Icon
+                  color="#EDFFA5"
+                  name="contribution"
+                  size={16}
+                  width="32px"
+                />
               ) : (
                 <Icon name="branch" color="#999" size={16} width="32px" />
               )}
@@ -81,8 +89,12 @@ export const BranchListItem = ({
           </Column>
         </Grid>
         <IconButton
+          css={{
+            borderRadius: '2px',
+            cursor: 'default',
+          }}
           name="more"
-          size={9}
+          size={14}
           title="Branch actions"
           onClick={evt => {
             evt.stopPropagation();

--- a/packages/app/src/app/pages/Dashboard/Components/Filters/SortOptions/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Filters/SortOptions/index.tsx
@@ -36,6 +36,7 @@ export const SortOptions: FunctionComponent = React.memo(() => {
         <IconButton
           name="arrowDown"
           size={11}
+          variant="square"
           title="Reverse sort direction"
           onClick={toggleSort}
           css={{ transform: `rotate(${order === 'desc' ? 0 : 180}deg)` }}

--- a/packages/app/src/app/pages/Dashboard/Components/Folder/FolderCard.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Folder/FolderCard.tsx
@@ -54,6 +54,9 @@ export const FolderCard: React.FC<FolderItemComponentProps> = ({
       ':hover': {
         backgroundColor: 'card.backgroundHover',
       },
+      ':has(button:hover)': {
+        backgroundColor: 'card.background',
+      },
       ':focus-visible': {
         borderColor: 'focusBorder',
       },
@@ -67,8 +70,12 @@ export const FolderCard: React.FC<FolderItemComponentProps> = ({
     >
       {!isNewFolder ? (
         <IconButton
+          css={{
+            borderRadius: '2px',
+            cursor: 'default',
+          }}
           name="more"
-          size={9}
+          size={14}
           title="Folder actions"
           onClick={onContextMenu}
         />

--- a/packages/app/src/app/pages/Dashboard/Components/Folder/FolderCard.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Folder/FolderCard.tsx
@@ -70,10 +70,7 @@ export const FolderCard: React.FC<FolderItemComponentProps> = ({
     >
       {!isNewFolder ? (
         <IconButton
-          css={{
-            borderRadius: '2px',
-            cursor: 'default',
-          }}
+          variant="square"
           name="more"
           size={14}
           title="Folder actions"

--- a/packages/app/src/app/pages/Dashboard/Components/Folder/FolderListItem.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Folder/FolderListItem.tsx
@@ -56,6 +56,9 @@ export const FolderListItem = ({
           cursor: 'default',
           backgroundColor: selected ? 'purpleOpaque' : 'list.hoverBackground',
         },
+        ':has(button:hover)': {
+          backgroundColor: 'transparent',
+        },
         width: '100%',
         height: 64,
         borderBottom: '1px solid',
@@ -73,7 +76,13 @@ export const FolderListItem = ({
                 height: 32,
               })}
             >
-              <Icon name="folder" size={24} width={32} title="folder" color="#E3FF73" />
+              <Icon
+                name="folder"
+                size={24}
+                width={32}
+                title="folder"
+                color="#E3FF73"
+              />
             </Stack>
             <Stack justify="space-between" align="center">
               {editing ? (
@@ -109,8 +118,12 @@ export const FolderListItem = ({
       </Grid>
       {!isNewFolder ? (
         <IconButton
+          css={{
+            borderRadius: '2px',
+            cursor: 'default',
+          }}
           name="more"
-          size={9}
+          size={14}
           title="Sandbox actions"
           onClick={onContextMenu}
         />

--- a/packages/app/src/app/pages/Dashboard/Components/Folder/FolderListItem.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Folder/FolderListItem.tsx
@@ -118,10 +118,7 @@ export const FolderListItem = ({
       </Grid>
       {!isNewFolder ? (
         <IconButton
-          css={{
-            borderRadius: '2px',
-            cursor: 'default',
-          }}
+          variant="square"
           name="more"
           size={14}
           title="Sandbox actions"

--- a/packages/app/src/app/pages/Dashboard/Components/Notification/Notification.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Notification/Notification.tsx
@@ -58,6 +58,7 @@ export const Notification = ({ children, pageType }: NotificationProps) => {
           >
             <IconButton
               name="cross"
+              variant="round"
               title="Dismiss notification"
               onClick={dismissNotification}
             />

--- a/packages/app/src/app/pages/Dashboard/Components/Repository/RepositoryCard.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Repository/RepositoryCard.tsx
@@ -53,9 +53,8 @@ export const RepositoryCard: React.FC<RepositoryProps> = ({
         css={css({
           marginLeft: 'auto',
           marginRight: 0,
-          borderRadius: '2px',
-          cursor: 'default',
         })}
+        variant="square"
         name="more"
         size={14}
         title="Repository actions"

--- a/packages/app/src/app/pages/Dashboard/Components/Repository/RepositoryCard.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Repository/RepositoryCard.tsx
@@ -36,6 +36,9 @@ export const RepositoryCard: React.FC<RepositoryProps> = ({
         ':hover': {
           backgroundColor: 'card.backgroundHover',
         },
+        ':has(button:hover)': {
+          backgroundColor: 'card.background',
+        },
         ':focus-visible': {
           borderColor: 'focusBorder',
         },
@@ -50,9 +53,11 @@ export const RepositoryCard: React.FC<RepositoryProps> = ({
         css={css({
           marginLeft: 'auto',
           marginRight: 0,
+          borderRadius: '2px',
+          cursor: 'default',
         })}
         name="more"
-        size={9}
+        size={14}
         title="Repository actions"
         onClick={evt => {
           evt.stopPropagation();

--- a/packages/app/src/app/pages/Dashboard/Components/Repository/RepositoryListItem.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Repository/RepositoryListItem.tsx
@@ -80,10 +80,7 @@ export const RepositoryListItem: React.FC<RepositoryProps> = ({
           </Column>
         </Grid>
         <IconButton
-          css={css({
-            borderRadius: '2px',
-            cursor: 'default',
-          })}
+          variant="square"
           name="more"
           size={14}
           title="Repository actions"

--- a/packages/app/src/app/pages/Dashboard/Components/Repository/RepositoryListItem.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Repository/RepositoryListItem.tsx
@@ -35,6 +35,9 @@ export const RepositoryListItem: React.FC<RepositoryProps> = ({
           cursor: 'default',
           backgroundColor: selected ? 'purpleOpaque' : 'list.hoverBackground',
         },
+        ':has(button:hover)': {
+          backgroundColor: 'transparent',
+        },
       })}
     >
       <Element
@@ -77,8 +80,12 @@ export const RepositoryListItem: React.FC<RepositoryProps> = ({
           </Column>
         </Grid>
         <IconButton
+          css={css({
+            borderRadius: '2px',
+            cursor: 'default',
+          })}
           name="more"
-          size={9}
+          size={14}
           title="Repository actions"
           onClick={evt => {
             evt.stopPropagation();

--- a/packages/app/src/app/pages/Dashboard/Components/Sandbox/SandboxCard.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Sandbox/SandboxCard.tsx
@@ -131,10 +131,7 @@ const SandboxTitle: React.FC<SandboxTitleProps> = React.memo(
         </div>
       ) : (
         <IconButton
-          css={{
-            borderRadius: '2px',
-            cursor: 'default',
-          }}
+          variant="square"
           name="more"
           size={14}
           title="Sandbox Actions"

--- a/packages/app/src/app/pages/Dashboard/Components/Sandbox/SandboxCard.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Sandbox/SandboxCard.tsx
@@ -131,8 +131,12 @@ const SandboxTitle: React.FC<SandboxTitleProps> = React.memo(
         </div>
       ) : (
         <IconButton
+          css={{
+            borderRadius: '2px',
+            cursor: 'default',
+          }}
           name="more"
-          size={9}
+          size={14}
           title="Sandbox Actions"
           onClick={onContextMenu}
         />
@@ -258,6 +262,9 @@ export const SandboxCard = ({
         opacity,
         ':hover': {
           backgroundColor: 'card.backgroundHover',
+        },
+        ':has(button:hover)': {
+          backgroundColor: 'card.background',
         },
         ':focus-visible': {
           borderColor: 'focusBorder',

--- a/packages/app/src/app/pages/Dashboard/Components/Sandbox/SandboxListItem.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Sandbox/SandboxListItem.tsx
@@ -58,6 +58,9 @@ export const SandboxListItem = ({
         cursor: 'default',
         backgroundColor: selected ? 'purpleOpaque' : 'list.hoverBackground',
       },
+      ':has(button:hover)': {
+        backgroundColor: 'transparent',
+      },
     })}
   >
     <Element
@@ -186,8 +189,12 @@ export const SandboxListItem = ({
         </Column>
       </Grid>
       <IconButton
+        css={{
+          borderRadius: '2px',
+          cursor: 'default',
+        }}
         name="more"
-        size={9}
+        size={14}
         title="Sandbox actions"
         onClick={onContextMenu}
       />

--- a/packages/app/src/app/pages/Dashboard/Components/Sandbox/SandboxListItem.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Sandbox/SandboxListItem.tsx
@@ -189,11 +189,8 @@ export const SandboxListItem = ({
         </Column>
       </Grid>
       <IconButton
-        css={{
-          borderRadius: '2px',
-          cursor: 'default',
-        }}
         name="more"
+        variant="square"
         size={14}
         title="Sandbox actions"
         onClick={onContextMenu}

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/WorkspaceSettings.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/WorkspaceSettings.tsx
@@ -311,6 +311,7 @@ export const WorkspaceSettings = () => {
                   {activeWorkspaceAuthorization ===
                     TeamMemberAuthorization.Admin && (
                     <IconButton
+                      variant="square"
                       name="edit"
                       size={12}
                       title="Edit team"

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Settings/UserSettings/WorkspaceSettings.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Settings/UserSettings/WorkspaceSettings.tsx
@@ -189,6 +189,7 @@ export const WorkspaceSettings = () => {
                   </Text>
                   <IconButton
                     name="edit"
+                    variant="square"
                     size={12}
                     title="Edit team"
                     onClick={() => setEditing(false)}
@@ -294,6 +295,7 @@ export const WorkspaceSettings = () => {
                 </Text>
                 <IconButton
                   name="edit"
+                  variant="square"
                   size={12}
                   title="Edit team"
                   onClick={() => setEditing(true)}

--- a/packages/components/src/components/IconButton/index.tsx
+++ b/packages/components/src/components/IconButton/index.tsx
@@ -12,12 +12,15 @@ type IconButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
   title: string;
   /** Size of the icon, the button is set to 26x26 */
   size?: number;
+  /** Variant - square or round */
+  variant?: 'square' | 'round';
 };
 
 export const IconButton: React.FC<IconButtonProps> = ({
   name,
   title,
   size,
+  variant = 'round',
   css = {},
   ...props
 }) => (
@@ -29,7 +32,8 @@ export const IconButton: React.FC<IconButtonProps> = ({
         {
           width: '26px', // same width as (height of the button)
           paddingX: 0,
-          borderRadius: '50%',
+          borderRadius: variant === 'round' ? '50%' : '2px',
+          cursor: variant === 'round' ? 'pointer' : 'default',
           ':hover:not(:disabled)': {
             backgroundColor: 'secondaryButton.background',
           },

--- a/packages/components/src/components/IconButton/index.tsx
+++ b/packages/components/src/components/IconButton/index.tsx
@@ -33,6 +33,7 @@ export const IconButton: React.FC<IconButtonProps> = ({
           width: '26px', // same width as (height of the button)
           paddingX: 0,
           borderRadius: variant === 'round' ? '50%' : '2px',
+          // Round variant is legacy, so keeps cursor pointer for backwards compat in the editor
           cursor: variant === 'round' ? 'pointer' : 'default',
           ':hover:not(:disabled)': {
             backgroundColor: 'secondaryButton.background',


### PR DESCRIPTION
A bit of polishing on the card/list items when hovering to the more button
* bigger icon
* default cursor
* square with border radius instead of circle shape
* hover on icon reverts hover on card (using [:has](https://developer.mozilla.org/en-US/docs/Web/CSS/:has) which doesn't work in firefox unfortunately)
* applies on: sandboxes, folders, branches & repos


https://user-images.githubusercontent.com/9945366/195557649-9674efa1-f299-41a9-8c1a-8e7c4bc5ae87.mov


https://user-images.githubusercontent.com/9945366/195557700-41a3481c-9db8-4231-9c48-e14255baf838.mov


Notes
* There's a lot of duplication already with these cards, might be a good idea to think of a way to reuse the card/list item component

