### PR TITLE
feat: add invite link URL support to team onboarding

### DIFF
--- a/packages/app/src/app/pages/TeamInvitation/TeamInvitation.tsx
+++ b/packages/app/src/app/pages/TeamInvitation/TeamInvitation.tsx
@@ -119,11 +119,9 @@ const TeamSignIn = ({ inviteToken }: { inviteToken: string }) => {
             Join <b>{data.teamByToken.name}</b> on CodeSandbox
           </>
         }
-        description="Please sign in to GitHub to continue"
+        description="Please sign in to continue"
         action={
-          <Button onClick={() => actions.signInClicked()}>
-            Sign in to GitHub
-          </Button>
+          <Button onClick={() => actions.signInClicked()}>Sign in</Button>
         }
       />
     </>

--- a/packages/app/src/app/pages/common/Modals/NewTeamModal/TeamMembers.tsx
+++ b/packages/app/src/app/pages/common/Modals/NewTeamModal/TeamMembers.tsx
@@ -210,7 +210,7 @@ export const TeamMembers: React.FC<{ onComplete: () => void }> = ({
         <Icon
           size={12}
           style={{ marginRight: 8 }}
-          name={linkCopied ? 'check' : 'link'}
+          name={linkCopied ? 'simpleCheck' : 'link'}
         />
         {linkCopied ? 'Link Copied!' : 'Copy Invite URL'}
       </Button>

--- a/packages/app/src/app/pages/common/Modals/NewTeamModal/TeamMembers.tsx
+++ b/packages/app/src/app/pages/common/Modals/NewTeamModal/TeamMembers.tsx
@@ -133,7 +133,7 @@ export const TeamMembers: React.FC<{ onComplete: () => void }> = ({
       gap={4}
       css={{
         paddingTop: '60px',
-        paddingBottom: '48px',
+        paddingBottom: '32px',
         maxWidth: '370px',
         width: '100%',
       }}
@@ -207,7 +207,11 @@ export const TeamMembers: React.FC<{ onComplete: () => void }> = ({
         style={{ marginTop: 24 }}
         variant="link"
       >
-        <Icon size={12} style={{ marginRight: 8 }} name="link" />
+        <Icon
+          size={12}
+          style={{ marginRight: 8 }}
+          name={linkCopied ? 'check' : 'link'}
+        />
         {linkCopied ? 'Link Copied!' : 'Copy Invite URL'}
       </Button>
     </Stack>

--- a/packages/app/src/app/pages/common/Modals/NewTeamModal/TeamMembers.tsx
+++ b/packages/app/src/app/pages/common/Modals/NewTeamModal/TeamMembers.tsx
@@ -1,6 +1,6 @@
 import React, { FormEvent, useState } from 'react';
 import { Button, Icon, Stack, Text } from '@codesandbox/components';
-import { useAppState, useEffects } from 'app/overmind';
+import { useActions, useAppState, useEffects } from 'app/overmind';
 import { StyledButton } from 'app/components/dashboard/Button';
 import { Textarea } from 'app/components/dashboard/Textarea';
 import { TeamMemberAuthorization } from 'app/graphql/types';
@@ -36,6 +36,7 @@ export const TeamMembers: React.FC<{ onComplete: () => void }> = ({
   onComplete,
 }) => {
   const { activeTeamInfo } = useAppState();
+  const actions = useActions();
   const { gql } = useEffects();
   const { copyToClipboard } = useEffects().browser;
   const [addressesString, setAddressesString] = useState<string>();
@@ -54,6 +55,12 @@ export const TeamMembers: React.FC<{ onComplete: () => void }> = ({
     if (copyLinkTimeoutRef.current) {
       window.clearTimeout(copyLinkTimeoutRef.current);
     }
+
+    actions.track({
+      name: 'Dashboard - Copied Team Invite URL',
+      data: { place: 'modal', inviteLink },
+    });
+
     copyLinkTimeoutRef.current = window.setTimeout(() => {
       setLinkCopied(false);
     }, 1500);

--- a/packages/app/src/app/pages/common/Modals/NewTeamModal/TeamMembers.tsx
+++ b/packages/app/src/app/pages/common/Modals/NewTeamModal/TeamMembers.tsx
@@ -207,7 +207,7 @@ export const TeamMembers: React.FC<{ onComplete: () => void }> = ({
         style={{ marginTop: 24 }}
         variant="link"
       >
-        <Icon style={{ marginRight: 12 }} name="link" />
+        <Icon size={12} style={{ marginRight: 8 }} name="link" />
         {linkCopied ? 'Link Copied!' : 'Copy Invite URL'}
       </Button>
     </Stack>

--- a/packages/app/src/app/pages/common/Modals/NewTeamModal/TeamMembers.tsx
+++ b/packages/app/src/app/pages/common/Modals/NewTeamModal/TeamMembers.tsx
@@ -44,7 +44,7 @@ export const TeamMembers: React.FC<{ onComplete: () => void }> = ({
   const [inviteError, setInviteError] = useState<string>();
   const [linkCopied, setLinkCopied] = React.useState(false);
 
-  const copyLinkTimeoutRef = React.useRef<number>();
+  const copyLinkTimeoutRef = React.useRef<ReturnType<typeof setTimeout>>();
 
   const inviteLink = teamInviteLink(activeTeamInfo.inviteToken);
 
@@ -53,7 +53,7 @@ export const TeamMembers: React.FC<{ onComplete: () => void }> = ({
     setLinkCopied(true);
 
     if (copyLinkTimeoutRef.current) {
-      window.clearTimeout(copyLinkTimeoutRef.current);
+      clearTimeout(copyLinkTimeoutRef.current);
     }
 
     actions.track({
@@ -61,7 +61,7 @@ export const TeamMembers: React.FC<{ onComplete: () => void }> = ({
       data: { place: 'modal', inviteLink },
     });
 
-    copyLinkTimeoutRef.current = window.setTimeout(() => {
+    copyLinkTimeoutRef.current = setTimeout(() => {
       setLinkCopied(false);
     }, 1500);
   };

--- a/packages/app/src/app/pages/common/Modals/NewTeamModal/TeamMembers.tsx
+++ b/packages/app/src/app/pages/common/Modals/NewTeamModal/TeamMembers.tsx
@@ -1,10 +1,11 @@
 import React, { FormEvent, useState } from 'react';
-import { Button, Stack, Text } from '@codesandbox/components';
+import { Button, Icon, Stack, Text } from '@codesandbox/components';
 import { useAppState, useEffects } from 'app/overmind';
 import { StyledButton } from 'app/components/dashboard/Button';
 import { Textarea } from 'app/components/dashboard/Textarea';
 import { TeamMemberAuthorization } from 'app/graphql/types';
 import track from '@codesandbox/common/lib/utils/analytics';
+import { teamInviteLink } from '@codesandbox/common/lib/utils/url-generator';
 
 function validateEmail(email: string) {
   // Test for "anything@anything.anything" and check for
@@ -36,9 +37,27 @@ export const TeamMembers: React.FC<{ onComplete: () => void }> = ({
 }) => {
   const { activeTeamInfo } = useAppState();
   const { gql } = useEffects();
+  const { copyToClipboard } = useEffects().browser;
   const [addressesString, setAddressesString] = useState<string>();
   const [invalidEmails, setInvalidEmails] = useState<string[]>();
   const [inviteError, setInviteError] = useState<string>();
+  const [linkCopied, setLinkCopied] = React.useState(false);
+
+  const copyLinkTimeoutRef = React.useRef<number>();
+
+  const inviteLink = teamInviteLink(activeTeamInfo.inviteToken);
+
+  const copyTeamInviteLink = () => {
+    copyToClipboard(inviteLink);
+    setLinkCopied(true);
+
+    if (copyLinkTimeoutRef.current) {
+      window.clearTimeout(copyLinkTimeoutRef.current);
+    }
+    copyLinkTimeoutRef.current = window.setTimeout(() => {
+      setLinkCopied(false);
+    }, 1500);
+  };
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
@@ -104,7 +123,7 @@ export const TeamMembers: React.FC<{ onComplete: () => void }> = ({
     <Stack
       align="center"
       direction="vertical"
-      gap={6}
+      gap={4}
       css={{
         paddingTop: '60px',
         paddingBottom: '48px',
@@ -174,6 +193,15 @@ export const TeamMembers: React.FC<{ onComplete: () => void }> = ({
         variant="link"
       >
         Skip
+      </Button>
+
+      <Button
+        onClick={copyTeamInviteLink}
+        style={{ marginTop: 24 }}
+        variant="link"
+      >
+        <Icon style={{ marginRight: 12 }} name="link" />
+        {linkCopied ? 'Link Copied!' : 'Copy Invite URL'}
       </Button>
     </Stack>
   );


### PR DESCRIPTION
## What kind of change does this PR introduce?

Gives a link to invite team members

<img width="751" alt="image" src="https://user-images.githubusercontent.com/587016/200893702-56a16d0f-9d43-4eae-ae4f-9e87ce51a6df.png">

Tested it by clicking the button, and verifying that the right url was on clipboard :D
