### PR TITLE
feat(trial): Invite team members

### DIFF
--- a/packages/app/src/app/components/dashboard/Textarea.tsx
+++ b/packages/app/src/app/components/dashboard/Textarea.tsx
@@ -1,0 +1,36 @@
+import React, { TextareaHTMLAttributes } from 'react';
+import styled from 'styled-components';
+import { Stack } from '@codesandbox/components';
+import { Label } from './Label';
+
+const StyledTextarea = styled.textarea`
+  padding: 12px 16px;
+  background-color: #2a2a2a;
+  font-family: 'Inter', sans-serif;
+  font-size: 16px;
+  color: #e5e5e5;
+  line-height: 24px;
+  border: none;
+  border-radius: 2px;
+
+  &:hover {
+    box-shadow: 0 0 0 2px #e5e5e51a;
+  }
+
+  &:focus {
+    outline: 1px solid #ac9cff;
+  }
+`;
+
+interface TextareaProps extends TextareaHTMLAttributes<HTMLTextAreaElement> {
+  id: string;
+  label: string;
+  name: string;
+}
+
+export const Textarea = ({ id, label, name, ...restProps }: TextareaProps) => (
+  <Stack gap={2} direction="vertical">
+    <Label htmlFor={id}>{label}</Label>
+    <StyledTextarea id={id} name={name} {...restProps} />
+  </Stack>
+);

--- a/packages/app/src/app/overmind/effects/gql/dashboard/mutations.ts
+++ b/packages/app/src/app/overmind/effects/gql/dashboard/mutations.ts
@@ -272,7 +272,7 @@ export const inviteToTeam: Query<
   ${currentTeamInfoFragment}
 `;
 
-export const inviteToTeamVieEmail: Query<
+export const inviteToTeamViaEmail: Query<
   _InviteToTeamViaEmailMutation,
   _InviteToTeamViaEmailMutationVariables
 > = gql`

