### PR TITLE
feat(subscriptions): organization plan cta when 20+ editors

### DIFF
--- a/packages/app/src/app/components/CreateSandbox/stripes.tsx
+++ b/packages/app/src/app/components/CreateSandbox/stripes.tsx
@@ -3,6 +3,7 @@ import { MessageStripe } from '@codesandbox/components';
 import { Link } from 'react-router-dom';
 import React from 'react';
 import { useActions } from 'app/overmind';
+import { SUBSCRIPTION_DOCS_URLS } from 'app/constants';
 
 const getEventName = (isEligibleForTrial: boolean) =>
   isEligibleForTrial
@@ -52,6 +53,13 @@ export const MaxPublicSandboxes: React.FC<MaxPublicReposProps> = ({
         </MessageStripe.Action>
       ) : (
         <MessageStripe.Action
+          as="a"
+          href={
+            isEligibleForTrial
+              ? SUBSCRIPTION_DOCS_URLS.teams.trial
+              : SUBSCRIPTION_DOCS_URLS.teams.non_trial
+          }
+          target="_blank"
           onClick={() =>
             track('Limit banner: create sandbox - Learn more', EVENT_PROPS)
           }

--- a/packages/app/src/app/hooks/useSubscription.ts
+++ b/packages/app/src/app/hooks/useSubscription.ts
@@ -113,3 +113,9 @@ export const useSubscription = () => {
     hasMaxPublicSandboxes,
   };
 };
+
+// Soft limit of maximum amount of pro
+// editor a team can have. Above this,
+// we should prompt CTAs to enable
+// custom pricing.
+export const MAX_PRO_EDITORS = 20;

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/WorkspaceSettings.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/WorkspaceSettings.tsx
@@ -521,7 +521,7 @@ export const WorkspaceSettings = () => {
       {/**
        * Soft limit for pro teams.
        */}
-      {isTeamAdmin && numberOfEditors > MAX_PRO_EDITORS ? (
+      {numberOfEditors > MAX_PRO_EDITORS && (
         <MessageStripe justify="space-between">
           <span>
             You have over {MAX_PRO_EDITORS} editors. Upgrade to the Organization
@@ -529,15 +529,16 @@ export const WorkspaceSettings = () => {
           </span>
           <MessageStripe.Action
             as="a"
-            href="/pricing"
+            href="https://codesandbox.typeform.com/organization"
             onClick={() =>
               track('Limit banner - team editors - Custom plan contact')
             }
+            target="_blank"
           >
             Contact us
           </MessageStripe.Action>
         </MessageStripe>
-      ) : null}
+      )}
 
       <div>
         <MemberList

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/WorkspaceSettings.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/WorkspaceSettings.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { Link as RouterLink } from 'react-router-dom';
 import { useAppState, useActions, useEffects } from 'app/overmind';
 import { sortBy } from 'lodash-es';
 
@@ -18,7 +19,10 @@ import {
 import css from '@styled-system/css';
 import { UserSearchInput } from 'app/components/UserSearchInput';
 import { Header } from 'app/pages/Dashboard/Components/Header';
-import { teamInviteLink } from '@codesandbox/common/lib/utils/url-generator';
+import {
+  dashboard,
+  teamInviteLink,
+} from '@codesandbox/common/lib/utils/url-generator';
 import { TeamAvatar } from 'app/components/TeamAvatar';
 import {
   TeamMemberAuthorization,
@@ -26,6 +30,8 @@ import {
 } from 'app/graphql/types';
 import { useSubscription } from 'app/hooks/useSubscription';
 import { useWorkspaceAuthorization } from 'app/hooks/useWorkspaceAuthorization';
+import { useGetCheckoutURL } from 'app/hooks/useCreateCheckout';
+import track from '@codesandbox/common/lib/utils/analytics';
 import { Card } from '../components';
 import { MemberList, User } from '../components/MemberList';
 import { ManageSubscription } from './ManageSubscription';
@@ -58,12 +64,18 @@ export const WorkspaceSettings = () => {
 
   const {
     hasActiveSubscription,
+    isEligibleForTrial,
     numberOfSeats,
     numberOfEditors,
     hasMaxNumberOfEditors,
     numberOfEditorsIsOverTheLimit,
   } = useSubscription();
   const { isTeamAdmin, userRole, isTeamEditor } = useWorkspaceAuthorization();
+  const checkout = useGetCheckoutURL({
+    team_id: isTeamAdmin ? team?.id : undefined,
+    cancel_path: dashboard.settings(team?.id),
+  });
+
   const canInviteOtherMembers = isTeamAdmin || isTeamEditor;
 
   // We use `role` as the common term when referring to: `admin`, `editor` or `viewer`
@@ -463,16 +475,42 @@ export const WorkspaceSettings = () => {
           </Stack>
         )}
       </Stack>
-      {isTeamAdmin && numberOfEditorsIsOverTheLimit && (
+      {isTeamAdmin && (numberOfEditorsIsOverTheLimit || hasMaxNumberOfEditors) && (
         <MessageStripe justify="space-between">
-          Free teams are limited to 5 editor seats. Some permissions might have
-          changed.
-        </MessageStripe>
-      )}
-      {isTeamAdmin && hasMaxNumberOfEditors && (
-        <MessageStripe justify="space-between">
-          You&apos;ve reached the maximum amount of free editor seats. Upgrade
-          for more.
+          <span>
+            {numberOfEditorsIsOverTheLimit && (
+              <>
+                Free teams are limited to 5 editor seats. Some permissions might
+                have changed.
+              </>
+            )}
+            {hasMaxNumberOfEditors && (
+              <>
+                You&apos;ve reached the maximum amount of free editor seats.
+                Upgrade for more.
+              </>
+            )}
+          </span>
+          <MessageStripe.Action
+            {...(checkout.state === 'READY'
+              ? {
+                  as: 'a',
+                  href: checkout.url,
+                }
+              : {
+                  as: RouterLink,
+                  to: '/pro',
+                })}
+            onClick={() =>
+              track(
+                isEligibleForTrial
+                  ? 'Limit banner: team editors - Start Trial'
+                  : 'Limit banner: team editors - Upgrade'
+              )
+            }
+          >
+            {isEligibleForTrial ? 'Start trial' : 'Upgrade now'}
+          </MessageStripe.Action>
         </MessageStripe>
       )}
 

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/WorkspaceSettings.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/WorkspaceSettings.tsx
@@ -524,7 +524,7 @@ export const WorkspaceSettings = () => {
       {isTeamAdmin && numberOfEditors > MAX_PRO_EDITORS ? (
         <MessageStripe justify="space-between">
           <span>
-            You have over {MAX_PRO_EDITORS} editors. Upgrade to the Enterprise
+            You have over {MAX_PRO_EDITORS} editors. Upgrade to the Organization
             plan for more benefits.
           </span>
           <MessageStripe.Action

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/WorkspaceSettings.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/WorkspaceSettings.tsx
@@ -28,7 +28,7 @@ import {
   TeamMemberAuthorization,
   CurrentTeamInfoFragmentFragment,
 } from 'app/graphql/types';
-import { useSubscription } from 'app/hooks/useSubscription';
+import { MAX_PRO_EDITORS, useSubscription } from 'app/hooks/useSubscription';
 import { useWorkspaceAuthorization } from 'app/hooks/useWorkspaceAuthorization';
 import { useGetCheckoutURL } from 'app/hooks/useCreateCheckout';
 import track from '@codesandbox/common/lib/utils/analytics';
@@ -475,6 +475,10 @@ export const WorkspaceSettings = () => {
           </Stack>
         )}
       </Stack>
+
+      {/**
+       * Limit free plan amount of editors.
+       */}
       {isTeamAdmin && (numberOfEditorsIsOverTheLimit || hasMaxNumberOfEditors) && (
         <MessageStripe justify="space-between">
           <span>
@@ -513,6 +517,27 @@ export const WorkspaceSettings = () => {
           </MessageStripe.Action>
         </MessageStripe>
       )}
+
+      {/**
+       * Soft limit for pro teams.
+       */}
+      {isTeamAdmin && numberOfEditors > MAX_PRO_EDITORS ? (
+        <MessageStripe justify="space-between">
+          <span>
+            You have over {MAX_PRO_EDITORS} editors. Upgrade to the Enterprise
+            plan for more benefits.
+          </span>
+          <MessageStripe.Action
+            as="a"
+            href="/pricing"
+            onClick={() =>
+              track('Limit banner - team editors - Custom plan contact')
+            }
+          >
+            Contact us
+          </MessageStripe.Action>
+        </MessageStripe>
+      ) : null}
 
       <div>
         <MemberList


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?

<!-- Is it a Bug fix, feature, docs update, ... -->

- Fixes `MaxPublicSandboxes` for non-admin users by adding the proper links.
- Adds call to action to upgrade for max free editors.
- Adds message and call to action when the team has 20+ editors.

|20+ editors|
|:-:|
|![jbb2pl-3000 preview csb app_dashboard_settings_workspace=b5123bcc-da66-446f-88e2-5b89c9c37d27](https://user-images.githubusercontent.com/24959348/203468396-7a815428-cb7d-413d-ab92-d42e914256f6.png)|

|5+ editors (free)|
|:-:|
|![jbb2pl-3000 preview csb app_dashboard_settings_workspace=b5123bcc-da66-446f-88e2-5b89c9c37d27 (1)](https://user-images.githubusercontent.com/24959348/203468431-29de8474-a66b-43a2-91f0-b41517e5fea5.png)|