### PR TITLE
fix: null error and duplicate call

### DIFF
--- a/packages/app/src/app/pages/Dashboard/Content/routes/Sandboxes/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Sandboxes/index.tsx
@@ -1,12 +1,11 @@
 import React from 'react';
 import { Helmet } from 'react-helmet';
-import { useParams, useHistory } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import { useAppState, useActions } from 'app/overmind';
 import { Header } from 'app/pages/Dashboard/Components/Header';
 import { SelectionProvider } from 'app/pages/Dashboard/Components/Selection';
 import { VariableGrid } from 'app/pages/Dashboard/Components/VariableGrid';
 import { DashboardGridItem, PageTypes } from 'app/pages/Dashboard/types';
-import { dashboard } from '@codesandbox/common/lib/utils/url-generator';
 import { getPossibleTemplates } from '../../utils';
 import { useFilteredItems } from './useFilteredItems';
 
@@ -14,7 +13,6 @@ export const SandboxesPage = () => {
   const [level, setLevel] = React.useState(0);
   const [creating, setCreating] = React.useState(false);
   const params = useParams<{ path: string }>();
-  const history = useHistory();
   const currentPath = decodeURIComponent(params.path || '');
   const cleanParam = currentPath.split(' ').join('{}');
   const items = useFilteredItems(currentPath, cleanParam, level);
@@ -23,22 +21,6 @@ export const SandboxesPage = () => {
     dashboard: { allCollections, sandboxes },
     activeTeam,
   } = useAppState();
-  const [localTeam, setLocalTeam] = React.useState(activeTeam);
-
-  React.useEffect(() => {
-    actions.dashboard.getAllFolders();
-  }, [actions.dashboard, activeTeam]);
-
-  React.useEffect(() => {
-    if (localTeam !== activeTeam) {
-      setLocalTeam(activeTeam);
-
-      if (params) {
-        history.push(dashboard.sandboxes('/', activeTeam));
-      }
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [activeTeam]);
 
   React.useEffect(() => {
     if (!currentPath || currentPath === '/') {

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/ManageSubscription/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/ManageSubscription/index.tsx
@@ -41,7 +41,7 @@ export const ManageSubscription = () => {
   // we skip the payment processing/upgrade to pro screen.
   if (
     ![SubscriptionStatus.Active, SubscriptionStatus.Trialing].includes(
-      team.subscription.status
+      team.subscription?.status
     )
   ) {
     if (paymentPending) {
@@ -58,7 +58,7 @@ export const ManageSubscription = () => {
   );
 
   const renderProvider = () => {
-    if (team.subscription.origin === SubscriptionOrigin.Pilot) {
+    if (team.subscription?.origin === SubscriptionOrigin.Pilot) {
       return <Pilot />;
     }
 

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/ManageSubscription/upgrade.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/ManageSubscription/upgrade.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-
 import styled from 'styled-components';
 import css from '@styled-system/css';
 import { Button, Stack, Text } from '@codesandbox/components';
@@ -19,8 +18,6 @@ const List = styled(Stack)`
 export const Upgrade = () => {
   return (
     <Card
-      as="a"
-      href="/pro"
       css={{
         textDecoration: 'none',
         backgroundColor: 'white',
@@ -48,7 +45,7 @@ export const Upgrade = () => {
           </Text>
         </List>
 
-        <Button type="button" marginTop={2} variant="secondary">
+        <Button as="a" href="/pro" marginTop={2} variant="secondary">
           Upgrade to Pro
         </Button>
       </Stack>

--- a/packages/app/src/app/pages/Dashboard/Sidebar/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Sidebar/index.tsx
@@ -57,7 +57,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
     // Used to fetch collections
     actions.dashboard.getAllFolders();
     actions.dashboard.getStarredRepos();
-  }, [actions.dashboard, state.activeTeam]);
+  }, [state.activeTeam]);
 
   React.useEffect(() => {
     // Used to check for templates and synced sandboxes


### PR DESCRIPTION
Started fixing a duplicate call to getAllFolders, ended up with 3 different things:

 - **getAllFolders** called only once on the sidebar, when the activeTeam changes
 - null/undefined error when no **subscription** exists for team in team settings
 - **button in link** replaced with a simple button for upgrading to pro

For later: wasn't able to figure out why the router push to `/pro` doesn't work, so I left it as an anchor tag instead of using react router.