### PR TITLE
feat(subscription): enforce repositories limits

### DIFF
--- a/packages/app/src/app/graphql/types.ts
+++ b/packages/app/src/app/graphql/types.ts
@@ -382,6 +382,8 @@ export type GithubRepo = {
   name: Scalars['String'];
   /** Owning user or organization */
   owner: GithubOrganization;
+  /** Whether the repository is marked as private */
+  private: Scalars['Boolean'];
   /** ISO 8601 datetime */
   updatedAt: Scalars['String'];
 };
@@ -572,6 +574,7 @@ export type Project = {
 
 export type ProSubscription = {
   __typename?: 'ProSubscription';
+  active: Scalars['Boolean'];
   billingInterval: Maybe<SubscriptionInterval>;
   cancelAt: Maybe<Scalars['DateTime']>;
   cancelAtPeriodEnd: Scalars['Boolean'];
@@ -2328,7 +2331,7 @@ export type BranchFragment = { __typename?: 'Branch' } & Pick<
     project: { __typename?: 'Project' } & {
       repository: { __typename?: 'GitHubRepository' } & Pick<
         GitHubRepository,
-        'defaultBranch' | 'name' | 'owner'
+        'defaultBranch' | 'name' | 'owner' | 'private'
       >;
     };
   };
@@ -2337,7 +2340,7 @@ export type ProjectFragment = { __typename?: 'Project' } & {
   branches: Array<{ __typename?: 'Branch' } & BranchFragment>;
   repository: { __typename?: 'GitHubRepository' } & Pick<
     GitHubRepository,
-    'owner' | 'name' | 'defaultBranch'
+    'owner' | 'name' | 'defaultBranch' | 'private'
   >;
 };
 

--- a/packages/app/src/app/overmind/effects/gql/dashboard/fragments.ts
+++ b/packages/app/src/app/overmind/effects/gql/dashboard/fragments.ts
@@ -244,6 +244,7 @@ export const branchFragment = gql`
           defaultBranch
           name
           owner
+          private
         }
       }
     }
@@ -260,6 +261,7 @@ export const projectFragment = gql`
         owner
         name
         defaultBranch
+        private
       }
     }
   }

