### PR TITLE
feat(trial): save "role" and "usage" and add it to amplitude

### DIFF
--- a/packages/app/src/app/overmind/actions.ts
+++ b/packages/app/src/app/overmind/actions.ts
@@ -12,6 +12,7 @@ import * as internalActions from './internalActions';
 import { TEAM_ID_LOCAL_STORAGE } from './utils/team';
 import { Context } from '.';
 import { DEFAULT_DASHBOARD_SANDBOXES } from './namespaces/dashboard/state';
+import { FinalizeSignUpOptions } from './effects/api/types';
 
 export const internal = internalActions;
 
@@ -603,15 +604,10 @@ export const validateUsername = async (
   state.pendingUser.valid = validity.available;
 };
 
+type SignUpOptions = Omit<FinalizeSignUpOptions, 'id'>;
 export const finalizeSignUp = async (
   { effects, actions, state }: Context,
-  {
-    username,
-    name,
-  }: {
-    username: string;
-    name: string;
-  }
+  { username, name, role, usage }: SignUpOptions
 ) => {
   if (!state.pendingUser) return;
   try {
@@ -619,6 +615,8 @@ export const finalizeSignUp = async (
       id: state.pendingUser.id,
       username,
       name,
+      role,
+      usage,
     });
     window.postMessage(
       {

--- a/packages/app/src/app/overmind/effects/api/index.ts
+++ b/packages/app/src/app/overmind/effects/api/index.ts
@@ -39,6 +39,7 @@ import {
   IModuleAPIResponse,
   SandboxAPIResponse,
   AvatarAPIResponse,
+  FinalizeSignUpOptions,
 } from './types';
 
 let api: Api;
@@ -488,20 +489,8 @@ export default {
   validateUsername(username: string): Promise<{ available: boolean }> {
     return api.get('/users/available/' + username);
   },
-  finalizeSignUp({
-    username,
-    id,
-    name,
-  }: {
-    username: string;
-    id: string;
-    name: string;
-  }): Promise<void> {
-    return api.post('/users/finalize', {
-      username,
-      id,
-      name,
-    });
+  finalizeSignUp(options: FinalizeSignUpOptions): Promise<void> {
+    return api.post('/users/finalize', options);
   },
   updateShowcasedSandbox(username: string, sandboxId: string) {
     return api.patch(`/users/${username}`, {

--- a/packages/app/src/app/overmind/effects/api/types.ts
+++ b/packages/app/src/app/overmind/effects/api/types.ts
@@ -33,3 +33,11 @@ export type SandboxAPIResponse = Omit<Sandbox, 'environmentVariables'> & {
   modules: IModuleAPIResponse[];
   directories: IDirectoryAPIResponse[];
 };
+
+export type FinalizeSignUpOptions = {
+  id: string;
+  name: string;
+  username: string;
+  role: string;
+  usage: string;
+};

--- a/packages/app/src/app/overmind/internalActions.ts
+++ b/packages/app/src/app/overmind/internalActions.ts
@@ -570,6 +570,11 @@ export const identifyCurrentUser = async ({ state, effects }: Context) => {
   if (user) {
     effects.analytics.identify('pilot', user.experiments.inPilot);
     effects.browser.storage.set('pilot', user.experiments.inPilot);
+    Object.entries(user.metadata).forEach(([key, value]) => {
+      if (value) {
+        effects.analytics.identify(key, value);
+      }
+    });
 
     const profileData = await effects.api.getProfile(user.username);
     effects.analytics.identify('sandboxCount', profileData.sandboxCount);

--- a/packages/app/src/app/pages/SignIn/Onboarding.tsx
+++ b/packages/app/src/app/pages/SignIn/Onboarding.tsx
@@ -54,6 +54,8 @@ export const Onboarding = () => {
   const { validateUsername, finalizeSignUp } = useActions();
   const [newUsername, setNewUsername] = useState(pendingUser?.username || '');
   const [newDisplayName, setNewDisplayName] = useState(pendingUser?.name || '');
+  const [role, setRole] = useState('');
+  const [usage, setUsage] = useState('');
   const [loadingUsername, setLoadingUserName] = useState(false);
   const firstName = pendingUser?.name.split(' ')[0];
 
@@ -105,7 +107,13 @@ export const Onboarding = () => {
         gap={6}
         onSubmit={e => {
           e.preventDefault();
-          finalizeSignUp({ username: newUsername, name: newDisplayName });
+
+          finalizeSignUp({
+            username: newUsername,
+            name: newDisplayName,
+            role,
+            usage,
+          });
         }}
       >
         <Stack direction="vertical" gap={4}>
@@ -148,6 +156,8 @@ export const Onboarding = () => {
             label="What best describes your role?"
             options={ROLE_OPTIONS}
             placeholder="Please select an option"
+            value={role}
+            onChange={e => setRole(e.target.value)}
             required
           />
 
@@ -157,6 +167,8 @@ export const Onboarding = () => {
             label="How do you plan to use CodeSandbox?"
             options={USAGE_OPTIONS}
             placeholder="Please select an option"
+            value={usage}
+            onChange={e => setUsage(e.target.value)}
             required
           />
         </Stack>

--- a/packages/common/src/types/index.ts
+++ b/packages/common/src/types/index.ts
@@ -128,6 +128,9 @@ export type CurrentUser = {
   experiments: {
     [key: string]: boolean;
   };
+  metadata: {
+    [key: string]: string;
+  };
   curatorAt: string;
   badges: Badge[];
   betaAccess: boolean;


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?

<!-- Is it a Bug fix, feature, docs update, ... -->

- Saves the user's role and usage during the signup.
- Adds the metadata fields to amplitude when identifying the user.

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Step A
2. Step B
3. Step C

