### PR TITLE
fix(discover): page banner position and scroll

### DIFF
--- a/packages/app/src/app/pages/Dashboard/Content/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/index.tsx
@@ -47,7 +47,6 @@ export const Content = withRouter(({ history }) => {
         height: '100%',
         margin: '0 auto',
         display: 'flex',
-        flexDirection: 'column',
         justifyContent: 'center',
       })}
     >


### PR DESCRIPTION
Am I overlooking something by changing this line? I've checked the dashboard pages and all seems OK!

Before:
![image](https://user-images.githubusercontent.com/7533849/201088433-8eaef477-e3ad-4a99-b3ba-fa105e99cb5c.png)

After:
<img width="1908" alt="image" src="https://user-images.githubusercontent.com/7533849/201089294-a1944a65-34ee-463d-8f71-261eabd2cd6d.png">


Page with Banner component:
![image](https://user-images.githubusercontent.com/7533849/201088519-676430ae-bb10-43e4-a01c-8dbb155efb74.png)