--- a/packages/app/src/app/pages/Dashboard/Components/Branch/NewBranch.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Branch/NewBranch.tsx
@@ -6,12 +6,12 @@ import { v2DraftBranchUrl } from '@codesandbox/common/lib/utils/url-generator';
 export const NewBranchCard: React.FC<{
   owner: string;
   repoName: string;
-  isDisabled?: boolean;
-}> = ({ owner, repoName, isDisabled }) => {
+  disabled?: boolean;
+}> = ({ owner, repoName, disabled }) => {
   return (
     <Element
-      as={isDisabled ? undefined : 'a'}
-      href={isDisabled ? undefined : v2DraftBranchUrl(owner, repoName)}
+      as={disabled ? undefined : 'a'}
+      href={disabled ? undefined : v2DraftBranchUrl(owner, repoName)}
       css={css({
         display: 'flex',
         alignItems: 'center',
@@ -19,7 +19,7 @@ export const NewBranchCard: React.FC<{
         textDecoration: 'none',
         fontSize: 3,
         fontWeight: 'normal',
-        color: isDisabled ? '#999999' : '#808080',
+        color: disabled ? '#999999' : '#808080',
         height: 240,
         outline: 'none',
         backgroundColor: 'card.background',
@@ -28,7 +28,7 @@ export const NewBranchCard: React.FC<{
         borderRadius: 'medium',
         transition: 'background ease-in',
         transitionDuration: theme => theme.speeds[2],
-        ':hover': isDisabled
+        ':hover': disabled
           ? undefined
           : {
               backgroundColor: 'card.backgroundHover',
@@ -42,7 +42,7 @@ export const NewBranchCard: React.FC<{
         direction="vertical"
         align="center"
         gap={4}
-        css={isDisabled ? { opacity: 0.4 } : undefined}
+        css={disabled ? { opacity: 0.4 } : undefined}
       >
         <Icon name="plus" size={32} />
         <Text>Create branch</Text>

--- a/packages/app/src/app/pages/Dashboard/Components/Branch/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Branch/index.tsx
@@ -3,6 +3,7 @@ import { trackImprovedDashboardEvent } from '@codesandbox/common/lib/utils/analy
 import { useAppState } from 'app/overmind';
 import { PageTypes } from 'app/overmind/namespaces/dashboard/types';
 import React from 'react';
+import { useSubscription } from 'app/hooks/useSubscription';
 import { DashboardBranch } from '../../types';
 import { useSelection } from '../Selection';
 import { BranchCard } from './BranchCard';
@@ -42,6 +43,11 @@ export const Branch: React.FC<BranchProps> = ({ branch, page }) => {
     removingRepository?.owner === project.repository.owner &&
     removingRepository?.name === project.repository.name;
 
+  const { hasActiveSubscription } = useSubscription();
+
+  const isPrivate = branch?.project?.repository?.private;
+  const isViewOnly = !hasActiveSubscription && isPrivate;
+
   const props = {
     branch,
     branchUrl,
@@ -50,6 +56,7 @@ export const Branch: React.FC<BranchProps> = ({ branch, page }) => {
       removingBranch?.id === branch.id || isParentRepositoryBeingRemoved,
     onContextMenu: handleContextMenu,
     onClick: handleClick,
+    isViewOnly,
     /**
      * If we ever need selection for branch entries, `data-selection-id` must be set
      * 'data-selection-id': branch.id,

--- a/packages/app/src/app/pages/Dashboard/Components/Header/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Header/index.tsx
@@ -39,6 +39,7 @@ type Props = {
   CustomFilters?: React.ReactElement;
   selectedRepo?: { owner: string; name: string };
   loading?: boolean;
+  readOnly?: boolean;
 };
 
 export const Header = ({
@@ -57,6 +58,7 @@ export const Header = ({
   actions = [],
   selectedRepo,
   loading = false,
+  readOnly = false,
 }: Props) => {
   const location = useLocation();
   const { modals, dashboard: dashboardActions } = useActions();
@@ -134,7 +136,7 @@ export const Header = ({
         {repositoriesListPage && dashboard.viewMode === 'list' && (
           <Button
             onClick={() =>
-              modals.newSandboxModal.open({ initialTab: 'import' })
+              !readOnly && modals.newSandboxModal.open({ initialTab: 'import' })
             }
             variant="link"
             css={css({
@@ -143,6 +145,7 @@ export const Header = ({
               padding: 0,
               width: 'auto',
             })}
+            disabled={readOnly}
           >
             <Icon
               name="plus"
@@ -185,7 +188,7 @@ export const Header = ({
           dashboard.viewMode === 'list' &&
           selectedRepo && (
             <Button
-              as="a"
+              as={readOnly ? undefined : 'a'}
               href={v2DraftBranchUrl(selectedRepo.owner, selectedRepo.name)}
               variant="link"
               css={css({
@@ -201,6 +204,7 @@ export const Header = ({
                   color: '#e5e5e5',
                 },
               })}
+              disabled={readOnly}
             >
               <Icon
                 name="plus"

--- a/packages/app/src/app/pages/Dashboard/Components/Repository/ImportRepository.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Repository/ImportRepository.tsx
@@ -3,8 +3,8 @@ import { useActions } from 'app/overmind';
 import { Stack, Text, Icon, Element } from '@codesandbox/components';
 import css from '@styled-system/css';
 
-export const ImportRepositoryCard: React.FC<{ isDisabled?: boolean }> = ({
-  isDisabled,
+export const ImportRepositoryCard: React.FC<{ disabled?: boolean }> = ({
+  disabled,
 }) => {
   const { openCreateSandboxModal } = useActions();
 
@@ -20,7 +20,7 @@ export const ImportRepositoryCard: React.FC<{ isDisabled?: boolean }> = ({
         fontSize: 3,
         fontFamily: 'inherit',
         fontWeight: 'normal',
-        color: isDisabled ? '#999999' : '#808080',
+        color: disabled ? '#999999' : '#808080',
         height: 240,
         outline: 'none',
         backgroundColor: 'card.background',
@@ -36,13 +36,13 @@ export const ImportRepositoryCard: React.FC<{ isDisabled?: boolean }> = ({
           borderColor: 'focusBorder',
         },
       })}
-      disabled={isDisabled}
+      disabled={disabled}
     >
       <Stack
         direction="vertical"
         align="center"
         gap={4}
-        css={isDisabled ? { opacity: 0.4 } : undefined}
+        css={disabled ? { opacity: 0.4 } : undefined}
       >
         <Icon name="plus" size={32} />
         <Text>Import repository</Text>

--- a/packages/app/src/app/pages/Dashboard/Components/Repository/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Repository/index.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useAppState } from 'app/overmind';
 import { trackImprovedDashboardEvent } from '@codesandbox/common/lib/utils/analytics';
 import { dashboard } from '@codesandbox/common/lib/utils/url-generator';
+import { useSubscription } from 'app/hooks/useSubscription';
 import { DashboardRepository } from '../../types';
 import { RepositoryCard } from './RepositoryCard';
 import { RepositoryListItem } from './RepositoryListItem';
@@ -29,6 +30,11 @@ export const Repository: React.FC<DashboardRepository> = ({ repository }) => {
     else onMenuEvent(event, repositoryId);
   };
 
+  const { hasActiveSubscription } = useSubscription();
+
+  const isPrivate = providerRepository?.private;
+  const isViewOnly = !hasActiveSubscription && isPrivate;
+
   const props: RepositoryProps = {
     repository: {
       owner: providerRepository.owner,
@@ -47,6 +53,7 @@ export const Repository: React.FC<DashboardRepository> = ({ repository }) => {
     isBeingRemoved:
       removingRepository?.owner === providerRepository.owner &&
       removingRepository?.name === providerRepository.name,
+    isViewOnly,
   };
 
   return {

--- a/packages/app/src/app/pages/Dashboard/Components/VariableGrid/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/VariableGrid/index.tsx
@@ -151,9 +151,13 @@ const ComponentForTypes: IComponentForTypes = {
   branch: ({ item, page }) => <Branch page={page} {...item} />,
   repository: ({ item }) => <Repository {...item} />,
   'new-branch': ({ item }) => (
-    <NewBranchCard owner={item.repo.owner} repoName={item.repo.name} />
+    <NewBranchCard
+      owner={item.repo.owner}
+      repoName={item.repo.name}
+      disabled={item.disabled}
+    />
   ),
-  'import-repository': () => <ImportRepositoryCard />,
+  'import-repository': ({ item }) => <ImportRepositoryCard {...item} />,
 };
 
 const getSkeletonForPage = (

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Repositories/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Repositories/index.tsx
@@ -107,7 +107,7 @@ export const RepositoriesPage = () => {
     if (viewMode === 'grid' && repoItems.length > 0) {
       repoItems.unshift({
         type: 'import-repository',
-        disabled: !hasActiveSubscription && hasMaxRepositories,
+        disabled: !hasActiveSubscription && hasMaxPublicRepositories,
       });
     }
 
@@ -116,7 +116,7 @@ export const RepositoriesPage = () => {
 
   const itemsToShow = getItemsToShow();
   const readOnly = !hasActiveSubscription
-    ? selectedRepo?.private || hasMaxRepositories
+    ? selectedRepo?.private || hasMaxPublicRepositories
     : false;
 
   return (

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Repositories/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Repositories/index.tsx
@@ -89,6 +89,8 @@ export const RepositoriesPage = () => {
         branchItems.unshift({
           type: 'new-branch',
           repo: { owner, name },
+          disabled:
+            !hasActiveSubscription && currentRepository.repository.private,
         });
       }
 
@@ -101,7 +103,10 @@ export const RepositoriesPage = () => {
     }));
 
     if (viewMode === 'grid' && repoItems.length > 0) {
-      repoItems.unshift({ type: 'import-repository' });
+      repoItems.unshift({
+        type: 'import-repository',
+        disabled: !hasActiveSubscription && hasMaxRepositories,
+      });
     }
 
     return repoItems;

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Repositories/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Repositories/index.tsx
@@ -56,7 +56,9 @@ export const RepositoriesPage = () => {
   } = useSubscription();
 
   const pageType: PageTypes = 'repositories';
-  let selectedRepo: { owner: string; name: string } | undefined;
+  let selectedRepo:
+    | { owner: string; name: string; private: boolean }
+    | undefined;
 
   const getItemsToShow = (): DashboardGridItem[] => {
     if (repositories === null) {
@@ -76,6 +78,7 @@ export const RepositoriesPage = () => {
       selectedRepo = {
         owner,
         name,
+        private: currentRepository.repository.private,
       };
 
       const branchItems: DashboardGridItem[] = currentRepository.branches.map(
@@ -89,8 +92,7 @@ export const RepositoriesPage = () => {
         branchItems.unshift({
           type: 'new-branch',
           repo: { owner, name },
-          disabled:
-            !hasActiveSubscription && currentRepository.repository.private,
+          disabled: !hasActiveSubscription && selectedRepo.private,
         });
       }
 
@@ -113,6 +115,9 @@ export const RepositoriesPage = () => {
   };
 
   const itemsToShow = getItemsToShow();
+  const readOnly = !hasActiveSubscription
+    ? selectedRepo?.private || hasMaxRepositories
+    : false;
 
   return (
     <SelectionProvider
@@ -130,6 +135,7 @@ export const RepositoriesPage = () => {
         showBetaBadge
         nestedPageType={pageType}
         selectedRepo={selectedRepo}
+        readOnly={readOnly}
       />
 
       {!hasActiveSubscription && hasMaxPublicRepositories ? (

--- a/packages/app/src/app/pages/Dashboard/types.ts
+++ b/packages/app/src/app/pages/Dashboard/types.ts
@@ -153,6 +153,7 @@ export type DashboardNewBranch = {
     owner: string;
     name: string;
   };
+  disabled?: boolean;
 };
 
 export type DashboardRepository = {
@@ -162,6 +163,7 @@ export type DashboardRepository = {
 
 export type DashboardImportRepository = {
   type: 'import-repository';
+  disabled?: boolean;
 };
 
 export type PageTypes = PT;

--- a/packages/app/src/app/pages/Pro/legacy-pages/WorkspacePlanSelection.tsx
+++ b/packages/app/src/app/pages/Pro/legacy-pages/WorkspacePlanSelection.tsx
@@ -523,10 +523,10 @@ const PlanCard: React.FC<{
   plan: Plan;
   billingInterval: Plan['billingInterval'];
   setBillingInterval: (billingInterval: Plan['billingInterval']) => void;
-  // Omitting new trialEnd and trialStart
+  // Omitting new trialEnd, trialStart, cancelAtPeriodEnd and active
   currentSubscription: Omit<
     ProSubscription,
-    'trialEnd' | 'trialStart' | 'cancelAtPeriodEnd'
+    'trialEnd' | 'trialStart' | 'cancelAtPeriodEnd' | 'active'
   > | null;
 }> = ({ plan, billingInterval, setBillingInterval, currentSubscription }) => {
   const isSelected = plan.billingInterval === billingInterval;


### PR DESCRIPTION
Closes XTD-360 (2/2)

- ### Adds `viewOnly` flag to private repositories on teams that don't have an active subscription:

|Grid|
|:-:|
|![xwgwi1-3000 preview csb app_dashboard_repositories_github_olarclara_climbr_workspace=47968439-c1ee-494c-a6e1-ec7ea18ab162](https://user-images.githubusercontent.com/24959348/201800440-e3c3e828-772a-435c-b8c7-ce080b6e5cba.png)|

|List|
|:-:|
|![xwgwi1-3000 preview csb app_dashboard_repositories_github_olarclara_climbr_workspace=47968439-c1ee-494c-a6e1-ec7ea18ab162 (1)](https://user-images.githubusercontent.com/24959348/201800491-6f5dd3db-5ab6-4644-93e4-cf5457e21136.png)|

- ### Disables the `new branch` action on  private repositories on teams that don't have an active subscription:

|Grid|
|:-:|
|![xwgwi1-3000 preview csb app_dashboard_repositories_github_olarclara_climbr_workspace=47968439-c1ee-494c-a6e1-ec7ea18ab162 (2)](https://user-images.githubusercontent.com/24959348/201800633-38627d47-f7ce-4dec-9a7e-15635c66abe9.png)|

|List|
|:-:|
|![xwgwi1-3000 preview csb app_dashboard_repositories_github_olarclara_climbr_workspace=47968439-c1ee-494c-a6e1-ec7ea18ab162 (3)](https://user-images.githubusercontent.com/24959348/201800692-faa98e9c-8750-4cfa-b23c-7fc150d78665.png)|

- ### Disables the `Import repository` action if the workspaces have reached the max amount of public repositories:

|Grid|
|:-:|
|![xwgwi1-3000 preview csb app_dashboard_repositories_github_olarclara_climbr_workspace=47968439-c1ee-494c-a6e1-ec7ea18ab162 (6)](https://user-images.githubusercontent.com/24959348/201801518-2c984839-5074-4c34-be51-a55ba7ab21d0.png)|

|List|
|:-:|
|![xwgwi1-3000 preview csb app_dashboard_repositories_github_olarclara_climbr_workspace=47968439-c1ee-494c-a6e1-ec7ea18ab162 (5)](https://user-images.githubusercontent.com/24959348/201801431-6d5a9c92-24e3-4e11-b211-c24756497fe8.png)|