### PR TITLE
feat(messagestripe): add dismiss functionality

### DIFF
--- a/packages/components/src/components/IconButton/index.tsx
+++ b/packages/components/src/components/IconButton/index.tsx
@@ -4,6 +4,7 @@ import deepmerge from 'deepmerge';
 import { Button } from '../Button';
 import { Icon, IconNames } from '../Icon';
 import { Tooltip } from '../Tooltip';
+import { IElementProps } from '../Element';
 
 type IconButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
   /** name of the icon */
@@ -16,6 +17,8 @@ type IconButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
   variant?: 'square' | 'round';
   /** Not ideal, but should work when we move to prism */
   as?: any;
+  /** Any custom css necessary */
+  css?: IElementProps['css'];
 };
 
 export const IconButton: React.FC<IconButtonProps> = ({

--- a/packages/components/src/components/MessageStripe/MessageStripe.stories.tsx
+++ b/packages/components/src/components/MessageStripe/MessageStripe.stories.tsx
@@ -34,3 +34,30 @@ export const SpaceBetween = () => (
     <MessageStripe.Action>Update payment</MessageStripe.Action>
   </MessageStripe>
 );
+
+export const TrialVariantWithOnDismiss = () => (
+  <MessageStripe variant="trial" onDismiss={() => {}}>
+    You are no longer in a Pro team. This private repo is in view mode only.
+    Make it public or upgrade.
+  </MessageStripe>
+);
+
+export const WarningVariantWithOnDismiss = () => (
+  <MessageStripe variant="warning" onDismiss={() => {}}>
+    There are some issues with your payment. Please update your payment details.
+  </MessageStripe>
+);
+
+export const OnDismissWithAction = () => (
+  <MessageStripe variant="trial" onDismiss={() => {}}>
+    There are some issues with your payment. Please update your payment details.
+    <MessageStripe.Action>Update payment</MessageStripe.Action>
+  </MessageStripe>
+);
+
+export const OnDismissWithActionSpaceBetween = () => (
+  <MessageStripe variant="trial" justify="space-between" onDismiss={() => {}}>
+    There are some issues with your payment. Please update your payment details.
+    <MessageStripe.Action>Update payment</MessageStripe.Action>
+  </MessageStripe>
+);

--- a/packages/components/src/components/MessageStripe/MessageStripe.tsx
+++ b/packages/components/src/components/MessageStripe/MessageStripe.tsx
@@ -4,6 +4,7 @@ import { Element } from '../Element';
 import { Stack } from '../Stack';
 import { Button } from '../Button';
 import { Text } from '../Text';
+import { IconButton } from '../IconButton';
 
 type Variant = 'trial' | 'warning';
 
@@ -44,12 +45,14 @@ interface MessageStripeProps {
   children: React.ReactNode;
   variant?: Variant;
   justify?: 'center' | 'space-between';
+  onDismiss?: () => void;
 }
 
 const MessageStripe = ({
   children,
   variant = 'trial',
   justify = 'center',
+  onDismiss,
 }: MessageStripeProps) => {
   let hasAction: boolean;
 
@@ -73,14 +76,27 @@ const MessageStripe = ({
     <Element
       paddingY={hasAction ? 2 : 3}
       paddingX={4}
+      paddingRight={onDismiss ? 11 : undefined}
       css={{
         backgroundColor: backgroundVariants[variant],
         color: colorVariants[variant],
+        position: 'relative',
         borderRadius: '4px',
       }}
     >
       <Stack direction="horizontal" justify={justify} align="center" gap={2}>
         {augmentedChildren}
+
+        {onDismiss ? (
+          <Element css={{ position: 'absolute', right: '16px' }}>
+            <IconButton
+              onClick={onDismiss}
+              css={{ color: variant === 'trial' ? '#F5F5F5' : '#0E0E0E' }}
+              name="cross"
+              title="Dismiss"
+            />
+          </Element>
+        ) : null}
       </Stack>
     </Element>
   );


### PR DESCRIPTION
Adds `onDismiss` function to be able to dismiss the `MessageStripe`.

![image](https://user-images.githubusercontent.com/7533849/201305481-38cc812b-bfea-4e37-a2ba-a226babcf213.png)
![image](https://user-images.githubusercontent.com/7533849/201305491-ea9ef282-2e8a-4e7c-a6e8-e8b99b498074.png)
