### PR TITLE
feat(subscriptions): import limitations

### DIFF
--- a/packages/app/src/app/components/CreateSandbox/Import/Import.tsx
+++ b/packages/app/src/app/components/CreateSandbox/Import/Import.tsx
@@ -222,12 +222,15 @@ export const Import: React.FC<ImportProps> = ({ onRepoSelect }) => {
         </MessageStripe>
       ) : null}
       <Element
-        as="form"
-        css={{
-          opacity: hasMaxPublicRepositories ? 0.4 : 1,
-          pointerEvents: hasMaxPublicRepositories ? 'none' : 'initial',
-        }}
-        onSubmit={handleFormSubmit}
+        {...(hasMaxPublicRepositories
+          ? {
+              as: 'div',
+              css: {
+                opacity: hasMaxPublicRepositories ? 0.4 : 1,
+                pointerEvents: hasMaxPublicRepositories ? 'none' : 'initial',
+              },
+            }
+          : { as: 'form', onSubmit: handleFormSubmit })}
       >
         <Stack gap={2}>
           <Input

--- a/packages/app/src/app/components/CreateSandbox/Import/importLimits.tsx
+++ b/packages/app/src/app/components/CreateSandbox/Import/importLimits.tsx
@@ -4,6 +4,7 @@ import {
   Link as StyledLink,
   MessageStripe,
 } from '@codesandbox/components';
+import { SUBSCRIPTION_DOCS_URLS } from 'app/constants';
 import { useGetCheckoutURL } from 'app/hooks/useCreateCheckout';
 import { useSubscription } from 'app/hooks/useSubscription';
 import { useWorkspaceAuthorization } from 'app/hooks/useWorkspaceAuthorization';
