### PR TITLE
fix: Add v2 flag to search result to show beta badge

### DIFF
--- a/packages/app/src/app/components/CreateSandbox/SearchResults/SearchResultList.tsx
+++ b/packages/app/src/app/components/CreateSandbox/SearchResults/SearchResultList.tsx
@@ -52,7 +52,7 @@ const Results = (props: ResultsProps) => {
       insertedAt: new Date(hit.inserted_at).toString(),
       updatedAt: new Date(hit.updated_at).toString(),
       author: hit.author,
-      isV2: false,
+      isV2: hit.custom_template.v2,
       source: {
         template: hit.template,
       },

--- a/packages/common/src/types/algolia.ts
+++ b/packages/common/src/types/algolia.ts
@@ -39,6 +39,7 @@ interface CustomTemplate {
   id: string;
   icon_url: string | null;
   color: string;
+  v2: boolean | null;
 }
 
 interface Author {

--- a/packages/common/src/types/index.ts
+++ b/packages/common/src/types/index.ts
@@ -152,6 +152,7 @@ export type CustomTemplate = {
   published?: boolean;
   title: string;
   url: string | null;
+  v2: boolean | null;
 };
 
 export type GitInfo = {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Adds `v2` to the Algolia search result types, and pass it to the template card. This way it will show the badge on the card when searching. This distinction makes it more clear what kind of template the user is selecting, conforming to expectations.

Closes XTD-275

## What is the current behavior?

No beta badge.

## What is the new behavior?

Beta badge!

<img width="955" alt="image" src="https://user-images.githubusercontent.com/7533849/195584415-421dd827-3753-480a-9c6d-a36a386e4650.png">

