### PR TITLE
fix: show correct owner for template

### DIFF
--- a/packages/app/src/app/components/CreateSandbox/TemplateCard.tsx
+++ b/packages/app/src/app/components/CreateSandbox/TemplateCard.tsx
@@ -69,7 +69,7 @@ export const TemplateCard = ({
 
           <Text size={2} css={{ color: '#999' }}>
             <VisuallyHidden>by </VisuallyHidden>
-            {teamName || 'CodeSandbox'}
+            {teamName || 'GitHub'}
           </Text>
         </Stack>
       </Stack>


### PR DESCRIPTION
When a template has no `team`, it is a template that's been automatically created since it was imported from GitHub. Right now we show "CodeSandbox" as owner, but that's not true, it's probably GitHub.