### PR TITLE
fix(common): add default value to `container.node` in `ConfigWizard`

### DIFF
--- a/packages/common/src/templates/configuration/sandbox/ui.tsx
+++ b/packages/common/src/templates/configuration/sandbox/ui.tsx
@@ -193,7 +193,7 @@ export const ConfigWizard = (props: ConfigurationUIProps) => {
               title="Node Version"
               type="dropdown"
               options={['10', '12', '14', '16']}
-              {...bindValue(parsedFile, 'container.node')}
+              {...bindValue(parsedFile, 'container.node', '14')}
             />
             <ConfigDescription>
               Which node version to use for this sandbox. Please restart the


### PR DESCRIPTION
When looking at a config file, it shows `10`, but it actually is `14` by default now.
https://codesandbox.io/s/github/remix-run/examples/tree/main/tailwindcss?file=/sandbox.config.json