### PR TITLE
fix(dashboard): nullcheck for selected team after accepting invite

### DIFF
--- a/packages/app/src/app/components/WorkspaceSelect/WorkspaceSelect.tsx
+++ b/packages/app/src/app/components/WorkspaceSelect/WorkspaceSelect.tsx
@@ -70,12 +70,12 @@ export const WorkspaceSelect: React.FC<WorkspaceSelectProps> = React.memo(
               <Stack align="center" gap={1} css={{ paddingRight: 4 }}>
                 <Text
                   size={16}
-                  maxWidth={selectedTeam.subscription ? 166 : 126}
+                  maxWidth={selectedTeam?.subscription ? 166 : 126}
                 >
-                  {isPersonalTeam ? 'Personal' : selectedTeam.name}
+                  {isPersonalTeam ? 'Personal' : selectedTeam?.name}
                 </Text>
 
-                {!selectedTeam.subscription && (
+                {!selectedTeam?.subscription && (
                   <Badge color="accent">Free</Badge>
                 )}
               </Stack>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Checking if we the selected team is in the state before reading properties. I have videos with current behaviour and proof but those show an invite link so I'm not uploading them here :)
 
## What is the current behavior?

After an invite, the dashboard breaks when joining a team since the selected team is still `undefined` on first render.

## What is the new behavior?

After an invite, the dashboard works and after the second render the selected team is defined.