### PR TITLE
fix: open stripe directly on start trial

### DIFF
--- a/packages/app/src/app/pages/Dashboard/Sidebar/BottomMessages/AdminStartTrial.tsx
+++ b/packages/app/src/app/pages/Dashboard/Sidebar/BottomMessages/AdminStartTrial.tsx
@@ -3,11 +3,13 @@ import React from 'react';
 import { useCreateCheckout } from 'app/hooks';
 import track from '@codesandbox/common/lib/utils/analytics';
 import { dashboard } from '@codesandbox/common/lib/utils/url-generator';
+import { useActions } from 'app/overmind';
 
 export const AdminStartTrial: React.FC<{ activeTeam: string }> = ({
   activeTeam,
 }) => {
   const [checkout, createCheckout] = useCreateCheckout();
+  const { modalOpened } = useActions();
 
   return (
     <Stack align="flex-start" direction="vertical" gap={2}>
@@ -17,7 +19,24 @@ export const AdminStartTrial: React.FC<{ activeTeam: string }> = ({
       {checkout.status === 'error' ? (
         <Text variant="danger" css={{ fontWeight: 400, fontSize: 12 }}>
           An error ocurred while trying to load the trial subscription. Please
-          try again later and report the issue if it persists.
+          try again later and{' '}
+          <Button
+            variant="link"
+            css={{
+              color: 'inherit',
+              textDecoration: 'underline',
+              padding: '0',
+              display: 'inline',
+              width: 'auto',
+              height: 'auto',
+            }}
+            onClick={() => {
+              modalOpened({ modal: 'feedback' });
+            }}
+          >
+            report the issue
+          </Button>{' '}
+          if it persists.
         </Text>
       ) : (
         <Button

--- a/packages/app/src/app/pages/Dashboard/Sidebar/BottomMessages/AdminStartTrial.tsx
+++ b/packages/app/src/app/pages/Dashboard/Sidebar/BottomMessages/AdminStartTrial.tsx
@@ -16,8 +16,8 @@ export const AdminStartTrial: React.FC<{ activeTeam: string }> = ({
       </Text>
       {checkout.status === 'error' ? (
         <Text variant="danger" css={{ fontWeight: 400, fontSize: 12 }}>
-          An error ocurred while trying to load the payment gateway. Please try
-          again later.
+          An error ocurred while trying to load the trial subscription. Please
+          try again later and report the issue if it persists.
         </Text>
       ) : (
         <Button

--- a/packages/app/src/app/pages/Dashboard/Sidebar/BottomMessages/AdminStartTrial.tsx
+++ b/packages/app/src/app/pages/Dashboard/Sidebar/BottomMessages/AdminStartTrial.tsx
@@ -1,24 +1,53 @@
-import { Stack, Text, Link } from '@codesandbox/components';
-import { Link as RouterLink } from 'react-router-dom';
+import { Stack, Text, Button } from '@codesandbox/components';
 import React from 'react';
+import { useCreateCheckout } from 'app/hooks';
+import track from '@codesandbox/common/lib/utils/analytics';
+import { dashboard } from '@codesandbox/common/lib/utils/url-generator';
 
-export const AdminStartTrial = () => (
-  <Stack align="flex-start" direction="vertical" gap={2}>
-    <Text css={{ color: '#999', fontWeight: 400, fontSize: 12 }}>
-      Upgrade to Team PRO for the full Codesandbox Experience.
-    </Text>
-    <Link
-      as={RouterLink}
-      to="/pro"
-      title="Start Team PRO trial"
-      css={{
-        fontSize: '12px',
-        fontWeight: 500,
-        color: '#EDFFA5',
-        textDecoration: 'none',
-      }}
-    >
-      Start trial
-    </Link>
-  </Stack>
-);
+export const AdminStartTrial: React.FC<{ activeTeam: string }> = ({
+  activeTeam,
+}) => {
+  const [checkout, createCheckout] = useCreateCheckout();
+
+  return (
+    <Stack align="flex-start" direction="vertical" gap={2}>
+      <Text css={{ color: '#999', fontWeight: 400, fontSize: 12 }}>
+        Upgrade to Team PRO for the full Codesandbox Experience.
+      </Text>
+      {checkout.status === 'error' ? (
+        <Text variant="danger" css={{ fontWeight: 400, fontSize: 12 }}>
+          An error ocurred while trying to load the payment gateway. Please try
+          again later.
+        </Text>
+      ) : (
+        <Button
+          autoWidth
+          variant="link"
+          loading={checkout.status === 'loading'}
+          onClick={() => {
+            track('Existing Team - Start Trial', {
+              codesandbox: 'V1',
+              event_source: 'UI',
+            });
+
+            createCheckout({
+              team_id: activeTeam,
+              recurring_interval: 'month' as string,
+              success_path: dashboard.recent(activeTeam),
+              cancel_path: dashboard.recent(activeTeam),
+            });
+          }}
+          css={{
+            fontSize: '12px',
+            fontWeight: 500,
+            color: '#EDFFA5',
+            textDecoration: 'none',
+            padding: '4px 0',
+          }}
+        >
+          Start trial
+        </Button>
+      )}
+    </Stack>
+  );
+};

--- a/packages/app/src/app/pages/Dashboard/Sidebar/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Sidebar/index.tsx
@@ -33,7 +33,7 @@ import { SidebarContext } from './utils';
 import { RowItem } from './RowItem';
 import { NestableRowItem } from './NestableRowItem';
 
-const END_OF_TRIAL_DAYS_NOTIFICATION = 14;
+const END_OF_TRIAL_DAYS_NOTIFICATION = 5;
 
 interface SidebarProps {
   visible: boolean;

--- a/packages/app/src/app/pages/Dashboard/Sidebar/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Sidebar/index.tsx
@@ -33,7 +33,7 @@ import { SidebarContext } from './utils';
 import { RowItem } from './RowItem';
 import { NestableRowItem } from './NestableRowItem';
 
-const END_OF_TRIAL_DAYS_NOTIFICATION = 5;
+const END_OF_TRIAL_DAYS_NOTIFICATION = 14;
 
 interface SidebarProps {
   visible: boolean;
@@ -337,7 +337,9 @@ export const Sidebar: React.FC<SidebarProps> = ({
 
         {teamDataLoaded && showBottomMessage && (
           <Element css={{ margin: '24px', paddingTop: 0 }}>
-            {isTeamFreeAdmin && eligibleToStartTrial && <AdminStartTrial />}
+            {isTeamFreeAdmin && eligibleToStartTrial && (
+              <AdminStartTrial activeTeam={activeTeam} />
+            )}
             {isTeamFreeAdmin && !eligibleToStartTrial && (
               <AdminUpgradeToTeamPro />
             )}


### PR DESCRIPTION
Since now it's possible to switch from monthly to yearly, we open the trial on a monthly subscription directly in stripe.