### PR TITLE
feat(trial): create team and subscribe to pro

### DIFF
--- a/packages/app/src/app/hooks/index.ts
+++ b/packages/app/src/app/hooks/index.ts
@@ -1,2 +1,3 @@
 export { useInterval } from './useInterval';
 export { useScript } from './useScript';
+export { useCreateCheckout } from './useCreateCheckout';

--- a/packages/app/src/app/hooks/useCreateCheckout.ts
+++ b/packages/app/src/app/hooks/useCreateCheckout.ts
@@ -34,7 +34,7 @@ export const useCreateCheckout = (): [
     } catch (err) {
       setStatus({
         status: 'error',
-        error: err?.message ?? 'Failed to create checkout link.',
+        error: err?.message ?? 'Failed to create checkout link',
       });
     }
   };

--- a/packages/app/src/app/hooks/useCreateCheckout.ts
+++ b/packages/app/src/app/hooks/useCreateCheckout.ts
@@ -1,0 +1,43 @@
+import { useState } from 'react';
+import { useEffects } from 'app/overmind';
+import { dashboard } from '@codesandbox/common/lib/utils/url-generator';
+
+type CheckoutStatus =
+  | { status: 'idle' }
+  | { status: 'loading' }
+  | { status: 'error'; error: string };
+
+export const useCreateCheckout = (): [
+  CheckoutStatus,
+  (arg: Record<'team_id' | 'recurring_interval', string>) => void
+] => {
+  const [status, setStatus] = useState<CheckoutStatus>({ status: 'idle' });
+  const { api } = useEffects();
+
+  const createCheckout = async ({
+    team_id,
+    recurring_interval,
+  }: Record<'team_id' | 'recurring_interval', string>) => {
+    try {
+      setStatus({ status: 'loading' });
+
+      const payload = await api.stripeCreateCheckout({
+        success_path: dashboard.settings(team_id) + '&payment_pending=true',
+        cancel_path: '/pro',
+        team_id,
+        recurring_interval,
+      });
+
+      if (payload.stripeCheckoutUrl) {
+        window.location.href = payload.stripeCheckoutUrl;
+      }
+    } catch (err) {
+      setStatus({
+        status: 'error',
+        error: err?.message ?? 'Failed to create checkout link.',
+      });
+    }
+  };
+
+  return [status, createCheckout];
+};

--- a/packages/app/src/app/overmind/namespaces/pro/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/pro/actions.ts
@@ -3,6 +3,14 @@ import { Context } from 'app/overmind';
 import { withLoadApp } from 'app/overmind/factories';
 import { Step, Plan, PaymentSummary, PaymentPreview } from './types';
 
