### PR TITLE
chore(create-new): remove cloud beta badge from title

### DIFF
--- a/packages/app/src/app/components/CreateSandbox/TemplateCategoryList.tsx
+++ b/packages/app/src/app/components/CreateSandbox/TemplateCategoryList.tsx
@@ -2,7 +2,6 @@ import React, { useEffect } from 'react';
 import track from '@codesandbox/common/lib/utils/analytics';
 import { Button, Text, Stack } from '@codesandbox/components';
 import { css } from '@styled-system/css';
-import { CloudBetaBadge } from 'app/components/CloudBetaBadge';
 import { useAppState, useActions } from 'app/overmind';
 import { TemplateFragment } from 'app/graphql/types';
 import { TemplateCard } from './TemplateCard';
@@ -52,7 +51,6 @@ export const TemplateCategoryList = ({
         >
           {title}
         </Text>
-        {isCloudTemplateList && <CloudBetaBadge hideIcon />}
       </Stack>
       {!hasLogIn && isCloudTemplateList ? (
         <Stack direction="vertical" gap={4}>


### PR DESCRIPTION
Removed the cloud beta badge from the panel title because it is already present in the tab button and every template in the panel.
