### PR TITLE
feat(subscriptions): stripe banner in repository view

### DIFF
--- a/packages/app/src/app/pages/Dashboard/Content/routes/Repositories/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Repositories/index.tsx
@@ -1,18 +1,15 @@
 import React from 'react';
 import { Helmet } from 'react-helmet';
-import { /* Link, */ useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import { useAppState, useActions } from 'app/overmind';
-// import { dashboard as dashboardUrls } from '@codesandbox/common/lib/utils/url-generator';
-// import track from '@codesandbox/common/lib/utils/analytics';
 import { Header } from 'app/pages/Dashboard/Components/Header';
 import { VariableGrid } from 'app/pages/Dashboard/Components/VariableGrid';
 import { DashboardGridItem, PageTypes } from 'app/pages/Dashboard/types';
 import { SelectionProvider } from 'app/pages/Dashboard/Components/Selection';
 import { Notification } from 'app/pages/Dashboard/Components/Notification/Notification';
-import { Text /* , Element, MessageStripe */ } from '@codesandbox/components';
-// import { useWorkspaceAuthorization } from 'app/hooks/useWorkspaceAuthorization';
+import { Text, Element } from '@codesandbox/components';
 import { useSubscription } from 'app/hooks/useSubscription';
-// import { useGetCheckoutURL } from 'app/hooks/useCreateCheckout';
+import { /* MaxPublicReposFreeTeam, */ PrivateRepoFreeTeam } from './stripes';
 
 export const RepositoriesPage = () => {
   const params = useParams<{ path: string }>();
@@ -51,21 +48,10 @@ export const RepositoriesPage = () => {
     pathRef.current = path;
   }, [path]);
 
-  // const { isTeamAdmin, isPersonalSpace } = useWorkspaceAuthorization();
   const {
     hasActiveSubscription,
-    // isEligibleForTrial,
     // hasMaxPublicRepositories,
   } = useSubscription();
-
-  // const checkout = useGetCheckoutURL({
-  //   team_id:
-  //     (isTeamAdmin || isPersonalSpace) && !hasActiveSubscription
-  //       ? activeTeam
-  //       : undefined,
-  //   success_path: dashboardUrls.registrySettings(activeTeam),
-  //   cancel_path: dashboardUrls.registrySettings(activeTeam),
-  // });
 
   const pageType: PageTypes = 'repositories';
   let selectedRepo:
@@ -151,53 +137,12 @@ export const RepositoriesPage = () => {
         readOnly={readOnly}
       />
 
-      {/* {!hasActiveSubscription && hasMaxPublicRepositories ? (
+      {readOnly && (
         <Element paddingX={4} paddingY={2}>
-          <MessageStripe justify="space-between">
-            Free teams are limited to 3 public repositories. Upgrade for
-            unlimited repositories.
-            {isTeamAdmin ? (
-              <MessageStripe.Action
-                {...(checkout.state === 'READY'
-                  ? {
-                      as: 'a',
-                      href: checkout.url,
-                    }
-                  : {
-                      as: Link,
-                      to: '/pro',
-                    })}
-                onClick={() =>
-                  isEligibleForTrial
-                    ? track('Limit banner: repos - Start Trial', {
-                        codesandbox: 'V1',
-                        event_source: 'UI',
-                      })
-                    : track('Limit banner: repos - Upgrade', {
-                        codesandbox: 'V1',
-                        event_source: 'UI',
-                      })
-                }
-              >
-                {isEligibleForTrial ? 'Start free trial' : 'Upgrade now'}
-              </MessageStripe.Action>
-            ) : (
-              <MessageStripe.Action
-                as="a"
-                href="https://codesandbox.io/docs/learn/plan-billing/trials"
-                onClick={() => {
-                  track('Limit banner: repos - Learn More', {
-                    codesandbox: 'V1',
-                    event_source: 'UI',
-                  });
-                }}
-              >
-                Learn more
-              </MessageStripe.Action>
-            )}
-          </MessageStripe>
+          {selectedRepo?.private && <PrivateRepoFreeTeam />}
+          {/* {(hasMaxPublicRepositories && !selectedRepo) && <MaxPublicReposFreeTeam />} */}
         </Element>
-      ) : null} */}
+      )}
 
       {itemsToShow.length === 0 ? (
         <Notification pageType={pageType}>

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Repositories/stripes.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Repositories/stripes.tsx
@@ -31,11 +31,11 @@ export const PrivateRepoFreeTeam: React.FC = () => {
         <MessageStripe.Action
           {...(checkout.state === 'READY'
             ? {
-                // as: 'a',
+                as: 'a',
                 href: checkout.url,
               }
             : {
-                // as: Link,
+                as: Link,
                 to: '/pro',
               })}
           onClick={() => {

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Repositories/stripes.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Repositories/stripes.tsx
@@ -1,0 +1,112 @@
+import { MessageStripe } from '@codesandbox/components';
+import track from '@codesandbox/common/lib/utils/analytics';
+import { dashboard as dashboardUrls } from '@codesandbox/common/lib/utils/url-generator';
+import { useSubscription } from 'app/hooks/useSubscription';
+import { useWorkspaceAuthorization } from 'app/hooks/useWorkspaceAuthorization';
+import React from 'react';
+import { Link, useLocation } from 'react-router-dom';
+import { useGetCheckoutURL } from 'app/hooks/useCreateCheckout';
+import { useAppState } from 'app/overmind';
+
+export const PrivateRepoFreeTeam: React.FC = () => {
+  const { activeTeam } = useAppState();
+  const { isEligibleForTrial } = useSubscription();
+  const { isTeamAdmin, isPersonalSpace } = useWorkspaceAuthorization();
+  const { pathname } = useLocation();
+
+  const checkout = useGetCheckoutURL({
+    team_id: isTeamAdmin || isPersonalSpace ? activeTeam : undefined,
+    success_path: pathname,
+    cancel_path: pathname,
+  });
+
+  return (
+    <MessageStripe
+      justify={isTeamAdmin ? 'space-between' : 'center'}
+      variant="trial"
+    >
+      This repository is in view mode only. Upgrade your account for unlimited
+      repositories.
+      {isTeamAdmin && (
+        <MessageStripe.Action
+          {...(checkout.state === 'READY'
+            ? {
+                // as: 'a',
+                href: checkout.url,
+              }
+            : {
+                // as: Link,
+                to: '/pro',
+              })}
+          onClick={() => {
+            track('Limit banner: repos - Learn More', {
+              codesandbox: 'V1',
+              event_source: 'UI',
+            });
+          }}
+        >
+          {isEligibleForTrial ? 'Learn more' : 'Upgrade now'}
+        </MessageStripe.Action>
+      )}
+    </MessageStripe>
+  );
+};
+
+export const MaxPublicReposFreeTeam: React.FC = () => {
+  const { activeTeam } = useAppState();
+  const { isEligibleForTrial } = useSubscription();
+  const { isTeamAdmin, isPersonalSpace } = useWorkspaceAuthorization();
+
+  const checkout = useGetCheckoutURL({
+    team_id: isTeamAdmin || isPersonalSpace ? activeTeam : undefined,
+    success_path: dashboardUrls.repositories(activeTeam),
+    cancel_path: dashboardUrls.repositories(activeTeam),
+  });
+
+  return (
+    <MessageStripe justify="space-between" variant="trial">
+      Free teams are limited to 3 public repositories. Upgrade for unlimited
+      repositories.
+      {isTeamAdmin ? (
+        <MessageStripe.Action
+          {...(checkout.state === 'READY'
+            ? {
+                as: 'a',
+                href: checkout.url,
+              }
+            : {
+                as: Link,
+                to: '/pro',
+              })}
+          onClick={() =>
+            isEligibleForTrial
+              ? track('Limit banner: repos - Start Trial', {
+                  codesandbox: 'V1',
+                  event_source: 'UI',
+                })
+              : track('Limit banner: repos - Upgrade', {
+                  codesandbox: 'V1',
+                  event_source: 'UI',
+                })
+          }
+        >
+          {isEligibleForTrial ? 'Start free trial' : 'Upgrade now'}
+        </MessageStripe.Action>
+      ) : (
+        <MessageStripe.Action
+          as="a"
+          href="https://codesandbox.io/docs/learn/plan-billing/trials"
+          onClick={() => {
+            track('Limit banner: repos - Learn More', {
+              codesandbox: 'V1',
+              event_source: 'UI',
+            });
+          }}
+          variant="trial"
+        >
+          Learn more
+        </MessageStripe.Action>
+      )}
+    </MessageStripe>
+  );
+};

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Repositories/stripes.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Repositories/stripes.tsx
@@ -8,6 +8,11 @@ import { Link, useLocation } from 'react-router-dom';
 import { useGetCheckoutURL } from 'app/hooks/useCreateCheckout';
 import { useAppState } from 'app/overmind';
 
+const getEventName = (isEligibleForTrial: boolean) =>
+  isEligibleForTrial
+    ? 'Limit banner: repos - Start Trial'
+    : 'Limit banner: repos - Upgrade';
+
 export const PrivateRepoFreeTeam: React.FC = () => {
   const { activeTeam } = useAppState();
   const { isEligibleForTrial } = useSubscription();
@@ -39,13 +44,13 @@ export const PrivateRepoFreeTeam: React.FC = () => {
                 to: '/pro',
               })}
           onClick={() => {
-            track('Limit banner: repos - Learn More', {
+            track(getEventName(isEligibleForTrial), {
               codesandbox: 'V1',
               event_source: 'UI',
             });
           }}
         >
-          {isEligibleForTrial ? 'Learn more' : 'Upgrade now'}
+          {isEligibleForTrial ? 'Start trial' : 'Upgrade now'}
         </MessageStripe.Action>
       )}
     </MessageStripe>
@@ -79,18 +84,13 @@ export const MaxPublicReposFreeTeam: React.FC = () => {
                 to: '/pro',
               })}
           onClick={() =>
-            isEligibleForTrial
-              ? track('Limit banner: repos - Start Trial', {
-                  codesandbox: 'V1',
-                  event_source: 'UI',
-                })
-              : track('Limit banner: repos - Upgrade', {
-                  codesandbox: 'V1',
-                  event_source: 'UI',
-                })
+            track(getEventName(isEligibleForTrial), {
+              codesandbox: 'V1',
+              event_source: 'UI',
+            })
           }
         >
-          {isEligibleForTrial ? 'Start free trial' : 'Upgrade now'}
+          {isEligibleForTrial ? 'Start trial' : 'Upgrade now'}
         </MessageStripe.Action>
       ) : (
         <MessageStripe.Action


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?

<!-- Is it a Bug fix, feature, docs update, ... -->

- Centralizes the stripe messages for the repositories page:
  - Max amount of public repositories (currently disabled)
  - Selected repo is private and the team doesn't have an active subscription

## What is the current behavior?

<!-- You can also link to an open issue here -->

No visual indicator of why the repository is read-only:

|Current|
|:-:|
|![codesandbox stream_dashboard_repositories_github_olarclara_project-template-nuxt_workspace=608e42de-934e-4a76-80ec-8addda9c620a](https://user-images.githubusercontent.com/24959348/202014849-9482c885-f855-4010-b054-75a0de8302a7.png)|

## What is the new behavior?

<!-- if this is a feature change -->

There's a banner explaining why it's read-only and a call to action to upgrade/start a trial.

|Admin|
|:-:|
|![1x54ks-3000 preview csb app_dashboard_repositories_github_olarclara_climbr_workspace=47968439-c1ee-494c-a6e1-ec7ea18ab162](https://user-images.githubusercontent.com/24959348/202015925-d1ae5e3f-746a-4c8e-9699-765bf924743a.png)|
|**Non-admin**|
|![1x54ks-3000 preview csb app_dashboard_repositories_github_olarclara_project-template-nuxt_workspace=608e42de-934e-4a76-80ec-8addda9c620a](https://user-images.githubusercontent.com/24959348/202015416-49d4af3f-e0fb-42a8-9e97-5422ccdac169.png)|

"Upgrade now" sends to the stripe checkout as expected:

https://user-images.githubusercontent.com/24959348/202017042-371fa064-46bd-4335-8122-f44c101af301.mov

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Launch the dashboard
2. Select a team without an active subscription
3. Open a private repository
