### PR TITLE
feat(trial): Disabled styles for import and create branch buttons

### DIFF
--- a/packages/app/src/app/pages/Dashboard/Components/Branch/NewBranch.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Branch/NewBranch.tsx
@@ -3,14 +3,15 @@ import { Stack, Text, Element, Icon } from '@codesandbox/components';
 import css from '@styled-system/css';
 import { v2DraftBranchUrl } from '@codesandbox/common/lib/utils/url-generator';
 
-export const NewBranchCard: React.FC<{ owner: string; repoName: string }> = ({
-  owner,
-  repoName,
-}) => {
+export const NewBranchCard: React.FC<{
+  owner: string;
+  repoName: string;
+  isDisabled?: boolean;
+}> = ({ owner, repoName, isDisabled }) => {
   return (
     <Element
-      as="a"
-      href={v2DraftBranchUrl(owner, repoName)}
+      as={isDisabled ? undefined : 'a'}
+      href={isDisabled ? undefined : v2DraftBranchUrl(owner, repoName)}
       css={css({
         display: 'flex',
         alignItems: 'center',
@@ -18,7 +19,7 @@ export const NewBranchCard: React.FC<{ owner: string; repoName: string }> = ({
         textDecoration: 'none',
         fontSize: 3,
         fontWeight: 'normal',
-        color: '#999',
+        color: isDisabled ? '#999999' : '#808080',
         height: 240,
         outline: 'none',
         backgroundColor: 'card.background',
@@ -27,15 +28,22 @@ export const NewBranchCard: React.FC<{ owner: string; repoName: string }> = ({
         borderRadius: 'medium',
         transition: 'background ease-in',
         transitionDuration: theme => theme.speeds[2],
-        ':hover': {
-          backgroundColor: 'card.backgroundHover',
-        },
+        ':hover': isDisabled
+          ? undefined
+          : {
+              backgroundColor: 'card.backgroundHover',
+            },
         ':focus-visible': {
           borderColor: 'focusBorder',
         },
       })}
     >
-      <Stack direction="vertical" align="center" gap={4}>
+      <Stack
+        direction="vertical"
+        align="center"
+        gap={4}
+        css={isDisabled ? { opacity: 0.4 } : undefined}
+      >
         <Icon name="plus" size={32} />
         <Text>Create branch</Text>
       </Stack>

--- a/packages/app/src/app/pages/Dashboard/Components/Repository/ImportRepository.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Repository/ImportRepository.tsx
@@ -3,7 +3,9 @@ import { useActions } from 'app/overmind';
 import { Stack, Text, Icon, Element } from '@codesandbox/components';
 import css from '@styled-system/css';
 
-export const ImportRepositoryCard: React.FC = () => {
+export const ImportRepositoryCard: React.FC<{ isDisabled?: boolean }> = ({
+  isDisabled,
+}) => {
   const { openCreateSandboxModal } = useActions();
 
   return (
@@ -18,7 +20,7 @@ export const ImportRepositoryCard: React.FC = () => {
         fontSize: 3,
         fontFamily: 'inherit',
         fontWeight: 'normal',
-        color: '#999',
+        color: isDisabled ? '#999999' : '#808080',
         height: 240,
         outline: 'none',
         backgroundColor: 'card.background',
@@ -27,15 +29,21 @@ export const ImportRepositoryCard: React.FC = () => {
         borderRadius: 'medium',
         transition: 'background ease-in',
         transitionDuration: theme => theme.speeds[2],
-        ':hover': {
+        ':not([disabled]):hover': {
           backgroundColor: 'card.backgroundHover',
         },
         ':focus-visible': {
           borderColor: 'focusBorder',
         },
       })}
+      disabled={isDisabled}
     >
-      <Stack direction="vertical" align="center" gap={4}>
+      <Stack
+        direction="vertical"
+        align="center"
+        gap={4}
+        css={isDisabled ? { opacity: 0.4 } : undefined}
+      >
         <Icon name="plus" size={32} />
         <Text>Import repository</Text>
       </Stack>


### PR DESCRIPTION
Added `isDisabled` state for repository buttons. This state should be enabled when the repository is in view only mode. The logic to trigger this does not yet exist.

#### How to test

`NewBranch` and `ImportRepository` now have an `isDisabled` property. Since we don't have the data yet to properly populate this it's easiest to test by changing the destructured property to `isDisabled = true`.