+export const getPrices = async ({ state, effects }: Context) => {
+  try {
+    state.pro.prices = await effects.api.prices();
+  } catch (err) {
+    // Fail silently.
+  }
+};
+
 export const pageMounted = withLoadApp(async ({ effects, state, actions }) => {
   state.pro.prices = await effects.api.prices();
 

--- a/packages/app/src/app/pages/Pro/upgrade.tsx
+++ b/packages/app/src/app/pages/Pro/upgrade.tsx
@@ -15,11 +15,8 @@ import { AnimatePresence, motion } from 'framer-motion';
 import { dashboard as dashboardUrls } from '@codesandbox/common/lib/utils/url-generator';
 import { useLocation, useHistory } from 'react-router-dom';
 import { formatCurrency } from 'app/utils/currency';
-import {
-  useCreateCheckout,
-  useCreateCustomerPortal,
-  Interval,
-} from './upgrade/utils';
+import { useCreateCheckout } from 'app/hooks';
+import { useCreateCustomerPortal, Interval } from './upgrade/utils';
 import {
   UpgradeButton,
   Caption,
@@ -54,7 +51,7 @@ export const ProUpgrade = () => {
   const location = useLocation();
   const history = useHistory();
 
-  const [loadingCheckout, createCheckout] = useCreateCheckout();
+  const [checkout, createCheckout] = useCreateCheckout();
   const [loadingCustomerPortal, createCustomerPortal] = useCreateCustomerPortal(
     activeTeam
   );
@@ -225,7 +222,7 @@ export const ProUpgrade = () => {
             padding: '24px 1em',
           })}
         >
-          <Element css={{ width: '100%', paddingTop:'24px' }}>
+          <Element css={{ width: '100%', paddingTop: '24px' }}>
             <Switcher
               workspaceType={workspaceType}
               workspaces={workspacesList}
@@ -366,15 +363,19 @@ export const ProUpgrade = () => {
                   )}
                 </AnimatePresence>
 
-                <Stack direction="horizontal" css={{ marginTop: 24 }}>
-                  <Element
-                    css={{
-                      flex: 1,
-                      display: 'none',
-                      '@media (min-width: 720px)': { display: 'block' },
-                    }}
-                  />
+                <Stack
+                  direction="vertical"
+                  css={{
+                    width: '100%',
+                    marginTop: 24,
+                    alignItems: 'flex-start',
 
+                    '@media screen and (min-width: 720px)': {
+                      alignItems: 'flex-end',
+                    },
+                  }}
+                  gap={1}
+                >
                   <UpgradeButton
                     planType={workspaceType}
                     type="button"
@@ -384,10 +385,19 @@ export const ProUpgrade = () => {
                         recurring_interval: interval as string,
                       })
                     }
-                    disabled={!isAdmin || isPro || loadingCheckout}
+                    disabled={
+                      !isAdmin || isPro || checkout.status === 'loading'
+                    }
                   >
-                    {loadingCheckout ? 'Loading...' : 'Proceed to checkout'}
+                    {checkout.status === 'loading'
+                      ? 'Loading...'
+                      : 'Proceed to checkout'}
                   </UpgradeButton>
+                  {checkout.status === 'error' && (
+                    <Text variant="danger">
+                      {checkout.error}. Please try again.
+                    </Text>
+                  )}
                 </Stack>
 
                 <Summary>

--- a/packages/app/src/app/pages/Pro/upgrade/utils.ts
+++ b/packages/app/src/app/pages/Pro/upgrade/utils.ts
@@ -5,39 +5,6 @@ import { dashboard } from '@codesandbox/common/lib/utils/url-generator';
 export type WorkspaceType = 'pro' | 'teamPro';
 export type Interval = 'month' | 'year';
 
