### PR TITLE
fix(subscriptions/banner): hide upgrade banner and fix not eligible for trial link

### DIFF
--- a/packages/app/src/app/pages/Dashboard/Components/UpgradeBanner/UpgradeBanner.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/UpgradeBanner/UpgradeBanner.tsx
@@ -151,7 +151,7 @@ export const UpgradeBanner: React.FC<UpgradeBannerProps> = ({ teamId }) => {
                       href={
                         isEligibleForTrial
                           ? '/docs/learn/plan-billing/trials'
-                          : 'docs/learn/introduction/workspace#managing-teams-and-subscriptions'
+                          : '/docs/learn/introduction/workspace#managing-teams-and-subscriptions'
                       }
                       target="_blank"
                       onClick={() => {

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Recent/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Recent/index.tsx
@@ -13,6 +13,7 @@ import { DashboardGridItem, PageTypes } from 'app/pages/Dashboard/types';
 import { Element } from '@codesandbox/components';
 import { UpgradeBanner } from 'app/pages/Dashboard/Components/UpgradeBanner';
 import { useSubscription } from 'app/hooks/useSubscription';
+import { useWorkspaceAuthorization } from 'app/hooks/useWorkspaceAuthorization';
 
 export const Recent = () => {
   const {
@@ -34,6 +35,7 @@ export const Recent = () => {
     sandboxes.RECENT_BRANCHES === null || sandboxes.RECENT_SANDBOXES === null;
 
   const { hasActiveSubscription } = useSubscription();
+  const { isPersonalSpace } = useWorkspaceAuthorization();
 
   const items: DashboardGridItem[] = dataIsLoading
     ? [
@@ -78,7 +80,7 @@ export const Recent = () => {
       <Helmet>
         <title>Dashboard - CodeSandbox</title>
       </Helmet>
-      {!hasActiveSubscription && (
+      {!hasActiveSubscription && !isPersonalSpace && (
         <Element
           css={{
             width: `calc(100% - ${2 * GUTTER}px)`,


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?

<!-- Is it a Bug fix, feature, docs update, ... -->

- Fixes the "Learn more" link if the workspace is not eligible for a trial
- Hides the upgrade banner is the workspace is a personal team

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Sign up as a user with a free personal account
2. No banner should be shown