### PR TITLE
fix(create new): hide my/team templates if there are none

### DIFF
--- a/packages/app/src/app/components/CreateSandbox/CreateSandbox.tsx
+++ b/packages/app/src/app/components/CreateSandbox/CreateSandbox.tsx
@@ -97,12 +97,6 @@ export const CreateSandbox: React.FC<CreateSandboxProps> = ({
   const mediaQuery = window.matchMedia('screen and (max-width: 950px)');
   const mobileScreenSize = mediaQuery.matches;
 
-  /**
-   * Checking for user because user is undefined when landing on /s/, even though
-   * hasLogIn is true.
-   */
-  const showTeamTemplates = hasLogIn && user;
-
   const essentialState = useEssentialTemplates();
   const officialTemplatesData = useOfficialTemplates();
   const teamTemplatesData = useTeamTemplates({
@@ -114,6 +108,16 @@ export const CreateSandbox: React.FC<CreateSandboxProps> = ({
     officialTemplatesData.state === 'ready'
       ? officialTemplatesData.templates
       : [];
+
+  /**
+   * Checking for user because user is undefined when landing on /s/, even though
+   * hasLogIn is true. Only show the team/my templates if the list is populated.
+   */
+  const showTeamTemplates =
+    hasLogIn &&
+    user &&
+    teamTemplatesData.state === 'ready' &&
+    teamTemplatesData.teamTemplates.length > 0;
 
   /**
    * For the quick start we show:


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

Closes xtd-203.

## What kind of change does this PR introduce?

<!-- Is it a Bug fix, feature, docs update, ... -->

Hides/shows the "my/team templates" section if they exist or not.

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Open the create modal.
2. If the user/team has templates, the third item in the sidebar is "My/Team templates"
3. If the user/team doesn't have templates, there's no sidebar item.
