### PR TITLE
fix: user name flicker before Personal is shown

### DIFF
--- a/packages/app/src/app/pages/Sandbox/Editor/Header/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Header/index.tsx
@@ -34,7 +34,7 @@ export const Header = () => {
     >
       <Stack align="center">
         <AppMenu />
-        {activeTeamInfo && (
+        {activeTeamInfo && personalWorkspaceId && (
           <WorkspaceName
             name={
               activeTeamInfo.id === personalWorkspaceId

--- a/yarn.lock
+++ b/yarn.lock
@@ -13692,7 +13692,7 @@ esprima@^4.0.0, esprima@^4.0.1, esprima@~4.0.0:
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
 
-esquery@^1.0.0, esquery@^1.0.1:
+esquery@1.0.1, esquery@^1.0.0, esquery@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.0.1.tgz#406c51658b1f5991a5f9b62b1dc25b00e3e5c708"
   integrity sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==


### PR DESCRIPTION
When refreshing on the editor, there was a split second in which the activeTeam was there, but the personalWorkspaceId was not set, hence the username appeared, then it switched to `Personal`