### PR TITLE
feat(import): prevent if repo is private and account is free

### DIFF
--- a/packages/app/src/app/components/CreateSandbox/Import/Import.tsx
+++ b/packages/app/src/app/components/CreateSandbox/Import/Import.tsx
@@ -1,5 +1,8 @@
 import track from '@codesandbox/common/lib/utils/analytics';
-import { gitHubRepoPattern } from '@codesandbox/common/lib/utils/url-generator';
+import {
+  gitHubRepoPattern,
+  dashboard,
+} from '@codesandbox/common/lib/utils/url-generator';
 
 import {
   Button,
@@ -72,6 +75,8 @@ export const Import: React.FC<ImportProps> = ({ onRepoSelect }) => {
   const { isTeamAdmin, isPersonalSpace } = useWorkspaceAuthorization();
   const checkout = useGetCheckoutURL({
     team_id: isTeamAdmin || isPersonalSpace ? activeTeam : undefined,
+    success_path: dashboard.recent(activeTeam),
+    cancel_path: dashboard.recent(activeTeam),
   });
 
   const checkoutURL = React.useMemo(() => {

--- a/packages/app/src/app/components/CreateSandbox/Import/Import.tsx
+++ b/packages/app/src/app/components/CreateSandbox/Import/Import.tsx
@@ -65,7 +65,10 @@ type ImportProps = {
 export const Import: React.FC<ImportProps> = ({ onRepoSelect }) => {
   const { hasLogIn, activeTeam } = useAppState();
   const importAndRedirect = useImportAndRedirect();
-  const { hasActiveSubscription } = useSubscription();
+  const {
+    hasActiveSubscription,
+    hasPastOrActiveSubscription,
+  } = useSubscription();
   const { isTeamAdmin, isPersonalSpace } = useWorkspaceAuthorization();
   const checkout = useGetCheckoutURL({
     team_id: isTeamAdmin || isPersonalSpace ? activeTeam : undefined,
@@ -79,8 +82,10 @@ export const Import: React.FC<ImportProps> = ({ onRepoSelect }) => {
       return '/pro';
     }
 
-    return '/docs';
-  }, [checkout, isTeamAdmin, isPersonalSpace]);
+    return hasPastOrActiveSubscription
+      ? '/docs/learn/introduction/workspace#managing-teams-and-subscriptions'
+      : '/docs/learn/plan-billing/trials';
+  }, [checkout, hasPastOrActiveSubscription, isTeamAdmin, isPersonalSpace]);
   const [isImporting, setIsImporting] = React.useState(false);
   const [shouldFetch, setShouldFetch] = React.useState(false);
   const [

--- a/packages/app/src/app/components/CreateSandbox/queries.ts
+++ b/packages/app/src/app/components/CreateSandbox/queries.ts
@@ -80,6 +80,7 @@ export const GET_GITHUB_REPO = gql`
       fullName
       updatedAt
       authorization
+      private
       owner {
         id
         login

--- a/packages/app/src/app/graphql/types.ts
+++ b/packages/app/src/app/graphql/types.ts
@@ -382,6 +382,8 @@ export type GithubRepo = {
   name: Scalars['String'];
   /** Owning user or organization */
   owner: GithubOrganization;
+  /** Whether the repository is marked as private */
+  private: Scalars['Boolean'];
   /** ISO 8601 datetime */
   updatedAt: Scalars['String'];
 };
@@ -572,6 +574,7 @@ export type Project = {
 
 export type ProSubscription = {
   __typename?: 'ProSubscription';
+  active: Scalars['Boolean'];
   billingInterval: Maybe<SubscriptionInterval>;
   cancelAt: Maybe<Scalars['DateTime']>;
   cancelAtPeriodEnd: Scalars['Boolean'];
@@ -1659,7 +1662,7 @@ export type GetGithubRepoQuery = { __typename?: 'RootQueryType' } & {
   githubRepo: Maybe<
     { __typename?: 'GithubRepo' } & Pick<
       GithubRepo,
-      'name' | 'fullName' | 'updatedAt' | 'authorization'
+      'name' | 'fullName' | 'updatedAt' | 'authorization' | 'private'
     > & {
         owner: { __typename?: 'GithubOrganization' } & Pick<
           GithubOrganization,

--- a/packages/app/src/app/hooks/useCreateCheckout.ts
+++ b/packages/app/src/app/hooks/useCreateCheckout.ts
@@ -27,6 +27,11 @@ export const useCreateCheckout = (): [
     success_path = dashboard.settings(team_id) + '&payment_pending=true',
     cancel_path = '/pro',
   }: CheckoutOptions) => {
+    if (!team_id) {
+      setStatus({ status: 'idle' });
+      return;
+    }
+
     try {
       setStatus({ status: 'loading' });
 

--- a/packages/app/src/app/hooks/useCreateCheckout.ts
+++ b/packages/app/src/app/hooks/useCreateCheckout.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useEffects } from 'app/overmind';
 import { dashboard } from '@codesandbox/common/lib/utils/url-generator';
 
@@ -8,8 +8,8 @@ type CheckoutStatus =
   | { status: 'error'; error: string };
 
 type CheckoutOptions = {
-  team_id: string;
-  recurring_interval: string;
+  team_id: string | undefined;
+  recurring_interval?: string;
   success_path?: string;
   cancel_path?: string;
 };
@@ -23,7 +23,7 @@ export const useCreateCheckout = (): [
 
   const createCheckout = async ({
     team_id,
-    recurring_interval,
+    recurring_interval = 'month',
     success_path = dashboard.settings(team_id) + '&payment_pending=true',
     cancel_path = '/pro',
   }: CheckoutOptions) => {
@@ -49,4 +49,70 @@ export const useCreateCheckout = (): [
   };
 
   return [status, createCheckout];
+};
+
+type CheckoutState =
+  | { state: 'IDLE' }
+  | {
+      state: 'READY';
+      url: string;
+    }
+  | { state: 'LOADING' }
+  | { state: 'ERROR'; error: string };
+
+// TODO: replace useCreateCheckout usages
+// with useGetCheckoutURL to remove the
+// loading state when redirecting users
+// to the checkout page.
+export const useGetCheckoutURL = ({
+  team_id,
+  success_path = dashboard.settings(team_id) + '&payment_pending=true',
+  cancel_path = '/pro',
+  recurring_interval = 'month',
+}: CheckoutOptions): CheckoutState => {
+  const [checkout, setCheckout] = useState<CheckoutState>({ state: 'IDLE' });
+  const { api } = useEffects();
+
+  const getCheckoutUrl = async () => {
+    if (!team_id) {
+      setCheckout({
+        state: 'IDLE',
+      });
+
+      return;
+    }
+
+    try {
+      setCheckout({
+        state: 'LOADING',
+      });
+
+      const payload = await api.stripeCreateCheckout({
+        success_path,
+        cancel_path,
+        team_id,
+        recurring_interval,
+      });
+
+      if (payload.stripeCheckoutUrl) {
+        setCheckout({
+          state: 'READY',
+          url: payload.stripeCheckoutUrl,
+        });
+      }
+    } catch (error) {
+      setCheckout({
+        state: 'ERROR',
+        error:
+          JSON.stringify(error?.messagge || error) ??
+          'Failed to get checkout URL.',
+      });
+    }
+  };
+
+  useEffect(() => {
+    getCheckoutUrl();
+  }, [team_id]);
+
+  return checkout;
 };

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Repositories/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Repositories/index.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Helmet } from 'react-helmet';
 import { Link, useParams } from 'react-router-dom';
 import { useAppState, useActions } from 'app/overmind';
+import { dashboard as dashboardUrls } from '@codesandbox/common/lib/utils/url-generator';
 import { Header } from 'app/pages/Dashboard/Components/Header';
 import { VariableGrid } from 'app/pages/Dashboard/Components/VariableGrid';
 import { DashboardGridItem, PageTypes } from 'app/pages/Dashboard/types';
@@ -10,6 +11,7 @@ import { Notification } from 'app/pages/Dashboard/Components/Notification/Notifi
 import { Text, Element, MessageStripe } from '@codesandbox/components';
 import { useWorkspaceAuthorization } from 'app/hooks/useWorkspaceAuthorization';
 import { useSubscription } from 'app/hooks/useSubscription';
+import { useGetCheckoutURL } from 'app/hooks/useCreateCheckout';
 
 export const RepositoriesPage = () => {
   const params = useParams<{ path: string }>();
@@ -52,8 +54,17 @@ export const RepositoriesPage = () => {
   // be returned from an API. Can be implemented when ready.
   const hasMaxRepositories = false;
 
-  const { isTeamAdmin } = useWorkspaceAuthorization();
+  const { isTeamAdmin, isPersonalSpace } = useWorkspaceAuthorization();
   const { hasActiveSubscription, isEligibleForTrial } = useSubscription();
+
+  const checkout = useGetCheckoutURL({
+    team_id:
+      (isTeamAdmin || isPersonalSpace) && !hasActiveSubscription
+        ? activeTeam
+        : undefined,
+    success_path: dashboardUrls.registrySettings(activeTeam),
+    cancel_path: dashboardUrls.registrySettings(activeTeam),
+  });
 
   const pageType: PageTypes = 'repositories';
   let selectedRepo: { owner: string; name: string } | undefined;
@@ -133,7 +144,10 @@ export const RepositoriesPage = () => {
             Free teams are limited to 3 public repositories. Upgrade for
             unlimited repositories.
             {isTeamAdmin ? (
-              <MessageStripe.Action as={Link} to="/pro">
+              <MessageStripe.Action
+                as={Link}
+                to={checkout.state === 'READY' ? checkout.url : '/pro'}
+              >
                 {isEligibleForTrial ? 'Start free trial' : 'Upgrade now'}
               </MessageStripe.Action>
             ) : (

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Sandboxes/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Sandboxes/index.tsx
@@ -3,12 +3,14 @@ import { Helmet } from 'react-helmet';
 import { Link, useParams } from 'react-router-dom';
 import { useAppState, useActions } from 'app/overmind';
 import { Element, MessageStripe } from '@codesandbox/components';
+import { dashboard as dashboardUrls } from '@codesandbox/common/lib/utils/url-generator';
 import { Header } from 'app/pages/Dashboard/Components/Header';
 import { SelectionProvider } from 'app/pages/Dashboard/Components/Selection';
 import { VariableGrid } from 'app/pages/Dashboard/Components/VariableGrid';
 import { DashboardGridItem, PageTypes } from 'app/pages/Dashboard/types';
 import { useWorkspaceAuthorization } from 'app/hooks/useWorkspaceAuthorization';
 import { useSubscription } from 'app/hooks/useSubscription';
+import { useGetCheckoutURL } from 'app/hooks/useCreateCheckout';
 import { getPossibleTemplates } from '../../utils';
 import { useFilteredItems } from './useFilteredItems';
 
@@ -29,8 +31,17 @@ export const SandboxesPage = () => {
   // be returned from an API. Can be implemented when ready.
   const hasMaxSandboxes = false;
 
-  const { isTeamAdmin } = useWorkspaceAuthorization();
+  const { isTeamAdmin, isPersonalSpace } = useWorkspaceAuthorization();
   const { hasActiveSubscription, isEligibleForTrial } = useSubscription();
+
+  const checkout = useGetCheckoutURL({
+    team_id:
+      (isTeamAdmin || isPersonalSpace) && !hasActiveSubscription
+        ? activeTeam
+        : undefined,
+    success_path: dashboardUrls.registrySettings(activeTeam),
+    cancel_path: dashboardUrls.registrySettings(activeTeam),
+  });
 
   React.useEffect(() => {
     if (!currentPath || currentPath === '/') {
@@ -96,7 +107,10 @@ export const SandboxesPage = () => {
             Free teams are limited to 20 public sandboxes. Upgrade for unlimited
             sandboxes.
             {isTeamAdmin ? (
-              <MessageStripe.Action as={Link} to="/pro">
+              <MessageStripe.Action
+                as={Link}
+                to={checkout.state === 'READY' ? checkout.url : '/pro'}
+              >
                 {isEligibleForTrial ? 'Start free trial' : 'Upgrade now'}
               </MessageStripe.Action>
             ) : (

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/ManageSubscription/upgrade.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/ManageSubscription/upgrade.tsx
@@ -2,7 +2,12 @@ import React from 'react';
 import styled from 'styled-components';
 import css from '@styled-system/css';
 import { Button, Stack, Text } from '@codesandbox/components';
+import { dashboard as dashboardUrls } from '@codesandbox/common/lib/utils/url-generator';
 
+import { useGetCheckoutURL } from 'app/hooks/useCreateCheckout';
+import { useWorkspaceAuthorization } from 'app/hooks/useWorkspaceAuthorization';
+import { useAppState } from 'app/overmind';
+import { useSubscription } from 'app/hooks/useSubscription';
 import { Card } from '../../components';
 
 const List = styled(Stack)`
@@ -16,6 +21,18 @@ const List = styled(Stack)`
 `;
 
 export const Upgrade = () => {
+  const { activeTeam } = useAppState();
+  const { isTeamAdmin, isPersonalSpace } = useWorkspaceAuthorization();
+  const { hasActiveSubscription } = useSubscription();
+  const checkout = useGetCheckoutURL({
+    team_id:
+      (isTeamAdmin || isPersonalSpace) && !hasActiveSubscription
+        ? activeTeam
+        : undefined,
+    success_path: dashboardUrls.settings(activeTeam),
+    cancel_path: dashboardUrls.settings(activeTeam),
+  });
+
   return (
     <Card
       css={{
@@ -45,7 +62,12 @@ export const Upgrade = () => {
           </Text>
         </List>
 
-        <Button as="a" href="/pro" marginTop={2} variant="secondary">
+        <Button
+          as="a"
+          href={checkout.state === 'READY' ? checkout.url : '/pro'}
+          marginTop={2}
+          variant="secondary"
+        >
           Upgrade to Pro
         </Button>
       </Stack>

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/RegistrySettings.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/RegistrySettings.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect } from 'react';
 import { Text, Button, MessageStripe, Stack } from '@codesandbox/components';
 import css from '@styled-system/css';
-import { Link } from 'react-router-dom';
 
 import { useActions, useAppState } from 'app/overmind';
 import { useSubscription } from 'app/hooks/useSubscription';
@@ -64,7 +63,7 @@ export const RegistrySettings = () => {
             custom npm Registry.
           </span>
           {isTeamAdmin ? (
-            <MessageStripe.Action as={Link} to="/pro">
+            <MessageStripe.Action as="a" href="/pro">
               Upgrade now
             </MessageStripe.Action>
           ) : (

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Settings/components/Alert.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Settings/components/Alert.tsx
@@ -9,13 +9,14 @@ interface AlertProps {
     label: string;
     href: string;
     onClick?: () => void;
+    newTab?: boolean;
   };
 }
 
-export const Alert = (props: AlertProps) => (
+export const Alert: React.FC<AlertProps> = ({ message, upgrade, cta }) => (
   <Stack
     css={css({
-      backgroundColor: props.upgrade ? 'white' : 'grays.600',
+      backgroundColor: upgrade ? 'white' : 'grays.600',
       borderRadius: 'medium',
       height: 9,
       paddingX: 3,
@@ -23,16 +24,16 @@ export const Alert = (props: AlertProps) => (
     gap={4}
     align="center"
   >
-    {!props.upgrade && <Icon size={16} name="info" />}
+    {!upgrade && <Icon size={16} name="info" />}
     <Text
-      css={css({ width: '100%', color: props.upgrade ? '#151515' : 'white' })}
+      css={css({ width: '100%', color: upgrade ? '#151515' : 'white' })}
       weight="medium"
       size={2}
     >
-      {props.message}
+      {message}
     </Text>
 
-    {props.cta && (
+    {cta && (
       <Link
         size={2}
         css={css({
@@ -41,13 +42,21 @@ export const Alert = (props: AlertProps) => (
           minWidth: 'fit-content',
           fontWeight: 'medium',
           paddingRight: 1,
+
+          '&:hover, &:focus, &:active': {
+            color: 'blues.600',
+          },
         })}
-        target="_blank"
-        rel="noreferrer noopener"
-        href={props.cta.href}
-        onClick={props.cta.onClick}
+        {...(cta.newTab
+          ? {
+              target: '_blank',
+              rel: 'noreferrer noopener',
+            }
+          : {})}
+        href={cta.href}
+        onClick={cta.onClick}
       >
-        {props.cta.label}
+        {cta.label}
       </Link>
     )}
   </Stack>

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Settings/components/PermissionSettings.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Settings/components/PermissionSettings.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
 import { useAppState, useActions } from 'app/overmind';
 import {
   Button,
@@ -43,7 +42,7 @@ export const PermissionSettings = () => {
             to change sandbox permissions.
           </span>
           {isTeamAdmin || isPersonalSpace ? (
-            <MessageStripe.Action as={Link} to="/pro" onClick={proTracking}>
+            <MessageStripe.Action as="a" href="/pro" onClick={proTracking}>
               Upgrade now
             </MessageStripe.Action>
           ) : (

--- a/packages/app/src/app/pages/Pro/legacy-pages/WorkspacePlanSelection.tsx
+++ b/packages/app/src/app/pages/Pro/legacy-pages/WorkspacePlanSelection.tsx
@@ -526,7 +526,7 @@ const PlanCard: React.FC<{
   // Omitting new trialEnd and trialStart
   currentSubscription: Omit<
     ProSubscription,
-    'trialEnd' | 'trialStart' | 'cancelAtPeriodEnd'
+    'trialEnd' | 'trialStart' | 'cancelAtPeriodEnd' | 'active'
   > | null;
 }> = ({ plan, billingInterval, setBillingInterval, currentSubscription }) => {
   const isSelected = plan.billingInterval === billingInterval;


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?

<!-- Is it a Bug fix, feature, docs update, ... -->

Prevents importing private repositories if the team doesn't have an active subscription.

Part of XTD-360 1/2

## What is the new behavior?

<!-- if this is a feature change -->

https://www.loom.com/share/d749e2970b77467bbb3acfee92f7cf31

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Launch the app
2. Select a team w/o an active subscription
3. Open the import modal
4. Try to import a private GitHub repo