### PR TITLE
fix: show sign in on cloud sandbox message

### DIFF
--- a/packages/app/src/app/overmind/internalActions.ts
+++ b/packages/app/src/app/overmind/internalActions.ts
@@ -529,6 +529,9 @@ export const handleError = (
   } else if (
     error.message.startsWith(
       'You need to be signed in to fork a server template.'
+    ) ||
+    error.message.startsWith(
+      'You need to be signed in to fork a cloud sandbox.'
     )
   ) {
     notificationActions.primary = {


### PR DESCRIPTION
The message changed and we weren't checking for that so the previously added sign in button was lost again. Talked to Sanne and we agreed that this is not the ideal way to do this, but for now in v1 it is what it is.