### PR TITLE
feat(subscription/polish): cancel subscription modal

### DIFF
--- a/packages/app/src/app/constants.ts
+++ b/packages/app/src/app/constants.ts
@@ -14,3 +14,11 @@ export const SUBSCRIPTION_DOCS_URLS = {
 // we should prompt CTAs to enable
 // custom pricing.
 export const MAX_PRO_EDITORS = 20;
+
+export const TEAM_FREE_LIMITS = {
+  editors: 5,
+  public_sandboxes: 20,
+  private_sandboxes: 0,
+  public_repos: 3,
+  private_repos: 0,
+};

--- a/packages/app/src/app/hooks/useCreateCustomerPortal.ts
+++ b/packages/app/src/app/hooks/useCreateCustomerPortal.ts
@@ -3,7 +3,7 @@ import { useEffects } from 'app/overmind';
 import { dashboard } from '@codesandbox/common/lib/utils/url-generator';
 
 type CheckoutOptions = {
-  team_id: string;
+  team_id?: string;
   return_path?: string;
 };
 
@@ -15,6 +15,10 @@ export const useCreateCustomerPortal = ({
   const { api } = useEffects();
 
   const createCustomerPortal = async () => {
+    if (!team_id) {
+      return;
+    }
+
     try {
       setLoading(true);
       const payload = await api.stripeCustomerPortal(

--- a/packages/app/src/app/overmind/actions.ts
+++ b/packages/app/src/app/overmind/actions.ts
@@ -637,3 +637,7 @@ export const getSandboxesLimits = async ({ effects, state }: Context) => {
 
   state.sandboxesLimits = limits;
 };
+
+export const openCancelSubscriptionModal = ({ state }: Context) => {
+  state.currentModal = 'subscriptionCancellation';
+};

--- a/packages/app/src/app/overmind/namespaces/pro/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/pro/actions.ts
@@ -1,4 +1,3 @@
-import { format, subDays } from 'date-fns';
 import { Context } from 'app/overmind';
 import { withLoadApp } from 'app/overmind/factories';
 import { Step, Plan, PaymentSummary, PaymentPreview } from './types';
@@ -95,20 +94,9 @@ export const updateSubscriptionBillingInterval = async (
 
 export const cancelWorkspaceSubscription = async ({
   state,
-  actions,
   effects,
+  actions,
 }: Context) => {
-  const nextBillDate = state.activeTeamInfo!.subscription!.nextBillDate;
-  const expirationDate = format(subDays(new Date(nextBillDate), 1), 'PP');
-
-  const confirmed = await actions.modals.alertModal.open({
-    title: 'Cancel Subscription',
-    message: `Are you sure? Your subscription will expire on the next billing date - ${expirationDate}.`,
-    type: 'danger',
-  });
-
-  if (!confirmed) return;
-
   try {
     const response = await effects.gql.mutations.softCancelSubscription({
       teamId: state.activeTeam,
@@ -122,6 +110,8 @@ export const cancelWorkspaceSubscription = async ({
     effects.notificationToast.error(
       'There was a problem cancelling your subscription. Please email us at support@codesandbox.io'
     );
+  } finally {
+    actions.modalClosed();
   }
 };
 

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/ManageSubscription/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/ManageSubscription/index.tsx
@@ -56,9 +56,7 @@ export const ManageSubscription = () => {
     }
 
     if (isStripe) {
-      return (
-        <Stripe hasActiveTrial={hasActiveTeamTrial && !subscription.cancelAt} />
-      );
+      return <Stripe />;
     }
 
     return null;

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/ManageSubscription/paddle.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/ManageSubscription/paddle.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useAppState, useActions } from 'app/overmind';
+import { useActions } from 'app/overmind';
 
 import css from '@styled-system/css';
 import { format } from 'date-fns';
@@ -11,42 +11,69 @@ import {
   Icon,
   Tooltip,
 } from '@codesandbox/components';
+import { useWorkspaceSubscription } from 'app/hooks/useWorkspaceSubscription';
 
 export const Paddle = () => {
-  const { activeTeamInfo: team } = useAppState();
+  const { subscription } = useWorkspaceSubscription();
   const actions = useActions();
+
+  if (!subscription.cancelAt) {
+    return (
+      <Stack
+        css={{
+          height: '100%',
+        }}
+        direction="vertical"
+        justify="space-between"
+      >
+        <Text size={3} css={{ color: '#F7CC66' }}>
+          Your access to Pro features will expire on on{' '}
+          {format(new Date(subscription.cancelAt), 'PP')}. After this period,
+          your team will be automatically migrated to the Free plan.
+        </Text>
+        <Button
+          autoWidth
+          variant="link"
+          css={css({
+            color: '#F7CC66',
+            padding: 0,
+            fontSize: 3,
+          })}
+          onClick={() => actions.pro.reactivateWorkspaceSubscription()}
+        >
+          Upgrade to pro
+        </Button>
+      </Stack>
+    );
+  }
 
   return (
     <Stack direction="vertical" gap={2}>
-      {!team.subscription.cancelAt ? (
-        <Tooltip
-          label={`Next invoice of ${team.subscription.currency} ${(
-            (team.subscription.quantity * team.subscription.unitPrice) /
-            100
-          ).toFixed(2)} (excl. tax) scheduled for ${format(
-            new Date(team.subscription.nextBillDate),
-            'PP'
-          )}`}
-        >
-          <Stack align="center" gap={1}>
-            <Text size={3} variant="muted">
-              Next invoice: {team.subscription.currency}{' '}
-              {(
-                (team.subscription.quantity * team.subscription.unitPrice) /
-                100
-              ).toFixed(2)}{' '}
-            </Text>
-            <Text variant="muted">
-              <Icon name="info" size={12} />
-            </Text>
-          </Stack>
-        </Tooltip>
-      ) : null}
-
+      <Tooltip
+        label={`Next invoice of ${subscription.currency} ${(
+          (subscription.quantity * subscription.unitPrice) /
+          100
+        ).toFixed(2)} (excl. tax) scheduled for ${format(
+          new Date(subscription.nextBillDate),
+          'PP'
+        )}`}
+      >
+        <Stack align="center" gap={1}>
+          <Text size={3} variant="muted">
+            Next invoice: {subscription.currency}{' '}
+            {((subscription.quantity * subscription.unitPrice) / 100).toFixed(
+              2
+            )}{' '}
+          </Text>
+          <Text variant="muted">
+            <Icon name="info" size={12} />
+          </Text>
+        </Stack>
+      </Tooltip>
       <Link
         size={3}
         variant="active"
-        href={team.subscription.updateBillingUrl}
+        href={subscription.updateBillingUrl}
         css={css({ fontWeight: 'medium' })}
       >
         Update payment information
@@ -59,40 +86,19 @@ export const Paddle = () => {
       >
         Change billing interval
       </Link>
-
-      {team.subscription.cancelAt ? (
-        <Text size={3} css={css({ color: '#F7CC66' })}>
-          Your subscription expires on{' '}
-          {format(new Date(team.subscription.cancelAt), 'PP')}.{' '}
-          <Button
-            autoWidth
-            variant="link"
-            css={css({
-              color: 'inherit',
-              padding: 0,
-              textDecoration: 'underline',
-              fontSize: 3,
-            })}
-            onClick={() => actions.pro.reactivateWorkspaceSubscription()}
-          >
-            Reactivate subscription
-          </Button>
-        </Text>
-      ) : (
-        <Button
-          autoWidth
-          variant="link"
-          css={css({
-            height: 'auto',
-            fontSize: 3,
-            color: 'errorForeground',
-            padding: 0,
-          })}
-          onClick={() => actions.pro.cancelWorkspaceSubscription()}
-        >
-          Cancel subscription
-        </Button>
-      )}
+      <Button
+        autoWidth
+        variant="link"
+        css={css({
+          height: 'auto',
+          fontSize: 3,
+          color: 'errorForeground',
+          padding: 0,
+        })}
+        onClick={() => actions.openCancelSubscriptionModal()}
+      >
+        Cancel subscription
+      </Button>
     </Stack>
   );
 };

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/ManageSubscription/paddle.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/ManageSubscription/paddle.tsx
@@ -12,12 +12,13 @@ import {
   Tooltip,
 } from '@codesandbox/components';
 import { useWorkspaceSubscription } from 'app/hooks/useWorkspaceSubscription';
+import track from '@codesandbox/common/lib/utils/analytics';
 
 export const Paddle = () => {
   const { subscription } = useWorkspaceSubscription();
   const actions = useActions();
 
-  if (!subscription.cancelAt) {
+  if (subscription.cancelAt) {
     return (
       <Stack
         css={{
@@ -95,7 +96,14 @@ export const Paddle = () => {
           color: 'errorForeground',
           padding: 0,
         })}
-        onClick={() => actions.openCancelSubscriptionModal()}
+        onClick={() => {
+          track('Team Settings: Cancel subscription', {
+            codesandbox: 'V1',
+            event_source: 'UI',
+          });
+
+          actions.openCancelSubscriptionModal();
+        }}
       >
         Cancel subscription
       </Button>

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/ManageSubscription/paddle.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/ManageSubscription/paddle.tsx
@@ -40,7 +40,14 @@ export const Paddle = () => {
             padding: 0,
             fontSize: 3,
           })}
-          onClick={() => actions.pro.reactivateWorkspaceSubscription()}
+          onClick={() => {
+            track('Team Settings - Renew subscription', {
+              codesandbox: 'V1',
+              event_source: 'UI',
+            });
+
+            actions.pro.reactivateWorkspaceSubscription();
+          }}
         >
           Upgrade to pro
         </Button>
@@ -48,23 +55,19 @@ export const Paddle = () => {
     );
   }
 
+  const nextInvoiceDate = format(new Date(subscription.nextBillDate), 'PP');
+  const nextInvoiceValue = (
+    (subscription.quantity * subscription.unitPrice) /
+    100
+  ).toFixed(2);
   return (
     <Stack direction="vertical" gap={2}>
       <Tooltip
-        label={`Next invoice of ${subscription.currency} ${(
-          (subscription.quantity * subscription.unitPrice) /
-          100
-        ).toFixed(2)} (excl. tax) scheduled for ${format(
-          new Date(subscription.nextBillDate),
-          'PP'
-        )}`}
+        label={`Next invoice of ${subscription.currency} ${nextInvoiceValue} (excl. tax) scheduled for ${nextInvoiceDate}`}
       >
         <Stack align="center" gap={1}>
           <Text size={3} variant="muted">
-            Next invoice: {subscription.currency}{' '}
-            {((subscription.quantity * subscription.unitPrice) / 100).toFixed(
-              2
-            )}{' '}
+            Next invoice: {subscription.currency} {nextInvoiceValue}{' '}
           </Text>
           <Text variant="muted">
             <Icon name="info" size={12} />
@@ -76,6 +79,12 @@ export const Paddle = () => {
         variant="active"
         href={subscription.updateBillingUrl}
         css={css({ fontWeight: 'medium' })}
+        onClick={() =>
+          track('Team Settings - Update payment details', {
+            codesandbox: 'V1',
+            event_source: 'UI',
+          })
+        }
       >
         Update payment information
       </Link>
@@ -84,6 +93,12 @@ export const Paddle = () => {
         variant="active"
         href="/pro"
         css={css({ fontWeight: 'medium' })}
+        onClick={() =>
+          track('Team Settings - Update billing interval', {
+            codesandbox: 'V1',
+            event_source: 'UI',
+          })
+        }
       >
         Change billing interval
       </Link>
@@ -97,7 +112,7 @@ export const Paddle = () => {
           padding: 0,
         })}
         onClick={() => {
-          track('Team Settings: Cancel subscription', {
+          track('Team Settings: open cancel subscription modal', {
             codesandbox: 'V1',
             event_source: 'UI',
           });

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/ManageSubscription/stripe.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/ManageSubscription/stripe.tsx
@@ -2,43 +2,88 @@ import React from 'react';
 import { format } from 'date-fns';
 import { Stack, Text, Link } from '@codesandbox/components';
 import track from '@codesandbox/common/lib/utils/analytics';
-import { useActions } from 'app/overmind';
+import { useActions, useAppState } from 'app/overmind';
 import { useWorkspaceSubscription } from 'app/hooks/useWorkspaceSubscription';
+import { useCreateCustomerPortal } from 'app/hooks/useCreateCustomerPortal';
 
 export const Stripe: React.FC = () => {
   const { openCancelSubscriptionModal } = useActions();
+  const { activeTeam } = useAppState();
   const { subscription, hasActiveTeamTrial } = useWorkspaceSubscription();
+  const [loading, createCustomerPortal] = useCreateCustomerPortal({
+    team_id: activeTeam,
+  });
+
+  if (!subscription) {
+    return null;
+  }
+
+  if (subscription.cancelAt) {
+    return (
+      <Stack
+        css={{ height: '100%' }}
+        direction="vertical"
+        justify="space-between"
+      >
+        <Text size={3} css={{ color: '#F7CC66' }}>
+          Your access to Pro features will expire on on{' '}
+          {format(new Date(subscription.cancelAt), 'PP')}. After this period,
+          your team will be automatically migrated to the Free plan.
+        </Text>
+
+        <Link
+          onClick={() => {
+            track('Team Settings - Renew subscription', {
+              codesandbox: 'V1',
+              event_source: 'UI',
+            });
+
+            createCustomerPortal();
+          }}
+          size={3}
+          variant="active"
+        >
+          {loading ? 'Loading...' : 'Upgrade to Pro'}
+        </Link>
+      </Stack>
+    );
+  }
 
   return (
     <Stack direction="vertical" gap={2}>
       <Link
         onClick={() => {
-          if (hasActiveTeamTrial) {
-            track('Team Settings - Cancel trial', {
-              codesandbox: 'V1',
-              event_source: 'UI',
-            });
-          } else {
-            track('Team Settings - Manage Subscription', {
-              codesandbox: 'V1',
-              event_source: 'UI',
-            });
-          }
+          track('Team Settings - Update payment details', {
+            codesandbox: 'V1',
+            event_source: 'UI',
+          });
 
-          openCancelSubscriptionModal();
+          createCustomerPortal();
         }}
         size={3}
         variant="active"
       >
-        {hasActiveTeamTrial ? 'Cancel trial' : 'Manage subscription'}
+        {loading ? 'Loading...' : 'Update payment details'}
       </Link>
+      <Link
+        color="#EE8269"
+        onClick={() => {
+          track(
+            hasActiveTeamTrial
+              ? 'Team Settings - Cancel trial'
+              : 'Team Settings: Cancel subscription',
+            {
+              codesandbox: 'V1',
+              event_source: 'UI',
+            }
+          );
 
-      {subscription?.cancelAt ? (
-        <Text size={3} css={{ color: '#F7CC66' }}>
-          Your subscription expires on{' '}
-          {format(new Date(subscription.cancelAt), 'PP')}.{' '}
-        </Text>
-      ) : null}
+          openCancelSubscriptionModal();
+        }}
+        size={3}
+      >
+        {hasActiveTeamTrial ? 'Cancel trial' : 'Cancel subscription'}
+      </Link>
     </Stack>
   );
 };

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/ManageSubscription/stripe.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/ManageSubscription/stripe.tsx
@@ -1,15 +1,19 @@
 import React from 'react';
 import { format } from 'date-fns';
 import { Stack, Text, Link } from '@codesandbox/components';
-import track from '@codesandbox/common/lib/utils/analytics';
-import { useAppState } from 'app/overmind';
+// import track from '@codesandbox/common/lib/utils/analytics';
+import { useActions, useAppState } from 'app/overmind';
 import { useCreateCustomerPortal } from 'app/hooks/useCreateCustomerPortal';
 
 export const Stripe: React.FC<{ hasActiveTrial: boolean }> = ({
   hasActiveTrial,
 }) => {
+  const { openCancelSubscriptionModal } = useActions();
   const { activeTeam, activeTeamInfo: team } = useAppState();
-  const [loading, createCustomerPortal] = useCreateCustomerPortal({
+  const [
+    loading,
+    // createCustomerPortal
+  ] = useCreateCustomerPortal({
     team_id: activeTeam,
   });
 
@@ -19,18 +23,20 @@ export const Stripe: React.FC<{ hasActiveTrial: boolean }> = ({
     <Stack direction="vertical" gap={2}>
       <Link
         onClick={() => {
-          if (hasActiveTrial) {
-            track('Team Settings - Cancel trial', {
-              codesandbox: 'V1',
-              event_source: 'UI',
-            });
-          } else {
-            track('Team Settings - Manage Subscription', {
-              codesandbox: 'V1',
-              event_source: 'UI',
-            });
-          }
-          createCustomerPortal();
+          // if (hasActiveTrial) {
+          //   track('Team Settings - Cancel trial', {
+          //     codesandbox: 'V1',
+          //     event_source: 'UI',
+          //   });
+          // } else {
+          //   track('Team Settings - Manage Subscription', {
+          //     codesandbox: 'V1',
+          //     event_source: 'UI',
+          //   });
+          // }
+          // createCustomerPortal();
+
+          openCancelSubscriptionModal();
         }}
         size={3}
         variant="active"

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/ManageSubscription/stripe.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/ManageSubscription/stripe.tsx
@@ -2,22 +2,12 @@ import React from 'react';
 import { format } from 'date-fns';
 import { Stack, Text, Link } from '@codesandbox/components';
 // import track from '@codesandbox/common/lib/utils/analytics';
-import { useActions, useAppState } from 'app/overmind';
-import { useCreateCustomerPortal } from 'app/hooks/useCreateCustomerPortal';
+import { useActions } from 'app/overmind';
+import { useWorkspaceSubscription } from 'app/hooks/useWorkspaceSubscription';
 
-export const Stripe: React.FC<{ hasActiveTrial: boolean }> = ({
-  hasActiveTrial,
-}) => {
+export const Stripe: React.FC = () => {
   const { openCancelSubscriptionModal } = useActions();
-  const { activeTeam, activeTeamInfo: team } = useAppState();
-  const [
-    loading,
-    // createCustomerPortal
-  ] = useCreateCustomerPortal({
-    team_id: activeTeam,
-  });
-
-  const ctaText = hasActiveTrial ? 'Cancel trial' : 'Manage subscription';
+  const { subscription, hasActiveTeamTrial } = useWorkspaceSubscription();
 
   return (
     <Stack direction="vertical" gap={2}>
@@ -34,22 +24,21 @@ export const Stripe: React.FC<{ hasActiveTrial: boolean }> = ({
           //     event_source: 'UI',
           //   });
           // }
-          // createCustomerPortal();
 
           openCancelSubscriptionModal();
         }}
         size={3}
         variant="active"
       >
-        {loading ? 'Loading...' : ctaText}
+        {hasActiveTeamTrial ? 'Cancel trial' : 'Manage subscription'}
       </Link>
 
-      {!loading && team.subscription.cancelAt && (
+      {subscription?.cancelAt ? (
         <Text size={3} css={{ color: '#F7CC66' }}>
           Your subscription expires on{' '}
-          {format(new Date(team.subscription.cancelAt), 'PP')}.{' '}
+          {format(new Date(subscription.cancelAt), 'PP')}.{' '}
         </Text>
-      )}
+      ) : null}
     </Stack>
   );
 };

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/ManageSubscription/stripe.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/ManageSubscription/stripe.tsx
@@ -70,8 +70,8 @@ export const Stripe: React.FC = () => {
         onClick={() => {
           track(
             hasActiveTeamTrial
-              ? 'Team Settings - Cancel trial'
-              : 'Team Settings: Cancel subscription',
+              ? 'Team Settings: open cancel trial modal'
+              : 'Team Settings: open cancel subscription modal',
             {
               codesandbox: 'V1',
               event_source: 'UI',

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/ManageSubscription/stripe.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/ManageSubscription/stripe.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { format } from 'date-fns';
 import { Stack, Text, Link } from '@codesandbox/components';
-// import track from '@codesandbox/common/lib/utils/analytics';
+import track from '@codesandbox/common/lib/utils/analytics';
 import { useActions } from 'app/overmind';
 import { useWorkspaceSubscription } from 'app/hooks/useWorkspaceSubscription';
 
@@ -13,17 +13,17 @@ export const Stripe: React.FC = () => {
     <Stack direction="vertical" gap={2}>
       <Link
         onClick={() => {
-          // if (hasActiveTrial) {
-          //   track('Team Settings - Cancel trial', {
-          //     codesandbox: 'V1',
-          //     event_source: 'UI',
-          //   });
-          // } else {
-          //   track('Team Settings - Manage Subscription', {
-          //     codesandbox: 'V1',
-          //     event_source: 'UI',
-          //   });
-          // }
+          if (hasActiveTeamTrial) {
+            track('Team Settings - Cancel trial', {
+              codesandbox: 'V1',
+              event_source: 'UI',
+            });
+          } else {
+            track('Team Settings - Manage Subscription', {
+              codesandbox: 'V1',
+              event_source: 'UI',
+            });
+          }
 
           openCancelSubscriptionModal();
         }}

--- a/packages/app/src/app/pages/common/Modals/SubscriptionCancellation/SubscriptionCancellation.tsx
+++ b/packages/app/src/app/pages/common/Modals/SubscriptionCancellation/SubscriptionCancellation.tsx
@@ -193,8 +193,7 @@ export const SubscriptionCancellationModal: React.FC = () => {
             loading={paddleLoading}
             onClick={() => {
               setPaddeLoading(true);
-              // TO DO: confirm event name.
-              track('Team Settings - Cancel paddle subscription', {
+              track('Team Settings - confirm paddle cancel subscription', {
                 codesandbox: 'V1',
                 event_source: 'UI',
               });
@@ -210,14 +209,10 @@ export const SubscriptionCancellationModal: React.FC = () => {
             css={{ padding: '0 32px' }}
             loading={loadingCustomerPortal}
             onClick={() => {
-              // TO DO: confirm event name.
-              track(
-                'Team Settings - Open stripe portal from subscription cancellation modal',
-                {
-                  codesandbox: 'V1',
-                  event_source: 'UI',
-                }
-              );
+              track('Team Settings: confirm cancellation from modal', {
+                codesandbox: 'V1',
+                event_source: 'UI',
+              });
 
               createCustomerPortal();
             }}

--- a/packages/app/src/app/pages/common/Modals/SubscriptionCancellation/SubscriptionCancellation.tsx
+++ b/packages/app/src/app/pages/common/Modals/SubscriptionCancellation/SubscriptionCancellation.tsx
@@ -3,6 +3,7 @@ import { Button, IconButton, Stack, Text } from '@codesandbox/components';
 import { TEAM_FREE_LIMITS } from 'app/constants';
 import { useCreateCustomerPortal } from 'app/hooks/useCreateCustomerPortal';
 import { useWorkspaceAuthorization } from 'app/hooks/useWorkspaceAuthorization';
+import { useWorkspaceSubscription } from 'app/hooks/useWorkspaceSubscription';
 import { useActions, useAppState } from 'app/overmind';
 import React from 'react';
 import styled from 'styled-components';
@@ -17,6 +18,7 @@ const StyledListItem = styled('li')`
 export const SubscriptionCancellationModal: React.FC = () => {
   const { activeTeamInfo } = useAppState();
   const { isTeamAdmin } = useWorkspaceAuthorization();
+  const { hasActiveTeamTrial } = useWorkspaceSubscription();
   const { modalClosed } = useActions();
   const [loadingCustomerPortal, createCustomerPortal] = useCreateCustomerPortal(
     {
@@ -65,8 +67,8 @@ export const SubscriptionCancellationModal: React.FC = () => {
       (teamUsage?.privateProjectsQuantity ?? 0) -
       TEAM_FREE_LIMITS.private_repos;
     if (restrictedRepositoriesCount > 0) {
-      return `${restrictedRepositoriesCount} sandbox${
-        restrictedRepositoriesCount === 1 ? '' : 'es'
+      return `${restrictedRepositoriesCount} repositor${
+        restrictedRepositoriesCount === 1 ? 'y' : 'ies'
       } will be restricted`;
     }
 
@@ -126,7 +128,7 @@ export const SubscriptionCancellationModal: React.FC = () => {
         gap={6}
       >
         <Button onClick={modalClosed} variant="link" autoWidth>
-          Continue trial
+          {hasActiveTeamTrial ? 'Continue trial' : 'Keep subscription'}
         </Button>
         <Button
           css={{ padding: '0 32px' }}

--- a/packages/app/src/app/pages/common/Modals/SubscriptionCancellation/SubscriptionCancellation.tsx
+++ b/packages/app/src/app/pages/common/Modals/SubscriptionCancellation/SubscriptionCancellation.tsx
@@ -227,7 +227,7 @@ export const SubscriptionCancellationModal: React.FC = () => {
             }}
             autoWidth
           >
-            I understand
+            Ok
           </Button>
         )}
       </Stack>

--- a/packages/app/src/app/pages/common/Modals/SubscriptionCancellation/SubscriptionCancellation.tsx
+++ b/packages/app/src/app/pages/common/Modals/SubscriptionCancellation/SubscriptionCancellation.tsx
@@ -1,0 +1,6 @@
+import { Stack } from '@codesandbox/components';
+import React from 'react';
+
+export const SubscriptionCancellationModal: React.FC = () => {
+  return <Stack>hello, world.</Stack>;
+};

--- a/packages/app/src/app/pages/common/Modals/SubscriptionCancellation/SubscriptionCancellation.tsx
+++ b/packages/app/src/app/pages/common/Modals/SubscriptionCancellation/SubscriptionCancellation.tsx
@@ -1,5 +1,5 @@
 import track from '@codesandbox/common/lib/utils/analytics';
-import { Button, Stack } from '@codesandbox/components';
+import { Button, Stack, IconButton, Text } from '@codesandbox/components';
 import { useCreateCustomerPortal } from 'app/hooks/useCreateCustomerPortal';
 import { useWorkspaceAuthorization } from 'app/hooks/useWorkspaceAuthorization';
 import { useActions, useAppState } from 'app/overmind';
@@ -24,12 +24,27 @@ export const SubscriptionCancellationModal: React.FC = () => {
       }}
       direction="vertical"
     >
-      hello, world.
+      <Stack>
+        <Text
+          as="h1"
+          css={{
+            margin: 0,
+            lineHeight: '28px',
+            letterSpacing: '-0.019em',
+          }}
+          size={19}
+          weight="normal"
+        >
+          You&apos;ll lose access to all Pro features if you decide to cancel
+        </Text>
+        <IconButton name="cross" title="Close" />
+      </Stack>
       <Stack
         css={{
           flexWrap: 'wrap',
           marginLeft: 'auto',
           marginRight: 0,
+          marginTop: '32px',
         }}
         gap={6}
       >

--- a/packages/app/src/app/pages/common/Modals/SubscriptionCancellation/SubscriptionCancellation.tsx
+++ b/packages/app/src/app/pages/common/Modals/SubscriptionCancellation/SubscriptionCancellation.tsx
@@ -2,7 +2,6 @@ import track from '@codesandbox/common/lib/utils/analytics';
 import { Button, IconButton, Stack, Text } from '@codesandbox/components';
 import { TEAM_FREE_LIMITS } from 'app/constants';
 import { useCreateCustomerPortal } from 'app/hooks/useCreateCustomerPortal';
-import { useWorkspaceAuthorization } from 'app/hooks/useWorkspaceAuthorization';
 import { useWorkspaceSubscription } from 'app/hooks/useWorkspaceSubscription';
 import { useActions, useAppState } from 'app/overmind';
 import { pluralize } from 'app/utils/pluralize';
@@ -18,12 +17,11 @@ const StyledListItem = styled('li')`
 
 export const SubscriptionCancellationModal: React.FC = () => {
   const { activeTeamInfo } = useAppState();
-  const { isTeamAdmin } = useWorkspaceAuthorization();
   const { hasActiveTeamTrial } = useWorkspaceSubscription();
   const { modalClosed } = useActions();
   const [loadingCustomerPortal, createCustomerPortal] = useCreateCustomerPortal(
     {
-      team_id: isTeamAdmin ? activeTeamInfo?.id : undefined,
+      team_id: activeTeamInfo?.id,
     }
   );
   // TO DO: if we need this info more often, extract
@@ -138,13 +136,8 @@ export const SubscriptionCancellationModal: React.FC = () => {
         </Button>
         <Button
           css={{ padding: '0 32px' }}
-          disabled={!isTeamAdmin}
           loading={loadingCustomerPortal}
           onClick={() => {
-            if (!isTeamAdmin) {
-              return;
-            }
-
             // TO DO: confirm event name.
             track(
               'Team Settings - Open stripe portal from subscription cancellation modal',

--- a/packages/app/src/app/pages/common/Modals/SubscriptionCancellation/SubscriptionCancellation.tsx
+++ b/packages/app/src/app/pages/common/Modals/SubscriptionCancellation/SubscriptionCancellation.tsx
@@ -54,8 +54,7 @@ export const SubscriptionCancellationModal: React.FC = () => {
         word: 'sandbox',
         count: restrictedSandboxesCount,
         suffixPlural: 'es',
-      })}
-      } will be restricted`;
+      })} will be restricted`;
     }
 
     return `Limited to ${TEAM_FREE_LIMITS.public_sandboxes} public sandboxes`;
@@ -71,9 +70,12 @@ export const SubscriptionCancellationModal: React.FC = () => {
       (teamUsage?.privateProjectsQuantity ?? 0) -
       TEAM_FREE_LIMITS.private_repos;
     if (restrictedRepositoriesCount > 0) {
-      return `${restrictedRepositoriesCount} repositor${
-        restrictedRepositoriesCount === 1 ? 'y' : 'ies'
-      } will be restricted`;
+      return `${restrictedRepositoriesCount} ${pluralize({
+        word: 'repositor',
+        count: restrictedRepositoriesCount,
+        suffixPlural: 'ies',
+        suffixSingular: 'y',
+      })} will be restricted`;
     }
 
     return `Limited to ${TEAM_FREE_LIMITS.public_repos} public repositories`;

--- a/packages/app/src/app/pages/common/Modals/SubscriptionCancellation/SubscriptionCancellation.tsx
+++ b/packages/app/src/app/pages/common/Modals/SubscriptionCancellation/SubscriptionCancellation.tsx
@@ -97,7 +97,7 @@ export const SubscriptionCancellationModal: React.FC = () => {
         >
           You&apos;ll lose access to all Pro features if you decide to cancel
         </Text>
-        <IconButton name="cross" title="Close" />
+        <IconButton name="cross" title="Close" onClick={modalClosed} />
       </Stack>
       <Stack
         as="ul"

--- a/packages/app/src/app/pages/common/Modals/SubscriptionCancellation/SubscriptionCancellation.tsx
+++ b/packages/app/src/app/pages/common/Modals/SubscriptionCancellation/SubscriptionCancellation.tsx
@@ -9,9 +9,11 @@ export const SubscriptionCancellationModal: React.FC = () => {
   const { activeTeam } = useAppState();
   const { isTeamAdmin } = useWorkspaceAuthorization();
   const { modalClosed } = useActions();
-  const [loading, createCustomerPortal] = useCreateCustomerPortal({
-    team_id: isTeamAdmin ? activeTeam : undefined,
-  });
+  const [loadingCustomerPortal, createCustomerPortal] = useCreateCustomerPortal(
+    {
+      team_id: isTeamAdmin ? activeTeam : undefined,
+    }
+  );
 
   return (
     <Stack
@@ -37,6 +39,7 @@ export const SubscriptionCancellationModal: React.FC = () => {
         <Button
           css={{ padding: '0 32px' }}
           disabled={!isTeamAdmin}
+          loading={loadingCustomerPortal}
           onClick={() => {
             if (!isTeamAdmin) {
               return;
@@ -55,7 +58,7 @@ export const SubscriptionCancellationModal: React.FC = () => {
           }}
           autoWidth
         >
-          {loading ? 'Loading...' : 'I understand'}
+          I understand
         </Button>
       </Stack>
     </Stack>

--- a/packages/app/src/app/pages/common/Modals/SubscriptionCancellation/SubscriptionCancellation.tsx
+++ b/packages/app/src/app/pages/common/Modals/SubscriptionCancellation/SubscriptionCancellation.tsx
@@ -176,7 +176,7 @@ export const SubscriptionCancellationModal: React.FC = () => {
               >
                 {f.pro}
               </Text>
-              <Stack gap={3}>
+              <Stack align="baseline" gap={3}>
                 <Text size={13}>{f.free}</Text>
                 {badge ? <Badge variant="warning">{badge}</Badge> : null}
               </Stack>
@@ -194,7 +194,7 @@ export const SubscriptionCancellationModal: React.FC = () => {
         gap={6}
       >
         <Button onClick={handleCloseModal} variant="link" autoWidth>
-          {hasActiveTeamTrial ? 'Continue trial' : 'Keep subscription'}
+          {hasActiveTeamTrial ? 'Continue trial' : 'Continue subscription'}
         </Button>
         {isPaddle ? (
           <Button
@@ -227,7 +227,7 @@ export const SubscriptionCancellationModal: React.FC = () => {
             }}
             autoWidth
           >
-            Ok
+            OK
           </Button>
         )}
       </Stack>

--- a/packages/app/src/app/pages/common/Modals/SubscriptionCancellation/SubscriptionCancellation.tsx
+++ b/packages/app/src/app/pages/common/Modals/SubscriptionCancellation/SubscriptionCancellation.tsx
@@ -17,8 +17,9 @@ const StyledListItem = styled('li')`
 
 export const SubscriptionCancellationModal: React.FC = () => {
   const { activeTeamInfo } = useAppState();
-  const { hasActiveTeamTrial } = useWorkspaceSubscription();
-  const { modalClosed } = useActions();
+  const { hasActiveTeamTrial, isPaddle } = useWorkspaceSubscription();
+  const [paddleLoading, setPaddeLoading] = React.useState(false);
+  const { modalClosed, pro } = useActions();
   const [loadingCustomerPortal, createCustomerPortal] = useCreateCustomerPortal(
     {
       team_id: activeTeamInfo?.id,
@@ -134,25 +135,45 @@ export const SubscriptionCancellationModal: React.FC = () => {
         <Button onClick={modalClosed} variant="link" autoWidth>
           {hasActiveTeamTrial ? 'Continue trial' : 'Keep subscription'}
         </Button>
-        <Button
-          css={{ padding: '0 32px' }}
-          loading={loadingCustomerPortal}
-          onClick={() => {
-            // TO DO: confirm event name.
-            track(
-              'Team Settings - Open stripe portal from subscription cancellation modal',
-              {
+        {isPaddle ? (
+          <Button
+            css={{ padding: '0 32px' }}
+            loading={paddleLoading}
+            onClick={() => {
+              setPaddeLoading(true);
+              // TO DO: confirm event name.
+              track('Team Settings - Cancel paddle subscription', {
                 codesandbox: 'V1',
                 event_source: 'UI',
-              }
-            );
+              });
 
-            createCustomerPortal();
-          }}
-          autoWidth
-        >
-          I understand
-        </Button>
+              pro.cancelWorkspaceSubscription();
+            }}
+            autoWidth
+          >
+            I understand
+          </Button>
+        ) : (
+          <Button
+            css={{ padding: '0 32px' }}
+            loading={loadingCustomerPortal}
+            onClick={() => {
+              // TO DO: confirm event name.
+              track(
+                'Team Settings - Open stripe portal from subscription cancellation modal',
+                {
+                  codesandbox: 'V1',
+                  event_source: 'UI',
+                }
+              );
+
+              createCustomerPortal();
+            }}
+            autoWidth
+          >
+            I understand
+          </Button>
+        )}
       </Stack>
     </Stack>
   );

--- a/packages/app/src/app/pages/common/Modals/SubscriptionCancellation/SubscriptionCancellation.tsx
+++ b/packages/app/src/app/pages/common/Modals/SubscriptionCancellation/SubscriptionCancellation.tsx
@@ -5,6 +5,7 @@ import { useCreateCustomerPortal } from 'app/hooks/useCreateCustomerPortal';
 import { useWorkspaceAuthorization } from 'app/hooks/useWorkspaceAuthorization';
 import { useWorkspaceSubscription } from 'app/hooks/useWorkspaceSubscription';
 import { useActions, useAppState } from 'app/overmind';
+import { pluralize } from 'app/utils/pluralize';
 import React from 'react';
 import styled from 'styled-components';
 
@@ -49,8 +50,11 @@ export const SubscriptionCancellationModal: React.FC = () => {
       (teamUsage?.privateProjectsQuantity ?? 0) -
       TEAM_FREE_LIMITS.private_repos;
     if (restrictedSandboxesCount > 0) {
-      return `${restrictedSandboxesCount} sandbox${
-        restrictedSandboxesCount === 1 ? '' : 'es'
+      return `${restrictedSandboxesCount} ${pluralize({
+        word: 'sandbox',
+        count: restrictedSandboxesCount,
+        suffixPlural: 'es',
+      })}
       } will be restricted`;
     }
 

--- a/packages/app/src/app/pages/common/Modals/SubscriptionCancellation/SubscriptionCancellation.tsx
+++ b/packages/app/src/app/pages/common/Modals/SubscriptionCancellation/SubscriptionCancellation.tsx
@@ -1,9 +1,23 @@
 import track from '@codesandbox/common/lib/utils/analytics';
-import { Button, Stack, IconButton, Text } from '@codesandbox/components';
+import { Button, IconButton, Stack, Text } from '@codesandbox/components';
 import { useCreateCustomerPortal } from 'app/hooks/useCreateCustomerPortal';
 import { useWorkspaceAuthorization } from 'app/hooks/useWorkspaceAuthorization';
 import { useActions, useAppState } from 'app/overmind';
 import React from 'react';
+import styled from 'styled-components';
+
+// const LIMITS = [
+//   '-3 editor seats',
+//   '25 sandboxes will be restricted',
+//   '7 repositories will be restricted',
+// ];
+
+const StyledListItem = styled('li')`
+  font-weight: 500;
+  font-size: 16px;
+  line-height: 1;
+  color: #ef7a7a;
+`;
 
 export const SubscriptionCancellationModal: React.FC = () => {
   const { activeTeam } = useAppState();
@@ -38,6 +52,25 @@ export const SubscriptionCancellationModal: React.FC = () => {
           You&apos;ll lose access to all Pro features if you decide to cancel
         </Text>
         <IconButton name="cross" title="Close" />
+      </Stack>
+      <Stack
+        as="ul"
+        css={{
+          listStyle: 'none',
+          margin: '24px 0 0',
+          padding: 0,
+        }}
+        direction="vertical"
+        gap={6}
+      >
+        <StyledListItem>Limited to 5 editors seats</StyledListItem>
+        <StyledListItem>Limited to 20 public sandboxes</StyledListItem>
+        <StyledListItem>Limited to 3 public repositories</StyledListItem>
+        <StyledListItem>Only public NPM packages</StyledListItem>
+        <StyledListItem>Only basic privacy settings</StyledListItem>
+        <StyledListItem>-67% GB RAM</StyledListItem>
+        <StyledListItem>-33% Disk space</StyledListItem>
+        <StyledListItem>-2 vCPUs</StyledListItem>
       </Stack>
       <Stack
         css={{

--- a/packages/app/src/app/pages/common/Modals/SubscriptionCancellation/SubscriptionCancellation.tsx
+++ b/packages/app/src/app/pages/common/Modals/SubscriptionCancellation/SubscriptionCancellation.tsx
@@ -1,6 +1,63 @@
-import { Stack } from '@codesandbox/components';
+import track from '@codesandbox/common/lib/utils/analytics';
+import { Button, Stack } from '@codesandbox/components';
+import { useCreateCustomerPortal } from 'app/hooks/useCreateCustomerPortal';
+import { useWorkspaceAuthorization } from 'app/hooks/useWorkspaceAuthorization';
+import { useActions, useAppState } from 'app/overmind';
 import React from 'react';
 
 export const SubscriptionCancellationModal: React.FC = () => {
-  return <Stack>hello, world.</Stack>;
+  const { activeTeam } = useAppState();
+  const { isTeamAdmin } = useWorkspaceAuthorization();
+  const { modalClosed } = useActions();
+  const [loading, createCustomerPortal] = useCreateCustomerPortal({
+    team_id: isTeamAdmin ? activeTeam : undefined,
+  });
+
+  return (
+    <Stack
+      css={{
+        position: 'relative',
+        overflow: 'hidden',
+        padding: '24px 32px 32px',
+      }}
+      direction="vertical"
+    >
+      hello, world.
+      <Stack
+        css={{
+          flexWrap: 'wrap',
+          marginLeft: 'auto',
+          marginRight: 0,
+        }}
+        gap={6}
+      >
+        <Button onClick={modalClosed} variant="link" autoWidth>
+          Continue trial
+        </Button>
+        <Button
+          css={{ padding: '0 32px' }}
+          disabled={!isTeamAdmin}
+          onClick={() => {
+            if (!isTeamAdmin) {
+              return;
+            }
+
+            // TO DO: confirm event name.
+            track(
+              'Team Settings - Open stripe portal from subscription cancellation modal',
+              {
+                codesandbox: 'V1',
+                event_source: 'UI',
+              }
+            );
+
+            createCustomerPortal();
+          }}
+          autoWidth
+        >
+          {loading ? 'Loading...' : 'I understand'}
+        </Button>
+      </Stack>
+    </Stack>
+  );
 };

--- a/packages/app/src/app/pages/common/Modals/SubscriptionCancellation/SubscriptionCancellation.tsx
+++ b/packages/app/src/app/pages/common/Modals/SubscriptionCancellation/SubscriptionCancellation.tsx
@@ -73,6 +73,15 @@ export const SubscriptionCancellationModal: React.FC = () => {
     }
   );
 
+  const handleCloseModal = () => {
+    track('Team Settings: close cancel subscription modal', {
+      codesandbox: 'V1',
+      event_source: 'UI',
+    });
+
+    modalClosed();
+  };
+
   // TO DO: if we need this info more often, extract
   // to a custom useWorkspaceUsage similar to
   // useWorkspaceLimits.
@@ -134,7 +143,7 @@ export const SubscriptionCancellationModal: React.FC = () => {
         >
           You&apos;ll lose access to all Pro features
         </Text>
-        <IconButton name="cross" title="Close" onClick={modalClosed} />
+        <IconButton name="cross" title="Close" onClick={handleCloseModal} />
       </Stack>
       <Stack
         as="ul"
@@ -184,7 +193,7 @@ export const SubscriptionCancellationModal: React.FC = () => {
         }}
         gap={6}
       >
-        <Button onClick={modalClosed} variant="link" autoWidth>
+        <Button onClick={handleCloseModal} variant="link" autoWidth>
           {hasActiveTeamTrial ? 'Continue trial' : 'Keep subscription'}
         </Button>
         {isPaddle ? (

--- a/packages/app/src/app/pages/common/Modals/SubscriptionCancellation/index.tsx
+++ b/packages/app/src/app/pages/common/Modals/SubscriptionCancellation/index.tsx
@@ -1,0 +1,1 @@
+export { SubscriptionCancellationModal } from './SubscriptionCancellation';

--- a/packages/app/src/app/pages/common/Modals/index.tsx
+++ b/packages/app/src/app/pages/common/Modals/index.tsx
@@ -48,6 +48,7 @@ import { NotFoundBranchModal } from './NotFoundBranchModal';
 import { GithubPagesLogs } from './GithubPagesLogs';
 import { CropThumbnail } from './CropThumbnail';
 import { NewTeamModal } from './NewTeamModal';
+import { SubscriptionCancellationModal } from './SubscriptionCancellation';
 
 const modals = {
   preferences: {
@@ -203,6 +204,10 @@ const modals = {
     Component: NewTeamModal,
     top: 15,
     width: 724,
+  },
+  subscriptionCancellation: {
+    Component: SubscriptionCancellationModal,
+    width: 444,
   },
 };
 

--- a/packages/app/src/app/utils/pluralize.ts
+++ b/packages/app/src/app/utils/pluralize.ts
@@ -1,0 +1,12 @@
+type PluralOptions = {
+  count: number;
+  word: string;
+  suffixSingular?: string;
+  suffixPlural?: string;
+};
+export const pluralize = ({
+  count,
+  word,
+  suffixSingular = '',
+  suffixPlural = 's',
+}: PluralOptions) => `$${word}${count === 1 ? suffixSingular : suffixPlural}`;

--- a/packages/app/src/app/utils/pluralize.ts
+++ b/packages/app/src/app/utils/pluralize.ts
@@ -9,4 +9,4 @@ export const pluralize = ({
   word,
   suffixSingular = '',
   suffixPlural = 's',
-}: PluralOptions) => `$${word}${count === 1 ? suffixSingular : suffixPlural}`;
+}: PluralOptions) => `${word}${count === 1 ? suffixSingular : suffixPlural}`;

--- a/packages/components/src/components/Badge/index.stories.tsx
+++ b/packages/components/src/components/Badge/index.stories.tsx
@@ -15,5 +15,8 @@ export const Examples = () => (
     <Badge icon="bell" variant="trial">
       Free with icon
     </Badge>
+    <Badge icon="warning" variant="warning">
+      Warning
+    </Badge>
   </Stack>
 );

--- a/packages/components/src/components/Badge/index.tsx
+++ b/packages/components/src/components/Badge/index.tsx
@@ -4,10 +4,22 @@ import { Stack } from '../Stack';
 import { Text } from '../Text';
 
 export interface BadgeProps {
-  variant?: 'trial' | 'neutral';
+  variant?: 'trial' | 'neutral' | 'warning';
   icon?: IconNames;
   isPadded?: boolean;
 }
+
+const BG_MAP: Record<BadgeProps['variant'], string> = {
+  trial: '#644ed7',
+  neutral: '#2e2e2e',
+  warning: 'rgba(255, 255, 255, 0.06)',
+};
+
+const COLOR_MAP: Record<BadgeProps['variant'], string> = {
+  trial: '#fff',
+  neutral: 'inherit',
+  warning: '#ef7a7a',
+};
 
 export const Badge: React.FC<BadgeProps> = ({
   variant = 'neutral',
@@ -21,8 +33,8 @@ export const Badge: React.FC<BadgeProps> = ({
         padding: '2px 8px',
         userSelect: 'none',
         borderRadius: '999px',
-        backgroundColor: variant === 'trial' ? '#644ED7' : '#2e2e2e',
-        color: variant === 'trial' ? '#fff' : 'inherit',
+        backgroundColor: BG_MAP[variant],
+        color: COLOR_MAP[variant],
       }}
       gap={1}
     >


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?

<!-- Is it a Bug fix, feature, docs update, ... -->

![gpk4m5-3000 preview csb app_dashboard_settings_workspace=21ae43d2-67ca-4c18-94dd-a24cc1c258e4](https://user-images.githubusercontent.com/24959348/205193989-b33a55be-94db-47cb-8cb3-8c810e1191cf.png)

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Launch the dashboard
2. Select a pro team that you are an admin
3. Go to settings -> "Cancel trial/Manage subscription"
4. See modal
5. Clicking on "Continue trial/Keep subscription", dismisses modal
6. Clicking on "I understand" opens the customer portal 