-export const useCreateCheckout = (): [
-  boolean,
-  (arg: Record<'team_id' | 'recurring_interval', string>) => void
-] => {
-  const [loading, setLoading] = useState(false);
-  const { api } = useEffects();
-
-  const createCheckout = async ({
-    team_id,
-    recurring_interval,
-  }: Record<'team_id' | 'recurring_interval', string>) => {
-    try {
-      setLoading(true);
-
-      const payload = await api.stripeCreateCheckout({
-        success_path: dashboard.settings(team_id) + '&payment_pending=true',
-        cancel_path: '/pro',
-        team_id,
-        recurring_interval,
-      });
-
-      if (payload.stripeCheckoutUrl) {
-        window.location.href = payload.stripeCheckoutUrl;
-      }
-    } catch (err) {
-      setLoading(false);
-      console.error(err);
-    }
-  };
-
-  return [loading, createCheckout];
-};
-
 export const useCreateCustomerPortal = (
   activeTeam: string
 ): [boolean, () => void] => {

--- a/packages/app/src/app/pages/common/Modals/NewTeamModal/TeamSubscription.tsx
+++ b/packages/app/src/app/pages/common/Modals/NewTeamModal/TeamSubscription.tsx
@@ -1,27 +1,167 @@
 import React from 'react';
+import css from '@styled-system/css';
+
+import { Button, Icon, Stack, Text } from '@codesandbox/components';
 import { useActions, useAppState } from 'app/overmind';
-import { Button, Stack, Text } from '@codesandbox/components';
+import { TeamAvatar } from 'app/components/TeamAvatar';
+import { formatCurrency } from 'app/utils/currency';
+
+type Feature = {
+  key: string;
+  label: string;
+  icon: React.ComponentProps<typeof Icon>['name'];
+};
+const FEATURES: Feature[] = [
+  { key: 'editors', label: 'Up to 20 editors', icon: 'profile' },
+  {
+    key: 'limit',
+    label: 'Unlimited sandboxes and repositories',
+    icon: 'CodeSandboxIcon',
+  },
+  { key: 'npm', label: 'Private NPM packages', icon: 'npm' },
+  {
+    key: 'privacy',
+    label: 'Private repositories and advanced permissions',
+    icon: 'lock',
+  },
+  { key: 'vm', label: '6GB RAM, 12GB Disk, 4 vCPUs', icon: 'server' },
+];
+
+const pricingLabel = (
+  price: { currency: string; unitAmount: number } | undefined
+) => {
+  if (typeof price === 'undefined') {
+    return '';
+  }
+
+  return ` ${formatCurrency({
+    currency: price.currency,
+    amount: price.unitAmount,
+  })} ${price.currency.toUpperCase()} per editor per month`;
+};
 
 export const TeamSubscription: React.FC = () => {
-  const { activeTeamInfo } = useAppState();
+  const { activeTeamInfo, pro } = useAppState();
   const actions = useActions();
+
+  React.useEffect(() => {
+    actions.pro.getPrices();
+  }, []);
 
   // Only teams that never had a subscription are elligible for
   // the 14-day free trial.
   const isElligibleForTrial = activeTeamInfo.subscription === null;
 
   return (
-    <Stack direction="vertical">
-      <Text as="p">{activeTeamInfo.name}</Text>
-      <Text as="h2">Try Team Pro for free</Text>
-      <Button disabled>
-        {isElligibleForTrial
-          ? 'Start 14 day free trial'
-          : 'Proceed to checkout'}
-      </Button>
-      <Button onClick={() => actions.modalClosed()} variant="secondary">
-        Continue with free plan
-      </Button>
+    <Stack
+      css={css({
+        width: '100%',
+        flex: 1,
+      })}
+      align="center"
+      direction="vertical"
+    >
+      <Stack
+        css={css({
+          width: '396px',
+          flex: 1,
+        })}
+        align="center"
+        direction="vertical"
+        gap={6}
+      >
+        <Stack direction="vertical" gap={3}>
+          <Stack align="center" justify="center" gap={3}>
+            <TeamAvatar
+              avatar={activeTeamInfo.avatarUrl}
+              name={activeTeamInfo.name}
+            />
+            <Text as="p" size={3}>
+              {activeTeamInfo.name}
+            </Text>
+          </Stack>
+          <Text
+            as="h2"
+            css={{
+              fontFamily: 'Everett, sans-serif',
+              fontWeight: 500,
+              fontSize: '32px',
+              lineHeight: '42px',
+              letterSpacing: '-0.01em',
+              margin: 0,
+            }}
+            size={8}
+          >
+            {isElligibleForTrial
+              ? 'Try Team Pro for free'
+              : 'Upgrade to Team Pro'}
+          </Text>
+        </Stack>
+        <Stack
+          as="ul"
+          css={css({
+            width: '100%',
+            margin: 0,
+            padding: 2,
+            listStyle: 'none',
+            background: '#161616',
+            borderRadius: '4px',
+          })}
+          direction="vertical"
+          gap={1}
+        >
+          {FEATURES.map(feature => (
+            <Stack
+              key={feature.key}
+              as="li"
+              css={css({
+                color: '#C2C2C2',
+                paddingX: 4,
+                paddingY: 3,
+              })}
+              align="center"
+              gap={3}
+            >
+              <Icon name={feature.icon} />
+              <Text size={3}>{feature.label}</Text>
+            </Stack>
+          ))}
+        </Stack>
+        <Stack css={{ width: '100%' }} direction="vertical" gap={4}>
+          <Button
+            css={css({
+              height: '32px',
+            })}
+          >
+            {isElligibleForTrial
+              ? 'Start 14 day free trial'
+              : 'Proceed to checkout'}
+          </Button>
+          <Button onClick={() => actions.modalClosed()} variant="link">
+            Continue with free plan
+          </Button>
+        </Stack>
+      </Stack>
+      {isElligibleForTrial ? (
+        <Stack
+          css={css({
+            width: '100%',
+            padding: 6,
+            borderTop: '1px solid rgba(153, 153, 153, 0.2)',
+          })}
+          direction="vertical"
+        >
+          <Text css={css({ color: '#999999' })} size={2}>
+            You&apos;ll be notified before trial ends.
+          </Text>
+          <Text css={css({ color: '#999999' })} size={2}>
+            {`After trial, you will be charged${pricingLabel(
+              pro.prices?.teamPro.month
+            )}`}
+            . Taxes may apply.
+          </Text>
+        </Stack>
+      ) : null}
     </Stack>
   );
 };

--- a/packages/app/src/app/pages/common/Modals/NewTeamModal/index.tsx
+++ b/packages/app/src/app/pages/common/Modals/NewTeamModal/index.tsx
@@ -11,9 +11,7 @@ type TeamStep = 'info' | 'members' | 'subscription';
 
 export const NewTeamModal: React.FC = () => {
   const actions = useActions();
-  const [currentStep, setCurrentStep] = React.useState<TeamStep>(
-    'subscription'
-  );
+  const [currentStep, setCurrentStep] = React.useState<TeamStep>('info');
 
   return (
     <Stack

--- a/packages/app/src/app/pages/common/Modals/NewTeamModal/index.tsx
+++ b/packages/app/src/app/pages/common/Modals/NewTeamModal/index.tsx
@@ -11,7 +11,9 @@ type TeamStep = 'info' | 'members' | 'subscription';
 
 export const NewTeamModal: React.FC = () => {
   const actions = useActions();
-  const [currentStep, setCurrentStep] = React.useState<TeamStep>('info');
+  const [currentStep, setCurrentStep] = React.useState<TeamStep>(
+    'subscription'
+  );
 
   return (
     <Stack

--- a/packages/components/src/components/Icon/icons.tsx
+++ b/packages/components/src/components/Icon/icons.tsx
@@ -1170,3 +1170,19 @@ export const grid = props => (
     </g>
   </Element>
 );
+
+export const npm = props => (
+  <Element
+    as="svg"
+    viewBox="0 0 16 16"
+    xmlns="http://www.w3.org/2000/svg"
+    {...props}
+  >
+    <path
+      fillRule="evenodd"
+      clipRule="evenodd"
+      d="M0 11.875h2V8.312h1v3.563h1v-4.75H0v4.75Zm5-4.75v5.938h2v-1.188h2v-4.75H5Zm3 3.563H7V8.312h1v2.376Zm2 1.187v-4.75h6v4.75h-1V8.312h-1v3.563h-1V8.312h-1v3.563h-2Z"
+      fill="currentColor"
+    />
+  </Element>
+);


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?

<!-- Is it a Bug fix, feature, docs update, ... -->

Adds UI for signing up for the trial on the create team flow.

## What is the new behavior?

<!-- if this is a feature change -->

Loom: https://www.loom.com/share/1cbc221612f444d0bf5940f0043c9618

## What steps did you take to test this? This is required before we can merge, make sure to try the flow you've updated.

⚠️ The trial flag is enabled on the back end only, so this should be tested against the stream.

1. Open the dashboard
2. In the workspace selector, click "Create a new team"
3. Go through step 1 (actual team creation)
4. Go through step 2 (placeholder for team members)
5. In step 3, click on "Start 14-day free trial"
6. In stripe, use a test card
7. After a successful subscription, get redirected to your new team settings

