### PR TITLE
feat(subscriptions/sandboxes): soft limits

### DIFF
--- a/packages/app/src/app/components/CreateSandbox/CreateSandbox.tsx
+++ b/packages/app/src/app/components/CreateSandbox/CreateSandbox.tsx
@@ -421,6 +421,7 @@ export const CreateSandbox: React.FC<CreateSandboxProps> = ({
             {viewState === 'initial' &&
               (searchQuery ? (
                 <SearchResults
+                  checkoutUrl={checkoutUrl}
                   search={searchQuery}
                   onSelectTemplate={selectTemplate}
                   onOpenTemplate={openTemplate}

--- a/packages/app/src/app/components/CreateSandbox/SearchResults/SearchResultList.tsx
+++ b/packages/app/src/app/components/CreateSandbox/SearchResults/SearchResultList.tsx
@@ -7,12 +7,13 @@ import { TemplateGrid } from '../elements';
 import { TemplateCard } from '../TemplateCard';
 
 type ResultsProps = InfiniteHitsProvided<AlgoliaSandboxHit> & {
+  disableTemplates?: boolean;
   onSelectTemplate: (template: TemplateFragment) => void;
   onOpenTemplate: (template: TemplateFragment) => void;
 };
 
 const Results = (props: ResultsProps) => {
-  const { hits } = props;
+  const { disableTemplates, hits } = props;
   const bottomDetectionEl = React.useRef<HTMLDivElement>();
 
   useEffect(() => {
@@ -67,6 +68,7 @@ const Results = (props: ResultsProps) => {
       {templates.map(template => (
         <TemplateCard
           key={template.id}
+          disabled={disableTemplates}
           template={template}
           onSelectTemplate={props.onSelectTemplate}
           onOpenTemplate={props.onOpenTemplate}

--- a/packages/app/src/app/components/CreateSandbox/SearchResults/SearchResults.tsx
+++ b/packages/app/src/app/components/CreateSandbox/SearchResults/SearchResults.tsx
@@ -9,8 +9,11 @@ import { connectStateResults } from 'react-instantsearch-dom';
 import { createGlobalStyle } from 'styled-components';
 import { Text, Stack } from '@codesandbox/components';
 import { TemplateFragment } from 'app/graphql/types';
+import { useSubscription } from 'app/hooks/useSubscription';
+import { useWorkspaceAuthorization } from 'app/hooks/useWorkspaceAuthorization';
 import { SearchResultList } from './SearchResultList';
 import { Loader } from '../Loader';
+import { MaxPublicSandboxes } from '../stripes';
 
 const LoadingIndicator = connectStateResults(({ isSearchStalled }) =>
   isSearchStalled ? <Loader /> : null
@@ -25,55 +28,78 @@ const GlobalSearchStyles = createGlobalStyle`
 `;
 
 export const SearchResults = ({
+  checkoutUrl,
   search,
   onSelectTemplate,
   onOpenTemplate,
 }: {
+  // Receiving as prop to avoid fetching the checkout
+  // url every time the templates list re-renders.
+  checkoutUrl: string | undefined;
   search: string;
   onSelectTemplate: (template: TemplateFragment) => void;
   onOpenTemplate: (template: TemplateFragment) => void;
-}) => (
-  <>
-    <GlobalSearchStyles />
-    <InstantSearch
-      appId={ALGOLIA_APPLICATION_ID}
-      apiKey={ALGOLIA_API_KEY}
-      indexName={ALGOLIA_DEFAULT_INDEX}
-    >
-      <Configure
-        query={search}
-        hitsPerPage={50}
-        facetFilters={[
-          [
-            'custom_template.published: true',
-            'custom_template.published: false',
-          ],
-        ]}
-      />
+}) => {
+  const {
+    hasActiveSubscription,
+    hasMaxPublicSandboxes,
+    isEligibleForTrial,
+  } = useSubscription();
+  const { isTeamAdmin } = useWorkspaceAuthorization();
 
-      <Stack css={{ height: '100%' }} direction="vertical" gap={6}>
-        <Text
-          as="h2"
-          size={4}
-          css={{
-            fontWeight: 500,
-            lineHeight: 1.5,
-            margin: 0,
-          }}
-        >
-          <Stats
-            translations={{
-              stats: nbHits => `${nbHits.toLocaleString()} results found`,
-            }}
-          />
-        </Text>
+  const limitNewSandboxes = !hasActiveSubscription && hasMaxPublicSandboxes;
 
-        <LoadingIndicator />
-        <SearchResultList
-          onSelectTemplate={onSelectTemplate}
-          onOpenTemplate={onOpenTemplate}
+  return (
+    <>
+      <GlobalSearchStyles />
+      <InstantSearch
+        appId={ALGOLIA_APPLICATION_ID}
+        apiKey={ALGOLIA_API_KEY}
+        indexName={ALGOLIA_DEFAULT_INDEX}
+      >
+        <Configure
+          query={search}
+          hitsPerPage={50}
+          facetFilters={[
+            [
+              'custom_template.published: true',
+              'custom_template.published: false',
+            ],
+          ]}
         />
-      </Stack>
-    </InstantSearch>
-  </>
-);
+
+        <Stack css={{ height: '100%' }} direction="vertical" gap={6}>
+          <Text
+            as="h2"
+            size={4}
+            css={{
+              fontWeight: 500,
+              lineHeight: 1.5,
+              margin: 0,
+            }}
+          >
+            <Stats
+              translations={{
+                stats: nbHits => `${nbHits.toLocaleString()} results found`,
+              }}
+            />
+          </Text>
+
+          {limitNewSandboxes ? (
+            <MaxPublicSandboxes
+              checkoutUrl={checkoutUrl}
+              isEligibleForTrial={isEligibleForTrial}
+              isTeamAdmin={isTeamAdmin}
+            />
+          ) : null}
+
+          <LoadingIndicator />
+          <SearchResultList
+            onSelectTemplate={onSelectTemplate}
+            onOpenTemplate={onOpenTemplate}
+          />
+        </Stack>
+      </InstantSearch>
+    </>
+  );
+};

--- a/packages/app/src/app/components/CreateSandbox/SearchResults/SearchResults.tsx
+++ b/packages/app/src/app/components/CreateSandbox/SearchResults/SearchResults.tsx
@@ -95,6 +95,7 @@ export const SearchResults = ({
 
           <LoadingIndicator />
           <SearchResultList
+            disableTemplates={limitNewSandboxes}
             onSelectTemplate={onSelectTemplate}
             onOpenTemplate={onOpenTemplate}
           />

--- a/packages/app/src/app/components/CreateSandbox/TemplateCard.tsx
+++ b/packages/app/src/app/components/CreateSandbox/TemplateCard.tsx
@@ -7,12 +7,14 @@ import { useAppState } from 'app/overmind';
 import { TemplateButton } from './elements';
 
 interface TemplateCardProps {
+  disabled?: boolean;
   template: TemplateFragment;
   onSelectTemplate: (template: TemplateFragment) => void;
   onOpenTemplate: (template: TemplateFragment) => void;
 }
 
 export const TemplateCard = ({
+  disabled,
   template,
   onSelectTemplate,
   onOpenTemplate,
@@ -32,6 +34,10 @@ export const TemplateCard = ({
       title={sandboxTitle}
       type="button"
       onClick={evt => {
+        if (disabled) {
+          return;
+        }
+
         if (evt.metaKey || evt.ctrlKey || !isLoggedIn) {
           onOpenTemplate(template);
         } else {
@@ -39,6 +45,10 @@ export const TemplateCard = ({
         }
       }}
       onKeyDown={evt => {
+        if (disabled) {
+          return;
+        }
+
         if (evt.key === 'Enter') {
           evt.preventDefault();
           if (evt.metaKey || evt.ctrlKey) {
@@ -48,6 +58,7 @@ export const TemplateCard = ({
           }
         }
       }}
+      disabled={disabled}
     >
       <Stack css={{ height: '100%' }} direction="vertical" gap={4}>
         <Stack

--- a/packages/app/src/app/components/CreateSandbox/TemplateCategoryList.tsx
+++ b/packages/app/src/app/components/CreateSandbox/TemplateCategoryList.tsx
@@ -4,11 +4,17 @@ import { Button, Text, Stack } from '@codesandbox/components';
 import { css } from '@styled-system/css';
 import { useAppState, useActions } from 'app/overmind';
 import { TemplateFragment } from 'app/graphql/types';
+import { useSubscription } from 'app/hooks/useSubscription';
+import { useWorkspaceAuthorization } from 'app/hooks/useWorkspaceAuthorization';
 import { TemplateCard } from './TemplateCard';
 import { TemplateGrid } from './elements';
+import { MaxPublicSandboxes } from './stripes';
 
 interface TemplateCategoryListProps {
   title: string;
+  // Receiving as prop to avoid fetching the checkout
+  // url every time the templates list re-renders.
+  checkoutUrl: string | undefined;
   isCloudTemplateList?: boolean;
   templates: TemplateFragment[];
   onSelectTemplate: (template: TemplateFragment) => void;
@@ -17,6 +23,7 @@ interface TemplateCategoryListProps {
 
 export const TemplateCategoryList = ({
   title,
+  checkoutUrl,
   isCloudTemplateList,
   templates,
   onSelectTemplate,
@@ -24,6 +31,12 @@ export const TemplateCategoryList = ({
 }: TemplateCategoryListProps) => {
   const { hasLogIn } = useAppState();
   const actions = useActions();
+  const {
+    hasActiveSubscription,
+    hasMaxPublicSandboxes,
+    isEligibleForTrial,
+  } = useSubscription();
+  const { isTeamAdmin } = useWorkspaceAuthorization();
 
   useEffect(() => {
     track('Create Sandbox Tab Open', { tab: title });
@@ -52,6 +65,13 @@ export const TemplateCategoryList = ({
           {title}
         </Text>
       </Stack>
+      {!hasActiveSubscription && hasMaxPublicSandboxes ? (
+        <MaxPublicSandboxes
+          checkoutUrl={checkoutUrl}
+          isEligibleForTrial={isEligibleForTrial}
+          isTeamAdmin={isTeamAdmin}
+        />
+      ) : null}
       {!hasLogIn && isCloudTemplateList ? (
         <Stack direction="vertical" gap={4}>
           <Text id="unauthenticated-label" css={{ color: '#999999' }} size={3}>

--- a/packages/app/src/app/components/CreateSandbox/TemplateCategoryList.tsx
+++ b/packages/app/src/app/components/CreateSandbox/TemplateCategoryList.tsx
@@ -42,6 +42,8 @@ export const TemplateCategoryList = ({
     track('Create Sandbox Tab Open', { tab: title });
   }, [title]);
 
+  const limitNewSandboxes = !hasActiveSubscription && hasMaxPublicSandboxes;
+
   return (
     <Stack direction="vertical" css={{ height: '100%' }} gap={4}>
       <Stack
@@ -65,7 +67,7 @@ export const TemplateCategoryList = ({
           {title}
         </Text>
       </Stack>
-      {!hasActiveSubscription && hasMaxPublicSandboxes ? (
+      {limitNewSandboxes ? (
         <MaxPublicSandboxes
           checkoutUrl={checkoutUrl}
           isEligibleForTrial={isEligibleForTrial}
@@ -94,6 +96,7 @@ export const TemplateCategoryList = ({
           templates.map(template => (
             <TemplateCard
               key={template.id}
+              disabled={limitNewSandboxes}
               template={template}
               onSelectTemplate={onSelectTemplate}
               onOpenTemplate={onOpenTemplate}

--- a/packages/app/src/app/components/CreateSandbox/elements.ts
+++ b/packages/app/src/app/components/CreateSandbox/elements.ts
@@ -103,12 +103,16 @@ export const TemplateButton = styled.button`
   transition: background ${props => props.theme.speeds[2]} ease-out;
   outline: none;
 
-  &:hover {
+  &:hover:not(:disabled) {
     background: #252525;
   }
 
   &:focus-visible {
     border-color: ${props => props.theme.colors.purple};
+  }
+
+  &:disabled {
+    opacity: 0.4;
   }
 `;
 

--- a/packages/app/src/app/components/CreateSandbox/stripes.tsx
+++ b/packages/app/src/app/components/CreateSandbox/stripes.tsx
@@ -1,0 +1,64 @@
+import track from '@codesandbox/common/lib/utils/analytics';
+import { MessageStripe } from '@codesandbox/components';
+import { Link } from 'react-router-dom';
+import React from 'react';
+import { useActions } from 'app/overmind';
+
+const getEventName = (isEligibleForTrial: boolean) =>
+  isEligibleForTrial
+    ? 'Limit banner: create sandbox - Start trial'
+    : 'Limit banner: create sandbox - Upgrade';
+
+const EVENT_PROPS = {
+  codesandbox: 'V1',
+  event_source: 'UI',
+};
+
+type MaxPublicReposProps = {
+  checkoutUrl?: string;
+  isTeamAdmin: boolean;
+  isEligibleForTrial: boolean;
+};
+export const MaxPublicSandboxes: React.FC<MaxPublicReposProps> = ({
+  checkoutUrl,
+  isEligibleForTrial,
+  isTeamAdmin,
+}) => {
+  const { newSandboxModal } = useActions().modals;
+
+  return (
+    <MessageStripe justify="space-between">
+      You&apos;ve reached the maximum amount of free sandboxes. Upgrade for
+      more.
+      {isTeamAdmin ? (
+        <MessageStripe.Action
+          {...(checkoutUrl
+            ? {
+                as: 'a',
+                href: checkoutUrl,
+              }
+            : {
+                as: Link,
+                to: '/pro',
+              })}
+          onClick={() => {
+            if (!checkoutUrl) {
+              newSandboxModal.close();
+            }
+            track(getEventName(isEligibleForTrial), EVENT_PROPS);
+          }}
+        >
+          {isTeamAdmin ? 'Upgrade now' : 'Learn more'}
+        </MessageStripe.Action>
+      ) : (
+        <MessageStripe.Action
+          onClick={() =>
+            track('Limit banner: create sandbox - Learn more', EVENT_PROPS)
+          }
+        >
+          Learn more
+        </MessageStripe.Action>
+      )}
+    </MessageStripe>
+  );
+};

--- a/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenus/MultiItemMenu.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenus/MultiItemMenu.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useEffects, useActions, useAppState } from 'app/overmind';
 import { Menu } from '@codesandbox/components';
 import { SubscriptionType } from 'app/graphql/types';
+import { useSubscription } from 'app/hooks/useSubscription';
 import { Context, MenuItem } from '../ContextMenu';
 import {
   DashboardSandbox,
@@ -37,6 +38,7 @@ export const MultiMenu = ({ selectedItems, page }: IMultiMenuProps) => {
   const actions = useActions();
   const { notificationToast } = useEffects();
   const { visible, setVisibility, position } = React.useContext(Context);
+  const { hasActiveSubscription, hasMaxPublicSandboxes } = useSubscription();
 
   /*
     sandbox options - export, make template, delete
@@ -261,27 +263,43 @@ export const MultiMenu = ({ selectedItems, page }: IMultiMenuProps) => {
   } else if (sandboxes.length && templates.length) {
     options = [...PRIVACY_ITEMS, ...EXPORT, MOVE_ITEMS, DIVIDER, DELETE];
   } else if (templates.length) {
-    options = [
-      ...PRIVACY_ITEMS,
-      ...EXPORT,
-      MOVE_ITEMS,
-      CONVERT_TO_SANDBOX,
-      DIVIDER,
-      DELETE,
-    ];
+    options =
+      hasActiveSubscription && !hasMaxPublicSandboxes
+        ? [
+            ...PRIVACY_ITEMS,
+            ...EXPORT,
+            MOVE_ITEMS,
+            CONVERT_TO_SANDBOX,
+            DIVIDER,
+            DELETE,
+          ]
+        : [...PRIVACY_ITEMS, ...EXPORT, CONVERT_TO_SANDBOX, DIVIDER, DELETE];
   } else if (sandboxes.length) {
-    options = [
-      ...PRIVACY_ITEMS,
-      ...EXPORT,
-      DIVIDER,
-      ...FROZEN_ITEMS,
-      DIVIDER,
-      MOVE_ITEMS,
-      CONVERT_TO_TEMPLATE,
-      ...PROTECTED_SANDBOXES_ITEMS,
-      DIVIDER,
-      DELETE,
-    ];
+    options =
+      hasActiveSubscription && !hasMaxPublicSandboxes
+        ? [
+            ...PRIVACY_ITEMS,
+            ...EXPORT,
+            DIVIDER,
+            ...FROZEN_ITEMS,
+            DIVIDER,
+            MOVE_ITEMS,
+            CONVERT_TO_TEMPLATE,
+            ...PROTECTED_SANDBOXES_ITEMS,
+            DIVIDER,
+            DELETE,
+          ]
+        : [
+            ...PRIVACY_ITEMS,
+            ...EXPORT,
+            DIVIDER,
+            ...FROZEN_ITEMS,
+            DIVIDER,
+            CONVERT_TO_TEMPLATE,
+            ...PROTECTED_SANDBOXES_ITEMS,
+            DIVIDER,
+            DELETE,
+          ];
   }
 
   return options.length > 0 ? (

--- a/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenus/MultiItemMenu.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenus/MultiItemMenu.tsx
@@ -102,7 +102,8 @@ export const MultiMenu = ({ selectedItems, page }: IMultiMenuProps) => {
       preventSandboxLeaving: Boolean(
         [...sandboxes, ...templates].find(
           s => s.sandbox.permissions.preventSandboxLeaving
-        )
+        ) ||
+          (!hasActiveSubscription && hasMaxPublicSandboxes)
       ),
     });
   };
@@ -263,43 +264,27 @@ export const MultiMenu = ({ selectedItems, page }: IMultiMenuProps) => {
   } else if (sandboxes.length && templates.length) {
     options = [...PRIVACY_ITEMS, ...EXPORT, MOVE_ITEMS, DIVIDER, DELETE];
   } else if (templates.length) {
-    options =
-      hasActiveSubscription && !hasMaxPublicSandboxes
-        ? [
-            ...PRIVACY_ITEMS,
-            ...EXPORT,
-            MOVE_ITEMS,
-            CONVERT_TO_SANDBOX,
-            DIVIDER,
-            DELETE,
-          ]
-        : [...PRIVACY_ITEMS, ...EXPORT, CONVERT_TO_SANDBOX, DIVIDER, DELETE];
+    options = [
+      ...PRIVACY_ITEMS,
+      ...EXPORT,
+      MOVE_ITEMS,
+      CONVERT_TO_SANDBOX,
+      DIVIDER,
+      DELETE,
+    ];
   } else if (sandboxes.length) {
-    options =
-      hasActiveSubscription && !hasMaxPublicSandboxes
-        ? [
-            ...PRIVACY_ITEMS,
-            ...EXPORT,
-            DIVIDER,
-            ...FROZEN_ITEMS,
-            DIVIDER,
-            MOVE_ITEMS,
-            CONVERT_TO_TEMPLATE,
-            ...PROTECTED_SANDBOXES_ITEMS,
-            DIVIDER,
-            DELETE,
-          ]
-        : [
-            ...PRIVACY_ITEMS,
-            ...EXPORT,
-            DIVIDER,
-            ...FROZEN_ITEMS,
-            DIVIDER,
-            CONVERT_TO_TEMPLATE,
-            ...PROTECTED_SANDBOXES_ITEMS,
-            DIVIDER,
-            DELETE,
-          ];
+    options = [
+      ...PRIVACY_ITEMS,
+      ...EXPORT,
+      DIVIDER,
+      ...FROZEN_ITEMS,
+      DIVIDER,
+      MOVE_ITEMS,
+      CONVERT_TO_TEMPLATE,
+      ...PROTECTED_SANDBOXES_ITEMS,
+      DIVIDER,
+      DELETE,
+    ];
   }
 
   return options.length > 0 ? (

--- a/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenus/SandboxMenu.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenus/SandboxMenu.tsx
@@ -21,7 +21,7 @@ export const SandboxMenu: React.FC<SandboxMenuProps> = ({
 }) => {
   const actions = useActions();
   const { user, activeTeam, activeWorkspaceAuthorization } = useAppState();
-  const { hasActiveSubscription, hasMaxPublicRepositories } = useSubscription();
+  const { hasActiveSubscription, hasMaxPublicSandboxes } = useSubscription();
   const {
     browser: { copyToClipboard },
   } = useEffects();
@@ -179,7 +179,7 @@ export const SandboxMenu: React.FC<SandboxMenuProps> = ({
               sandboxIds: [item.sandbox.id],
               preventSandboxLeaving:
                 item.sandbox.permissions.preventSandboxLeaving ||
-                (!hasActiveSubscription && hasMaxPublicRepositories),
+                (!hasActiveSubscription && hasMaxPublicSandboxes),
             });
           }}
         >

--- a/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenus/SandboxMenu.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenus/SandboxMenu.tsx
@@ -21,7 +21,7 @@ export const SandboxMenu: React.FC<SandboxMenuProps> = ({
 }) => {
   const actions = useActions();
   const { user, activeTeam, activeWorkspaceAuthorization } = useAppState();
-  const { hasActiveSubscription, hasMaxPublicSandboxes } = useSubscription();
+  const { hasActiveSubscription, hasMaxPublicRepositories } = useSubscription();
   const {
     browser: { copyToClipboard },
   } = useEffects();
@@ -172,16 +172,14 @@ export const SandboxMenu: React.FC<SandboxMenuProps> = ({
           Fork Sandbox
         </MenuItem>
       ) : null}
-      {isOwner &&
-      activeWorkspaceAuthorization !== 'READ' &&
-      hasActiveSubscription &&
-      !hasMaxPublicSandboxes ? (
+      {isOwner && activeWorkspaceAuthorization !== 'READ' ? (
         <MenuItem
           onSelect={() => {
             actions.modals.moveSandboxModal.open({
               sandboxIds: [item.sandbox.id],
               preventSandboxLeaving:
-                item.sandbox.permissions.preventSandboxLeaving,
+                item.sandbox.permissions.preventSandboxLeaving ||
+                (!hasActiveSubscription && hasMaxPublicRepositories),
             });
           }}
         >

--- a/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenus/SandboxMenu.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenus/SandboxMenu.tsx
@@ -21,7 +21,7 @@ export const SandboxMenu: React.FC<SandboxMenuProps> = ({
 }) => {
   const actions = useActions();
   const { user, activeTeam, activeWorkspaceAuthorization } = useAppState();
-  const { hasActiveSubscription } = useSubscription();
+  const { hasActiveSubscription, hasMaxPublicSandboxes } = useSubscription();
   const {
     browser: { copyToClipboard },
   } = useEffects();
@@ -172,7 +172,10 @@ export const SandboxMenu: React.FC<SandboxMenuProps> = ({
           Fork Sandbox
         </MenuItem>
       ) : null}
-      {isOwner && activeWorkspaceAuthorization !== 'READ' ? (
+      {isOwner &&
+      activeWorkspaceAuthorization !== 'READ' &&
+      hasActiveSubscription &&
+      !hasMaxPublicSandboxes ? (
         <MenuItem
           onSelect={() => {
             actions.modals.moveSandboxModal.open({

--- a/packages/app/src/app/pages/Dashboard/Components/Selection/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Selection/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useLocation, useHistory } from 'react-router-dom';
 import { useAppState, useActions, useEffects } from 'app/overmind';
+import { useSubscription } from 'app/hooks/useSubscription';
 import { Element, SkipNav } from '@codesandbox/components';
 import css from '@styled-system/css';
 import {
@@ -150,6 +151,7 @@ export const SelectionProvider: React.FC<SelectionProviderProps> = ({
   const actions = useActions();
   const { dashboard, activeTeam } = useAppState();
   const { analytics } = useEffects();
+  const { hasActiveSubscription, hasMaxPublicSandboxes } = useSubscription();
 
   const onClick = (event: React.MouseEvent<HTMLDivElement>, itemId: string) => {
     if (event.ctrlKey || event.metaKey) {
@@ -453,6 +455,10 @@ export const SelectionProvider: React.FC<SelectionProviderProps> = ({
           collectionPath: activeTeam ? null : '/',
         });
       } else if (dropPage === 'sandboxes') {
+        if (!hasActiveSubscription && hasMaxPublicSandboxes) {
+          return;
+        }
+
         actions.dashboard.addSandboxesToFolder({
           sandboxIds,
           collectionPath: dropResult.path,

--- a/packages/app/src/app/pages/Dashboard/Components/TemplatesRow/TemplatesRow.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/TemplatesRow/TemplatesRow.tsx
@@ -9,6 +9,7 @@ import { GitHubIcon } from 'app/components/CreateSandbox/Icons';
 import { useActions, useAppState } from 'app/overmind';
 import { TemplateFragment } from 'app/graphql/types';
 import track from '@codesandbox/common/lib/utils/analytics';
+import { useSubscription } from 'app/hooks/useSubscription';
 import { GUTTER } from '../VariableGrid';
 import { TemplatesGrid } from './elements';
 
@@ -16,6 +17,7 @@ export const TemplatesRow: React.FC = () => {
   const officialTemplates = useOfficialTemplates();
   const actions = useActions();
   const { dashboard } = useAppState();
+  const { hasActiveSubscription, hasMaxPublicSandboxes } = useSubscription();
 
   const handleOpenTemplate = (template: TemplateFragment) => {
     const { sandbox } = template;
@@ -83,6 +85,7 @@ export const TemplatesRow: React.FC = () => {
               .map(template => (
                 <TemplateCard
                   key={template.id}
+                  disabled={!hasActiveSubscription && hasMaxPublicSandboxes}
                   template={template}
                   onOpenTemplate={handleOpenTemplate}
                   onSelectTemplate={handleSelectTemplate}

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Sandboxes/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Sandboxes/index.tsx
@@ -28,7 +28,7 @@ export const SandboxesPage = () => {
     activeTeam,
   } = useAppState();
 
-  const { isTeamAdmin, isPersonalSpace } = useWorkspaceAuthorization();
+  const { isTeamAdmin } = useWorkspaceAuthorization();
   const {
     hasActiveSubscription,
     isEligibleForTrial,
@@ -36,10 +36,7 @@ export const SandboxesPage = () => {
   } = useSubscription();
 
   const checkout = useGetCheckoutURL({
-    team_id:
-      (isTeamAdmin || isPersonalSpace) && !hasActiveSubscription
-        ? activeTeam
-        : undefined,
+    team_id: isTeamAdmin && !hasActiveSubscription ? activeTeam : undefined,
     success_path: dashboardUrls.sandboxes(activeTeam),
     cancel_path: dashboardUrls.sandboxes(activeTeam),
   });

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Sandboxes/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Sandboxes/index.tsx
@@ -1,17 +1,17 @@
 import React from 'react';
 import { Helmet } from 'react-helmet';
-import { /* Link, */ useParams } from 'react-router-dom';
+import { Link, useParams } from 'react-router-dom';
 import { useAppState, useActions } from 'app/overmind';
-// import { Element, MessageStripe } from '@codesandbox/components';
-// import { dashboard as dashboardUrls } from '@codesandbox/common/lib/utils/url-generator';
-// import track from '@codesandbox/common/lib/utils/analytics';
+import { Element, MessageStripe } from '@codesandbox/components';
+import { dashboard as dashboardUrls } from '@codesandbox/common/lib/utils/url-generator';
+import track from '@codesandbox/common/lib/utils/analytics';
 import { Header } from 'app/pages/Dashboard/Components/Header';
 import { SelectionProvider } from 'app/pages/Dashboard/Components/Selection';
 import { VariableGrid } from 'app/pages/Dashboard/Components/VariableGrid';
 import { DashboardGridItem, PageTypes } from 'app/pages/Dashboard/types';
-// import { useWorkspaceAuthorization } from 'app/hooks/useWorkspaceAuthorization';
-// import { useSubscription } from 'app/hooks/useSubscription';
-// import { useGetCheckoutURL } from 'app/hooks/useCreateCheckout';
+import { useWorkspaceAuthorization } from 'app/hooks/useWorkspaceAuthorization';
+import { useSubscription } from 'app/hooks/useSubscription';
+import { useGetCheckoutURL } from 'app/hooks/useCreateCheckout';
 import { getPossibleTemplates } from '../../utils';
 import { useFilteredItems } from './useFilteredItems';
 
@@ -28,21 +28,21 @@ export const SandboxesPage = () => {
     activeTeam,
   } = useAppState();
 
-  // const { isTeamAdmin, isPersonalSpace } = useWorkspaceAuthorization();
-  // const {
-  //   hasActiveSubscription,
-  //   isEligibleForTrial,
-  //   hasMaxPublicSandboxes,
-  // } = useSubscription();
+  const { isTeamAdmin, isPersonalSpace } = useWorkspaceAuthorization();
+  const {
+    hasActiveSubscription,
+    isEligibleForTrial,
+    hasMaxPublicSandboxes,
+  } = useSubscription();
 
-  // const checkout = useGetCheckoutURL({
-  //   team_id:
-  //     (isTeamAdmin || isPersonalSpace) && !hasActiveSubscription
-  //       ? activeTeam
-  //       : undefined,
-  //   success_path: dashboardUrls.registrySettings(activeTeam),
-  //   cancel_path: dashboardUrls.registrySettings(activeTeam),
-  // });
+  const checkout = useGetCheckoutURL({
+    team_id:
+      (isTeamAdmin || isPersonalSpace) && !hasActiveSubscription
+        ? activeTeam
+        : undefined,
+    success_path: dashboardUrls.registrySettings(activeTeam),
+    cancel_path: dashboardUrls.registrySettings(activeTeam),
+  });
 
   React.useEffect(() => {
     if (!currentPath || currentPath === '/') {
@@ -102,7 +102,7 @@ export const SandboxesPage = () => {
         showSortOptions={Boolean(currentPath)}
       />
 
-      {/* {!hasActiveSubscription && hasMaxPublicSandboxes ? (
+      {!hasActiveSubscription && hasMaxPublicSandboxes ? (
         <Element paddingX={4} paddingY={2}>
           <MessageStripe justify="space-between">
             Free teams are limited to 20 public sandboxes. Upgrade for unlimited
@@ -150,7 +150,7 @@ export const SandboxesPage = () => {
             )}
           </MessageStripe>
         </Element>
-      ) : null} */}
+      ) : null}
 
       <VariableGrid
         page={pageType}

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Sandboxes/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Sandboxes/index.tsx
@@ -40,8 +40,8 @@ export const SandboxesPage = () => {
       (isTeamAdmin || isPersonalSpace) && !hasActiveSubscription
         ? activeTeam
         : undefined,
-    success_path: dashboardUrls.registrySettings(activeTeam),
-    cancel_path: dashboardUrls.registrySettings(activeTeam),
+    success_path: dashboardUrls.sandboxes(activeTeam),
+    cancel_path: dashboardUrls.sandboxes(activeTeam),
   });
 
   React.useEffect(() => {

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Sandboxes/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Sandboxes/index.tsx
@@ -75,7 +75,7 @@ export const SandboxesPage = () => {
       activeTeamId={activeTeam}
       createNewFolder={() => setCreating(true)}
       createNewSandbox={
-        currentCollection
+        currentCollection && hasActiveSubscription && !hasMaxPublicSandboxes
           ? () => {
               actions.modals.newSandboxModal.open({
                 collectionId: currentCollection.id,


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?

<!-- Is it a Bug fix, feature, docs update, ... -->

- Adds stripe banner to the sandboxes page if the workspace has 20+ items:

![m6m2dw-3000 preview csb app_dashboard](https://user-images.githubusercontent.com/24959348/202638777-cbe88fc8-d5bd-4100-a59f-c130a483161f.png)

- Adds stripe banner to the create sandbox modal if the workspace has 20+ items:
  - Also handles disabling the template cards. 

|Templates list|Search results list|
|:-:|:-:|
|![m6m2dw-3000 preview csb app_s](https://user-images.githubusercontent.com/24959348/202638879-d2b825db-3ce7-43ec-b707-3429cc75a1fb.png)|![m6m2dw-3000 preview csb app_s (1)](https://user-images.githubusercontent.com/24959348/202639078-d0e19aaf-2376-4045-ad07-942a0b5b4e1c.png)|

- Removes 'Create new sandbox' from the container menu:

<img width="1552" alt="Screen Shot 2022-11-18 at 03 52 45" src="https://user-images.githubusercontent.com/24959348/202639805-421ddcf8-f70c-458d-9277-b43a891520a8.png">

- I haven't disabled the `Fork sandbox` from the context menu because it creates sandboxes as drafts.

- Moving drafts to sandboxes
  - Right now it doesn't have any feedback such as a `not-allowed` cursor.
  - It's still possible to trigger the action through the 'Move to Folder' modal, although it will fail on the backend.
    - Should we remove the `Move to Folder` modal altogether? Might be the simplest way to prevent moving sandboxes around... The downside I see is that moving the sandboxes between folders will only be possible through drag-and-drop.
    - It's possible to move sandboxes back and forth from the templates section, should it stay as-is?

- Moving sandboxes to other teams:
<img width="523" alt="Screen Shot 2022-11-18 at 03 59 51" src="https://user-images.githubusercontent.com/24959348/202640942-f298f77e-8a94-41ee-ad3b-8a0a78d49412.png">
