### PR TITLE
feat(pro): Public sandbox limits

### DIFF
--- a/packages/app/config/webpack.common.js
+++ b/packages/app/config/webpack.common.js
@@ -359,6 +359,12 @@ module.exports = {
           name: 'static/media/[name].[hash:8].[ext]',
         },
       },
+      // https://github.com/gaearon/react-hot-loader/issues/1311
+      {
+        test: /\.js$/,
+        include: /node_modules\/react-dom/,
+        use: ['react-hot-loader/webpack'],
+      },
     ],
 
     noParse: [

--- a/packages/app/src/app/hooks/useSubscription.ts
+++ b/packages/app/src/app/hooks/useSubscription.ts
@@ -1,0 +1,63 @@
+import {
+  SubscriptionStatus,
+  SubscriptionType,
+  TeamMemberAuthorization,
+} from 'app/graphql/types';
+import { useAppState } from 'app/overmind';
+
+export const useSubscription = () => {
+  const {
+    activeTeam,
+    activeTeamInfo,
+    personalWorkspaceId,
+    activeWorkspaceAuthorization,
+  } = useAppState();
+
+  /**
+   * Personal states
+   */
+  const isPersonalSpace = activeTeam === personalWorkspaceId;
+
+  /**
+   * Team states
+   */
+  const isTeamSpace = !isPersonalSpace;
+
+  const isTeamAdmin =
+    isTeamSpace &&
+    activeWorkspaceAuthorization === TeamMemberAuthorization.Admin;
+
+  /**
+   * Subscription states
+   */
+
+  // There are different statuses for a subscription, but only ACTIVE and TRIALING
+  // should be considered an active TeamPro subscription.
+  // TODO: This might change based on how we use other statuses in the subscription (eg: PAUSED)
+  const hasActiveSubscription =
+    activeTeamInfo?.subscription?.status === SubscriptionStatus.Active ||
+    activeTeamInfo?.subscription?.status === SubscriptionStatus.Trialing;
+
+  const hasPastSubscription = Boolean(activeTeamInfo?.subscription?.status);
+
+  /**
+   * Trial states
+   */
+  const hasActiveTeamTrial =
+    isTeamSpace &&
+    activeTeamInfo?.subscription?.type === SubscriptionType.TeamPro &&
+    activeTeamInfo?.subscription?.status === SubscriptionStatus.Trialing;
+
+  const isEligibleForTrial = !isPersonalSpace && !hasPastSubscription;
+
+  return {
+    subscription: activeTeamInfo?.subscription,
+    isPersonalSpace,
+    isTeamSpace: !isPersonalSpace,
+    isTeamAdmin,
+    hasActiveSubscription,
+    hasActiveTeamTrial,
+    hasPastSubscription,
+    isEligibleForTrial,
+  };
+};

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Sandboxes/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Sandboxes/index.tsx
@@ -102,8 +102,10 @@ export const SandboxesPage = () => {
                 {isEligibleForTrial ? 'Start free trial' : 'Upgrade now'}
               </MessageStripe.Action>
             ) : (
-              // ❗️ TODO: Confirm that this link should go to /pricing
-              <MessageStripe.Action as={Link} to="/pricing">
+              <MessageStripe.Action
+                as="a"
+                to="https://codesandbox.io/docs/learn/plan-billing/trials"
+              >
                 Learn more
               </MessageStripe.Action>
             )}

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Sandboxes/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Sandboxes/index.tsx
@@ -3,11 +3,11 @@ import { Helmet } from 'react-helmet';
 import { Link, useParams } from 'react-router-dom';
 import { useAppState, useActions } from 'app/overmind';
 import { Element, MessageStripe } from '@codesandbox/components';
-import { SubscriptionStatus, TeamMemberAuthorization } from 'app/graphql/types';
 import { Header } from 'app/pages/Dashboard/Components/Header';
 import { SelectionProvider } from 'app/pages/Dashboard/Components/Selection';
 import { VariableGrid } from 'app/pages/Dashboard/Components/VariableGrid';
 import { DashboardGridItem, PageTypes } from 'app/pages/Dashboard/types';
+import { useSubscription } from 'app/hooks/useSubscription';
 import { getPossibleTemplates } from '../../utils';
 import { useFilteredItems } from './useFilteredItems';
 
