### PR TITLE
feat(dashboard): "Upgrade to Pro" banner

### DIFF
--- a/packages/app/src/app/hooks/index.ts
+++ b/packages/app/src/app/hooks/index.ts
@@ -1,2 +1,3 @@
 export { useScript } from './useScript';
 export { useCreateCheckout } from './useCreateCheckout';
+export { useDismissible } from './useDismissible';

--- a/packages/app/src/app/hooks/useDismissible.ts
+++ b/packages/app/src/app/hooks/useDismissible.ts
@@ -1,20 +1,50 @@
+import { useState } from 'react';
 import { useEffects } from 'app/overmind';
 
 /**
  * Localstorage keys used for dismissible modals and banners.
  */
-type DismissibleKeys =
-  // TODO - Any key in this type should refer to a dismissible item. Right
-  // now there are none yet.
-  'TODO';
+type DismissibleKeys = 'DASHBOARD_RECENT_UPGRADE';
 
 type Dismissibles = Partial<Record<DismissibleKeys, true>>;
 
-export const useDismissible = (key: DismissibleKeys) => {
-  const { browser } = useEffects();
+// export const useLocalPersistedState = <T>(
+//   key: string,
+//   initialValue: T
+// ): [T, (arg: T) => void] => {
 
-  const dismissibles = browser.storage.get<Dismissibles>('DISMISSIBLES');
-  const isDismissed = dismissibles?.[key] === true;
+//   const [storedValue, setStoredValue] = useState<T>(() => {
+//     try {
+//       const item: T | null = storage.get(key);
+//       return item ?? initialValue;
+//     } catch (error) {
+//       logger.error(
+//         `[persisted-state]: Failed to retrieve data from local storage`,
+//         error
+//       );
+//       return initialValue;
+//     }
+//   });
+
+//   const setValue = (value: T) => {
+//     try {
+//       const valueToStore =
+//         value instanceof Function ? value(storedValue) : value;
+//       setStoredValue(value);
+//       storage.set(key, valueToStore);
+//     } catch (error) {
+//       logger.error(`[persisted-state]:`, error);
+//     }
+//   };
+//   return [storedValue, setValue];
+// };
+
+export const useDismissible = (key: DismissibleKeys): [boolean, () => void] => {
+  const { browser } = useEffects();
+  const [isDismissed, setIsDismissed] = useState(() => {
+    const dismissibles = browser.storage.get<Dismissibles>('DISMISSIBLES');
+    return dismissibles?.[key] === true;
+  });
 
   const dismiss = () => {
     // Getting the dismissibles again to make sure other instances aren't
@@ -26,6 +56,7 @@ export const useDismissible = (key: DismissibleKeys) => {
       ...prevDismissibles,
       [key]: true,
     });
+    setIsDismissed(true);
   };
 
   return [isDismissed, dismiss];

--- a/packages/app/src/app/hooks/useDismissible.ts
+++ b/packages/app/src/app/hooks/useDismissible.ts
@@ -8,37 +8,6 @@ type DismissibleKeys = 'DASHBOARD_RECENT_UPGRADE';
 
 type Dismissibles = Partial<Record<DismissibleKeys, true>>;
 
-// export const useLocalPersistedState = <T>(
-//   key: string,
-//   initialValue: T
-// ): [T, (arg: T) => void] => {
-
-//   const [storedValue, setStoredValue] = useState<T>(() => {
-//     try {
-//       const item: T | null = storage.get(key);
-//       return item ?? initialValue;
-//     } catch (error) {
-//       logger.error(
-//         `[persisted-state]: Failed to retrieve data from local storage`,
-//         error
-//       );
-//       return initialValue;
-//     }
-//   });
-
-//   const setValue = (value: T) => {
-//     try {
-//       const valueToStore =
-//         value instanceof Function ? value(storedValue) : value;
-//       setStoredValue(value);
-//       storage.set(key, valueToStore);
-//     } catch (error) {
-//       logger.error(`[persisted-state]:`, error);
-//     }
-//   };
-//   return [storedValue, setValue];
-// };
-
 export const useDismissible = (key: DismissibleKeys): [boolean, () => void] => {
   const { browser } = useEffects();
   const [isDismissed, setIsDismissed] = useState(() => {

--- a/packages/app/src/app/pages/Dashboard/Components/UpgradeBanner/UpgradeBanner.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/UpgradeBanner/UpgradeBanner.tsx
@@ -1,89 +1,113 @@
 import React from 'react';
+import styled from 'styled-components';
 import {
   Banner,
   Button,
   Column,
-  Icon,
   Grid,
+  Icon,
+  IconNames,
+  Link,
   Stack,
   Text,
 } from '@codesandbox/components';
 
+const StyledTitle = styled(Text)`
+  font-size: 24px;
+  line-height: 32px;
+  letter-spacing: -0.019em;
+  margin: 0;
+`;
+
+// When flex wraps and the list of features is shown
+// above the call to action.
+const WRAP_WIDTH = '1332px';
+
+type Feature = {
+  icon: IconNames;
+  label: string;
+};
+const FEATURES: Feature[] = [
+  {
+    icon: 'profile',
+    label: 'Up to 20 editors',
+  },
+  {
+    icon: 'npm',
+    label: 'Private NPM packages',
+  },
+  {
+    icon: 'sandbox',
+    label: 'Unlimited sandboxes',
+  },
+  {
+    icon: 'lock',
+    label: 'Advanced privacy settings',
+  },
+  {
+    icon: 'repository',
+    label: 'Unlimited repositories',
+  },
+  {
+    icon: 'server',
+    label: '6GB RAM, 12GB Disk, 4 vCPUs',
+  },
+];
+
 export const UpgradeBanner: React.FC = () => {
   return (
-    <Banner>
-      <Stack gap={2} justify="space-between">
-        <Stack direction="vertical" gap={8} justify="space-between">
-          <Text fontFamily="everett" size={24}>
-            <Text color="#EDFFA5" weight="600" block>
-              Upgrade to <Text css={{ textTransform: 'uppercase' }}>pro</Text>
-            </Text>
-            <Text block>Enjoy the full CodeSandbox experience.</Text>
-          </Text>
-          <Button autoWidth>Learn more</Button>
-        </Stack>
-        <Stack align="flex-end">
-          <Grid
-            as="ul"
-            columnGap={3}
-            rowGap={3}
+    <Banner onDismiss={() => {}}>
+      <StyledTitle color="#EDFFA5" weight="600" block>
+        Upgrade to <span css={{ textTransform: 'uppercase' }}>pro</span>
+      </StyledTitle>
+      <Stack
+        css={{
+          flexWrap: 'wrap',
+        }}
+        justify="space-between"
+      >
+        <Stack direction="vertical" justify="space-between">
+          <StyledTitle block>
+            Enjoy the full CodeSandbox experience.
+          </StyledTitle>
+          <Stack
+            align="center"
             css={{
-              color: '#EBEBEB',
-              margin: 0,
-              padding: 0,
-              listStyleType: 'none',
+              [`@media screen and (max-width: ${WRAP_WIDTH})`]: {
+                marginTop: '24px',
+              },
             }}
+            gap={6}
           >
-            <Column as="li" span={6}>
-              <Stack gap={4}>
-                <Icon name="profile" />
-                <Text size={13} lineHeight="16px">
-                  Up to 20 editors
-                </Text>
-              </Stack>
-            </Column>
-            <Column as="li" span={6}>
-              <Stack gap={4}>
-                <Icon name="profile" />
-                <Text size={13} lineHeight="16px">
-                  Private NPM packages
-                </Text>
-              </Stack>
-            </Column>
-            <Column as="li" span={6}>
-              <Stack gap={4}>
-                <Icon name="profile" />
-                <Text size={13} lineHeight="16px">
-                  Unlimited sandboxes
-                </Text>
-              </Stack>
-            </Column>
-            <Column as="li" span={6}>
-              <Stack gap={4}>
-                <Icon name="profile" />
-                <Text size={13} lineHeight="16px">
-                  Advanced privacy settings
-                </Text>
-              </Stack>
-            </Column>
-            <Column as="li" span={6}>
-              <Stack gap={4}>
-                <Icon name="profile" />
-                <Text size={13} lineHeight="16px">
-                  Unlimited repositories
-                </Text>
-              </Stack>
-            </Column>
-            <Column as="li" span={6}>
-              <Stack gap={4}>
-                <Icon name="profile" />
-                <Text size={13} lineHeight="16px">
-                  6GB RAM, 12GB Disk, 4 vCPUs
-                </Text>
-              </Stack>
-            </Column>
-          </Grid>
+            <Button autoWidth>Upgrade now</Button>
+            <Link>
+              <Text color="#999999" size={3}>
+                Learn more
+              </Text>
+            </Link>
+          </Stack>
         </Stack>
+        <Grid
+          as="ul"
+          css={{
+            listStyle: 'none',
+            margin: 0,
+            padding: 0,
+
+            [`@media screen and (max-width: ${WRAP_WIDTH})`]: {
+              marginTop: '24px',
+            },
+          }}
+        >
+          {FEATURES.map(f => (
+            <Column key={f.icon} as="li" span={[12, 12, 6]}>
+              <Stack css={{ color: '#EBEBEB' }} gap={4}>
+                <Icon css={{ flexShrink: 0 }} name={f.icon} />
+                <Text size={3}>{f.label}</Text>
+              </Stack>
+            </Column>
+          ))}
+        </Grid>
       </Stack>
     </Banner>
   );

--- a/packages/app/src/app/pages/Dashboard/Components/UpgradeBanner/UpgradeBanner.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/UpgradeBanner/UpgradeBanner.tsx
@@ -23,8 +23,8 @@ const StyledTitle = styled(Text)`
   margin: 0;
 `;
 
-// When flex wraps and the list of features is shown
-// above the call to action.
+// When flex wraps and the list of features is
+// shown below the call to action.
 const WRAP_WIDTH = 1332;
 
 type Feature = {
@@ -59,10 +59,12 @@ const FEATURES: Feature[] = [
 ];
 
 type UpgradeBannerProps = {
+  elligibleForTrial: boolean;
   isAdmin: boolean;
   teamId: string;
 };
 export const UpgradeBanner: React.FC<UpgradeBannerProps> = ({
+  elligibleForTrial,
   isAdmin,
   teamId,
 }) => {
@@ -136,7 +138,7 @@ export const UpgradeBanner: React.FC<UpgradeBannerProps> = ({
                     type="button"
                     autoWidth
                   >
-                    Upgrade now
+                    {elligibleForTrial ? 'Start trial' : 'Upgrade now'}
                   </Button>
                   <Link
                     href="/docs/learn/introduction/workspace#team-workspace"

--- a/packages/app/src/app/pages/Dashboard/Components/UpgradeBanner/UpgradeBanner.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/UpgradeBanner/UpgradeBanner.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import {
+  Banner,
+  Button,
+  Column,
+  Icon,
+  Grid,
+  Stack,
+  Text,
+} from '@codesandbox/components';
+
+export const UpgradeBanner: React.FC = () => {
+  return (
+    <Banner>
+      <Stack gap={2} justify="space-between">
+        <Stack direction="vertical" gap={8} justify="space-between">
+          <Text fontFamily="everett" size={24}>
+            <Text color="#EDFFA5" weight="600" block>
+              Upgrade to <Text css={{ textTransform: 'uppercase' }}>pro</Text>
+            </Text>
+            <Text block>Enjoy the full CodeSandbox experience.</Text>
+          </Text>
+          <Button autoWidth>Learn more</Button>
+        </Stack>
+        <Stack align="flex-end">
+          <Grid
+            as="ul"
+            columnGap={3}
+            rowGap={3}
+            css={{
+              color: '#EBEBEB',
+              margin: 0,
+              padding: 0,
+              listStyleType: 'none',
+            }}
+          >
+            <Column as="li" span={6}>
+              <Stack gap={4}>
+                <Icon name="profile" />
+                <Text size={13} lineHeight="16px">
+                  Up to 20 editors
+                </Text>
+              </Stack>
+            </Column>
+            <Column as="li" span={6}>
+              <Stack gap={4}>
+                <Icon name="profile" />
+                <Text size={13} lineHeight="16px">
+                  Private NPM packages
+                </Text>
+              </Stack>
+            </Column>
+            <Column as="li" span={6}>
+              <Stack gap={4}>
+                <Icon name="profile" />
+                <Text size={13} lineHeight="16px">
+                  Unlimited sandboxes
+                </Text>
+              </Stack>
+            </Column>
+            <Column as="li" span={6}>
+              <Stack gap={4}>
+                <Icon name="profile" />
+                <Text size={13} lineHeight="16px">
+                  Advanced privacy settings
+                </Text>
+              </Stack>
+            </Column>
+            <Column as="li" span={6}>
+              <Stack gap={4}>
+                <Icon name="profile" />
+                <Text size={13} lineHeight="16px">
+                  Unlimited repositories
+                </Text>
+              </Stack>
+            </Column>
+            <Column as="li" span={6}>
+              <Stack gap={4}>
+                <Icon name="profile" />
+                <Text size={13} lineHeight="16px">
+                  6GB RAM, 12GB Disk, 4 vCPUs
+                </Text>
+              </Stack>
+            </Column>
+          </Grid>
+        </Stack>
+      </Stack>
+    </Banner>
+  );
+};

--- a/packages/app/src/app/pages/Dashboard/Components/UpgradeBanner/UpgradeBanner.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/UpgradeBanner/UpgradeBanner.tsx
@@ -105,49 +105,62 @@ export const UpgradeBanner: React.FC<UpgradeBannerProps> = ({
               Enjoy the full CodeSandbox experience.
             </StyledTitle>
             <Stack
-              align="center"
               css={{
                 [`@media screen and (max-width: ${WRAP_WIDTH}px)`]: {
                   marginTop: '24px',
                 },
               }}
-              gap={6}
+              direction="vertical"
             >
               {isAdmin ? (
                 <>
-                  <Button
-                    onClick={() => {
-                      if (checkoutBtnDisabled) {
-                        return;
-                      }
+                  <Stack align="center" gap={6}>
+                    <Button
+                      aria-describedby="checkout-error"
+                      onClick={() => {
+                        if (checkoutBtnDisabled) {
+                          return;
+                        }
 
-                      track('Banner - Upgrade now - Checkout', {
-                        codesandbox: 'V1',
-                        event_source: 'UI',
-                      });
+                        track('Banner - Upgrade now - Checkout', {
+                          codesandbox: 'V1',
+                          event_source: 'UI',
+                        });
 
-                      createCheckout({
-                        team_id: teamId,
-                        recurring_interval: 'month',
-                        success_path: dashboard.recent(teamId),
-                        cancel_path: dashboard.recent(teamId),
-                      });
-                    }}
-                    loading={checkout.status === 'loading'}
-                    disabled={checkoutBtnDisabled}
-                    type="button"
-                    autoWidth
-                  >
-                    {elligibleForTrial ? 'Start trial' : 'Upgrade now'}
-                  </Button>
-                  <Link
-                    href="/docs/learn/introduction/workspace#team-workspace"
-                    target="_blank"
-                  >
-                    <Text color="#999999" size={3}>
-                      Learn more
+                        createCheckout({
+                          team_id: teamId,
+                          recurring_interval: 'month',
+                          success_path: dashboard.recent(teamId),
+                          cancel_path: dashboard.recent(teamId),
+                        });
+                      }}
+                      loading={checkout.status === 'loading'}
+                      disabled={checkoutBtnDisabled}
+                      type="button"
+                      autoWidth
+                    >
+                      {elligibleForTrial ? 'Start trial' : 'Upgrade now'}
+                    </Button>
+
+                    <Link
+                      href="/docs/learn/introduction/workspace#team-workspace"
+                      target="_blank"
+                    >
+                      <Text color="#999999" size={3}>
+                        Learn more
+                      </Text>
+                    </Link>
+                  </Stack>
+                  {checkout.status === 'error' && (
+                    <Text
+                      css={{ marginTop: '8px' }}
+                      id="checkout-error"
+                      size={2}
+                      variant="danger"
+                    >
+                      {checkout.error}. Please try again.
                     </Text>
-                  </Link>
+                  )}
                 </>
               ) : (
                 <Button

--- a/packages/app/src/app/pages/Dashboard/Components/UpgradeBanner/UpgradeBanner.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/UpgradeBanner/UpgradeBanner.tsx
@@ -12,7 +12,7 @@ import {
   Stack,
   Text,
 } from '@codesandbox/components';
-import { useCreateCheckout } from 'app/hooks';
+import { useCreateCheckout, useDismissible } from 'app/hooks';
 import { dashboard } from '@codesandbox/common/lib/utils/url-generator';
 import track from '@codesandbox/common/lib/utils/analytics';
 
@@ -67,11 +67,27 @@ export const UpgradeBanner: React.FC<UpgradeBannerProps> = ({
   teamId,
 }) => {
   const [checkout, createCheckout] = useCreateCheckout();
+  const [isBannerDismissed, dismissBanner] = useDismissible(
+    'DASHBOARD_RECENT_UPGRADE'
+  );
+
+  if (isBannerDismissed) {
+    return null;
+  }
 
   const checkoutBtnDisabled = !isAdmin || checkout.status === 'loading';
 
   return (
-    <Banner onDismiss={() => {}}>
+    <Banner
+      onDismiss={() => {
+        track('Banner - Upgrade Now - Dismiss', {
+          codesandbox: 'V1',
+          event_source: 'UI',
+        });
+
+        dismissBanner();
+      }}
+    >
       <Element css={{ overflow: 'hidden' }}>
         <StyledTitle color="#EDFFA5" weight="600" block>
           Upgrade to <span css={{ textTransform: 'uppercase' }}>pro</span>
@@ -103,7 +119,7 @@ export const UpgradeBanner: React.FC<UpgradeBannerProps> = ({
                         return;
                       }
 
-                      track('Banner - Upgrade now', {
+                      track('Banner - Upgrade now - Checkout', {
                         codesandbox: 'V1',
                         event_source: 'UI',
                       });
@@ -158,6 +174,8 @@ export const UpgradeBanner: React.FC<UpgradeBannerProps> = ({
             {FEATURES.map(f => (
               <Column
                 css={{
+                  // Manually defining the columns width to ensure that the
+                  // columns have visual alignment on multiple breakpoints.
                   gridColumnEnd: 'span 12',
 
                   '@media screen and (min-width: 576px) and (max-width: 885px)': {
@@ -178,7 +196,6 @@ export const UpgradeBanner: React.FC<UpgradeBannerProps> = ({
                 }}
                 key={f.icon}
                 as="li"
-                // span={[12, 12, 6]}
               >
                 <Stack css={{ color: '#EBEBEB' }} gap={4}>
                   <Icon css={{ flexShrink: 0 }} name={f.icon} />

--- a/packages/app/src/app/pages/Dashboard/Components/UpgradeBanner/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/UpgradeBanner/index.tsx
@@ -1,0 +1,1 @@
+export { UpgradeBanner } from './UpgradeBanner';

--- a/packages/app/src/app/pages/Dashboard/Content/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/index.tsx
@@ -4,7 +4,6 @@ import { Element } from '@codesandbox/components';
 import { dashboard as dashboardUrls } from '@codesandbox/common/lib/utils/url-generator';
 import css from '@styled-system/css';
 import { useAppState, useActions } from 'app/overmind';
-import { SubscriptionType } from 'app/graphql/types';
 import { Templates } from './routes/Templates';
 import { Archive } from './routes/Archive';
 import { Drafts } from './routes/Drafts';
@@ -21,17 +20,10 @@ import { Curate } from './routes/Discover/Curate';
 import { CommunitySearch } from './routes/Discover/CommunitySearch';
 import { MyContributions } from './routes/MyContributions';
 import { RepositoriesPage } from './routes/Repositories';
-import { UpgradeBanner } from '../Components/UpgradeBanner/UpgradeBanner';
-import { GRID_MAX_WIDTH, GUTTER } from '../Components/VariableGrid';
 
 export const Content = withRouter(({ history }) => {
   const { dashboard } = useActions();
-  const { activeTeamInfo } = useAppState();
-
-  const isPro = [
-    SubscriptionType.PersonalPro,
-    SubscriptionType.TeamPro,
-  ].includes(activeTeamInfo?.subscription?.type);
+  const { activeTeam } = useAppState();
 
   useEffect(() => {
     dashboard.dashboardMounted();
@@ -59,17 +51,6 @@ export const Content = withRouter(({ history }) => {
         justifyContent: 'center',
       })}
     >
-      {!isPro && (
-        <Element
-          css={{
-            width: `calc(100% - ${2 * GUTTER}px)`,
-            maxWidth: GRID_MAX_WIDTH - 2 * GUTTER,
-            margin: '24px auto 0',
-          }}
-        >
-          <UpgradeBanner />
-        </Element>
-      )}
       <Switch>
         <Route path="/dashboard/recent" component={Recent} />
         <Route path="/dashboard/drafts" component={Drafts} />
@@ -104,7 +85,7 @@ export const Content = withRouter(({ history }) => {
           to="/dashboard/sandboxes/:path*"
         />
         <Redirect from="/dashboard/always-on" to="/dashboard/recent" />
-        <Redirect to={dashboardUrls.recent(activeTeamInfo?.id)} />
+        <Redirect to={dashboardUrls.recent(activeTeam)} />
       </Switch>
     </Element>
   );

--- a/packages/app/src/app/pages/Dashboard/Content/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/index.tsx
@@ -4,6 +4,7 @@ import { Element } from '@codesandbox/components';
 import { dashboard as dashboardUrls } from '@codesandbox/common/lib/utils/url-generator';
 import css from '@styled-system/css';
 import { useAppState, useActions } from 'app/overmind';
+import { SubscriptionType } from 'app/graphql/types';
 import { Templates } from './routes/Templates';
 import { Archive } from './routes/Archive';
 import { Drafts } from './routes/Drafts';
@@ -20,10 +21,17 @@ import { Curate } from './routes/Discover/Curate';
 import { CommunitySearch } from './routes/Discover/CommunitySearch';
 import { MyContributions } from './routes/MyContributions';
 import { RepositoriesPage } from './routes/Repositories';
+import { UpgradeBanner } from '../Components/UpgradeBanner/UpgradeBanner';
+import { GRID_MAX_WIDTH, GUTTER } from '../Components/VariableGrid';
 
 export const Content = withRouter(({ history }) => {
   const { dashboard } = useActions();
-  const { activeTeam } = useAppState();
+  const { activeTeamInfo } = useAppState();
+
+  const isPro = [
+    SubscriptionType.PersonalPro,
+    SubscriptionType.TeamPro,
+  ].includes(activeTeamInfo?.subscription?.type);
 
   useEffect(() => {
     dashboard.dashboardMounted();
@@ -47,9 +55,21 @@ export const Content = withRouter(({ history }) => {
         height: '100%',
         margin: '0 auto',
         display: 'flex',
+        flexDirection: 'column',
         justifyContent: 'center',
       })}
     >
+      {!isPro && (
+        <Element
+          css={{
+            width: `calc(100% - ${2 * GUTTER}px)`,
+            maxWidth: GRID_MAX_WIDTH - 2 * GUTTER,
+            margin: '24px auto 0',
+          }}
+        >
+          <UpgradeBanner />
+        </Element>
+      )}
       <Switch>
         <Route path="/dashboard/recent" component={Recent} />
         <Route path="/dashboard/drafts" component={Drafts} />
@@ -84,7 +104,7 @@ export const Content = withRouter(({ history }) => {
           to="/dashboard/sandboxes/:path*"
         />
         <Redirect from="/dashboard/always-on" to="/dashboard/recent" />
-        <Redirect to={dashboardUrls.recent(activeTeam)} />
+        <Redirect to={dashboardUrls.recent(activeTeamInfo?.id)} />
       </Switch>
     </Element>
   );

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Recent/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Recent/index.tsx
@@ -2,27 +2,42 @@ import React, { useEffect } from 'react';
 import { useAppState, useActions } from 'app/overmind';
 import { sandboxesTypes } from 'app/overmind/namespaces/dashboard/types';
 import { Header } from 'app/pages/Dashboard/Components/Header';
-import { VariableGrid } from 'app/pages/Dashboard/Components/VariableGrid';
+import {
+  GRID_MAX_WIDTH,
+  GUTTER,
+  VariableGrid,
+} from 'app/pages/Dashboard/Components/VariableGrid';
 import { SelectionProvider } from 'app/pages/Dashboard/Components/Selection';
 import { Helmet } from 'react-helmet';
 import { DashboardGridItem, PageTypes } from 'app/pages/Dashboard/types';
+import { Element } from '@codesandbox/components';
+import { UpgradeBanner } from 'app/pages/Dashboard/Components/UpgradeBanner';
+import { SubscriptionType, TeamMemberAuthorization } from 'app/graphql/types';
 
 export const Recent = () => {
   const {
-    activeTeam,
+    activeTeamInfo,
+    activeWorkspaceAuthorization,
     dashboard: { sandboxes },
   } = useAppState();
   const {
     dashboard: { getPage },
   } = useActions();
 
+  const activeTeamId = activeTeamInfo?.id;
+
   useEffect(() => {
     getPage(sandboxesTypes.RECENT);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [activeTeam]);
+  }, [activeTeamId]);
 
   const dataIsLoading =
     sandboxes.RECENT_BRANCHES === null || sandboxes.RECENT_SANDBOXES === null;
+
+  const isPro = [
+    SubscriptionType.PersonalPro,
+    SubscriptionType.TeamPro,
+  ].includes(activeTeamInfo?.subscription?.type);
 
   const items: DashboardGridItem[] = dataIsLoading
     ? [
@@ -59,13 +74,33 @@ export const Recent = () => {
   const isEmpty = !dataIsLoading && items.length === 0;
 
   return (
-    <SelectionProvider activeTeamId={activeTeam} page={pageType} items={items}>
+    <SelectionProvider
+      activeTeamId={activeTeamId}
+      page={pageType}
+      items={items}
+    >
       <Helmet>
         <title>Dashboard - CodeSandbox</title>
       </Helmet>
+      {!isPro && (
+        <Element
+          css={{
+            width: `calc(100% - ${2 * GUTTER}px)`,
+            maxWidth: GRID_MAX_WIDTH - 2 * GUTTER,
+            margin: '0 auto 28px',
+          }}
+        >
+          <UpgradeBanner
+            isAdmin={
+              activeWorkspaceAuthorization === TeamMemberAuthorization.Admin
+            }
+            teamId={activeTeamId}
+          />
+        </Element>
+      )}
       <Header
         title={isEmpty ? "Let's start building" : 'Recent'}
-        activeTeam={activeTeam}
+        activeTeam={activeTeamId}
         loading={dataIsLoading}
         showViewOptions
       />

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Recent/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Recent/index.tsx
@@ -12,13 +12,18 @@ import { Helmet } from 'react-helmet';
 import { DashboardGridItem, PageTypes } from 'app/pages/Dashboard/types';
 import { Element } from '@codesandbox/components';
 import { UpgradeBanner } from 'app/pages/Dashboard/Components/UpgradeBanner';
-import { SubscriptionType, TeamMemberAuthorization } from 'app/graphql/types';
+import {
+  SubscriptionStatus,
+  SubscriptionType,
+  TeamMemberAuthorization,
+} from 'app/graphql/types';
 
 export const Recent = () => {
   const {
     activeTeamInfo,
     activeWorkspaceAuthorization,
     dashboard: { sandboxes },
+    personalWorkspaceId,
   } = useAppState();
   const {
     dashboard: { getPage },
@@ -34,10 +39,18 @@ export const Recent = () => {
   const dataIsLoading =
     sandboxes.RECENT_BRANCHES === null || sandboxes.RECENT_SANDBOXES === null;
 
-  const isPro = [
-    SubscriptionType.PersonalPro,
-    SubscriptionType.TeamPro,
-  ].includes(activeTeamInfo?.subscription?.type);
+  const subscriptionType = activeTeamInfo?.subscription?.type;
+  const subscriptionStatus = activeTeamInfo?.subscription?.status;
+
+  const isPro =
+    subscriptionType === SubscriptionType.TeamPro &&
+    [SubscriptionStatus.Active, SubscriptionStatus.Trialing].includes(
+      subscriptionStatus
+    );
+
+  const isPersonalWorkspace = personalWorkspaceId === activeTeamId;
+  const elligibleForTrial =
+    !isPersonalWorkspace && !activeTeamInfo?.subscription;
 
   const items: DashboardGridItem[] = dataIsLoading
     ? [
@@ -91,6 +104,7 @@ export const Recent = () => {
           }}
         >
           <UpgradeBanner
+            elligibleForTrial={elligibleForTrial}
             isAdmin={
               activeWorkspaceAuthorization === TeamMemberAuthorization.Admin
             }

--- a/packages/components/src/components/Banner/index.tsx
+++ b/packages/components/src/components/Banner/index.tsx
@@ -1,0 +1,1 @@
+export { Banner } from './Banner';

--- a/packages/components/src/components/Icon/icons.tsx
+++ b/packages/components/src/components/Icon/icons.tsx
@@ -1214,3 +1214,19 @@ export const camera = props => (
     />
   </Element>
 );
+
+export const sandbox = props => (
+  <svg
+    width="16"
+    height="16"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    {...props}
+  >
+    <path
+      d="M14 4.7 8.017 7.997a.034.034 0 0 1-.034 0L2 4.701M8 8v6.666m5.99-3.328-5.982 3.326a.017.017 0 0 1-.016 0L2.01 11.34A.021.021 0 0 1 2 11.32V4.708c0-.008.004-.015.01-.019l5.982-3.353a.017.017 0 0 1 .016 0L13.99 4.69c.006.004.01.011.01.019v6.612a.021.021 0 0 1-.01.019Z"
+      stroke="currentColor"
+      strokeLinejoin="round"
+    />
+  </svg>
+);

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -5,6 +5,7 @@ export * from './components/ThemeProvider';
 // atoms
 export * from './components/Avatar';
 export * from './components/Badge';
+export * from './components/Banner';
 export * from './components/Button';
 export * from './components/Checkbox';
 export * from './components/Icon';


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?

<!-- Is it a Bug fix, feature, docs update, ... -->

- Updates the dismissible hook to instantly reflect the changes in state.
- Adds the `sandbox` icon.
- Adds the upgrade banner to the dashboard.

## What is the new behavior?

<!-- if this is a feature change -->

![jrz5lm-3000 preview csb app_dashboard_recent_workspace=a60c2923-d31d-4ade-8a9c-fb14bf1ac076](https://user-images.githubusercontent.com/24959348/200916358-7d60cbe9-ef1f-423c-b101-aca38c173ea9.png)

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Visit the dashboard home: `/dashboard/recent`
2. Select a team on a free account
3. View banner
  - See the "Upgrade now" CTA and the "Learn more" link if you are an admin.
  - See the "Learn mode" CTA if you are not an admin.
