### PR TITLE
feat(dashboard): recent page empty state

### DIFF
--- a/packages/app/src/app/pages/Dashboard/Components/EmptyScreen/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/EmptyScreen/index.tsx
@@ -6,6 +6,7 @@ import { useActions } from 'app/overmind';
 import { NewSandbox } from '../Sandbox/NewSandbox';
 import { PageTypes } from '../../types';
 import { GRID_MAX_WIDTH, GUTTER } from '../VariableGrid';
+import { TemplatesRow } from '../TemplatesRow';
 
 interface EmptyScreenProps {
   collectionId?: string;
@@ -336,6 +337,14 @@ export const EmptyScreen: React.FC<EmptyScreenProps> = ({
           </Stack>
         </Stack>
       </Stack>
+    );
+  }
+
+  if (page === 'recent') {
+    return (
+      <Element marginTop={32}>
+        <TemplatesRow />
+      </Element>
     );
   }
 

--- a/packages/app/src/app/pages/Dashboard/Components/Header/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Header/index.tsx
@@ -1,7 +1,14 @@
 import React, { useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import { useAppState, useActions } from 'app/overmind';
-import { Stack, Text, Button, Icon, Badge } from '@codesandbox/components';
+import {
+  Badge,
+  Stack,
+  Text,
+  Button,
+  Icon,
+  SkeletonText,
+} from '@codesandbox/components';
 import css from '@styled-system/css';
 import { v2DraftBranchUrl } from '@codesandbox/common/lib/utils/url-generator';
 import { Breadcrumbs, BreadcrumbProps } from '../Breadcrumbs';
@@ -31,6 +38,7 @@ type Props = {
   activeTeam: string;
   CustomFilters?: React.ReactElement;
   selectedRepo?: { owner: string; name: string };
+  loading?: boolean;
 };
 
 export const Header = ({
@@ -48,6 +56,7 @@ export const Header = ({
   CustomFilters,
   actions = [],
   selectedRepo,
+  loading = false,
 }: Props) => {
   const location = useLocation();
   const { modals, dashboard: dashboardActions } = useActions();
@@ -83,17 +92,23 @@ export const Header = ({
       })}
     >
       <Stack align="center" marginBottom={1} marginTop={-2} gap={2}>
-        {title ? (
-          <Text size={6}>{title}</Text>
+        {loading ? (
+          <SkeletonText css={css({ height: 6 })} />
         ) : (
-          <Breadcrumbs
-            nestedPageType={nestedPageType}
-            activeTeam={activeTeam}
-            path={path}
-            albumId={albumId}
-          />
+          <>
+            {title ? (
+              <Text size={6}>{title}</Text>
+            ) : (
+              <Breadcrumbs
+                nestedPageType={nestedPageType}
+                activeTeam={activeTeam}
+                path={path}
+                albumId={albumId}
+              />
+            )}
+            {showBetaBadge && <Badge icon="cloud">Beta</Badge>}
+          </>
         )}
-        {showBetaBadge && <Badge icon="cloud">Beta</Badge>}
       </Stack>
       <Stack gap={4} align="center">
         {location.pathname.includes('/sandboxes') && (

--- a/packages/app/src/app/pages/Dashboard/Components/TemplatesRow/TemplatesRow.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/TemplatesRow/TemplatesRow.tsx
@@ -56,7 +56,7 @@ export const TemplatesRow: React.FC = () => {
         weight="400"
         size={4}
       >
-        Pick up where you left off
+        Start from a template or import from Github
       </Text>
       <TemplatesGrid>
         {officialTemplates.state === 'loading' &&

--- a/packages/app/src/app/pages/Dashboard/Components/TemplatesRow/TemplatesRow.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/TemplatesRow/TemplatesRow.tsx
@@ -1,9 +1,16 @@
 import React from 'react';
 import css from '@styled-system/css';
-import { Stack, Text } from '@codesandbox/components';
+import { Icon, SkeletonText, Stack, Text } from '@codesandbox/components';
+import { useOfficialTemplates } from 'app/components/CreateSandbox/useOfficialTemplates';
+import { TemplateCard } from 'app/components/CreateSandbox/TemplateCard';
+import { TemplateButton } from 'app/components/CreateSandbox/elements';
+import { GitHubIcon } from 'app/components/CreateSandbox/Icons';
 import { GUTTER } from '../VariableGrid';
+import { TemplatesGrid } from './elements';
 
 export const TemplatesRow: React.FC = () => {
+  const officialTemplates = useOfficialTemplates();
+
   return (
     <Stack
       as="section"
@@ -24,6 +31,60 @@ export const TemplatesRow: React.FC = () => {
       >
         Pick up where you left off
       </Text>
+      <TemplatesGrid>
+        {officialTemplates.state === 'loading' &&
+          new Array(5).fill(undefined).map((_, i) => (
+            <SkeletonText
+              // eslint-disable-next-line react/no-array-index-key
+              key={`templates-skeleton-${i}`}
+              css={css({
+                width: '100%',
+                height: '124px',
+              })}
+            />
+          ))}
+
+        {officialTemplates.state === 'ready' && (
+          <>
+            {officialTemplates.templates
+              .slice(0, 3) // TODO: define which templates to show
+              .map(template => (
+                <TemplateCard
+                  key={template.id}
+                  template={template}
+                  onOpenTemplate={() => alert('open')}
+                  onSelectTemplate={() => alert('select')}
+                />
+              ))}
+            <TemplateButton>
+              <Stack
+                css={{
+                  height: '124px',
+                }}
+                justify="center"
+                direction="vertical"
+                gap={4}
+              >
+                <GitHubIcon />
+                <Text
+                  css={{
+                    fontSize: '14px',
+                    fontWeight: 500,
+                    textOverflow: 'ellipsis',
+                    overflow: 'hidden',
+                    whiteSpace: 'nowrap',
+                  }}
+                >
+                  Open from GitHub
+                </Text>
+              </Stack>
+            </TemplateButton>
+            <TemplateButton>
+              <Icon name="plus" size={32} />
+            </TemplateButton>
+          </>
+        )}
+      </TemplatesGrid>
     </Stack>
   );
 };

--- a/packages/app/src/app/pages/Dashboard/Components/TemplatesRow/TemplatesRow.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/TemplatesRow/TemplatesRow.tsx
@@ -88,19 +88,32 @@ export const TemplatesRow: React.FC = () => {
                 actions.openCreateSandboxModal({ initialTab: 'import' })
               }
             >
-              <Stack justify="center" direction="vertical" gap={4}>
-                <GitHubIcon />
-                <Text
+              <Stack
+                css={{
+                  height: '100%',
+                }}
+                direction="vertical"
+                gap={4}
+              >
+                <GitHubIcon size={32} />
+                <Stack
+                  align="center"
                   css={{
-                    fontSize: '14px',
-                    fontWeight: 500,
-                    textOverflow: 'ellipsis',
-                    overflow: 'hidden',
-                    whiteSpace: 'nowrap',
+                    flex: 1,
                   }}
                 >
-                  Open from GitHub
-                </Text>
+                  <Text
+                    css={{
+                      fontSize: '14px',
+                      fontWeight: 500,
+                      textOverflow: 'ellipsis',
+                      overflow: 'hidden',
+                      whiteSpace: 'nowrap',
+                    }}
+                  >
+                    Open from GitHub
+                  </Text>
+                </Stack>
               </Stack>
             </TemplateButton>
             <TemplateButton

--- a/packages/app/src/app/pages/Dashboard/Components/TemplatesRow/TemplatesRow.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/TemplatesRow/TemplatesRow.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import css from '@styled-system/css';
+import { Stack, Text } from '@codesandbox/components';
+import { GUTTER } from '../VariableGrid';
+
+export const TemplatesRow: React.FC = () => {
+  return (
+    <Stack
+      as="section"
+      css={css({
+        width: `calc(100% - ${2 * GUTTER}px)`,
+        marginX: 'auto',
+      })}
+      direction="vertical"
+      gap={4}
+    >
+      <Text
+        as="h2"
+        css={css({
+          margin: 0,
+        })}
+        weight="400"
+        size={4}
+      >
+        Pick up where you left off
+      </Text>
+    </Stack>
+  );
+};

--- a/packages/app/src/app/pages/Dashboard/Components/TemplatesRow/elements.ts
+++ b/packages/app/src/app/pages/Dashboard/Components/TemplatesRow/elements.ts
@@ -5,6 +5,6 @@ export const TemplatesGrid = styled.div`
   overflow: hidden;
   display: grid;
   gap: 16px;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
   grid-auto-rows: 1fr;
 `;

--- a/packages/app/src/app/pages/Dashboard/Components/TemplatesRow/elements.ts
+++ b/packages/app/src/app/pages/Dashboard/Components/TemplatesRow/elements.ts
@@ -6,4 +6,5 @@ export const TemplatesGrid = styled.div`
   display: grid;
   gap: 16px;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  grid-auto-rows: 1fr;
 `;

--- a/packages/app/src/app/pages/Dashboard/Components/TemplatesRow/elements.ts
+++ b/packages/app/src/app/pages/Dashboard/Components/TemplatesRow/elements.ts
@@ -1,0 +1,9 @@
+import styled from 'styled-components';
+
+export const TemplatesGrid = styled.div`
+  position: relative;
+  overflow: hidden;
+  display: grid;
+  grid-template-columns: repeat(minmax(0, 1fr));
+  gap: 16px;
+`;

--- a/packages/app/src/app/pages/Dashboard/Components/TemplatesRow/elements.ts
+++ b/packages/app/src/app/pages/Dashboard/Components/TemplatesRow/elements.ts
@@ -4,6 +4,6 @@ export const TemplatesGrid = styled.div`
   position: relative;
   overflow: hidden;
   display: grid;
-  grid-template-columns: repeat(minmax(0, 1fr));
   gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
 `;

--- a/packages/app/src/app/pages/Dashboard/Components/TemplatesRow/elements.ts
+++ b/packages/app/src/app/pages/Dashboard/Components/TemplatesRow/elements.ts
@@ -5,6 +5,6 @@ export const TemplatesGrid = styled.div`
   overflow: hidden;
   display: grid;
   gap: 16px;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
   grid-auto-rows: 1fr;
 `;

--- a/packages/app/src/app/pages/Dashboard/Components/TemplatesRow/index.ts
+++ b/packages/app/src/app/pages/Dashboard/Components/TemplatesRow/index.ts
@@ -1,0 +1,1 @@
+export { TemplatesRow } from './TemplatesRow';

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Recent/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Recent/index.tsx
@@ -56,12 +56,19 @@ export const Recent = () => {
         .slice(0, 12);
 
   const pageType: PageTypes = 'recent';
+  const isEmpty = !dataIsLoading && items.length === 0;
+
   return (
     <SelectionProvider activeTeamId={activeTeam} page={pageType} items={items}>
       <Helmet>
         <title>Dashboard - CodeSandbox</title>
       </Helmet>
-      <Header title="Recent" activeTeam={activeTeam} showViewOptions />
+      <Header
+        title={isEmpty ? "Let's start building" : 'Recent'}
+        activeTeam={activeTeam}
+        loading={dataIsLoading}
+        showViewOptions
+      />
       <VariableGrid page={pageType} items={items} />
     </SelectionProvider>
   );


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?

<!-- Is it a Bug fix, feature, docs update, ... -->

Creates templates row to display on the recent page if the user/team doesn't have any recent sandboxes/branches.

## What is the current behavior?

<!-- You can also link to an open issue here -->

![codesandbox io_dashboard_recent](https://user-images.githubusercontent.com/24959348/197793609-ea8ef4f0-2fdd-4d89-849e-adc45c7822ba.png)


## What is the new behavior?

<!-- if this is a feature change -->

![localhost_3000_dashboard_recent](https://user-images.githubusercontent.com/24959348/197792913-356c7de6-08c7-430c-b8a8-44f981424b62.png)

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Create a team (or use a team without any recent sandboxes/branches)
2. Open the dashboard recent page
3. See empty state