### PR TITLE
Add reference to private SBXs and Repos on Pro

### DIFF
--- a/packages/app/src/app/pages/Dashboard/Content/routes/Repositories/stripes.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Repositories/stripes.tsx
@@ -71,7 +71,7 @@ export const MaxPublicReposFreeTeam: React.FC = () => {
   return (
     <MessageStripe justify="space-between" variant="trial">
       Free teams are limited to 3 public repositories. Upgrade for unlimited
-      repositories.
+      public and private repositories.
       {isTeamAdmin ? (
         <MessageStripe.Action
           {...(checkout.state === 'READY'

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Sandboxes/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Sandboxes/index.tsx
@@ -101,7 +101,7 @@ export const SandboxesPage = () => {
         <Element paddingX={4} paddingY={2}>
           <MessageStripe justify="space-between">
             Free teams are limited to 20 public sandboxes. Upgrade for unlimited
-            sandboxes.
+            public and private sandboxes.
             {isTeamAdmin ? (
               <MessageStripe.Action
                 {...(checkout.state === 'READY'


### PR DESCRIPTION
## What kind of change does this PR introduce?

Tex change to limit banner

## What is the current behavior?

<img width="738" alt="image" src="https://user-images.githubusercontent.com/20410256/204352777-fca884ad-b24c-4817-9229-887523841e6a.png">


## What is the new behavior?

<img width="759" alt="image" src="https://user-images.githubusercontent.com/20410256/204353029-4fec8da2-bcc9-43c7-be36-2fdb31a284a5.png">

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

Validated that the additional text didn't cause any major issues on various screen sizes - It's wordy on mobile but it looks kind of verbose even without the additional text which makes me wonder if we should have a different banner on small screens, but that's a discussion for a different ticket. 


## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Testing <!-- We can only merge the PR if this is checked -->
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
