### PR TITLE
feat(search): enable repository search

### DIFF
--- a/packages/app/src/app/components/CreateSandbox/TemplateCard.tsx
+++ b/packages/app/src/app/components/CreateSandbox/TemplateCard.tsx
@@ -24,14 +24,7 @@ export const TemplateCard = ({
 
   const sandboxTitle = template.sandbox?.title || template.sandbox?.alias;
   const isV2 = template.sandbox?.isV2;
-  const teamName = template.sandbox?.collection?.team?.name; // Search is different
-
-  if (!teamName) {
-    console.log('template', template);
-  }
-  const authorName = template.sandbox?.author?.username;
-
-  // console.log('teamName', teamName);
+  const teamName = template.sandbox?.collection?.team?.name;
 
   return (
     <TemplateButton
@@ -77,7 +70,7 @@ export const TemplateCard = ({
 
           <Text size={2} css={{ color: '#999' }}>
             <VisuallyHidden>by </VisuallyHidden>
-            {teamName || authorName || 'CodeSandbox'}
+            {teamName || 'CodeSandbox'}
           </Text>
         </Stack>
       </Stack>

--- a/packages/app/src/app/components/CreateSandbox/TemplateCard.tsx
+++ b/packages/app/src/app/components/CreateSandbox/TemplateCard.tsx
@@ -24,7 +24,14 @@ export const TemplateCard = ({
 
   const sandboxTitle = template.sandbox?.title || template.sandbox?.alias;
   const isV2 = template.sandbox?.isV2;
-  const teamName = template.sandbox?.collection?.team?.name;
+  const teamName = template.sandbox?.collection?.team?.name; // Search is different
+
+  if (!teamName) {
+    console.log('template', template);
+  }
+  const authorName = template.sandbox?.author?.username;
+
+  // console.log('teamName', teamName);
 
   return (
     <TemplateButton
@@ -70,7 +77,7 @@ export const TemplateCard = ({
 
           <Text size={2} css={{ color: '#999' }}>
             <VisuallyHidden>by </VisuallyHidden>
-            {teamName || 'CodeSandbox'}
+            {teamName || authorName || 'CodeSandbox'}
           </Text>
         </Stack>
       </Stack>

--- a/packages/app/src/app/overmind/namespaces/dashboard/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/dashboard/actions.ts
@@ -1000,6 +1000,7 @@ export const getPage = async ({ actions }: Context, page: sandboxesTypes) => {
       break;
     case sandboxesTypes.SEARCH:
       dashboard.getSearchSandboxes();
+      dashboard.getRepositoriesByTeam({ bypassLoading: true });
       break;
     case sandboxesTypes.ALWAYS_ON:
       dashboard.getAlwaysOnSandboxes();


### PR DESCRIPTION
## What kind of change does this PR introduce?

We're now able to search for repositories on the dashboard 🥳

https://user-images.githubusercontent.com/7533849/195845514-2bdd20b6-b2a5-498c-93bf-94e1abfeb028.mov

Right now, the search works a bit janky. We only fetch the sandboxes and repositories when we visit an empty search page - I haven't changed anything about that logic. The search itself or fetching the sandboxes and repositories can be slow too -maybe because it fetches all the branches as well? We can also make an effort of removing the `ts-ignores` from the search feature.

