### PR TITLE
feat(trial): Reusable banner components

### DIFF
--- a/packages/components/.storybook/config.tsx
+++ b/packages/components/.storybook/config.tsx
@@ -51,7 +51,6 @@ const GlobalStyle = createGlobalStyle`
     min-height: 100%;
     height: 100%;
     font-size: 16px;
-    width: 400px;
     margin: 0;
     background-color: ${({ theme }: { theme: Theme }) =>
       theme.colors.sideBar.background};

--- a/packages/components/src/components/Banner/Banner.stories.tsx
+++ b/packages/components/src/components/Banner/Banner.stories.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+
+import { Banner } from './Banner';
+import { Stack } from '../Stack';
+import { Text } from '../Text';
+import { Button } from '../Button';
+import { Icon } from '../Icon';
+import { Grid, Column } from '../Grid';
+
+export default {
+  title: 'components/facelift/Banner',
+  component: Banner,
+};
+
+export const WithDismiss = () => (
+  <Banner onDismiss={() => {}}>
+    You are no longer in a Pro team. This private repo is in view mode only.
+    Make it public or upgrade.
+  </Banner>
+);
+
+export const WithoutDismiss = () => (
+  <Banner>
+    You are no longer in a Pro team. This private repo is in view mode only.
+    Make it public or upgrade.
+  </Banner>
+);
+
+export const ExampleUsage = () => (
+  <Banner onDismiss={() => {}}>
+    <Stack gap={2} justify="space-between">
+      <Stack direction="vertical" gap={8} justify="space-between">
+        <Text fontFamily="everett" size={24}>
+          <Text color="#EDFFA5" weight="600" block>
+            Upgrade to <Text css={{ textTransform: 'uppercase' }}>pro</Text>
+          </Text>
+          <Text block>Enjoy the full CodeSandbox experience.</Text>
+        </Text>
+        <Button autoWidth>Learn more</Button>
+      </Stack>
+      <Stack align="flex-end">
+        <Grid
+          as="ul"
+          columnGap={3}
+          rowGap={3}
+          css={{
+            color: '#EBEBEB',
+            margin: 0,
+            padding: 0,
+            listStyleType: 'none',
+          }}
+        >
+          <Column as="li" span={6}>
+            <Stack gap={4}>
+              <Icon name="profile" />
+              <Text size={13} lineHeight="16px">
+                Up to 20 editors
+              </Text>
+            </Stack>
+          </Column>
+          <Column as="li" span={6}>
+            <Stack gap={4}>
+              <Icon name="profile" />
+              <Text size={13} lineHeight="16px">
+                Private NPM packages
+              </Text>
+            </Stack>
+          </Column>
+          <Column as="li" span={6}>
+            <Stack gap={4}>
+              <Icon name="profile" />
+              <Text size={13} lineHeight="16px">
+                Unlimited sandboxes
+              </Text>
+            </Stack>
+          </Column>
+          <Column as="li" span={6}>
+            <Stack gap={4}>
+              <Icon name="profile" />
+              <Text size={13} lineHeight="16px">
+                Advanced privacy settings
+              </Text>
+            </Stack>
+          </Column>
+          <Column as="li" span={6}>
+            <Stack gap={4}>
+              <Icon name="profile" />
+              <Text size={13} lineHeight="16px">
+                Unlimited repositories
+              </Text>
+            </Stack>
+          </Column>
+          <Column as="li" span={6}>
+            <Stack gap={4}>
+              <Icon name="profile" />
+              <Text size={13} lineHeight="16px">
+                6GB RAM, 12GB Disk, 4 vCPUs
+              </Text>
+            </Stack>
+          </Column>
+        </Grid>
+      </Stack>
+    </Stack>
+  </Banner>
+);

--- a/packages/components/src/components/Banner/Banner.tsx
+++ b/packages/components/src/components/Banner/Banner.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+
+import { Element } from '../Element';
+import { IconButton } from '../IconButton';
+
+interface BannerProps {
+  children: React.ReactNode;
+  onDismiss?: () => void;
+}
+
+export const Banner = ({ children, onDismiss }: BannerProps) => {
+  return (
+    <Element
+      css={{
+        position: 'relative',
+        padding: [4, 6, 8],
+        backgroundColor: '#252525',
+        borderRadius: '4px',
+      }}
+    >
+      {children}
+
+      {onDismiss ? (
+        <Element
+          css={{ position: 'absolute', right: [1, 2, 4], top: [1, 2, 4] }}
+        >
+          <IconButton
+            name="cross"
+            variant="round"
+            title="Dismiss"
+            onClick={onDismiss}
+          />
+        </Element>
+      ) : null}
+    </Element>
+  );
+};

--- a/packages/components/src/components/Button/index.tsx
+++ b/packages/components/src/components/Button/index.tsx
@@ -57,6 +57,22 @@ const variantStyles = {
       background: theme => theme.colors.dangerButton.hoverBackground,
     },
   },
+  light: {
+    backgroundColor: '#FFFFFF',
+    color: '#0E0E0E',
+
+    ':hover': {
+      backgroundColor: '#E0E0E0', // three up in the gray scale (gray[400])
+    },
+  },
+  dark: {
+    backgroundColor: '#0E0E0E',
+    color: '#FFFFFF',
+
+    ':hover': {
+      backgroundColor: '#252525', // three down in the black scale (black[500])
+    },
+  },
 };
 
 const commonStyles = {
@@ -101,7 +117,7 @@ const commonStyles = {
 export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
     IElementProps {
-  variant?: 'primary' | 'secondary' | 'link' | 'danger';
+  variant?: 'primary' | 'secondary' | 'link' | 'danger' | 'light' | 'dark';
   loading?: boolean;
   href?: string;
   rel?: string; // Only use when using href and as="a"

--- a/packages/components/src/components/MessageStripe/MessageStripe.stories.tsx
+++ b/packages/components/src/components/MessageStripe/MessageStripe.stories.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { MessageStripe } from './MessageStripe';
+
+export default {
+  title: 'components/facelift/MessageStripe',
+  component: MessageStripe,
+};
+
+export const TrialVariant = () => (
+  <MessageStripe variant="trial">
+    You are no longer in a Pro team. This private repo is in view mode only.
+    Make it public or upgrade.
+    <MessageStripe.Action>Upgrade now</MessageStripe.Action>
+  </MessageStripe>
+);
+
+export const WarningVariant = () => (
+  <MessageStripe variant="warning">
+    There are some issues with your payment. Please update your payment details.
+    <MessageStripe.Action>Update payment</MessageStripe.Action>
+  </MessageStripe>
+);
+
+export const WithoutAction = () => (
+  <MessageStripe variant="warning">
+    You are no longer in a Pro team. This private repo is in view mode only,
+    contact your team admin to upgrade.
+  </MessageStripe>
+);
+
+export const SpaceBetween = () => (
+  <MessageStripe variant="trial" justify="space-between">
+    There are some issues with your payment. Please update your payment details.
+    <MessageStripe.Action>Update payment</MessageStripe.Action>
+  </MessageStripe>
+);

--- a/packages/components/src/components/MessageStripe/MessageStripe.tsx
+++ b/packages/components/src/components/MessageStripe/MessageStripe.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+
+import { Element } from '../Element';
+import { Stack } from '../Stack';
+import { Button } from '../Button';
+import { Text } from '../Text';
+
+type Variant = 'trial' | 'warning';
+
+interface MessageActionProps
+  extends Omit<React.ComponentProps<typeof Button>, 'variant'> {
+  children: string;
+  variant?: Variant;
+}
+
+export const MessageAction = ({
+  children,
+  variant,
+  ...buttonProps
+}: MessageActionProps) => {
+  return (
+    <div>
+      <Button
+        variant={({ trial: 'light', warning: 'dark' } as const)[variant]}
+        {...buttonProps}
+      >
+        {children}
+      </Button>
+    </div>
+  );
+};
+
+const backgroundVariants = {
+  trial: '#644ED7',
+  warning: '#F7CC66',
+};
+
+const colorVariants = {
+  trial: 'inherit',
+  warning: '#0E0E0E',
+};
+
+interface MessageStripeProps {
+  children: React.ReactNode;
+  variant?: Variant;
+  justify?: 'center' | 'space-between';
+}
+
+const MessageStripe = ({
+  children,
+  variant = 'trial',
+  justify = 'center',
+}: MessageStripeProps) => {
+  let hasAction: boolean;
+
+  const augmentedChildren = React.Children.map(children, child => {
+    if (React.isValidElement(child) && child.type === MessageAction) {
+      hasAction = true;
+
+      return React.cloneElement<Partial<MessageActionProps>>(child, {
+        variant,
+      });
+    }
+
+    return (
+      <Text size={13} lineHeight="16px">
+        {child}
+      </Text>
+    );
+  });
+
+  return (
+    <Element
+      paddingY={hasAction ? 2 : 3}
+      paddingX={4}
+      css={{
+        backgroundColor: backgroundVariants[variant],
+        color: colorVariants[variant],
+      }}
+    >
+      <Stack direction="horizontal" justify={justify} align="center" gap={2}>
+        {augmentedChildren}
+      </Stack>
+    </Element>
+  );
+};
+
+MessageStripe.Action = MessageAction;
+
+export { MessageStripe };

--- a/packages/components/src/components/Stack/index.tsx
+++ b/packages/components/src/components/Stack/index.tsx
@@ -9,12 +9,14 @@ export const Stack = styled(Element)<{
   justify?: React.CSSProperties['justifyContent'];
   align?: React.CSSProperties['alignItems'];
   inline?: boolean;
-}>(({ gap = 0, direction = 'horizontal', justify, align, inline }) =>
+  wrap?: boolean;
+}>(({ gap = 0, direction = 'horizontal', justify, align, inline, wrap }) =>
   css({
     display: inline ? 'inline-flex' : 'flex',
     flexDirection: direction === 'horizontal' ? 'row' : 'column',
     justifyContent: justify,
     alignItems: align,
+    flexWrap: wrap ? 'wrap' : 'nowrap',
 
     '> *:not(:last-child)': {
       [direction === 'horizontal' ? 'marginRight' : 'marginBottom']: gap,

--- a/packages/components/src/components/Text/index.tsx
+++ b/packages/components/src/components/Text/index.tsx
@@ -16,6 +16,11 @@ const overflowStyles = {
   whiteSpace: 'nowrap',
 };
 
+const fontFamilies = {
+  inter: 'Inter, sans-serif',
+  everett: 'Everett, sans-serif',
+};
+
 export interface ITextProps extends React.HTMLAttributes<HTMLSpanElement> {
   size?: number;
   align?: string;
@@ -26,6 +31,8 @@ export interface ITextProps extends React.HTMLAttributes<HTMLSpanElement> {
   variant?: 'body' | 'muted' | 'danger' | 'active';
   dateTime?: string;
   lineHeight?: string;
+  color?: string;
+  fontFamily?: 'inter' | 'everett';
 }
 
 export const Text = styled(Element).attrs(p => ({
@@ -40,6 +47,8 @@ export const Text = styled(Element).attrs(p => ({
     variant = 'body',
     maxWidth,
     lineHeight,
+    color,
+    fontFamily,
     ...props
   }) =>
     css({
@@ -49,8 +58,9 @@ export const Text = styled(Element).attrs(p => ({
       lineHeight: lineHeight || 'normal',
       fontStyle: fontStyle || null, // from theme.fontWeights
       display: block || maxWidth ? 'block' : 'inline',
-      color: variants[variant],
+      color: color || variants[variant],
       maxWidth,
+      fontFamily: fontFamilies[fontFamily],
       ...(maxWidth ? overflowStyles : {}),
     })
 );

--- a/packages/components/src/components/Text/index.tsx
+++ b/packages/components/src/components/Text/index.tsx
@@ -25,6 +25,7 @@ export interface ITextProps extends React.HTMLAttributes<HTMLSpanElement> {
   maxWidth?: number | string;
   variant?: 'body' | 'muted' | 'danger' | 'active';
   dateTime?: string;
+  lineHeight?: string;
 }
 
 export const Text = styled(Element).attrs(p => ({
@@ -38,13 +39,14 @@ export const Text = styled(Element).attrs(p => ({
     block,
     variant = 'body',
     maxWidth,
+    lineHeight,
     ...props
   }) =>
     css({
       fontSize: size || 'inherit', // from theme.fontSizes
       textAlign: align || 'left',
       fontWeight: weight || null, // from theme.fontWeights
-      lineHeight: 'normal',
+      lineHeight: lineHeight || 'normal',
       fontStyle: fontStyle || null, // from theme.fontWeights
       display: block || maxWidth ? 'block' : 'inline',
       color: variants[variant],

--- a/packages/notifications/src/component/Toast.tsx
+++ b/packages/notifications/src/component/Toast.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Stack, Element, Text } from '@codesandbox/components';
+import { Stack, Element, Text, ButtonProps } from '@codesandbox/components';
 
 import { NotificationToast } from './Toasts';
 import { NotificationStatus } from '../state';
@@ -39,11 +39,9 @@ export interface IColors {
   [NotificationStatus.NOTICE]: string;
 }
 
-export type IButtonType = React.ComponentType<{
-  style?: React.CSSProperties;
-  onClick: (e: React.MouseEvent<HTMLButtonElement>) => void;
-  variant: 'primary' | 'secondary' | 'link' | 'danger';
-}>;
+export type IButtonType = React.ComponentType<
+  Pick<ButtonProps, 'style' | 'onClick' | 'variant'>
+>;
 
 export type Props = {
   toast: NotificationToast;


### PR DESCRIPTION
Created `MessageStripe` and `Banner` components. I've also updated some components to be more flexible and to make sure we don't have to use the same `css` prop with the same values everytime.

**Message Stripe Trial**

<img width="1038" alt="image" src="https://user-images.githubusercontent.com/7533849/199718822-3acaf221-e9d3-4560-99f1-91caea9ffe67.png">

**Message Stripe Warning**

<img width="1035" alt="image" src="https://user-images.githubusercontent.com/7533849/199718864-86c3a665-c3ec-42f0-9e3c-7b9b793a012c.png">

**Message Stripe without action**

<img width="1037" alt="image" src="https://user-images.githubusercontent.com/7533849/199718897-c07f5524-6a2a-4f83-97e3-f6d3f737f3df.png">

**Message Stripe with space between**

<img width="1040" alt="image" src="https://user-images.githubusercontent.com/7533849/199718930-1d759fc6-8c9a-4535-a853-b17ce6395941.png">

**Banner**
Note: Everett font does not work in Storybook

<img width="1038" alt="image" src="https://user-images.githubusercontent.com/7533849/199718578-54f0c593-3bcd-40f1-9d42-713a10279fb8.png">