--- a/packages/app/src/app/overmind/namespaces/dashboard/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/dashboard/actions.ts
@@ -259,7 +259,7 @@ export const inviteToTeam = async (
     });
     let data: any | null = null;
     if (isEmail) {
-      const emailInvited = await effects.gql.mutations.inviteToTeamVieEmail({
+      const emailInvited = await effects.gql.mutations.inviteToTeamViaEmail({
         teamId: state.activeTeam,
         email: value,
         authorization,

--- a/packages/app/src/app/pages/common/Modals/NewTeamModal/TeamInfo.tsx
+++ b/packages/app/src/app/pages/common/Modals/NewTeamModal/TeamInfo.tsx
@@ -70,7 +70,7 @@ export const TeamInfo: React.FC<{ onComplete: () => void }> = ({
       </Element>
       <Stack align="center" direction="vertical" gap={2}>
         <Text
-          as="h1"
+          as="h2"
           size={32}
           weight="500"
           align="center"

--- a/packages/app/src/app/pages/common/Modals/NewTeamModal/TeamMembers.tsx
+++ b/packages/app/src/app/pages/common/Modals/NewTeamModal/TeamMembers.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
-import { Button, Stack, Textarea, Text } from '@codesandbox/components';
+import { Button, Stack, Text } from '@codesandbox/components';
 import { useAppState } from 'app/overmind';
+import { StyledButton } from 'app/components/dashboard/Button';
+import { Textarea } from 'app/components/dashboard/Textarea';
 
 export const TeamMembers: React.FC<{ onComplete: () => void }> = ({
   onComplete,
@@ -8,18 +10,52 @@ export const TeamMembers: React.FC<{ onComplete: () => void }> = ({
   const { activeTeamInfo } = useAppState();
 
   return (
-    <Stack direction="vertical">
-      <Text as="h2">{activeTeamInfo.name}</Text>
-      <Stack as="form" direction="vertical" onSubmit={e => e.preventDefault()}>
-        <Text as="label" htmlFor="">
-          Invite team members (Insert emails separated by a comma)
-        </Text>
-        <Textarea autoFocus required />
-        <Button type="submit" disabled>
+    <Stack
+      align="center"
+      direction="vertical"
+      gap={6}
+      css={{
+        paddingTop: '60px',
+        paddingBottom: '48px',
+        maxWidth: '370px',
+        width: '100%',
+      }}
+    >
+      <Text
+        as="h2"
+        size={32}
+        weight="500"
+        align="center"
+        css={{
+          margin: 0,
+          color: '#ffffff',
+          fontFamily: 'Everett, sans-serif',
+          lineHeight: '42px',
+          letterSpacing: '-0.01em',
+        }}
+      >
+        {activeTeamInfo.name}
+      </Text>
+      <Stack
+        as="form"
+        onSubmit={e => e.preventDefault()}
+        direction="vertical"
+        gap={6}
+        css={{ width: '100%' }}
+      >
+        <Textarea
+          label="Invite team members (Insert emails separated by a comma)"
+          name="members"
+          id="member"
+          autoFocus
+          required
+          rows={3}
+        />
+        <StyledButton type="submit" disabled>
           Invite members
-        </Button>
+        </StyledButton>
       </Stack>
-      <Button onClick={onComplete} variant="secondary">
+      <Button onClick={onComplete} variant="link">
         Skip
       </Button>
     </Stack>

--- a/packages/app/src/app/pages/common/Modals/NewTeamModal/TeamMembers.tsx
+++ b/packages/app/src/app/pages/common/Modals/NewTeamModal/TeamMembers.tsx
@@ -64,6 +64,8 @@ export const TeamMembers: React.FC<{ onComplete: () => void }> = ({
           email: addressesString,
           authorization: TeamMemberAuthorization.Write,
         });
+
+        onComplete();
       } catch (error) {
         // ❗️ TODO: Validate if this works!
         // Copied logic from inviteToTeam function in dashboard/actions.ts

--- a/packages/app/src/app/pages/common/Modals/NewTeamModal/TeamMembers.tsx
+++ b/packages/app/src/app/pages/common/Modals/NewTeamModal/TeamMembers.tsx
@@ -1,13 +1,52 @@
-import React from 'react';
+import React, { FormEvent, useState } from 'react';
 import { Button, Stack, Text } from '@codesandbox/components';
 import { useAppState } from 'app/overmind';
 import { StyledButton } from 'app/components/dashboard/Button';
 import { Textarea } from 'app/components/dashboard/Textarea';
 
+// function validateEmail(email: string) {
+//   // Test for "anything@anything.anything" and check for
+//   // multiple @ signs.
+//   return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+// }
+
 export const TeamMembers: React.FC<{ onComplete: () => void }> = ({
   onComplete,
 }) => {
   const { activeTeamInfo } = useAppState();
+  const [addressesString, setAddressesString] = useState<string>();
+  const [invalidEmails /* , setInvalidEmails */] = useState<string[]>();
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+
+    /**
+     * Submitting emails is a work in progress. We're not sure if we
+     * can invite as many users at the same time.
+     */
+
+    // Remove spaces and split email addresses
+    // const emails = addressesString.replace(' ', '').split(',');
+
+    // // Validate emails
+    // const invalid = emails.filter(email => {
+    //   const isValidEmail = validateEmail(email);
+
+    //   // Return when the email is not valid
+    //   return !isValidEmail;
+    // });
+
+    // if (invalid.length === 0) {
+    //   // Send invites
+    //   emails.forEach(email => {
+    //     // send invite
+    //     // TODO: WIP
+    //   });
+    // } else {
+    //   // Set error with invalid
+    //   setInvalidEmails(invalid);
+    // }
+  };
 
   return (
     <Stack
@@ -38,7 +77,7 @@ export const TeamMembers: React.FC<{ onComplete: () => void }> = ({
       </Text>
       <Stack
         as="form"
-        onSubmit={e => e.preventDefault()}
+        onSubmit={handleSubmit}
         direction="vertical"
         gap={6}
         css={{ width: '100%' }}
@@ -50,7 +89,21 @@ export const TeamMembers: React.FC<{ onComplete: () => void }> = ({
           autoFocus
           required
           rows={3}
+          value={addressesString}
+          onChange={e => {
+            setAddressesString(e.target.value);
+          }}
         />
+        {invalidEmails?.length > 0 ? (
+          <Text size={2} variant="danger">
+            There seems to be an error in the following addresses, please
+            review:{' '}
+            {invalidEmails.map((invalidEmail, index, arr) => {
+              const isLastEmail = arr.length - 1 === index;
+              return `${invalidEmail}${isLastEmail ? '.' : ', '}`;
+            })}
+          </Text>
+        ) : null}
         <StyledButton type="submit" disabled>
           Invite members
         </StyledButton>


### PR DESCRIPTION
### Todo

- [x] ~Generate new GraphQL types~

No need to generate new GraphQL types, still using the `email` property and it still accepts a string.

### How to test

1. Open the dashboard
2. Create a new team
3. Input emails in the textarea
4. Press submit
5. Check if the next step is active and emails have been sent

### Video

https://user-images.githubusercontent.com/7533849/197798843-2894ca83-feee-437d-92de-a68b11f14d5b.mov



