### PR TITLE
feat(subscriptions): only restrict new sandbox if view collection and max amount reached

### DIFF
--- a/packages/app/src/app/components/CreateSandbox/CreateSandbox.tsx
+++ b/packages/app/src/app/components/CreateSandbox/CreateSandbox.tsx
@@ -422,6 +422,7 @@ export const CreateSandbox: React.FC<CreateSandboxProps> = ({
               (searchQuery ? (
                 <SearchResults
                   checkoutUrl={checkoutUrl}
+                  isInCollection={Boolean(collectionId)}
                   search={searchQuery}
                   onSelectTemplate={selectTemplate}
                   onOpenTemplate={openTemplate}
@@ -432,6 +433,7 @@ export const CreateSandbox: React.FC<CreateSandboxProps> = ({
                     <TemplateCategoryList
                       title="Start from a template"
                       checkoutUrl={checkoutUrl}
+                      isInCollection={Boolean(collectionId)}
                       templates={quickStartTemplates}
                       onSelectTemplate={template => {
                         track('Create New - Fork Quickstart template', {
@@ -456,6 +458,7 @@ export const CreateSandbox: React.FC<CreateSandboxProps> = ({
                           isUser ? 'My' : activeTeamInfo?.name || 'Team'
                         } templates`}
                         checkoutUrl={checkoutUrl}
+                        isInCollection={Boolean(collectionId)}
                         templates={teamTemplates}
                         onSelectTemplate={template => {
                           track(
@@ -476,6 +479,7 @@ export const CreateSandbox: React.FC<CreateSandboxProps> = ({
                     <TemplateCategoryList
                       title="Cloud templates"
                       checkoutUrl={checkoutUrl}
+                      isInCollection={Boolean(collectionId)}
                       templates={officialTemplates.filter(
                         template => template.sandbox.isV2
                       )}
@@ -496,6 +500,7 @@ export const CreateSandbox: React.FC<CreateSandboxProps> = ({
                     <TemplateCategoryList
                       title="Official templates"
                       checkoutUrl={checkoutUrl}
+                      isInCollection={Boolean(collectionId)}
                       templates={officialTemplates}
                       onSelectTemplate={template => {
                         track('Create New - Fork Official template', {
@@ -519,6 +524,7 @@ export const CreateSandbox: React.FC<CreateSandboxProps> = ({
                           <TemplateCategoryList
                             title={essential.title}
                             checkoutUrl={checkoutUrl}
+                            isInCollection={Boolean(collectionId)}
                             templates={essential.templates}
                             onSelectTemplate={template => {
                               track('Create New - Fork Essential template', {

--- a/packages/app/src/app/components/CreateSandbox/SearchResults/SearchResults.tsx
+++ b/packages/app/src/app/components/CreateSandbox/SearchResults/SearchResults.tsx
@@ -29,6 +29,7 @@ const GlobalSearchStyles = createGlobalStyle`
 
 export const SearchResults = ({
   checkoutUrl,
+  isInCollection,
   search,
   onSelectTemplate,
   onOpenTemplate,
@@ -36,18 +37,15 @@ export const SearchResults = ({
   // Receiving as prop to avoid fetching the checkout
   // url every time the templates list re-renders.
   checkoutUrl: string | undefined;
+  isInCollection: boolean;
   search: string;
   onSelectTemplate: (template: TemplateFragment) => void;
   onOpenTemplate: (template: TemplateFragment) => void;
 }) => {
-  const {
-    hasActiveSubscription,
-    hasMaxPublicSandboxes,
-    isEligibleForTrial,
-  } = useSubscription();
+  const { hasMaxPublicSandboxes, isEligibleForTrial } = useSubscription();
   const { isTeamAdmin } = useWorkspaceAuthorization();
 
-  const limitNewSandboxes = !hasActiveSubscription && hasMaxPublicSandboxes;
+  const limitNewSandboxes = isInCollection && hasMaxPublicSandboxes;
 
   return (
     <>

--- a/packages/app/src/app/components/CreateSandbox/TemplateCategoryList.tsx
+++ b/packages/app/src/app/components/CreateSandbox/TemplateCategoryList.tsx
@@ -16,6 +16,7 @@ interface TemplateCategoryListProps {
   // url every time the templates list re-renders.
   checkoutUrl: string | undefined;
   isCloudTemplateList?: boolean;
+  isInCollection: boolean;
   templates: TemplateFragment[];
   onSelectTemplate: (template: TemplateFragment) => void;
   onOpenTemplate: (template: TemplateFragment) => void;
@@ -25,24 +26,21 @@ export const TemplateCategoryList = ({
   title,
   checkoutUrl,
   isCloudTemplateList,
+  isInCollection,
   templates,
   onSelectTemplate,
   onOpenTemplate,
 }: TemplateCategoryListProps) => {
   const { hasLogIn } = useAppState();
   const actions = useActions();
-  const {
-    hasActiveSubscription,
-    hasMaxPublicSandboxes,
-    isEligibleForTrial,
-  } = useSubscription();
+  const { hasMaxPublicSandboxes, isEligibleForTrial } = useSubscription();
   const { isTeamAdmin } = useWorkspaceAuthorization();
 
   useEffect(() => {
     track('Create Sandbox Tab Open', { tab: title });
   }, [title]);
 
-  const limitNewSandboxes = !hasActiveSubscription && hasMaxPublicSandboxes;
+  const limitNewSandboxes = isInCollection && hasMaxPublicSandboxes;
 
   return (
     <Stack direction="vertical" css={{ height: '100%' }} gap={4}>


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?

<!-- Is it a Bug fix, feature, docs update, ... -->

Unless the current page is under a collection (`/dashboard/sandboxes/*`), enables the create sandbox modal cards.


https://user-images.githubusercontent.com/24959348/203142671-b98d2ac9-fbc8-4dd9-81e2-686df8083e18.mov


## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Launch the dashboard
2. Select a free team w/ 20+ public sandboxes
3. In collections (`/sandboxes`), launch the create modal
  - Template cards are disabled
  - Stripe message is shown
4. In other pages (such as `/drafts` and `/s`), launch the create modal
  - Template cards are enabled