### PR TITLE
fix: remove viewOnly badge from branches inside the repo page

### DIFF
--- a/packages/app/src/app/pages/Dashboard/Components/Branch/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Branch/index.tsx
@@ -46,7 +46,7 @@ export const Branch: React.FC<BranchProps> = ({ branch, page }) => {
   const { isFree } = useWorkspaceSubscription();
 
   const isPrivate = branch?.project?.repository?.private;
-  const isViewOnly = isFree && isPrivate;
+  const isViewOnly = isFree && isPrivate && page === 'recent';
 
   const props = {
     branch,


### PR DESCRIPTION
Badge shown on the recent page
![Screenshot 2022-11-24 at 17 10 47](https://user-images.githubusercontent.com/9945366/203816768-a4742fbf-c0bd-47a1-b314-4d0db1aa240f.png)

Not anymore on the repo page
![Screenshot 2022-11-24 at 17 11 00](https://user-images.githubusercontent.com/9945366/203816819-9282a200-4990-42dc-8092-2130dc188f47.png)

Might be an idea to replace the `Beta` tag maybe with a view only at the top of the repo page (header)