### PR TITLE
feat(trial): dont show create team modal after accepting invite

### DIFF
--- a/packages/app/src/app/pages/Dashboard/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/index.tsx
@@ -43,10 +43,10 @@ export const Dashboard: FunctionComponent = () => {
   const theme = useTheme() as any;
 
   useEffect(() => {
-    const isNewUser = browser.storage.get(NUOCT22);
+    const newUser = browser.storage.get(NUOCT22);
 
-    if (isNewUser || isNewUser === false) {
-      if (isNewUser) {
+    if (newUser) {
+      if (newUser === 'signup') {
         // Open the create team modal for newly signed up users
         // not coming from a team invite page.
         actions.openCreateTeamModal();

--- a/packages/app/src/app/pages/Dashboard/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/index.tsx
@@ -45,13 +45,14 @@ export const Dashboard: FunctionComponent = () => {
   useEffect(() => {
     const isNewUser = browser.storage.get(NUOCT22);
 
-    if (isNewUser) {
-      // Open the create team modal for newly signed up users
-      actions.openCreateTeamModal();
+    if (isNewUser || isNewUser === false) {
+      if (isNewUser) {
+        // Open the create team modal for newly signed up users
+        // not coming from a team invite page.
+        actions.openCreateTeamModal();
+      }
 
-      // Remove the new user flag
       browser.storage.remove(NUOCT22);
-      // Dismiss the whats new flag
       browser.storage.set(wnoct22, true);
     } else {
       const isWhatsNewModalDismissed = browser.storage.get(wnoct22);

--- a/packages/app/src/app/pages/SignIn/Onboarding.tsx
+++ b/packages/app/src/app/pages/SignIn/Onboarding.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useLocation } from 'react-router-dom';
 import { Element, Text, Stack } from '@codesandbox/components';
 import { useAppState, useActions, useEffects } from 'app/overmind';
 import { InputText } from 'app/components/dashboard/InputText';
@@ -50,6 +51,7 @@ export const Onboarding = () => {
     };
   }
 
+  const { pathname } = useLocation();
   const { browser } = useEffects();
   const { validateUsername, finalizeSignUp } = useActions();
   const [newUsername, setNewUsername] = useState(pendingUser?.username || '');
@@ -57,9 +59,15 @@ export const Onboarding = () => {
   const [loadingUsername, setLoadingUserName] = useState(false);
   const firstName = pendingUser?.name.split(' ')[0];
 
-  // Set flag to make sure we show the create team modal and not the
-  // what's new modal after signup.
-  browser.storage.set(NUOCT22, true);
+  if (pathname.includes('/invite')) {
+    // Set flag to neither show the create team modal and the
+    // what's new modal.
+    browser.storage.set(NUOCT22, false);
+  } else {
+    // Set flag to make sure we show the create team modal and
+    // not the what's new modal after signup.
+    browser.storage.set(NUOCT22, true);
+  }
 
   return (
     <Stack

--- a/packages/app/src/app/pages/SignIn/Onboarding.tsx
+++ b/packages/app/src/app/pages/SignIn/Onboarding.tsx
@@ -62,11 +62,11 @@ export const Onboarding = () => {
   if (pathname.includes('/invite')) {
     // Set flag to neither show the create team modal and the
     // what's new modal.
-    browser.storage.set(NUOCT22, false);
+    browser.storage.set(NUOCT22, 'invite');
   } else {
     // Set flag to make sure we show the create team modal and
     // not the what's new modal after signup.
-    browser.storage.set(NUOCT22, true);
+    browser.storage.set(NUOCT22, 'signup');
   }
 
   return (


### PR DESCRIPTION
When you're creating a new user it automatically showed the create team modal when viewing the dashboard page. As a user that created an account after an invitation, you don't want to immediately create a new team. For that reason we don't show the modal after creating a new account.

### Testing

You're able to test multiple scenarios by setting / removing flags in `localStorage`:

1. Viewing the create team modal
1.1 Login and go to any dashboard page
1.2 Paste the code below in the console and execute
1.3 Refresh the page

```
localStorage.setItem('NUOCT22', true);
```

2. Viewing the what's new modal
2.1 Login and go to any dashboard page
2.2 Paste the code below in the console and execute
2.3 Refresh the page

```
localStorage.removeItem('NUOCT22');
localStorage.removeItem('wnoct22', true);
```

3. Viewing neither the create team modal or what's new modal
3.1 Login and go to any dashboard page
3.2 Paste the code below in the console and execute
3.3 Refresh the page

```
localStorage.setItem('NUOCT22', false);
localStorage.removeItem('wnoct22', true);
```

#### Testing the whole flow

This is only possible on `stream`.