### PR TITLE
feat(trial): Show create team modal after new signup

### DIFF
--- a/packages/app/src/app/components/dashboard/InputText.tsx
+++ b/packages/app/src/app/components/dashboard/InputText.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { Stack } from '@codesandbox/components';
 import { Label } from './Label';
 
-const StyledInput = styled.input`
+const StyledInput = styled.input<{ isInvalid?: boolean }>`
   padding: 12px 16px;
   background-color: #2a2a2a;
   font-family: 'Inter', sans-serif;
@@ -12,6 +12,8 @@ const StyledInput = styled.input`
   line-height: 24px;
   border: none;
   border-radius: 2px;
+
+  ${props => (props.isInvalid ? 'outline: 1px solid #EB5E5E;' : '')}
 
   &:hover {
     box-shadow: 0 0 0 2px #e5e5e51a;
@@ -26,16 +28,24 @@ interface InputTextProps extends InputHTMLAttributes<HTMLInputElement> {
   id: string;
   label: string;
   name: string;
+  isInvalid?: boolean;
 }
 
 export const InputText = ({
   id,
   label,
   name,
+  isInvalid,
   ...restProps
 }: InputTextProps) => (
   <Stack gap={2} direction="vertical">
     <Label htmlFor={id}>{label}</Label>
-    <StyledInput id={id} name={name} type="text" {...restProps} />
+    <StyledInput
+      id={id}
+      name={name}
+      type="text"
+      isInvalid={isInvalid}
+      {...restProps}
+    />
   </Stack>
 );

--- a/packages/app/src/app/pages/Dashboard/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/index.tsx
@@ -20,6 +20,7 @@ import { Sidebar } from './Sidebar';
 import { SIDEBAR_WIDTH } from './Sidebar/constants';
 import { Content } from './Content';
 import { WhatsNew } from './Components/WhatsNew/WhatsNew';
+import { NUOCT22 } from '../SignIn/Onboarding';
 
 const GlobalStyles = createGlobalStyle({
   body: { overflow: 'hidden' },
@@ -42,12 +43,25 @@ export const Dashboard: FunctionComponent = () => {
   const theme = useTheme() as any;
 
   useEffect(() => {
-    const isModalDismissed = browser.storage.get(wnoct22);
+    const isNewUser = browser.storage.get(NUOCT22);
 
-    if (!isModalDismissed && !modals.whatsNew.isCurrent) {
-      actions.modals.whatsNew.open();
+    if (isNewUser) {
+      // Open the create team modal for newly signed up users
+      actions.openCreateTeamModal();
+
+      // Remove the new user flag
+      browser.storage.remove(NUOCT22);
+      // Dismiss the whats new flag
+      browser.storage.set(wnoct22, true);
+    } else {
+      const isWhatsNewModalDismissed = browser.storage.get(wnoct22);
+
+      if (!isWhatsNewModalDismissed && !modals.whatsNew.isCurrent) {
+        // For existing users we show the whats new modal
+        actions.modals.whatsNew.open();
+      }
     }
-  }, [browser.storage, modals.whatsNew.isCurrent, actions.modals.whatsNew]);
+  }, [browser.storage, modals.whatsNew.isCurrent, actions]);
 
   const handleWhatsNewModalClose = () => {
     browser.storage.set(wnoct22, true);

--- a/packages/app/src/app/pages/Dashboard/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/index.tsx
@@ -27,7 +27,7 @@ const GlobalStyles = createGlobalStyle({
 });
 
 const COLUMN_MEDIA_THRESHOLD = 1600;
-const wnoct22 = 'wnoct22'; // = whats new oct 22
+const WNOCT22 = 'WNOCT22'; // = whats new oct 22
 
 export const Dashboard: FunctionComponent = () => {
   const { hasLogIn, modals } = useAppState();
@@ -52,9 +52,9 @@ export const Dashboard: FunctionComponent = () => {
       // Remove the new user flag
       browser.storage.remove(NUOCT22);
       // Dismiss the whats new flag
-      browser.storage.set(wnoct22, true);
+      browser.storage.set(WNOCT22, true);
     } else {
-      const isWhatsNewModalDismissed = browser.storage.get(wnoct22);
+      const isWhatsNewModalDismissed = browser.storage.get(WNOCT22);
 
       if (!isWhatsNewModalDismissed && !modals.whatsNew.isCurrent) {
         // For existing users we show the whats new modal
@@ -64,7 +64,7 @@ export const Dashboard: FunctionComponent = () => {
   }, [browser.storage, modals.whatsNew.isCurrent, actions]);
 
   const handleWhatsNewModalClose = () => {
-    browser.storage.set(wnoct22, true);
+    browser.storage.set(WNOCT22, true);
     actions.modals.whatsNew.close();
   };
 

--- a/packages/app/src/app/pages/Dashboard/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/index.tsx
@@ -27,7 +27,7 @@ const GlobalStyles = createGlobalStyle({
 });
 
 const COLUMN_MEDIA_THRESHOLD = 1600;
-const WNOCT22 = 'WNOCT22'; // = whats new oct 22
+const wnoct22 = 'wnoct22'; // = whats new oct 22
 
 export const Dashboard: FunctionComponent = () => {
   const { hasLogIn, modals } = useAppState();
@@ -52,9 +52,9 @@ export const Dashboard: FunctionComponent = () => {
       // Remove the new user flag
       browser.storage.remove(NUOCT22);
       // Dismiss the whats new flag
-      browser.storage.set(WNOCT22, true);
+      browser.storage.set(wnoct22, true);
     } else {
-      const isWhatsNewModalDismissed = browser.storage.get(WNOCT22);
+      const isWhatsNewModalDismissed = browser.storage.get(wnoct22);
 
       if (!isWhatsNewModalDismissed && !modals.whatsNew.isCurrent) {
         // For existing users we show the whats new modal
@@ -64,7 +64,7 @@ export const Dashboard: FunctionComponent = () => {
   }, [browser.storage, modals.whatsNew.isCurrent, actions]);
 
   const handleWhatsNewModalClose = () => {
-    browser.storage.set(WNOCT22, true);
+    browser.storage.set(wnoct22, true);
     actions.modals.whatsNew.close();
   };
 

--- a/packages/app/src/app/pages/SignIn/Onboarding.tsx
+++ b/packages/app/src/app/pages/SignIn/Onboarding.tsx
@@ -121,8 +121,8 @@ export const Onboarding = () => {
             }}
             value={newUsername}
             onChange={e => setNewUsername(e.target.value)}
-            required
             isInvalid={pendingUser.valid === false}
+            required
           />
 
           {!pendingUser.valid ? (

--- a/packages/app/src/app/pages/SignIn/Onboarding.tsx
+++ b/packages/app/src/app/pages/SignIn/Onboarding.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Element, Text, Stack } from '@codesandbox/components';
-import { useAppState, useActions } from 'app/overmind';
+import { useAppState, useActions, useEffects } from 'app/overmind';
 import { InputText } from 'app/components/dashboard/InputText';
 import { InputSelect } from 'app/components/dashboard/InputSelect';
 import { StyledButton } from 'app/components/dashboard/Button';
@@ -25,6 +25,8 @@ const USAGE_OPTIONS = [
   { value: 'other', label: 'Other' },
 ];
 
+export const NUOCT22 = 'NUOCT22'; // = new user oct 22
+
 export const Onboarding = () => {
   /**
    * 🚧 Utility to debug Trial Onboarding Questions
@@ -48,11 +50,16 @@ export const Onboarding = () => {
     };
   }
 
+  const { browser } = useEffects();
   const { validateUsername, finalizeSignUp } = useActions();
   const [newUsername, setNewUsername] = useState(pendingUser?.username || '');
   const [newDisplayName, setNewDisplayName] = useState(pendingUser?.name || '');
   const [loadingUsername, setLoadingUserName] = useState(false);
   const firstName = pendingUser?.name.split(' ')[0];
+
+  // Set flag to make sure we show the create team modal and not the
+  // what's new modal after signup.
+  browser.storage.set(NUOCT22, true);
 
   return (
     <Stack

--- a/packages/app/src/app/pages/SignIn/Onboarding.tsx
+++ b/packages/app/src/app/pages/SignIn/Onboarding.tsx
@@ -122,11 +122,13 @@ export const Onboarding = () => {
             value={newUsername}
             onChange={e => setNewUsername(e.target.value)}
             isInvalid={pendingUser.valid === false}
+            aria-invalid={!pendingUser.valid ? true : undefined}
+            aria-describedby={!pendingUser.valid ? 'user-error' : undefined}
             required
           />
 
           {!pendingUser.valid ? (
-            <Text size={3} variant="danger">
+            <Text size={3} variant="danger" id="user-error">
               Sorry, that username is already taken.
             </Text>
           ) : null}

--- a/packages/app/src/app/pages/SignIn/Onboarding.tsx
+++ b/packages/app/src/app/pages/SignIn/Onboarding.tsx
@@ -114,7 +114,15 @@ export const Onboarding = () => {
             }}
             value={newUsername}
             onChange={e => setNewUsername(e.target.value)}
+            required
+            isInvalid={pendingUser.valid === false}
           />
+
+          {!pendingUser.valid ? (
+            <Text size={3} variant="danger">
+              Sorry, that username is already taken.
+            </Text>
+          ) : null}
 
           <InputText
             id="displayname"
@@ -122,6 +130,7 @@ export const Onboarding = () => {
             label="Display name"
             value={newDisplayName}
             onChange={e => setNewDisplayName(e.target.value)}
+            required
           />
 
           <InputSelect
@@ -130,6 +139,7 @@ export const Onboarding = () => {
             label="What best describes your role?"
             options={ROLE_OPTIONS}
             placeholder="Please select an option"
+            required
           />
 
           <InputSelect
@@ -138,14 +148,8 @@ export const Onboarding = () => {
             label="How do you plan to use CodeSandbox?"
             options={USAGE_OPTIONS}
             placeholder="Please select an option"
+            required
           />
-
-          {/* TODO: Move this to the username InputText */}
-          {!pendingUser.valid ? (
-            <Text size={3} variant="danger">
-              Sorry, that username is already taken.
-            </Text>
-          ) : null}
         </Stack>
         <StyledButton
           type="submit"

--- a/packages/app/src/app/pages/SignIn/SignIn.tsx
+++ b/packages/app/src/app/pages/SignIn/SignIn.tsx
@@ -22,8 +22,20 @@ export const SignIn = ({ redirectTo, onSignIn }: SignInProps) => {
     }
   }, [getPendingUser, pendingUserId]);
 
-  if (duplicateAccountStatus) {
-    return <DuplicateAccount provider={duplicateAccountStatus.provider} />;
+  /**
+   * 🚧 Utility to debug Duplicate Account
+   */
+  const DA_DEBUG = window.localStorage.getItem('DA_DEBUG') === 'ENABLED';
+
+  // 🚧 Remove || DA_DEBUG
+  if (duplicateAccountStatus || DA_DEBUG) {
+    // 🚧 Remove
+    return DA_DEBUG ? (
+      <DuplicateAccount provider={'google'} />
+    ) : (
+      // 🚧 Keep this (return)
+      <DuplicateAccount provider={duplicateAccountStatus.provider} />
+    );
   }
 
   /**


### PR DESCRIPTION
Shows the create team modal after a new signup and dismisses the what's new modal. Only existing users get to see the what's new modal and new users get prompted to create a team.

### Testing

This is quite hard to test on dev environments so we'll have to properly test this on stream. We can bypass certain steps to test if the modal shows up though:

1. Open the dashboard
2. Open the browser devtools console
3. Past and execute the following:
```
localStorage.setItem('NUOCT22', true);
```
4. Refresh the page
5. It should show the create team modal
6. Refresh the page again
7. The create team modal should not show up 