### PR TITLE
fix(end-of-trial): show different message if trial has been canceled

### DIFF
--- a/packages/app/src/app/graphql/types.ts
+++ b/packages/app/src/app/graphql/types.ts
@@ -574,6 +574,7 @@ export type ProSubscription = {
   __typename?: 'ProSubscription';
   billingInterval: Maybe<SubscriptionInterval>;
   cancelAt: Maybe<Scalars['DateTime']>;
+  cancelAtPeriodEnd: Scalars['Boolean'];
   currency: Maybe<Scalars['String']>;
   id: Maybe<Scalars['UUID4']>;
   nextBillDate: Maybe<Scalars['DateTime']>;
@@ -1459,6 +1460,7 @@ export type Team = {
   inviteToken: Scalars['String'];
   invitees: Array<User>;
   joinedPilotAt: Maybe<Scalars['DateTime']>;
+  limits: TeamLimits;
   name: Scalars['String'];
   privateRegistry: Maybe<PrivateRegistry>;
   projects: Array<Project>;
@@ -1467,6 +1469,7 @@ export type Team = {
   shortid: Scalars['String'];
   subscription: Maybe<ProSubscription>;
   templates: Array<Template>;
+  usage: TeamUsage;
   userAuthorizations: Array<UserAuthorization>;
   users: Array<User>;
 };
@@ -1490,6 +1493,19 @@ export type TeamSandboxesArgs = {
   showDeleted: Maybe<Scalars['Boolean']>;
 };
 
+export type TeamSubscriptionArgs = {
+  includeCancelled?: Maybe<Scalars['Boolean']>;
+};
+
+export type TeamLimits = {
+  __typename?: 'TeamLimits';
+  maxEditors: Maybe<Scalars['Int']>;
+  maxPrivateProjects: Maybe<Scalars['Int']>;
+  maxPrivateSandboxes: Maybe<Scalars['Int']>;
+  maxPublicProjects: Maybe<Scalars['Int']>;
+  maxPublicSandboxes: Maybe<Scalars['Int']>;
+};
+
 export enum TeamMemberAuthorization {
   /** Permission to add/remove users and change permissions (in addition to write and read). */
   Admin = 'ADMIN',
@@ -1505,6 +1521,15 @@ export type TeamsFeatureFlag = {
   enabledForTeam: Scalars['Boolean'];
   featureFlagId: Scalars['UUID4'];
   teamId: Scalars['UUID4'];
+};
+
+export type TeamUsage = {
+  __typename?: 'TeamUsage';
+  editorsQuantity: Scalars['Int'];
+  privateProjectsQuantity: Scalars['Int'];
+  privateSandboxesQuantity: Scalars['Int'];
+  publicProjectsQuantity: Scalars['Int'];
+  publicSandboxesQuantity: Scalars['Int'];
 };
 
 /** A Template */
@@ -2261,6 +2286,7 @@ export type CurrentTeamInfoFragmentFragment = { __typename?: 'Team' } & Pick<
         | 'nextBillDate'
         | 'paymentProvider'
         | 'cancelAt'
+        | 'cancelAtPeriodEnd'
         | 'trialStart'
         | 'trialEnd'
       >

--- a/packages/app/src/app/overmind/effects/gql/dashboard/fragments.ts
+++ b/packages/app/src/app/overmind/effects/gql/dashboard/fragments.ts
@@ -196,6 +196,7 @@ export const currentTeamInfoFragment = gql`
       nextBillDate
       paymentProvider
       cancelAt
+      cancelAtPeriodEnd
       trialStart
       trialEnd
     }

--- a/packages/app/src/app/pages/Dashboard/Sidebar/BottomMessages/TrialExpiring.tsx
+++ b/packages/app/src/app/pages/Dashboard/Sidebar/BottomMessages/TrialExpiring.tsx
@@ -6,7 +6,8 @@ export const TrialExpiring: React.FC<{
   activeTeam: string;
   daysLeft: number;
   isAdmin: boolean;
-}> = ({ daysLeft, isAdmin, activeTeam }) => {
+  cancelAtPeriodEnd: boolean;
+}> = ({ daysLeft, isAdmin, activeTeam, cancelAtPeriodEnd }) => {
   const [loading, createCustomerPortal] = useCreateCustomerPortal(activeTeam);
 
   return (
@@ -17,8 +18,14 @@ export const TrialExpiring: React.FC<{
         {daysLeft > 1 && <>{daysLeft} days left on your trial.</>}
       </Text>
       <Text css={{ color: '#999', fontWeight: 400, fontSize: 12 }}>
-        After this period, your Team Pro subscription will be automatically
-        renewed.
+        {cancelAtPeriodEnd ? (
+          <>After this period, your Team will be migrated to the Free plan.</>
+        ) : (
+          <>
+            After this period, your Team Pro subscription will be automatically
+            renewed.
+          </>
+        )}
       </Text>
       {isAdmin && (
         <Button

--- a/packages/app/src/app/pages/Dashboard/Sidebar/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Sidebar/index.tsx
@@ -33,7 +33,7 @@ import { SidebarContext } from './utils';
 import { RowItem } from './RowItem';
 import { NestableRowItem } from './NestableRowItem';
 
-const END_OF_TRIAL_DAYS_NOTIFICATION = 5;
+const END_OF_TRIAL_DAYS_NOTIFICATION = 14;
 
 interface SidebarProps {
   visible: boolean;
@@ -350,6 +350,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
               trialDaysLeft <= END_OF_TRIAL_DAYS_NOTIFICATION && (
                 <TrialExpiring
                   activeTeam={activeTeam}
+                  cancelAtPeriodEnd={subscription?.cancelAtPeriodEnd}
                   daysLeft={trialDaysLeft}
                   isAdmin={isTeamAdmin}
                 />

--- a/packages/app/src/app/pages/Dashboard/Sidebar/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Sidebar/index.tsx
@@ -33,7 +33,7 @@ import { SidebarContext } from './utils';
 import { RowItem } from './RowItem';
 import { NestableRowItem } from './NestableRowItem';
 
-const END_OF_TRIAL_DAYS_NOTIFICATION = 14;
+const END_OF_TRIAL_DAYS_NOTIFICATION = 5;
 
 interface SidebarProps {
   visible: boolean;


### PR DESCRIPTION
Passing `cancelAtPeriodEnd` flag to the trial CTA in the sidebar