@@ -22,29 +22,17 @@ export const SandboxesPage = () => {
   const {
     dashboard: { allCollections, sandboxes },
     activeTeam,
-    activeTeamInfo,
-    personalWorkspaceId,
-    activeWorkspaceAuthorization,
   } = useAppState();
-
-  const subscription = activeTeamInfo?.subscription;
 
   // 🚧 TODO: hasMaxSandboxes property (or something like it) is something that will
   // be returned from an API. Can be implemented when ready.
   const hasMaxSandboxes = true;
 
-  // ❗️hook maken hiervoor?
-  const isPersonalSpace = activeTeam === personalWorkspaceId;
-  const isTeamAdmin =
-    !isPersonalSpace &&
-    activeWorkspaceAuthorization === TeamMemberAuthorization.Admin;
-
-  const hasActiveSubscription =
-    subscription?.status === SubscriptionStatus.Active ||
-    subscription?.status === SubscriptionStatus.Trialing;
-
-  const hasPastSubscription = subscription?.status;
-  const isEligibleForTrial = !isPersonalSpace && !hasPastSubscription;
+  const {
+    isTeamAdmin,
+    hasActiveSubscription,
+    isEligibleForTrial,
+  } = useSubscription();
 
   React.useEffect(() => {
     if (!currentPath || currentPath === '/') {

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Sandboxes/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Sandboxes/index.tsx
@@ -26,7 +26,7 @@ export const SandboxesPage = () => {
 
   // 🚧 TODO: hasMaxSandboxes property (or something like it) is something that will
   // be returned from an API. Can be implemented when ready.
-  const hasMaxSandboxes = true;
+  const hasMaxSandboxes = false;
 
   const {
     isTeamAdmin,

--- a/packages/components/src/components/MessageStripe/MessageStripe.tsx
+++ b/packages/components/src/components/MessageStripe/MessageStripe.tsx
@@ -19,14 +19,14 @@ export const MessageAction = ({
   ...buttonProps
 }: MessageActionProps) => {
   return (
-    <div>
+    <Element as="div" css={{ flexShrink: 0 }}>
       <Button
         variant={({ trial: 'light', warning: 'dark' } as const)[variant]}
         {...buttonProps}
       >
         {children}
       </Button>
-    </div>
+    </Element>
   );
 };
 
@@ -76,6 +76,7 @@ const MessageStripe = ({
       css={{
         backgroundColor: backgroundVariants[variant],
         color: colorVariants[variant],
+        borderRadius: '4px',
       }}
     >
       <Stack direction="horizontal" justify={justify} align="center" gap={2}>

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -32,6 +32,8 @@ export * from './components/TagInput';
 export * from './components/Tags';
 export * from './components/Tags/Tag';
 export * from './components/Tooltip';
+export * from './components/Banner/Banner';
+export * from './components/MessageStripe/MessageStripe';
 
 // layout
 export * from './components/Grid';


### PR DESCRIPTION
#### Changes

- Fixed a few styling issues in the `MessageStripe` and made sure that the component and `Banner` are now properly exported from the package.

- Fixed an issue with `react-hot-reload` where mapping over children uses proxy components. With proxy components we aren't able to check the child type, which results in broken "augmented" children in the `MessageStripe` component.

- Added the `MessageStripe` with all the conditionals to the "All sandboxes" page.

- Created a hook `useSubscription` to contain subscription logic extracting it a way from the components and enabling reuse.

#### Testing

1. Open the code in the editor
2. Open `packages/app/src/app/pages/Dashboard/Content/routes/Sandboxes/index.tsx`
3. Change the `hasMaxSandboxes` boolean const to `true`
4. If you want to test certain scenario's use different accounts or change boolean values around

#### Screenshots

---

- Has max sandboxes ✅ 
- Eligible for trial ✅ 
- Current user is team admin ✅ 

<img width="1512" alt="image" src="https://user-images.githubusercontent.com/7533849/200808117-0d19f1ec-b550-45c7-8a6f-dd24c39e6ba5.png">

---

- Has max sandboxes ✅ 
- Eligible for trial ✅ 
- Current user is team admin ❌

<img width="1512" alt="image" src="https://user-images.githubusercontent.com/7533849/200809043-c9b7c7db-f8a3-4ab5-9feb-ebedead0b9a3.png">

---

- Has max sandboxes ✅
- Eligible for trial ❌
- Current user is team admin ✅

<img width="1512" alt="image" src="https://user-images.githubusercontent.com/7533849/200809171-8a1164fc-cbdc-4de9-bb1c-ea1550a6a3bc.png">

---

- Has max sandboxes ✅
- Eligible for trial ❌
- Current user is team admin ❌

<img width="1512" alt="image" src="https://user-images.githubusercontent.com/7533849/200809043-c9b7c7db-f8a3-4ab5-9feb-ebedead0b9a3.png">