### PR TITLE
feat(subscription): Public repo and sandbox max

### DIFF
--- a/packages/app/src/app/hooks/useSubscription.ts
+++ b/packages/app/src/app/hooks/useSubscription.ts
@@ -27,6 +27,20 @@ export const useSubscription = () => {
     activeTeamInfo?.subscription?.status
   );
 
+  const isPatron = activeTeamInfo?.subscription?.origin
+    ? [SubscriptionOrigin.Legacy, SubscriptionOrigin.Patron].includes(
+        activeTeamInfo.subscription.origin
+      )
+    : false;
+
+  const isPaddle =
+    activeTeamInfo?.subscription?.paymentProvider ===
+    SubscriptionPaymentProvider.Paddle;
+
+  const isStripe =
+    activeTeamInfo?.subscription?.paymentProvider ===
+    SubscriptionPaymentProvider.Stripe;
+
   /**
    * Trial states
    */
@@ -46,6 +60,10 @@ export const useSubscription = () => {
       ).length
     : 1; // Personal
 
+  /**
+   * Usage states
+   */
+
   const numberOfSeats = activeTeamInfo?.subscription?.quantity || 1;
 
   const hasMaxNumberOfEditors =
@@ -60,18 +78,13 @@ export const useSubscription = () => {
     activeTeamInfo?.limits?.maxEditors &&
     numberOfEditors > activeTeamInfo?.limits?.maxEditors;
 
-  const isPatron = activeTeamInfo?.subscription?.origin
-    ? [SubscriptionOrigin.Legacy, SubscriptionOrigin.Patron].includes(
-        activeTeamInfo.subscription.origin
-      )
-    : false;
-  const isPaddle =
-    activeTeamInfo?.subscription?.paymentProvider ===
-    SubscriptionPaymentProvider.Paddle;
+  const hasMaxPublicRepositories =
+    activeTeamInfo?.usage?.publicProjectsQuantity >=
+    activeTeamInfo?.limits?.maxPublicProjects;
 
-  const isStripe =
-    activeTeamInfo?.subscription?.paymentProvider ===
-    SubscriptionPaymentProvider.Stripe;
+  const hasMaxPublicSandboxes =
+    activeTeamInfo?.usage?.publicSandboxesQuantity >=
+    activeTeamInfo?.limits?.maxPublicSandboxes;
 
   return {
     subscription: activeTeamInfo?.subscription,
@@ -86,5 +99,7 @@ export const useSubscription = () => {
     isPatron,
     isPaddle,
     isStripe,
+    hasMaxPublicRepositories,
+    hasMaxPublicSandboxes,
   };
 };

--- a/packages/app/src/app/hooks/useSubscription.ts
+++ b/packages/app/src/app/hooks/useSubscription.ts
@@ -78,13 +78,22 @@ export const useSubscription = () => {
     activeTeamInfo?.limits?.maxEditors &&
     numberOfEditors > activeTeamInfo?.limits?.maxEditors;
 
+  const publicProjectsQuantity = activeTeamInfo?.usage?.publicProjectsQuantity;
+  const maxPublicProjects = activeTeamInfo?.limits?.maxPublicProjects;
+
   const hasMaxPublicRepositories =
-    activeTeamInfo?.usage?.publicProjectsQuantity >=
-    activeTeamInfo?.limits?.maxPublicProjects;
+    publicProjectsQuantity &&
+    maxPublicProjects &&
+    publicProjectsQuantity >= maxPublicProjects;
+
+  const publicSandboxesQuantity =
+    activeTeamInfo?.usage?.publicSandboxesQuantity;
+  const maxPublicSandboxes = activeTeamInfo?.limits?.maxPublicSandboxes;
 
   const hasMaxPublicSandboxes =
-    activeTeamInfo?.usage?.publicSandboxesQuantity >=
-    activeTeamInfo?.limits?.maxPublicSandboxes;
+    publicSandboxesQuantity &&
+    maxPublicSandboxes &&
+    publicSandboxesQuantity >= maxPublicSandboxes;
 
   return {
     subscription: activeTeamInfo?.subscription,

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Repositories/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Repositories/index.tsx
@@ -48,12 +48,12 @@ export const RepositoriesPage = () => {
     pathRef.current = path;
   }, [path]);
 
-  // 🚧 TODO: hasMaxRepositories property (or something like it) is something that will
-  // be returned from an API. Can be implemented when ready.
-  const hasMaxRepositories = false;
-
   const { isTeamAdmin } = useWorkspaceAuthorization();
-  const { hasActiveSubscription, isEligibleForTrial } = useSubscription();
+  const {
+    hasActiveSubscription,
+    isEligibleForTrial,
+    hasMaxPublicRepositories,
+  } = useSubscription();
 
   const pageType: PageTypes = 'repositories';
   let selectedRepo: { owner: string; name: string } | undefined;
@@ -127,7 +127,7 @@ export const RepositoriesPage = () => {
         selectedRepo={selectedRepo}
       />
 
-      {!hasActiveSubscription && hasMaxRepositories ? (
+      {!hasActiveSubscription && hasMaxPublicRepositories ? (
         <Element paddingX={4} paddingY={2}>
           <MessageStripe justify="space-between">
             Free teams are limited to 3 public repositories. Upgrade for

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Sandboxes/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Sandboxes/index.tsx
@@ -25,12 +25,12 @@ export const SandboxesPage = () => {
     activeTeam,
   } = useAppState();
 
-  // 🚧 TODO: hasMaxSandboxes property (or something like it) is something that will
-  // be returned from an API. Can be implemented when ready.
-  const hasMaxSandboxes = false;
-
   const { isTeamAdmin } = useWorkspaceAuthorization();
-  const { hasActiveSubscription, isEligibleForTrial } = useSubscription();
+  const {
+    hasActiveSubscription,
+    isEligibleForTrial,
+    hasMaxPublicSandboxes,
+  } = useSubscription();
 
   React.useEffect(() => {
     if (!currentPath || currentPath === '/') {
@@ -90,7 +90,7 @@ export const SandboxesPage = () => {
         showSortOptions={Boolean(currentPath)}
       />
 
-      {!hasActiveSubscription && hasMaxSandboxes ? (
+      {!hasActiveSubscription && hasMaxPublicSandboxes ? (
         <Element paddingX={4} paddingY={2}>
           <MessageStripe justify="space-between">
             Free teams are limited to 20 public sandboxes. Upgrade for unlimited


### PR DESCRIPTION
When working on `XTD-362` and `XTD-359` we weren't able to calculate the max public sandboxes and repositories yet. We are now, so I've added those flags to the `useSubscription` hook!