### PR TITLE
feat(subscriptions): max public repos limitations

### DIFF
--- a/packages/app/src/app/pages/Dashboard/Content/routes/Repositories/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Repositories/index.tsx
@@ -133,15 +133,6 @@ export const RepositoriesPage = () => {
         readOnly={readOnly}
       />
 
-      {readOnly && (
-        <Element paddingX={4} paddingY={2}>
-          {selectedRepo?.private && <PrivateRepoFreeTeam />}
-          {hasMaxPublicRepositories && !selectedRepo && (
-            <MaxPublicReposFreeTeam />
-          )}
-        </Element>
-      )}
-
       {itemsToShow.length === 0 ? (
         <Notification pageType={pageType}>
           <Text>
@@ -160,6 +151,15 @@ export const RepositoriesPage = () => {
             personal team.
           </Text>
         </Notification>
+      )}
+
+      {readOnly && (
+        <Element paddingX={4} paddingY={2}>
+          {selectedRepo?.private && <PrivateRepoFreeTeam />}
+          {hasMaxPublicRepositories && !selectedRepo && (
+            <MaxPublicReposFreeTeam />
+          )}
+        </Element>
       )}
 
       <VariableGrid page={pageType} items={itemsToShow} />

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Repositories/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Repositories/index.tsx
@@ -9,7 +9,7 @@ import { SelectionProvider } from 'app/pages/Dashboard/Components/Selection';
 import { Notification } from 'app/pages/Dashboard/Components/Notification/Notification';
 import { Text, Element } from '@codesandbox/components';
 import { useSubscription } from 'app/hooks/useSubscription';
-import { /* MaxPublicReposFreeTeam, */ PrivateRepoFreeTeam } from './stripes';
+import { MaxPublicReposFreeTeam, PrivateRepoFreeTeam } from './stripes';
 
 export const RepositoriesPage = () => {
   const params = useParams<{ path: string }>();
@@ -48,10 +48,7 @@ export const RepositoriesPage = () => {
     pathRef.current = path;
   }, [path]);
 
-  const {
-    hasActiveSubscription,
-    // hasMaxPublicRepositories,
-  } = useSubscription();
+  const { hasActiveSubscription, hasMaxPublicRepositories } = useSubscription();
 
   const pageType: PageTypes = 'repositories';
   let selectedRepo:
@@ -105,7 +102,7 @@ export const RepositoriesPage = () => {
     if (viewMode === 'grid' && repoItems.length > 0) {
       repoItems.unshift({
         type: 'import-repository',
-        // disabled: !hasActiveSubscription && hasMaxPublicRepositories,
+        disabled: !hasActiveSubscription && hasMaxPublicRepositories,
       });
     }
 
@@ -113,10 +110,9 @@ export const RepositoriesPage = () => {
   };
 
   const itemsToShow = getItemsToShow();
-  const readOnly = !hasActiveSubscription && selectedRepo?.private;
-  // const readOnly = !hasActiveSubscription
-  //   ? selectedRepo?.private || hasMaxPublicRepositories
-  //   : false;
+  const readOnly =
+    !hasActiveSubscription &&
+    (selectedRepo?.private || hasMaxPublicRepositories);
 
   return (
     <SelectionProvider
@@ -140,7 +136,9 @@ export const RepositoriesPage = () => {
       {readOnly && (
         <Element paddingX={4} paddingY={2}>
           {selectedRepo?.private && <PrivateRepoFreeTeam />}
-          {/* {(hasMaxPublicRepositories && !selectedRepo) && <MaxPublicReposFreeTeam />} */}
+          {hasMaxPublicRepositories && !selectedRepo && (
+            <MaxPublicReposFreeTeam />
+          )}
         </Element>
       )}
 


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?

<!-- Is it a Bug fix, feature, docs update, ... -->

Re-enables limitations on UI for teams w/o an active subscription with 3+ public repositories.

## What is the new behavior?

<!-- if this is a feature change -->

![1yc662-3000 preview csb app_dashboard_repositories_workspace=47968439-c1ee-494c-a6e1-ec7ea18ab162 (1)](https://user-images.githubusercontent.com/24959348/202595596-430aa6a2-0fb9-451a-9a0a-4ae37f7cf52d.png)

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Launch the dashboard
2. Select a team w/o an active subscription
3. If the team has 3+ public repositories
  - Stripe banner is show
  - "Import repo" action is disabled in both list and grid view