### PR TITLE
fix(trial): Properly catch spaces in email addresses instead of removing them all

### DIFF
--- a/packages/app/src/app/pages/common/Modals/NewTeamModal/TeamMembers.tsx
+++ b/packages/app/src/app/pages/common/Modals/NewTeamModal/TeamMembers.tsx
@@ -45,7 +45,20 @@ export const TeamMembers: React.FC<{ onComplete: () => void }> = ({
     setInviteError(null);
 
     // Remove spaces (and other whitespace) and split email addresses
-    const emails = addressesString.replace(/\s/g, '').split(',');
+    const emails = addressesString.split(',').map(email => {
+      const spaceRegex = /\s/g;
+
+      if (spaceRegex.test(email.charAt(0))) {
+        // remove space from start
+        return email.substring(1);
+      }
+      if (spaceRegex.test(email.charAt(email.length - 1))) {
+        // remove space from end
+        return email.substring(0, email.length);
+      }
+
+      return email;
+    });
 
     // Validate emails
     const invalid = emails.filter(email => {

--- a/packages/app/src/app/pages/common/Modals/NewTeamModal/TeamMembers.tsx
+++ b/packages/app/src/app/pages/common/Modals/NewTeamModal/TeamMembers.tsx
@@ -54,7 +54,7 @@ export const TeamMembers: React.FC<{ onComplete: () => void }> = ({
       }
       if (spaceRegex.test(email.charAt(email.length - 1))) {
         // remove space from end
-        return email.substring(0, email.length);
+        return email.substring(0, email.length - 1);
       }
 
       return email;

--- a/packages/app/src/app/pages/common/Modals/NewTeamModal/TeamMembers.tsx
+++ b/packages/app/src/app/pages/common/Modals/NewTeamModal/TeamMembers.tsx
@@ -44,7 +44,7 @@ export const TeamMembers: React.FC<{ onComplete: () => void }> = ({
     e.preventDefault();
     setInviteError(null);
 
-    // Remove spaces (and other whitespace) and split email addresses
+    // Split email addresses
     const emails = addressesString.split(',').map(email => {
       const spaceRegex = /\s/g;
 


### PR DESCRIPTION
Instead of removing all spaces, we remove spaces in front and behind the mail addresses. This way we catch emails with spaces as invalid emails.

#### How to test

1. Login and view dashboard
2. Create a new team
3. On the invite members step, input wrong emails with spaces and such
4. Result