### PR TITLE
feat(subscription): Add free team view only stripe to editor page

### DIFF
--- a/packages/app/src/app/components/StripeMessages/FreeViewOnlyStripe.tsx
+++ b/packages/app/src/app/components/StripeMessages/FreeViewOnlyStripe.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import track from '@codesandbox/common/lib/utils/analytics';
+import { MessageStripe, Text } from '@codesandbox/components';
+import { useWorkspaceAuthorization } from 'app/hooks/useWorkspaceAuthorization';
+
+export const FreeViewOnlyStripe = () => {
+  const { isTeamAdmin } = useWorkspaceAuthorization();
+
+  return (
+    <MessageStripe>
+      {isTeamAdmin ? (
+        <span>
+          You are no longer in a <Text weight="bold">PRO account</Text>. This
+          sandbox is in view mode only. Upgrade your account for unlimited
+          sandboxes.
+        </span>
+      ) : (
+        <span>
+          You are no longer in a <Text weight="bold">PRO team</Text>. This
+          sandbox is in view mode only, contact your team admin to upgrade.
+        </span>
+      )}
+      {isTeamAdmin ? (
+        <MessageStripe.Action
+          as="a"
+          href="/pro"
+          onClick={() => {
+            track('Limit banner: editor - Upgrade', {
+              codesandbox: 'V1',
+              event_source: 'UI',
+            });
+          }}
+        >
+          Upgrade now
+        </MessageStripe.Action>
+      ) : null}
+    </MessageStripe>
+  );
+};

--- a/packages/app/src/app/components/StripeMessages/index.tsx
+++ b/packages/app/src/app/components/StripeMessages/index.tsx
@@ -1,1 +1,2 @@
 export { PaymentPending } from './PaymentPending';
+export { FreeViewOnlyStripe } from './FreeViewOnlyStripe';

--- a/packages/app/src/app/pages/Sandbox/Editor/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/index.tsx
@@ -8,7 +8,10 @@ import {
   Stack,
 } from '@codesandbox/components';
 import { CreateSandbox } from 'app/components/CreateSandbox';
-import { PaymentPending } from 'app/components/StripeMessages';
+import {
+  FreeViewOnlyStripe,
+  PaymentPending,
+} from 'app/components/StripeMessages';
 import VisuallyHidden from '@reach/visually-hidden';
 import css from '@styled-system/css';
 import { useActions, useReaction, useEffects, useAppState } from 'app/overmind';
@@ -134,8 +137,13 @@ export const Editor = ({ showNewSandboxModal }: EditorTypes) => {
         {state.preferences.settings.zenMode ? null : (
           <ComponentsThemeProvider theme={localState.theme.vscodeTheme}>
             {!state.hasLogIn && <FixedSignInBanner />}
+
             {state.activeTeamInfo?.subscription?.status ===
               SubscriptionStatus.Unpaid && <PaymentPending />}
+
+            {state.editor?.currentSandbox?.freePlanEditingRestricted ? (
+              <FreeViewOnlyStripe />
+            ) : null}
             <Header />
           </ComponentsThemeProvider>
         )}


### PR DESCRIPTION
#### Screenshot
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/7533849/202673411-dfea9ece-edc3-4cf8-bd16-481c25106739.png">

_Don't mind the editing in the screenshot - this has been resolved._

#### Test

The `freePlanEditingRestricted` flag is `true` when accessing a private sandbox on a free account. If this is the case the message stripe should show up. Let me know if you need help setting this up! The flag is enabled on stream, not yet on production.