@@ -32,16 +33,22 @@ export const MaxPublicRepos: React.FC = () => {
   const { modals } = useActions();
 
   const checkout = useGetCheckoutURL({
-    team_id: isTeamAdmin || isPersonalSpace ? activeTeam : undefined,
+    team_id: isTeamAdmin ? activeTeam : undefined,
     success_path: pathname,
     cancel_path: pathname,
   });
 
+  // Personal worksaces don't have a limit
+  // for public repositories.
+  if (isPersonalSpace) {
+    return null;
+  }
+
   return (
-    <MessageStripe justify={isTeamAdmin ? 'space-between' : 'center'}>
+    <MessageStripe justify="space-between">
       You&apos;ve reached the maximum amount of free repositories. Upgrade for
       more.
-      {isTeamAdmin && (
+      {isTeamAdmin ? (
         <MessageStripe.Action
           {...(checkout.state === 'READY'
             ? {
@@ -68,6 +75,18 @@ export const MaxPublicRepos: React.FC = () => {
           }}
         >
           {isEligibleForTrial ? 'Start trial' : 'Upgrade now'}
+        </MessageStripe.Action>
+      ) : (
+        <MessageStripe.Action
+          as="a"
+          href={
+            isEligibleForTrial
+              ? SUBSCRIPTION_DOCS_URLS.teams.trial
+              : SUBSCRIPTION_DOCS_URLS.teams.non_trial
+          }
+          target="_blank"
+        >
+          Learn more
         </MessageStripe.Action>
       )}
     </MessageStripe>

--- a/packages/app/src/app/components/CreateSandbox/Import/importLimits.tsx
+++ b/packages/app/src/app/components/CreateSandbox/Import/importLimits.tsx
@@ -7,20 +7,29 @@ import {
 import { useGetCheckoutURL } from 'app/hooks/useCreateCheckout';
 import { useSubscription } from 'app/hooks/useSubscription';
 import { useWorkspaceAuthorization } from 'app/hooks/useWorkspaceAuthorization';
-import { useAppState } from 'app/overmind';
+import { useActions, useAppState } from 'app/overmind';
 import React from 'react';
 import { Link as RouterLink, useLocation } from 'react-router-dom';
 
-const getEventName = (isEligibleForTrial: boolean) =>
-  isEligibleForTrial
-    ? 'Limit banner: import - Start Trial'
-    : 'Limit banner: import - Upgrade';
+const getEventName = (
+  isEligibleForTrial: boolean,
+  isTeamAdmin?: boolean
+): string => {
+  if (isTeamAdmin) {
+    return isEligibleForTrial
+      ? 'Limit banner: import - Start Trial'
+      : 'Limit banner: import - Upgrade';
+  }
+
+  return 'Limit banner: import - Learn more';
+};
 
 export const MaxPublicRepos: React.FC = () => {
   const { activeTeam } = useAppState();
   const { isEligibleForTrial } = useSubscription();
   const { isTeamAdmin, isPersonalSpace } = useWorkspaceAuthorization();
   const { pathname } = useLocation();
+  const { modals } = useActions();
 
   const checkout = useGetCheckoutURL({
     team_id: isTeamAdmin || isPersonalSpace ? activeTeam : undefined,
@@ -44,6 +53,14 @@ export const MaxPublicRepos: React.FC = () => {
                 to: '/pro',
               })}
           onClick={() => {
+            // If we don't have a checkout URL, we
+            // default to `/pro` which uses a link
+            // from react router so we have to
+            // imperatively close the modal.
+            if (checkout.state !== 'READY') {
+              modals.newSandboxModal.close();
+            }
+
             track(getEventName(isEligibleForTrial), {
               codesandbox: 'V1',
               event_source: 'UI',
@@ -62,6 +79,7 @@ export const PrivateRepoFreeTeam: React.FC = () => {
   const { isEligibleForTrial } = useSubscription();
   const { isTeamAdmin, isPersonalSpace } = useWorkspaceAuthorization();
   const { pathname } = useLocation();
+  const { modals } = useActions();
 
   const checkout = useGetCheckoutURL({
     team_id: isTeamAdmin || isPersonalSpace ? activeTeam : undefined,
@@ -86,11 +104,29 @@ export const PrivateRepoFreeTeam: React.FC = () => {
     <>
       The free plan only allows public repos. For private repositories,{' '}
       <StyledLink
+        {...(checkoutURL.startsWith('/pro')
+          ? {
+              as: 'a',
+              href: checkoutURL,
+            }
+          : {
+              as: RouterLink,
+              to: '/pro',
+            })}
         css={{
           padding: 0,
         }}
         color="#FFFFFF"
-        href={checkoutURL}
+        onClick={() => {
+          if (checkoutURL.startsWith('/pro')) {
+            modals.newSandboxModal.close();
+          }
+
+          track(getEventName(isEligibleForTrial, isTeamAdmin), {
+            codesandbox: 'V1',
+            event_source: 'UI',
+          });
+        }}
       >
         upgrade to{' '}
         <Element as="span" css={{ textTransform: 'uppercase' }}>

--- a/packages/app/src/app/components/CreateSandbox/Import/importLimits.tsx
+++ b/packages/app/src/app/components/CreateSandbox/Import/importLimits.tsx
@@ -1,0 +1,103 @@
+import track from '@codesandbox/common/lib/utils/analytics';
+import {
+  Element,
+  Link as StyledLink,
+  MessageStripe,
+} from '@codesandbox/components';
+import { useGetCheckoutURL } from 'app/hooks/useCreateCheckout';
+import { useSubscription } from 'app/hooks/useSubscription';
+import { useWorkspaceAuthorization } from 'app/hooks/useWorkspaceAuthorization';
+import { useAppState } from 'app/overmind';
+import React from 'react';
+import { Link as RouterLink, useLocation } from 'react-router-dom';
+
+const getEventName = (isEligibleForTrial: boolean) =>
+  isEligibleForTrial
+    ? 'Limit banner: import - Start Trial'
+    : 'Limit banner: import - Upgrade';
+
+export const MaxPublicRepos: React.FC = () => {
+  const { activeTeam } = useAppState();
+  const { isEligibleForTrial } = useSubscription();
+  const { isTeamAdmin, isPersonalSpace } = useWorkspaceAuthorization();
+  const { pathname } = useLocation();
+
+  const checkout = useGetCheckoutURL({
+    team_id: isTeamAdmin || isPersonalSpace ? activeTeam : undefined,
+    success_path: pathname,
+    cancel_path: pathname,
+  });
+
+  return (
+    <MessageStripe justify={isTeamAdmin ? 'space-between' : 'center'}>
+      You&apos;ve reached the maximum amount of free repositories. Upgrade for
+      more.
+      {isTeamAdmin && (
+        <MessageStripe.Action
+          {...(checkout.state === 'READY'
+            ? {
+                as: 'a',
+                href: checkout.url,
+              }
+            : {
+                as: RouterLink,
+                to: '/pro',
+              })}
+          onClick={() => {
+            track(getEventName(isEligibleForTrial), {
+              codesandbox: 'V1',
+              event_source: 'UI',
+            });
+          }}
+        >
+          {isEligibleForTrial ? 'Start trial' : 'Upgrade now'}
+        </MessageStripe.Action>
+      )}
+    </MessageStripe>
+  );
+};
+
+export const PrivateRepoFreeTeam: React.FC = () => {
+  const { activeTeam } = useAppState();
+  const { isEligibleForTrial } = useSubscription();
+  const { isTeamAdmin, isPersonalSpace } = useWorkspaceAuthorization();
+  const { pathname } = useLocation();
+
+  const checkout = useGetCheckoutURL({
+    team_id: isTeamAdmin || isPersonalSpace ? activeTeam : undefined,
+    success_path: pathname,
+    cancel_path: pathname,
+  });
+
+  const checkoutURL = React.useMemo(() => {
+    if (isTeamAdmin || isPersonalSpace) {
+      if (checkout.state === 'READY') {
+        return checkout.url;
+      }
+      return '/pro';
+    }
+
+    return isEligibleForTrial
+      ? '/docs/learn/plan-billing/trials'
+      : '/docs/learn/introduction/workspace#managing-teams-and-subscriptions';
+  }, [checkout, isEligibleForTrial, isTeamAdmin, isPersonalSpace]);
+
+  return (
+    <>
+      The free plan only allows public repos. For private repositories,{' '}
+      <StyledLink
+        css={{
+          padding: 0,
+        }}
+        color="#FFFFFF"
+        href={checkoutURL}
+      >
+        upgrade to{' '}
+        <Element as="span" css={{ textTransform: 'uppercase' }}>
+          pro
+        </Element>
+        .
+      </StyledLink>
+    </>
+  );
+};

--- a/packages/app/src/app/components/CreateSandbox/Import/importLimits.tsx
+++ b/packages/app/src/app/components/CreateSandbox/Import/importLimits.tsx
@@ -28,7 +28,7 @@ const getEventName = (
 export const MaxPublicRepos: React.FC = () => {
   const { activeTeam } = useAppState();
   const { isEligibleForTrial } = useSubscription();
-  const { isTeamAdmin, isPersonalSpace } = useWorkspaceAuthorization();
+  const { isTeamAdmin } = useWorkspaceAuthorization();
   const { pathname } = useLocation();
   const { modals } = useActions();
 
@@ -37,12 +37,6 @@ export const MaxPublicRepos: React.FC = () => {
     success_path: pathname,
     cancel_path: pathname,
   });
-
-  // Personal worksaces don't have a limit
-  // for public repositories.
-  if (isPersonalSpace) {
-    return null;
-  }
 
   return (
     <MessageStripe justify="space-between">

--- a/packages/app/src/app/constants.ts
+++ b/packages/app/src/app/constants.ts
@@ -1,3 +1,10 @@
 export const DIALOG_TRANSITION_DURATION = 0.25;
 export const DIALOG_WIDTH = 420;
 export const REPLY_TRANSITION_DELAY = 0.5;
+export const SUBSCRIPTION_DOCS_URLS = {
+  teams: {
+    trial: '/docs/learn/plan-billing/trials',
+    non_trial:
+      '/docs/learn/introduction/workspace#managing-teams-and-subscriptions',
+  },
+};

--- a/packages/app/src/app/hooks/useSubscription.ts
+++ b/packages/app/src/app/hooks/useSubscription.ts
@@ -82,6 +82,7 @@ export const useSubscription = () => {
   const maxPublicProjects = activeTeamInfo?.limits?.maxPublicProjects;
 
   const hasMaxPublicRepositories =
+    isTeamSpace &&
     publicProjectsQuantity &&
     maxPublicProjects &&
     publicProjectsQuantity >= maxPublicProjects;

--- a/packages/app/src/app/pages/Dashboard/Components/UpgradeBanner/UpgradeBanner.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/UpgradeBanner/UpgradeBanner.tsx
@@ -17,12 +17,7 @@ import { dashboard } from '@codesandbox/common/lib/utils/url-generator';
 import track from '@codesandbox/common/lib/utils/analytics';
 import { useWorkspaceAuthorization } from 'app/hooks/useWorkspaceAuthorization';
 import { useSubscription } from 'app/hooks/useSubscription';
-
-const DOCS_URLS = {
-  trial: '/docs/learn/plan-billing/trials',
-  non_trial:
-    '/docs/learn/introduction/workspace#managing-teams-and-subscriptions',
-};
+import { SUBSCRIPTION_DOCS_URLS } from 'app/constants';
 
 const StyledTitle = styled(Text)`
   font-size: 24px;
@@ -183,7 +178,9 @@ export const UpgradeBanner: React.FC<UpgradeBannerProps> = ({ teamId }) => {
                 <Button
                   as="a"
                   href={
-                    isEligibleForTrial ? DOCS_URLS.trial : DOCS_URLS.non_trial
+                    isEligibleForTrial
+                      ? SUBSCRIPTION_DOCS_URLS.teams.trial
+                      : SUBSCRIPTION_DOCS_URLS.teams.non_trial
                   }
                   target="_blank"
                   autoWidth


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?

<!-- Is it a Bug fix, feature, docs update, ... -->

- Extracts import limits to a different file.
- Blocks the import form if the workspace has reached the limit for max public repos.
- Adds tracking to upgrade CTA when attempting to import a private repo.

## What is the current behavior?

<!-- You can also link to an open issue here -->

- No UI limitation if the workspace has reached the limit for max public repos.

## What is the new behavior?

<!-- if this is a feature change -->

- Dims UI and removes form controls if importing is not allowed.

|Admin|Non-admin|
|:-:|:-:|
|![qqmd2g-3000 preview csb app_dashboard_recent_workspace=608e42de-934e-4a76-80ec-8addda9c620a](https://user-images.githubusercontent.com/24959348/202044155-088a46c5-1252-4af3-b9bb-64e41a0aff9c.png)|![qqmd2g-3000 preview csb app_dashboard_repositories_workspace=608e42de-934e-4a76-80ec-8addda9c620a](https://user-images.githubusercontent.com/24959348/202288806-2ae12896-730f-492f-9f65-e5806344b9d1.png)|

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Launch the dashboard
2. Select a free team with 3+ imported public repos
3. Click on the 'Create' modal
4. Open the 'Import from GitHub' tab
