### PR TITLE
fix(website): alignments, colors, content

### DIFF
--- a/packages/homepage/src/pages/pricing/_elements.js
+++ b/packages/homepage/src/pages/pricing/_elements.js
@@ -64,9 +64,6 @@ export const BoxPlan = styled.a`
   text-align: center;
   color: #808080;
 
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
   transition: transform 0.3s ease-in-out;
 
   @media (min-width: 769px) {
@@ -97,7 +94,7 @@ export const BoxPlan = styled.a`
     margin-bottom: 0;
 
     @media (min-width: 769px) {
-      max-width: 220px;
+      max-width: 225px;
       font-size: 16px;
       line-height: 24px;
     }
@@ -199,6 +196,7 @@ export const BoxPlanPrice = styled(({ plan, price, caption, className }) => {
     font-weight: 500;
     line-height: 1;
     font-size: 48px;
+    height: 64px;
     margin-bottom: 8px;
 
     @media (min-width: 769px) {
@@ -209,6 +207,7 @@ export const BoxPlanPrice = styled(({ plan, price, caption, className }) => {
 
   .caption {
     font-size: 12px;
+    height: 32px;
     line-height: 16px;
     max-width: 200px;
 
@@ -222,17 +221,9 @@ export const BoxPlanPrice = styled(({ plan, price, caption, className }) => {
     return (
       customPrice &&
       css`
-        margin-top: -24px; // Visually align with the other cards.
-
-        .plan {
-          margin-bottom: 0;
-
-          @media (min-width: 769px) {
-            margin-bottom: 0;
-          }
-        }
-
         .price {
+          max-width: 220px;
+
           @media (min-width: 769px) {
             font-size: 48px;
             line-height: 68px;
@@ -241,6 +232,14 @@ export const BoxPlanPrice = styled(({ plan, price, caption, className }) => {
       `
     );
   }}
+`;
+
+export const BoxPlanList = styled.ul`
+  height: 210px;
+
+  @media (min-width: 769px) {
+    height: 258px;
+  }
 `;
 
 export const ComparePlansLink = styled(({ scrollTo, ...props }) => {

--- a/packages/homepage/src/pages/pricing/_intro.js
+++ b/packages/homepage/src/pages/pricing/_intro.js
@@ -6,6 +6,7 @@ import usePrefersReducedMotion from '../../utils/isReducedMOtion';
 import {
   BoxPlan,
   BoxPlanButton,
+  BoxPlanList,
   BoxPlanPrice,
   Caption,
   ComparePlansLink,
@@ -313,7 +314,7 @@ const TeamFree = () => {
 
       <BoxPlanPrice plan="Free" price="$0" caption="forever" />
 
-      <ul>
+      <BoxPlanList>
         <li>5 editors</li>
         <li>20 public sandboxes</li>
         <li>3 public repositories</li>
@@ -327,7 +328,7 @@ const TeamFree = () => {
         <li>4GB RAM</li>
         <li>2vCPUs</li>
         <li>4GB Disk</li>
-      </ul>
+      </BoxPlanList>
 
       <BoxPlanButton href="/s">Start coding now</BoxPlanButton>
     </BoxPlan>
@@ -353,7 +354,7 @@ const TeamPro = ({ plan, ...props }) => {
         per month.`}
       />
 
-      <ul>
+      <BoxPlanList>
         <li>20 editors</li>
         <li>Unlimited sandboxes</li>
         <li>Unlimited repositories</li>
@@ -367,7 +368,7 @@ const TeamPro = ({ plan, ...props }) => {
         <li>6GB RAM</li>
         <li>4vCPUs</li>
         <li>12GB Disk</li>
-      </ul>
+      </BoxPlanList>
 
       <BoxPlanButton>Upgrade to Team Pro</BoxPlanButton>
     </BoxPlan>
@@ -392,7 +393,7 @@ const OrgCustom = props => {
         customPrice
       />
 
-      <ul>
+      <BoxPlanList>
         <li>All Team Pro features, plus:</li>
         <li>20+ editors (no limit)</li>
         <li>Bulk pricing for seats</li>
@@ -400,11 +401,7 @@ const OrgCustom = props => {
         <li>Custom support</li>
         <li>Shared Slack channel</li>
         <li>Customer success manager </li>
-
-        {/* Visually aligned */}
-        <br />
-        <br />
-      </ul>
+      </BoxPlanList>
 
       <BoxPlanButton>Contact us</BoxPlanButton>
     </BoxPlan>
@@ -418,7 +415,7 @@ const PersonalFree = () => {
 
       <BoxPlanPrice plan="Free" price="$0" caption="forever" />
 
-      <ul>
+      <BoxPlanList>
         <li>Free for individuals</li>
         <li>All platform features</li>
         <li>Unlimited public sandboxes</li>
@@ -432,7 +429,7 @@ const PersonalFree = () => {
         <li>4GB RAM</li>
         <li>2vCPUs</li>
         <li>4GB Disk</li>
-      </ul>
+      </BoxPlanList>
 
       <BoxPlanButton href="/s">Start coding now</BoxPlanButton>
     </BoxPlan>
@@ -454,7 +451,7 @@ const PersonalPro = ({ plan, ...props }) => {
       per month.`}
       />
 
-      <ul>
+      <BoxPlanList>
         <li>All Free features, plus:</li>
         <li>Unlimited private sandboxes</li>
         <li>Unlimited private repositories</li>
@@ -463,11 +460,13 @@ const PersonalPro = ({ plan, ...props }) => {
         {/* Visually aligned */}
         <br />
         <br />
+        <br />
+        <br />
 
         <li>6GB RAM</li>
         <li>4vCPUs</li>
         <li>12GB Disk</li>
-      </ul>
+      </BoxPlanList>
 
       <BoxPlanButton>Upgrade to Personal Pro</BoxPlanButton>
     </BoxPlan>

--- a/packages/homepage/src/pages/pricing/_intro.js
+++ b/packages/homepage/src/pages/pricing/_intro.js
@@ -15,7 +15,30 @@ import { formatCurrency } from './_utils';
 /**
  * Main component
  */
-export const Intro = ({ plans }) => {
+export const Intro = ({
+  plans = {
+    team_pro: {
+      month: {
+        currency: '$',
+        unit_amount: 5,
+      },
+      year: {
+        currency: '$',
+        unit_amount: 5,
+      },
+    },
+    pro: {
+      month: {
+        currency: '$',
+        unit_amount: 5,
+      },
+      year: {
+        currency: '$',
+        unit_amount: 5,
+      },
+    },
+  },
+}) => {
   // plans: {
   //   pro | team_pro {
   //     month | year {
@@ -24,6 +47,7 @@ export const Intro = ({ plans }) => {
   //     }
   //   }
   // }
+
   const shouldReduceMotion = usePrefersReducedMotion();
 
   const [teamHover, setTeamHover] = useState(false);
@@ -145,18 +169,16 @@ const Title = styled.h1`
 
   letter-spacing: -0.025em;
   font-size: 40px;
-  line-height: 48px;
+  line-height: 1.1;
 
   @media (min-width: 769px) {
     font-size: 48px;
-    line-height: 56px;
   }
 
   @media (min-width: 1025px) {
     letter-spacing: -0.03em;
     font-weight: 500;
     font-size: 64px;
-    line-height: 1.45;
   }
 `;
 
@@ -192,7 +214,7 @@ const Gradient = styled.div`
       css`
         background: radial-gradient(
           61.76% 61.76% at 50% 38.24%,
-          #ac9cff 0%,
+          #edffa5 0%,
           #000000 60.35%
         );
       `
@@ -204,23 +226,9 @@ const Gradient = styled.div`
       personalSection &&
       css`
         background: radial-gradient(
-          50% 50% at 50% 50%,
-          hsl(72deg 100% 82%) 0%,
-          hsl(72deg 69% 76%) 3%,
-          hsl(72deg 50% 71%) 6%,
-          hsl(72deg 38% 65%) 9%,
-          hsl(72deg 30% 59%) 12%,
-          hsl(72deg 23% 54%) 15%,
-          hsl(72deg 20% 48%) 19%,
-          hsl(72deg 19% 43%) 22%,
-          hsl(71deg 19% 38%) 26%,
-          hsl(71deg 18% 32%) 30%,
-          hsl(71deg 17% 27%) 34%,
-          hsl(71deg 16% 23%) 39%,
-          hsl(71deg 15% 18%) 44%,
-          hsl(70deg 13% 13%) 51%,
-          hsl(69deg 9% 9%) 59%,
-          hsl(0deg 0% 4%) 77%
+          61.76% 61.76% at 50% 38.24%,
+          #ac9cff 0%,
+          #000000 60.35%
         );
       `
     );
@@ -369,7 +377,7 @@ const TeamPro = ({ plan, ...props }) => {
 const OrgCustom = props => {
   return (
     <BoxPlan
-      href="mailto:support@codesandbox.io?subject=Organization plan"
+      href="https://codesandbox.typeform.com/organization"
       target="_blank"
       rel="noopener noreferrer"
       orgCustom
@@ -386,7 +394,7 @@ const OrgCustom = props => {
 
       <ul>
         <li>All Team Pro features, plus:</li>
-        <li>Unlimited editors</li>
+        <li>20+ editors (no limit)</li>
         <li>Bulk pricing for seats</li>
         <li>Custom VM Specs</li>
         <li>Custom support</li>

--- a/packages/homepage/src/pages/pricing/_plans.js
+++ b/packages/homepage/src/pages/pricing/_plans.js
@@ -14,7 +14,7 @@ const team_plans = [
         caption: 'Maximum number of editors in a team.',
         team_free: '5',
         team_pro: '20',
-        org_custom: 'Unlimited',
+        org_custom: '20+ (no limit)',
       },
       {
         title: 'Sandboxes',
@@ -296,7 +296,7 @@ export const Plans = () => {
                       <th className="column__desktop plan__org-custom">
                         <p>Organization</p>
                         <a
-                          href="mailto:support@codesandbox.io?subject=Organization plan"
+                          href="https://codesandbox.typeform.com/organization"
                           target="_blank"
                           rel="noopener noreferrer"
                         >

--- a/packages/homepage/src/pages/pricing/index.js
+++ b/packages/homepage/src/pages/pricing/index.js
@@ -130,7 +130,7 @@ const Pricing = () => {
               </FAQLabel>
               <FAQLink
                 as="a"
-                href="mailto:support@codesandbox.io?subject=Education and Open Source plan&body=Hi,%0D%0A%0D%0AI'm using CodeSandbox for [describe usage] but I'm running into some limits. [Describe limits]. My username is [username]. Can you update my plan?%0D%0A%0D%0AThanks!"
+                href="mailto:support@codesandbox.io?subject=Open source and education plans"
                 target="_blank"
               >
                 Request access


### PR DESCRIPTION
- title line height set to 1.1
- spotlight colors flipped
- plan card alignments (this is a bit annoying to get right because of the implementation)
- some content changes request by @filipelima18 

Closes MKT-67

<img width="1053" alt="Screenshot 2022-10-21 at 16 23 06" src="https://user-images.githubusercontent.com/9945366/197206178-3f5f0f00-f551-4ab9-8f73-ae7d32d75d73.png">
<img width="1209" alt="Screenshot 2022-10-21 at 16 22 56" src="https://user-images.githubusercontent.com/9945366/197206151-ce1e2b73-25bb-4ae0-9d61-f5319e7fba8f.png">
