### PR TITLE
fix(editor): MessageStripe overlapping header

### DIFF
--- a/packages/app/src/app/pages/Sandbox/Editor/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/index.tsx
@@ -116,6 +116,16 @@ export const Editor = ({ showNewSandboxModal }: EditorTypes) => {
       return 5.5 * 16 + 2;
     }
 
+    // Has MessageStripe
+    if (
+      state.activeTeamInfo?.subscription?.status ===
+        SubscriptionStatus.Unpaid ||
+      state.editor?.currentSandbox?.freePlanEditingRestricted
+    ) {
+      // Header height + MessageStripe
+      return 3 * 16 + 42;
+    }
+
     // Header height
     return 3 * 16;
   };


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/7533849/203751592-2ef440dd-8740-4363-81e4-77768f7a89bd.png)

After:

<img width="1854" alt="image" src="https://user-images.githubusercontent.com/7533849/203751079-5f39952a-7523-4da3-99a3-73d5e987016b.png">

How to test:

1. Open a private sandbox on a free team (view only)
2. MessageStripe should no longer overlap the header in the editor