### PR TITLE
feat(trial): view only state for dashboard cards and list items

### DIFF
--- a/packages/app/src/app/pages/Dashboard/Components/Branch/BranchCard.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Branch/BranchCard.tsx
@@ -5,6 +5,8 @@ import {
   Stack,
   Text,
   Tooltip,
+  Element,
+  Badge,
 } from '@codesandbox/components';
 import { css } from '@styled-system/css';
 import { BranchProps } from './types';
@@ -15,6 +17,7 @@ export const BranchCard: React.FC<BranchProps> = ({
   isBeingRemoved,
   selected,
   onContextMenu,
+  isViewOnly = true,
   ...props
 }) => {
   const { name: branchName, project, contribution } = branch;
@@ -57,7 +60,7 @@ export const BranchCard: React.FC<BranchProps> = ({
     >
       <Stack
         css={css({
-          backgroundColor: 'rgba(229, 229, 229, 0.04)',
+          backgroundColor: isViewOnly ? '#252525' : '#161616',
           paddingY: 11,
           position: 'relative',
         })}
@@ -66,6 +69,13 @@ export const BranchCard: React.FC<BranchProps> = ({
       >
         <Icon color="#808080" name="branch" size={32} />
       </Stack>
+      {isViewOnly ? (
+        <Element css={{ position: 'absolute', top: 8, left: 8 }}>
+          <Badge color="accent" isPadded>
+            View only
+          </Badge>
+        </Element>
+      ) : null}
       <Stack
         css={css({
           paddingY: 5,
@@ -80,7 +90,7 @@ export const BranchCard: React.FC<BranchProps> = ({
           <Tooltip label={branchName}>
             <Text
               css={css({
-                color: '#E5E5E5',
+                color: isViewOnly ? '#999999' : '#E5E5E5',
                 flex: 1,
                 whiteSpace: 'nowrap',
                 overflow: 'hidden',

--- a/packages/app/src/app/pages/Dashboard/Components/Branch/BranchCard.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Branch/BranchCard.tsx
@@ -17,7 +17,7 @@ export const BranchCard: React.FC<BranchProps> = ({
   isBeingRemoved,
   selected,
   onContextMenu,
-  isViewOnly = true,
+  isViewOnly,
   ...props
 }) => {
   const { name: branchName, project, contribution } = branch;

--- a/packages/app/src/app/pages/Dashboard/Components/Branch/BranchListItem.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Branch/BranchListItem.tsx
@@ -4,6 +4,7 @@ import {
   Column,
   Stack,
   Element,
+  Badge,
   Text,
   ListAction,
   IconButton,
@@ -19,6 +20,7 @@ export const BranchListItem = ({
   selected,
   isBeingRemoved,
   onContextMenu,
+  isViewOnly,
 }: BranchProps) => {
   const { name: branchName, project, contribution } = branch;
   const { repository } = project;
@@ -61,9 +63,9 @@ export const BranchListItem = ({
         href={isBeingRemoved ? undefined : branchUrl}
         onContextMenu={onContextMenu}
       >
-        <Grid css={{ width: 'calc(100% - 26px - 8px)' }}>
+        <Grid css={{ width: 'calc(100% - 26px - 8px)' }} columnGap={4}>
           <Column
-            span={[12, 5, 5]}
+            span={[10, 5, 4]}
             css={{
               display: 'block',
               overflow: 'hidden',
@@ -85,14 +87,28 @@ export const BranchListItem = ({
 
               <Element css={{ overflow: 'hidden' }}>
                 <Tooltip label={branchName}>
-                  <Text size={3} weight="medium" maxWidth="100%">
+                  <Text
+                    size={3}
+                    weight="medium"
+                    maxWidth="100%"
+                    css={{ color: isViewOnly ? '#999999' : '#E5E5E5' }}
+                  >
                     {branchName}
                   </Text>
                 </Tooltip>
               </Element>
             </Stack>
           </Column>
-          <Column span={[0, 4, 4]} as={Stack} align="center">
+          <Column span={[0, 2, 2]}>
+            {isViewOnly ? (
+              <Stack align="center">
+                <Badge color="accent" isPadded>
+                  View only
+                </Badge>
+              </Stack>
+            ) : null}
+          </Column>
+          <Column span={[0, 5, 6]} as={Stack} align="center">
             <Text size={3} variant="muted" maxWidth="100%">
               {repository.owner}/{repository.name}
             </Text>

--- a/packages/app/src/app/pages/Dashboard/Components/Branch/types.ts
+++ b/packages/app/src/app/pages/Dashboard/Components/Branch/types.ts
@@ -7,4 +7,5 @@ export type BranchProps = {
   selected: boolean;
   onContextMenu: (evt: React.MouseEvent) => void;
   onClick: (evt: React.MouseEvent) => void;
+  isViewOnly?: boolean;
 };

--- a/packages/app/src/app/pages/Dashboard/Components/Repository/RepositoryCard.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Repository/RepositoryCard.tsx
@@ -17,7 +17,7 @@ export const RepositoryCard: React.FC<RepositoryProps> = ({
   selected,
   onContextMenu,
   isBeingRemoved,
-  isViewOnly = true,
+  isViewOnly,
   ...props
 }) => {
   return (

--- a/packages/app/src/app/pages/Dashboard/Components/Repository/RepositoryCard.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Repository/RepositoryCard.tsx
@@ -1,7 +1,14 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { css } from '@styled-system/css';
-import { Icon, IconButton, Stack, Text } from '@codesandbox/components';
+import {
+  Icon,
+  IconButton,
+  Stack,
+  Text,
+  Element,
+  Badge,
+} from '@codesandbox/components';
 import { RepositoryProps } from './types';
 
 export const RepositoryCard: React.FC<RepositoryProps> = ({
@@ -10,6 +17,7 @@ export const RepositoryCard: React.FC<RepositoryProps> = ({
   selected,
   onContextMenu,
   isBeingRemoved,
+  isViewOnly = true,
   ...props
 }) => {
   return (
@@ -49,6 +57,13 @@ export const RepositoryCard: React.FC<RepositoryProps> = ({
       onContextMenu={onContextMenu}
       {...props}
     >
+      {isViewOnly ? (
+        <Element css={{ position: 'absolute', top: 24, left: 24 }}>
+          <Badge color="accent" isPadded>
+            View only
+          </Badge>
+        </Element>
+      ) : null}
       <IconButton
         css={css({
           marginLeft: 'auto',
@@ -69,7 +84,7 @@ export const RepositoryCard: React.FC<RepositoryProps> = ({
         <Stack align="center" direction="vertical" gap={2}>
           <Text
             css={css({
-              color: '#E5E5E5',
+              color: isViewOnly ? '#999999' : '#E5E5E5',
               textAlign: 'center',
               minHeight: 42,
               paddingX: 6,

--- a/packages/app/src/app/pages/Dashboard/Components/Repository/RepositoryListItem.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Repository/RepositoryListItem.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import { css } from '@styled-system/css';
 import {
   Element,
+  Badge,
   Column,
   Grid,
   Icon,
@@ -19,6 +20,7 @@ export const RepositoryListItem: React.FC<RepositoryProps> = ({
   selected,
   onContextMenu,
   isBeingRemoved,
+  isViewOnly,
   ...props
 }) => {
   return (
@@ -62,9 +64,9 @@ export const RepositoryListItem: React.FC<RepositoryProps> = ({
         onContextMenu={onContextMenu}
         {...props}
       >
-        <Grid css={{ width: 'calc(100% - 26px - 8px)' }}>
+        <Grid css={{ width: 'calc(100% - 26px - 8px)' }} columnGap={4}>
           <Column
-            span={[12, 5, 5]}
+            span={[10, 5, 4]}
             css={{
               display: 'block',
               overflow: 'hidden',
@@ -75,13 +77,27 @@ export const RepositoryListItem: React.FC<RepositoryProps> = ({
             <Stack gap={4} align="center" marginLeft={2}>
               <Icon color="#999" name="repository" size={16} width="32px" />
               <Element css={{ overflow: 'hidden' }}>
-                <Text size={3} weight="medium" maxWidth="100%">
+                <Text
+                  size={3}
+                  weight="medium"
+                  maxWidth="100%"
+                  css={{ color: isViewOnly ? '#999999' : '#E5E5E5' }}
+                >
                   {repository.owner}/{repository.name}
                 </Text>
               </Element>
             </Stack>
           </Column>
-          <Column span={[0, 4, 4]} as={Stack} align="center">
+          <Column span={[0, 2, 2]}>
+            {isViewOnly ? (
+              <Stack align="center">
+                <Badge color="accent" isPadded>
+                  View only
+                </Badge>
+              </Stack>
+            ) : null}
+          </Column>
+          <Column span={[0, 5, 6]} as={Stack} align="center">
             <Text size={3} variant="muted" maxWidth="100%">
               {labels.branches}
             </Text>

--- a/packages/app/src/app/pages/Dashboard/Components/Repository/types.ts
+++ b/packages/app/src/app/pages/Dashboard/Components/Repository/types.ts
@@ -12,4 +12,5 @@ export type RepositoryProps = {
   onClick: (evt: React.MouseEvent) => void;
   selected: boolean;
   isBeingRemoved: boolean;
+  isViewOnly?: boolean;
 };

--- a/packages/app/src/app/pages/Dashboard/Components/Sandbox/NewMasterSandbox.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Sandbox/NewMasterSandbox.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {
+  Element,
   Stack,
   Text,
   Icon,
@@ -7,6 +8,7 @@ import {
   Column,
   Grid,
   ListAction,
+  Badge,
 } from '@codesandbox/components';
 import { useAppState } from 'app/overmind';
 import css from '@styled-system/css';
@@ -18,6 +20,7 @@ export interface NewMasterSandboxProps {
     name: string;
     branch: string;
   };
+  isViewOnly?: boolean;
 }
 
 export const NewMasterSandbox = (props: NewMasterSandboxProps) => {
@@ -32,7 +35,10 @@ export const NewMasterSandbox = (props: NewMasterSandboxProps) => {
   return <NewMasterSandboxListItem {...props} />;
 };
 
-export const NewMasterSandboxListItem = ({ repo }: NewMasterSandboxProps) => {
+export const NewMasterSandboxListItem = ({
+  repo,
+  isViewOnly = true, // 🚧
+}: NewMasterSandboxProps) => {
   const { onRightClick } = useSelection();
   return (
     <ListAction
@@ -56,7 +62,7 @@ export const NewMasterSandboxListItem = ({ repo }: NewMasterSandboxProps) => {
       })}
     >
       <Grid css={{ width: 'calc(100% - 26px - 8px)' }}>
-        <Column span={[12, 5, 5]}>
+        <Column span={[11, 4, 4]}>
           <Stack gap={4} align="center" marginLeft={2}>
             <Stack
               as="div"
@@ -77,6 +83,16 @@ export const NewMasterSandboxListItem = ({ repo }: NewMasterSandboxProps) => {
               </Text>
             </Stack>
           </Stack>
+        </Column>
+        {/* ❗️ TODO properly */}
+        <Column span={[1, 3, 1]}>
+          {isViewOnly ? (
+            <Element>
+              <Badge color="accent" isPadded>
+                View only
+              </Badge>
+            </Element>
+          ) : null}
         </Column>
         <Column span={[0, 4, 4]} as={Stack} align="center">
           <Text size={3} block variant="muted">
@@ -100,7 +116,10 @@ export const NewMasterSandboxListItem = ({ repo }: NewMasterSandboxProps) => {
   );
 };
 
-export const NewMasterSandboxCard = ({ repo }: NewMasterSandboxProps) => {
+export const NewMasterSandboxCard = ({
+  repo,
+  isViewOnly = true, // 🚧
+}: NewMasterSandboxProps) => {
   const { onRightClick } = useSelection();
   return (
     <Stack
@@ -125,6 +144,13 @@ export const NewMasterSandboxCard = ({ repo }: NewMasterSandboxProps) => {
         },
       })}
     >
+      {isViewOnly ? (
+        <Element css={{ position: 'absolute', top: 8, left: 8 }}>
+          <Badge color="accent" isPadded>
+            View only
+          </Badge>
+        </Element>
+      ) : null}
       <Stack
         justify="center"
         align="center"
@@ -156,7 +182,11 @@ export const NewMasterSandboxCard = ({ repo }: NewMasterSandboxProps) => {
           })}
         >
           <Stack gap={1} align="center">
-            <Text size={3} weight="medium">
+            <Text
+              size={3}
+              weight="medium"
+              css={{ color: isViewOnly ? '#999999' : '#E5E5E5' }}
+            >
               master
             </Text>
           </Stack>

--- a/packages/app/src/app/pages/Dashboard/Components/Sandbox/NewMasterSandbox.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Sandbox/NewMasterSandbox.tsx
@@ -61,8 +61,8 @@ export const NewMasterSandboxListItem = ({
         borderBottomColor: 'grays.600',
       })}
     >
-      <Grid css={{ width: 'calc(100% - 26px - 8px)' }}>
-        <Column span={[11, 4, 4]}>
+      <Grid css={{ width: 'calc(100% - 26px - 8px)' }} columnGap={4}>
+        <Column span={[10, 5, 4]}>
           <Stack gap={4} align="center" marginLeft={2}>
             <Stack
               as="div"
@@ -78,29 +78,29 @@ export const NewMasterSandboxListItem = ({
               <Icon color="#999" name="github" size={24} />
             </Stack>
             <Stack justify="space-between" align="center">
-              <Text size={3} weight="medium">
+              <Text
+                size={3}
+                weight="medium"
+                css={{ color: isViewOnly ? '#999999' : '#E5E5E5' }}
+              >
                 {repo.name}
               </Text>
             </Stack>
           </Stack>
         </Column>
-        {/* ❗️ TODO properly */}
-        <Column span={[1, 3, 1]}>
+        <Column span={[0, 2, 2]}>
           {isViewOnly ? (
-            <Element>
+            <Stack align="center">
               <Badge color="accent" isPadded>
                 View only
               </Badge>
-            </Element>
+            </Stack>
           ) : null}
         </Column>
         <Column span={[0, 4, 4]} as={Stack} align="center">
           <Text size={3} block variant="muted">
             {repo.owner}
           </Text>
-        </Column>
-        <Column span={[0, 3, 3]} as={Stack} align="center">
-          {/* empty column to align with sandbox list items */}
         </Column>
       </Grid>
       <IconButton

--- a/packages/app/src/app/pages/Dashboard/Components/Sandbox/NewMasterSandbox.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Sandbox/NewMasterSandbox.tsx
@@ -37,7 +37,7 @@ export const NewMasterSandbox = (props: NewMasterSandboxProps) => {
 
 export const NewMasterSandboxListItem = ({
   repo,
-  isViewOnly = true, // 🚧
+  isViewOnly,
 }: NewMasterSandboxProps) => {
   const { onRightClick } = useSelection();
   return (
@@ -118,7 +118,7 @@ export const NewMasterSandboxListItem = ({
 
 export const NewMasterSandboxCard = ({
   repo,
-  isViewOnly = true, // 🚧
+  isViewOnly,
 }: NewMasterSandboxProps) => {
   const { onRightClick } = useSelection();
   return (

--- a/packages/app/src/app/pages/Dashboard/Components/Sandbox/SandboxCard.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Sandbox/SandboxCard.tsx
@@ -221,7 +221,7 @@ export const SandboxCard = ({
   onInputKeyDown,
   onSubmit,
   onInputBlur,
-  isViewOnly = true,
+  isViewOnly,
   // drag preview
   thumbnailRef,
   opacity,

--- a/packages/app/src/app/pages/Dashboard/Components/Sandbox/SandboxCard.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Sandbox/SandboxCard.tsx
@@ -9,6 +9,7 @@ import {
   IconButton,
   Link,
   Tooltip,
+  Element,
 } from '@codesandbox/components';
 import css from '@styled-system/css';
 import { shortDistance } from '@codesandbox/common/lib/utils/short-distance';
@@ -44,6 +45,7 @@ type SandboxTitleProps = {
   isFrozen: boolean;
   prNumber?: number;
   originalGit?: RepoFragmentDashboardFragment['originalGit'];
+  isViewOnly?: boolean;
 } & Pick<
   SandboxItemComponentProps,
   | 'editing'
@@ -72,6 +74,7 @@ const SandboxTitle: React.FC<SandboxTitleProps> = React.memo(
     PrivacyIcon,
     newTitle,
     sandboxTitle,
+    isViewOnly,
   }) => (
     <Stack justify="space-between" marginLeft={5} marginRight={2}>
       {editing ? (
@@ -105,7 +108,11 @@ const SandboxTitle: React.FC<SandboxTitleProps> = React.memo(
           )}
 
           <PrivacyIcon />
-          <Text size={3} weight="medium">
+          <Text
+            size={3}
+            weight="medium"
+            css={{ color: isViewOnly ? '#999999' : '#E5E5E5' }}
+          >
             {sandboxTitle}
           </Text>
         </Stack>
@@ -214,6 +221,7 @@ export const SandboxCard = ({
   onInputKeyDown,
   onSubmit,
   onInputBlur,
+  isViewOnly = true,
   // drag preview
   thumbnailRef,
   opacity,
@@ -258,6 +266,14 @@ export const SandboxCard = ({
         },
       })}
     >
+      {isViewOnly ? (
+        <Element css={{ position: 'absolute', top: 8, left: 8 }}>
+          <Badge color="accent" isPadded>
+            View only
+          </Badge>
+        </Element>
+      ) : null}
+
       <Thumbnail
         sandboxId={sandbox.id}
         thumbnailRef={thumbnailRef}
@@ -286,6 +302,7 @@ export const SandboxCard = ({
           PrivacyIcon={PrivacyIcon}
           newTitle={newTitle}
           sandboxTitle={sandboxTitle}
+          isViewOnly={isViewOnly}
         />
         <SandboxStats
           noDrag={noDrag}
@@ -359,7 +376,7 @@ const Thumbnail = ({
           />
         )}
       </div>
-      <Stack gap={1} css={{ position: 'absolute', top: 6, right: 6 }}>
+      <Stack gap={1} css={{ position: 'absolute', top: 8, right: 8 }}>
         {showBetaBadge && <Badge icon="cloud">Beta</Badge>}
         <div
           style={{

--- a/packages/app/src/app/pages/Dashboard/Components/Sandbox/SandboxListItem.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Sandbox/SandboxListItem.tsx
@@ -5,6 +5,7 @@ import {
   Column,
   Stack,
   Element,
+  Badge,
   Text,
   Input,
   ListAction,
@@ -36,6 +37,7 @@ export const SandboxListItem = ({
   onInputKeyDown,
   onSubmit,
   onInputBlur,
+  isViewOnly,
   // drag preview
   thumbnailRef,
   opacity,
@@ -74,9 +76,9 @@ export const SandboxListItem = ({
       onContextMenu={onContextMenu}
       {...props}
     >
-      <Grid css={{ width: 'calc(100% - 26px - 8px)' }}>
+      <Grid css={{ width: 'calc(100% - 26px - 8px)' }} columnGap={4}>
         <Column
-          span={[12, 5, 5]}
+          span={[10, 5, 4]}
           css={{
             display: 'block',
             overflow: 'hidden',
@@ -128,7 +130,12 @@ export const SandboxListItem = ({
                 <Tooltip label={sandboxTitle}>
                   <Stack gap={1} align="center">
                     <PrivacyIcon />
-                    <Text size={3} weight="medium" maxWidth="100%">
+                    <Text
+                      size={3}
+                      weight="medium"
+                      maxWidth="100%"
+                      css={{ color: isViewOnly ? '#999999' : '#E5E5E5' }}
+                    >
                       {sandboxTitle}
                     </Text>
                   </Stack>
@@ -137,7 +144,17 @@ export const SandboxListItem = ({
             </Element>
           </Stack>
         </Column>
-        <Column span={[0, 4, 4]} as={Stack} align="center">
+        {/* Column span 0 on mobile because the Grid is bugged */}
+        <Column span={[0, 2, 2]}>
+          {isViewOnly ? (
+            <Stack align="center">
+              <Badge color="accent" isPadded>
+                View only
+              </Badge>
+            </Stack>
+          ) : null}
+        </Column>
+        <Column span={[0, 3, 3]} as={Stack} align="center">
           {sandbox.removedAt ? (
             <Text
               size={3}
@@ -165,7 +182,7 @@ export const SandboxListItem = ({
             </Text>
           )}
         </Column>
-        <Column span={[0, 3, 3]} as={Stack} align="center">
+        <Column span={[0, 2, 3]} as={Stack} align="center">
           <Text size={3} variant={selected ? 'body' : 'muted'} maxWidth="100%">
             {sandboxLocation}
           </Text>

--- a/packages/app/src/app/pages/Dashboard/Components/Sandbox/types.ts
+++ b/packages/app/src/app/pages/Dashboard/Components/Sandbox/types.ts
@@ -29,6 +29,7 @@ export interface SandboxItemComponentProps {
   onInputKeyDown: (evt: React.KeyboardEvent<HTMLInputElement>) => void;
   onSubmit: (evt: React.FormEvent<HTMLFormElement>) => void;
   onInputBlur: (evt: React.FocusEvent<HTMLInputElement>) => void;
+  isViewOnly?: boolean;
 
   thumbnailRef: React.Ref<HTMLDivElement>;
   opacity: number;

--- a/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenus/RepositoryMenu.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenus/RepositoryMenu.tsx
@@ -35,6 +35,9 @@ export const RepositoryMenu: React.FC<RepositoryMenuProps> = ({
   });
 
   const { repository: providerRepository } = repository;
+  // TODO: Get isViewOnly from repository 🚧
+  const isViewOnly = false;
+
   const repositoryUrl = dashboard.repository({
     owner: providerRepository.owner,
     name: providerRepository.name,
@@ -79,7 +82,10 @@ export const RepositoryMenu: React.FC<RepositoryMenuProps> = ({
 
       <Menu.Divider />
 
-      <MenuItem onSelect={() => window.open(branchFromDefaultUrl, '_blank')}>
+      <MenuItem
+        onSelect={() => window.open(branchFromDefaultUrl, '_blank')}
+        disabled={isViewOnly}
+      >
         Create branch
       </MenuItem>
       <MenuItem onSelect={() => history.push(repositoryUrl)}>

--- a/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenus/SandboxMenu.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenus/SandboxMenu.tsx
@@ -29,6 +29,8 @@ export const SandboxMenu: React.FC<SandboxMenuProps> = ({
     browser: { copyToClipboard },
   } = useEffects();
   const { sandbox, type } = item;
+  // TODO: Get isViewOnly from item 🚧
+  const isViewOnly = false;
   const isTemplate = type === 'template';
 
   const { visible, setVisibility, position } = React.useContext(Context);
@@ -171,6 +173,7 @@ export const SandboxMenu: React.FC<SandboxMenuProps> = ({
               openInNewWindow: true,
             });
           }}
+          disabled={isViewOnly}
         >
           Fork Sandbox
         </MenuItem>
@@ -234,6 +237,7 @@ export const SandboxMenu: React.FC<SandboxMenuProps> = ({
                   privacy: 1,
                 })
               }
+              disabled={isViewOnly}
             >
               Make {label} Unlisted
             </MenuItem>
@@ -246,6 +250,7 @@ export const SandboxMenu: React.FC<SandboxMenuProps> = ({
                   privacy: 2,
                 })
               }
+              disabled={isViewOnly}
             >
               Make {label} Private
             </MenuItem>
@@ -255,7 +260,9 @@ export const SandboxMenu: React.FC<SandboxMenuProps> = ({
       {hasAccess && activeWorkspaceAuthorization !== 'READ' && (
         <>
           <Menu.Divider />
-          <MenuItem onSelect={() => setRenaming(true)}>Rename {label}</MenuItem>
+          <MenuItem onSelect={() => setRenaming(true)} disabled={isViewOnly}>
+            Rename {label}
+          </MenuItem>
         </>
       )}
       {hasAccess &&
@@ -269,6 +276,7 @@ export const SandboxMenu: React.FC<SandboxMenuProps> = ({
                 isFrozen: false,
               });
             }}
+            disabled={isViewOnly}
           >
             Unfreeze {label}
           </MenuItem>
@@ -280,6 +288,7 @@ export const SandboxMenu: React.FC<SandboxMenuProps> = ({
                 isFrozen: true,
               });
             }}
+            disabled={isViewOnly}
           >
             Freeze {label}
           </MenuItem>
@@ -293,6 +302,7 @@ export const SandboxMenu: React.FC<SandboxMenuProps> = ({
                 templateIds: [sandbox.id],
               });
             }}
+            disabled={isViewOnly}
           >
             Convert to Sandbox
           </MenuItem>
@@ -303,6 +313,7 @@ export const SandboxMenu: React.FC<SandboxMenuProps> = ({
                 sandboxIds: [sandbox.id],
               });
             }}
+            disabled={isViewOnly}
           >
             Make Sandbox a Template
           </MenuItem>

--- a/packages/app/src/app/pages/Dashboard/Components/SyncedSandbox/SyncedSandboxListItem.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/SyncedSandbox/SyncedSandboxListItem.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {
   Icon,
   Stack,
+  Badge,
   ListAction,
   Text,
   Grid,
@@ -19,6 +20,7 @@ export const SyncedSandboxListItem = ({
   onDoubleClick,
   onContextMenu,
   isScrolling,
+  isViewOnly,
   ...props
 }) => {
   const [stoppedScrolling, setStoppedScrolling] = React.useState(false);
@@ -49,8 +51,8 @@ export const SyncedSandboxListItem = ({
         },
       })}
     >
-      <Grid css={{ width: 'calc(100% - 26px - 8px)' }}>
-        <Column span={[12, 5, 5]}>
+      <Grid css={{ width: 'calc(100% - 26px - 8px)' }} columnGap={4}>
+        <Column span={[10, 5, 4]}>
           <Stack gap={4} align="center" marginLeft={2}>
             <Stack
               as="div"
@@ -69,26 +71,30 @@ export const SyncedSandboxListItem = ({
               />
             </Stack>
             <Stack justify="space-between" align="center">
-              <Text size={3} weight="medium">
+              <Text
+                size={3}
+                weight="medium"
+                css={{ color: isViewOnly ? '#999999' : '#E5E5E5' }}
+              >
                 {name}
                 {props.branch !== 'master' ? `:${props.branch}` : ''}
               </Text>
             </Stack>
           </Stack>
         </Column>
-        <Column span={[0, 6, 1]} as={Stack} align="center">
-          <Text
-            size={3}
-            paddingX={4}
-            paddingY={2}
-            css={{
-              color: '#C2C2C2',
-              backgroundColor: '#1D1D1D',
-              borderRadius: 99,
-            }}
-          >
-            Synced
-          </Text>
+        <Column span={[0, 2, 2]}>
+          {isViewOnly ? (
+            <Stack align="center">
+              <Badge color="accent" isPadded>
+                View only
+              </Badge>
+            </Stack>
+          ) : null}
+        </Column>
+        <Column span={[0, 5, 2]} as={Stack} align="center">
+          <Stack align="center">
+            <Badge isPadded>Synced</Badge>
+          </Stack>
         </Column>
         <Column span={[0, 3, 3]} as={Stack} align="center">
           {/* empty column to align with sandbox list items */}

--- a/packages/components/src/components/Badge/index.tsx
+++ b/packages/components/src/components/Badge/index.tsx
@@ -6,28 +6,38 @@ import { Text } from '../Text';
 export interface BadgeProps {
   color?: 'accent' | 'neutral';
   icon?: IconNames;
+  isPadded?: boolean;
 }
 
 export const Badge: React.FC<BadgeProps> = ({
   color = 'neutral',
   icon,
+  isPadded,
   children,
-}) => (
-  <Stack
-    css={{
-      alignItems: 'center',
-      padding: icon ? '4px 8px' : '1px 6px',
-      userSelect: 'none',
+}) => {
+  let padding = '1px 6px';
 
-      borderRadius: '999px',
+  if (isPadded) {
+    padding = '8px 12px';
+  } else if (icon) {
+    padding = '4px 8px';
+  }
 
-      backgroundColor: color === 'accent' ? '#653FFD80' : '#2e2e2e',
-      color: color === 'accent' ? '#fff' : 'inherit',
-      fontSize: 11,
-    }}
-    gap={1}
-  >
-    {icon && <Icon size={12} name={icon} />}
-    <Text>{children}</Text>
-  </Stack>
-);
+  return (
+    <Stack
+      css={{
+        alignItems: 'center',
+        padding,
+        userSelect: 'none',
+        borderRadius: '999px',
+        backgroundColor: color === 'accent' ? '#644ED7' : '#2e2e2e',
+        color: color === 'accent' ? '#fff' : 'inherit',
+        fontSize: 11,
+      }}
+      gap={1}
+    >
+      {icon && <Icon size={12} name={icon} />}
+      <Text>{children}</Text>
+    </Stack>
+  );
+};


### PR DESCRIPTION
Dashboard cards and list items will have (slightly) different styles and a "View only" badge when they're in view only mode. Some actions in the context menu are disabled when in view only mode. 

#### How to test

`Cards` and `ListItem`s with changes now have an `isViewOnly` property. Since we don't have the data yet to properly populate this it's easiest to test by changing the destructured property to `isViewOnly = true`.

For the different context menus you can use the `isViewOnly` variable and set it to `true` instead of `false` to view the changes.

#### Note

Depending on how this mode will be implemented, the property name can change. In the frontend it will behave the same though.