### PR TITLE
feat(view-only): show badge on sandboxes and repos

### DIFF
--- a/packages/app/src/app/components/CreateSandbox/CreateSandbox.tsx
+++ b/packages/app/src/app/components/CreateSandbox/CreateSandbox.tsx
@@ -1,5 +1,4 @@
 import {
-  Badge,
   Text,
   Stack,
   Element,
@@ -335,10 +334,7 @@ export const CreateSandbox: React.FC<CreateSandboxProps> = ({
                     }}
                     stopId="cloud-templates"
                   >
-                    <Stack gap={2}>
-                      <span>Cloud templates</span>
-                      <Badge>Beta</Badge>
-                    </Stack>
+                    Cloud templates (Beta)
                   </Tab>
 
                   <Tab

--- a/packages/app/src/app/components/WorkspaceSelect/WorkspaceSelect.tsx
+++ b/packages/app/src/app/components/WorkspaceSelect/WorkspaceSelect.tsx
@@ -88,7 +88,7 @@ export const WorkspaceSelect: React.FC<WorkspaceSelectProps> = React.memo(
               <Stack align="center" gap={1} css={{ paddingRight: 4 }}>
                 <Text
                   size={16}
-                  maxWidth={selectedTeam?.subscription ? 166 : 126}
+                  maxWidth={selectedTeam?.subscription ? 163 : 123}
                 >
                   {isPersonalTeam ? 'Personal' : selectedTeam?.name}
                 </Text>

--- a/packages/app/src/app/components/WorkspaceSelect/WorkspaceSelect.tsx
+++ b/packages/app/src/app/components/WorkspaceSelect/WorkspaceSelect.tsx
@@ -94,7 +94,7 @@ export const WorkspaceSelect: React.FC<WorkspaceSelectProps> = React.memo(
                 </Text>
 
                 {!selectedTeam?.subscription && (
-                  <Badge color="accent">Free</Badge>
+                  <Badge variant="trial">Free</Badge>
                 )}
               </Stack>
 
@@ -147,7 +147,7 @@ export const WorkspaceSelect: React.FC<WorkspaceSelectProps> = React.memo(
                         : team.name}
                     </Text>
 
-                    {!team.subscription && <Badge color="accent">Free</Badge>}
+                    {!team.subscription && <Badge variant="trial">Free</Badge>}
                   </Stack>
                 </Stack>
               ))}

