### PR TITLE
feat: add trial information on subscription card

### DIFF
--- a/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/ManageSubscription/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/ManageSubscription/index.tsx
@@ -21,9 +21,11 @@ export const ManageSubscription = () => {
   const { activeTeamInfo: team } = useAppState();
   const {
     hasActiveSubscription,
+    hasActiveTeamTrial,
     numberOfSeats,
     isPaddle,
     isStripe,
+    subscription,
   } = useSubscription();
   const { isTeamAdmin } = useWorkspaceAuthorization();
 
@@ -71,7 +73,9 @@ export const ManageSubscription = () => {
     }
 
     if (isStripe) {
-      return <Stripe />;
+      return (
+        <Stripe hasActiveTrial={hasActiveTeamTrial && !subscription.cancelAt} />
+      );
     }
 
     return null;
@@ -87,12 +91,22 @@ export const ManageSubscription = () => {
       >
         <Stack direction="vertical" gap={4}>
           <Text size={4} weight="bold" maxWidth="100%">
-            Team Pro
+            Team Pro {hasActiveTeamTrial ? 'trial' : ''}
           </Text>
 
-          <Text variant="muted" size={3}>{`${numberOfSeats} paid seat${
-            numberOfSeats > 1 ? 's' : ''
-          }`}</Text>
+          <Stack direction="vertical" gap={1}>
+            <Text variant="muted" size={3}>{`${numberOfSeats} paid seat${
+              numberOfSeats > 1 ? 's' : ''
+            }`}</Text>
+
+            {/* TODO: the logic for figuring out a canceled vs an active trial should be revisited */}
+            {hasActiveTeamTrial && !subscription.cancelAt ? (
+              <Text variant="muted" size={3}>
+                Your free trial ends on{' '}
+                {printLocalDateFormat(subscription.trialEnd)}
+              </Text>
+            ) : null}
+          </Stack>
         </Stack>
 
         {renderProvider()}
@@ -100,3 +114,6 @@ export const ManageSubscription = () => {
     </Card>
   );
 };
+
+const printLocalDateFormat = (date: string) =>
+  new Date(date).toLocaleDateString();

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/ManageSubscription/stripe.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/ManageSubscription/stripe.tsx
@@ -4,16 +4,20 @@ import { Stack, Text, Link } from '@codesandbox/components';
 import { useAppState } from 'app/overmind';
 import { useCreateCustomerPortal } from 'app/hooks/useCreateCustomerPortal';
 
-export const Stripe = () => {
+export const Stripe: React.FC<{ hasActiveTrial: boolean }> = ({
+  hasActiveTrial,
+}) => {
   const { activeTeam, activeTeamInfo: team } = useAppState();
   const [loading, createCustomerPortal] = useCreateCustomerPortal({
     team_id: activeTeam,
   });
 
+  const ctaText = hasActiveTrial ? 'Cancel trial' : 'Manage subscription';
+
   return (
     <Stack direction="vertical" gap={2}>
       <Link onClick={createCustomerPortal} size={3} variant="active">
-        {loading ? 'Loading...' : 'Manage subscription'}
+        {loading ? 'Loading...' : ctaText}
       </Link>
 
       {!loading && team.subscription.cancelAt && (


### PR DESCRIPTION
Compared to the design, I had to drop some information we unfortunately don't have for stripe users:
* We don't have the price unit to show how much users will be billed
* We don't have the next billing date

Active trial
![Screenshot 2022-11-14 at 21 15 56](https://user-images.githubusercontent.com/9945366/201746674-57ea6925-be12-4640-b037-7d70cc101fb6.png)

Cancelled trial
![Screenshot 2022-11-14 at 21 15 46](https://user-images.githubusercontent.com/9945366/201746648-4e1b5c29-df49-4057-9e91-3ec600633261.png)

I believe we need to start modelling more details around the trial and subscription. We have the concept of an `ACTIVE` subscription, but we also have a `canceledAt` date time as well as a `cancelAtPeriodEnd` flag. For now I would leave it as it is, until after the release, but we could introduce for better clarity the following booleans:
* **isPro** - instead of checking for active subscription or trialing or any other combination, just return true or false if pro features apply for this user in this workspace
* **hasActiveSubscription** - this should mean that the subscription is active and ongoing beyond the current period
* **hasActiveTrial** - this means that the user has an active trial (not canceled)

wdyt @olarclara @tristandubbeld ?
