### PR TITLE
feat: useDismissible

### DIFF
--- a/packages/app/src/app/hooks/useDismissible.ts
+++ b/packages/app/src/app/hooks/useDismissible.ts
@@ -10,16 +10,17 @@ type DismissibleKeys =
 
 type Dismissibles = Partial<Record<DismissibleKeys, true>>;
 
-export const useDismissible = () => {
+export const useDismissible = (key: DismissibleKeys) => {
   const { browser } = useEffects();
+
   const dismissibles = browser.storage.get<Dismissibles>('DISMISSIBLES');
+  const isDismissed = dismissibles?.[key] === true;
 
-  const isDismissed = (key: DismissibleKeys) => {
-    return dismissibles?.[key] === true;
-  };
-
-  const dismiss = (key: DismissibleKeys) => {
-    const prevDismissibles = dismissibles || {};
+  const dismiss = () => {
+    // Getting the dismissibles again to make sure other instances aren't
+    // overwritten after the hook initialised.
+    const prevDismissibles =
+      browser.storage.get<Dismissibles>('DISMISSIBLES') || {};
 
     browser.storage.set('DISMISSIBLES', {
       ...prevDismissibles,
@@ -27,5 +28,5 @@ export const useDismissible = () => {
     });
   };
 
-  return { isDismissed, dismiss };
+  return [isDismissed, dismiss];
 };

--- a/packages/app/src/app/hooks/useDismissible.ts
+++ b/packages/app/src/app/hooks/useDismissible.ts
@@ -1,0 +1,31 @@
+import { useEffects } from 'app/overmind';
+
+/**
+ * Localstorage keys used for dismissible modals and banners.
+ */
+type DismissibleKeys =
+  // TODO - Any key in this type should refer to a dismissible item. Right
+  // now there are none yet.
+  'TODO';
+
+type Dismissibles = Partial<Record<DismissibleKeys, true>>;
+
+export const useDismissible = () => {
+  const { browser } = useEffects();
+  const dismissibles = browser.storage.get<Dismissibles>('DISMISSIBLES');
+
+  const isDismissed = (key: DismissibleKeys) => {
+    return dismissibles?.[key] === true;
+  };
+
+  const dismiss = (key: DismissibleKeys) => {
+    const prevDismissibles = dismissibles || {};
+
+    browser.storage.set('DISMISSIBLES', {
+      ...prevDismissibles,
+      [key]: true,
+    });
+  };
+
+  return { isDismissed, dismiss };
+};

--- a/packages/app/src/app/hooks/useScript.ts
+++ b/packages/app/src/app/hooks/useScript.ts
@@ -1,7 +1,7 @@
 // Based on https://usehooks.com/useScript/
 import { useEffect, useState } from 'react';
 
-const cachedScripts = [];
+const cachedScripts: Array<string> = [];
 
 export const useScript = (src: string) => {
   const [state, setState] = useState({

--- a/packages/app/src/app/overmind/effects/browser.ts
+++ b/packages/app/src/app/overmind/effects/browser.ts
@@ -91,15 +91,15 @@ export default {
     });
   },
   reload() {
-    location.reload(true);
+    location.reload();
   },
   storage: {
-    get(key: string): unknown | null {
+    get<T = unknown>(key: string): T | null {
       try {
         const value = localStorage.getItem(key);
 
         if (value) {
-          return JSON.parse(value);
+          return JSON.parse(value) as T;
         }
 
         return null;

--- a/packages/app/tsconfig.strictNullChecks.json
+++ b/packages/app/tsconfig.strictNullChecks.json
@@ -6,6 +6,9 @@
     "strictNullChecks": true,
     "skipLibCheck": true
   },
-  "include": ["./src/app/overmind/**/*.ts"],
+  "include": [
+    "./src/app/overmind/**/*.ts",
+    "./src/app/hooks/useDismissible.ts"
+  ],
   "exclude": ["codesandbox-browserfs/*"]
 }

--- a/packages/app/tsconfig.strictNullChecks.json
+++ b/packages/app/tsconfig.strictNullChecks.json
@@ -6,9 +6,6 @@
     "strictNullChecks": true,
     "skipLibCheck": true
   },
-  "include": [
-    "./src/app/overmind/**/*.ts",
-    "./src/app/hooks/useDismissible.ts"
-  ],
+  "include": ["./src/app/overmind/**/*.ts", "./src/app/hooks/**/*.ts"],
   "exclude": ["codesandbox-browserfs/*"]
 }


### PR DESCRIPTION
In the future we'll be writing more dismissible banners etc. that we want to keep track of in `localStorage`. We already created a few in the past weeks but found that keeping track and DX wasn't optimal. From now on we can use this hook to dismiss and check if items are dismissed while keeping track of all values.

Example usage
```tsx
const Component = () => {
  const { banners } = useAction();
  const [isBannerDismissed, dismissBanner] = useDismissible('BANNER');

  const onClose = () => {
    banners.banner.close();
    dismissBanner();
  };

  if (isBannerDismissed) {
    return null;
  }

  return (
    <Banner />
  );
};

```

Keep in mind that this hook does not keep track of state, most of this is handled in overmind. This hook should mostly be used for initial state of showing banners by a flag in `localStorage`.