--- a/packages/app/src/app/pages/Dashboard/Components/Branch/BranchCard.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Branch/BranchCard.tsx
@@ -71,9 +71,7 @@ export const BranchCard: React.FC<BranchProps> = ({
       </Stack>
       {isViewOnly ? (
         <Element css={{ position: 'absolute', top: 8, left: 8 }}>
-          <Badge color="accent" isPadded>
-            View only
-          </Badge>
+          <Badge variant="trial">View only</Badge>
         </Element>
       ) : null}
       <Stack

--- a/packages/app/src/app/pages/Dashboard/Components/Branch/BranchListItem.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Branch/BranchListItem.tsx
@@ -102,9 +102,7 @@ export const BranchListItem = ({
           <Column span={[0, 2, 2]}>
             {isViewOnly ? (
               <Stack align="center">
-                <Badge color="accent" isPadded>
-                  View only
-                </Badge>
+                <Badge variant="trial">View only</Badge>
               </Stack>
             ) : null}
           </Column>

--- a/packages/app/src/app/pages/Dashboard/Components/Repository/RepositoryCard.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Repository/RepositoryCard.tsx
@@ -58,10 +58,8 @@ export const RepositoryCard: React.FC<RepositoryProps> = ({
       {...props}
     >
       {isViewOnly ? (
-        <Element css={{ position: 'absolute', top: 24, left: 24 }}>
-          <Badge color="accent" isPadded>
-            View only
-          </Badge>
+        <Element css={{ position: 'absolute', top: 20, left: 20 }}>
+          <Badge variant="trial">View only</Badge>
         </Element>
       ) : null}
       <IconButton

--- a/packages/app/src/app/pages/Dashboard/Components/Repository/RepositoryListItem.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Repository/RepositoryListItem.tsx
@@ -91,9 +91,7 @@ export const RepositoryListItem: React.FC<RepositoryProps> = ({
           <Column span={[0, 2, 2]}>
             {isViewOnly ? (
               <Stack align="center">
-                <Badge color="accent" isPadded>
-                  View only
-                </Badge>
+                <Badge variant="trial">View only</Badge>
               </Stack>
             ) : null}
           </Column>

--- a/packages/app/src/app/pages/Dashboard/Components/Sandbox/NewMasterSandbox.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Sandbox/NewMasterSandbox.tsx
@@ -91,9 +91,7 @@ export const NewMasterSandboxListItem = ({
         <Column span={[0, 2, 2]}>
           {isViewOnly ? (
             <Stack align="center">
-              <Badge color="accent" isPadded>
-                View only
-              </Badge>
+              <Badge variant="trial">View only</Badge>
             </Stack>
           ) : null}
         </Column>
@@ -146,9 +144,7 @@ export const NewMasterSandboxCard = ({
     >
       {isViewOnly ? (
         <Element css={{ position: 'absolute', top: 8, left: 8 }}>
-          <Badge color="accent" isPadded>
-            View only
-          </Badge>
+          <Badge variant="trial">View only</Badge>
         </Element>
       ) : null}
       <Stack

--- a/packages/app/src/app/pages/Dashboard/Components/Sandbox/SandboxCard.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Sandbox/SandboxCard.tsx
@@ -268,9 +268,7 @@ export const SandboxCard = ({
     >
       {isViewOnly ? (
         <Element css={{ position: 'absolute', top: 8, left: 8 }}>
-          <Badge color="accent" isPadded>
-            View only
-          </Badge>
+          <Badge variant="trial">View only</Badge>
         </Element>
       ) : null}
 
@@ -380,15 +378,15 @@ const Thumbnail = ({
         {showBetaBadge && <Badge icon="cloud">Beta</Badge>}
         <div
           style={{
-            width: 18,
-            height: 18,
+            width: 16,
+            height: 16,
             borderRadius: 4,
             backgroundColor: '#343434',
             borderColor: '#343434',
-            padding: 3,
+            padding: 2,
           }}
         >
-          <TemplateIcon width="18" height="18" />
+          <TemplateIcon width="16" height="16" />
         </div>
       </Stack>
     </>

--- a/packages/app/src/app/pages/Dashboard/Components/Sandbox/SandboxListItem.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Sandbox/SandboxListItem.tsx
@@ -148,9 +148,7 @@ export const SandboxListItem = ({
         <Column span={[0, 2, 2]}>
           {isViewOnly ? (
             <Stack align="center">
-              <Badge color="accent" isPadded>
-                View only
-              </Badge>
+              <Badge variant="trial">View only</Badge>
             </Stack>
           ) : null}
         </Column>

--- a/packages/app/src/app/pages/Dashboard/Components/Sandbox/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Sandbox/index.tsx
@@ -12,6 +12,7 @@ import track, {
 } from '@codesandbox/common/lib/utils/analytics';
 import { Icon } from '@codesandbox/components';
 import { formatNumber } from '@codesandbox/components/lib/components/Stats';
+import { useSubscription } from 'app/hooks/useSubscription';
 import { SandboxCard } from './SandboxCard';
 import { SandboxListItem } from './SandboxListItem';
 import { getTemplateIcon } from './TemplateIcon';
@@ -68,6 +69,7 @@ function getFolderName(item: GenericSandboxProps['item']): string | undefined {
 const GenericSandbox = ({ isScrolling, item, page }: GenericSandboxProps) => {
   const { dashboard, activeWorkspaceAuthorization } = useAppState();
   const actions = useActions();
+  const { hasActiveSubscription } = useSubscription();
 
   const { sandbox } = item;
 
@@ -147,6 +149,7 @@ const GenericSandbox = ({ isScrolling, item, page }: GenericSandboxProps) => {
 
   const selected = selectedIds.includes(sandbox.id);
   const isDragging = isAnythingDragging && selected;
+  const isViewOnly = !hasActiveSubscription && sandbox.privacy !== 0;
 
   const sandboxAnalyticsEvent = !autoFork
     ? MAP_SANDBOX_EVENT_TO_PAGE_TYPE[page]
@@ -288,6 +291,7 @@ const GenericSandbox = ({ isScrolling, item, page }: GenericSandboxProps) => {
     TemplateIcon,
     PrivacyIcon,
     screenshotUrl,
+    isViewOnly,
     // edit mode
     editing: isRenaming && selected,
     newTitle,

--- a/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenus/RepositoryMenu.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenus/RepositoryMenu.tsx
@@ -10,6 +10,7 @@ import {
 import { useActions, useAppState } from 'app/overmind';
 import { quotes } from 'app/utils/quotes';
 import { PageTypes } from 'app/overmind/namespaces/dashboard/types';
+import { useSubscription } from 'app/hooks/useSubscription';
 import { Context, MenuItem } from '../ContextMenu';
 
 type RepositoryMenuProps = {
@@ -29,14 +30,15 @@ export const RepositoryMenu: React.FC<RepositoryMenuProps> = ({
   const history = useHistory();
   const state = useAppState();
   const actions = useActions();
+  const { hasActiveSubscription } = useSubscription();
 
   const [experimentalMode] = useState(() => {
     return window.localStorage.getItem('CSB_DEBUG') === 'ENABLED';
   });
 
   const { repository: providerRepository } = repository;
-  // TODO: Get isViewOnly from repository 🚧
-  const isViewOnly = false;
+
+  const isViewOnly = !hasActiveSubscription && providerRepository.private;
 
   const repositoryUrl = dashboard.repository({
     owner: providerRepository.owner,

--- a/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenus/SandboxMenu.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenus/SandboxMenu.tsx
@@ -26,8 +26,6 @@ export const SandboxMenu: React.FC<SandboxMenuProps> = ({
     browser: { copyToClipboard },
   } = useEffects();
   const { sandbox, type } = item;
-  // TODO: Get isViewOnly from item 🚧
-  const isViewOnly = false;
   const isTemplate = type === 'template';
 
   const { visible, setVisibility, position } = React.useContext(Context);
@@ -40,6 +38,7 @@ export const SandboxMenu: React.FC<SandboxMenuProps> = ({
   const folderUrl = getFolderUrl(item, activeTeam);
 
   const label = isTemplate ? 'Template' : 'Sandbox';
+  const isViewOnly = !hasActiveSubscription && sandbox.privacy !== 0;
 
   // TODO(@CompuIves): remove the `item.sandbox.teamId === null` check, once the server is not
   // responding with teamId == null for personal templates anymore.

--- a/packages/app/src/app/pages/Dashboard/Components/SyncedSandbox/SyncedSandboxListItem.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/SyncedSandbox/SyncedSandboxListItem.tsx
@@ -85,15 +85,13 @@ export const SyncedSandboxListItem = ({
         <Column span={[0, 2, 2]}>
           {isViewOnly ? (
             <Stack align="center">
-              <Badge color="accent" isPadded>
-                View only
-              </Badge>
+              <Badge variant="trial">View only</Badge>
             </Stack>
           ) : null}
         </Column>
         <Column span={[0, 5, 2]} as={Stack} align="center">
           <Stack align="center">
-            <Badge isPadded>Synced</Badge>
+            <Badge>Synced</Badge>
           </Stack>
         </Column>
         <Column span={[0, 3, 3]} as={Stack} align="center">

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/WorkspaceSettings.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/WorkspaceSettings.tsx
@@ -319,7 +319,7 @@ export const WorkspaceSettings = () => {
 
                 <Stack>
                   {hasActiveSubscription ? null : (
-                    <Badge color="accent">Free</Badge>
+                    <Badge variant="trial">Free</Badge>
                   )}
                 </Stack>
 

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Settings/UserSettings/WorkspaceSettings.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Settings/UserSettings/WorkspaceSettings.tsx
@@ -196,7 +196,7 @@ export const WorkspaceSettings = () => {
                 </Stack>
                 {!hasActiveSubscription && (
                   <Stack>
-                    <Badge color="accent">Free</Badge>
+                    <Badge variant="trial">Free</Badge>
                   </Stack>
                 )}
               </Stack>
@@ -258,7 +258,7 @@ export const WorkspaceSettings = () => {
               </Stack>
               {!hasActiveSubscription && (
                 <Stack>
-                  <Badge color="accent">Free</Badge>
+                  <Badge variant="trial">Free</Badge>
                 </Stack>
               )}
             </Stack>

--- a/packages/app/src/app/pages/Pro/components/Switcher.tsx
+++ b/packages/app/src/app/pages/Pro/components/Switcher.tsx
@@ -66,7 +66,7 @@ export const Switcher: React.FC<{
               <WorkspaceName>
                 <span>{activeTeamInfo.name}</span>
               </WorkspaceName>
-              {isFreeWorkspace && <Badge color="accent">Free</Badge>}
+              {isFreeWorkspace && <Badge variant="trial">Free</Badge>}
               <Icon css={{ color: '#fff' }} name="chevronDown" size={8} />
             </Stack>
             <WorkspaceType>
@@ -139,7 +139,7 @@ export const Switcher: React.FC<{
                       </Text>
                     </Stack>
 
-                    {!isPro && <Badge color="accent">Free</Badge>}
+                    {!isPro && <Badge variant="trial">Free</Badge>}
                   </Stack>
                 </MenuItem>
               );

--- a/packages/app/src/app/pages/Sandbox/Editor/Header/WorkspaceName/UpgradeToolTip.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Header/WorkspaceName/UpgradeToolTip.tsx
@@ -40,7 +40,7 @@ const UpgradeToolTip: React.FC = () => (
             </Stack>
           }
         >
-          <Badge color="accent">Free</Badge>
+          <Badge variant="trial">Free</Badge>
         </Tooltip>
       )}
     </SingletonTooltip>

--- a/packages/components/src/components/Badge/index.stories.tsx
+++ b/packages/components/src/components/Badge/index.stories.tsx
@@ -10,10 +10,10 @@ export default {
 export const Examples = () => (
   <Stack align="flex-start" gap={2} direction="vertical">
     <Badge>Neutral</Badge>
-    <Badge color="accent">Accent</Badge>
+    <Badge variant="trial">Free</Badge>
     <Badge icon="bell">With icon</Badge>
-    <Badge icon="bell" color="accent">
-      Accent with icon
+    <Badge icon="bell" variant="trial">
+      Free with icon
     </Badge>
   </Stack>
 );

--- a/packages/components/src/components/Badge/index.tsx
+++ b/packages/components/src/components/Badge/index.tsx
@@ -4,40 +4,32 @@ import { Stack } from '../Stack';
 import { Text } from '../Text';
 
 export interface BadgeProps {
-  color?: 'accent' | 'neutral';
+  variant?: 'trial' | 'neutral';
   icon?: IconNames;
   isPadded?: boolean;
 }
 
 export const Badge: React.FC<BadgeProps> = ({
-  color = 'neutral',
+  variant = 'neutral',
   icon,
-  isPadded,
   children,
 }) => {
-  let padding = '1px 6px';
-
-  if (isPadded) {
-    padding = '8px 12px';
-  } else if (icon) {
-    padding = '4px 8px';
-  }
-
   return (
     <Stack
       css={{
         alignItems: 'center',
-        padding,
+        padding: '2px 8px',
         userSelect: 'none',
         borderRadius: '999px',
-        backgroundColor: color === 'accent' ? '#644ED7' : '#2e2e2e',
-        color: color === 'accent' ? '#fff' : 'inherit',
-        fontSize: 11,
+        backgroundColor: variant === 'trial' ? '#644ED7' : '#2e2e2e',
+        color: variant === 'trial' ? '#fff' : 'inherit',
       }}
       gap={1}
     >
       {icon && <Icon size={12} name={icon} />}
-      <Text>{children}</Text>
+      <Text size={12} lineHeight="16px">
+        {children}
+      </Text>
     </Stack>
   );
 };


### PR DESCRIPTION
Quite some changes, but mostly updating the `Badge` component to reflect the prism version: 20px height, 12px font-size and same API

![Screenshot 2022-11-16 at 19 02 33](https://user-images.githubusercontent.com/9945366/202246396-ebbf334a-750c-4bc0-aada-5ed409a1300f.png)
![Screenshot 2022-11-16 at 19 02 44](https://user-images.githubusercontent.com/9945366/202246398-44399ca0-6ffb-4f3b-b212-58cc7a9c853c.png)
![Screenshot 2022-11-16 at 19 02 49](https://user-images.githubusercontent.com/9945366/202246400-b17b17fd-8431-4005-8954-3fef41f3f300.png)
![Screenshot 2022-11-16 at 19 03 01](https://user-images.githubusercontent.com/9945366/202246403-c9dca8a6-226e-48e5-b90d-dec7b8d07805.png)


Still todo:
- [ ] remove some context menu items for view only sandboxes and repositories
- [ ] add a stripe in the private repo (branch list) with a specific reference to the private repo on a free tier