### PR TITLE
fix(dashboard): Show MessageStripe when private repo limit is hit

### DIFF
--- a/packages/app/src/app/hooks/useWorkspaceLimits.ts
+++ b/packages/app/src/app/hooks/useWorkspaceLimits.ts
@@ -14,6 +14,7 @@ export const useWorkspaceLimits = (): WorkspaceLimitsReturn => {
       hasMaxNumberOfEditors: undefined,
       numberOfEditorsIsOverTheLimit: undefined,
       hasMaxPublicRepositories: undefined,
+      hasMaxPrivateRepositories: undefined,
       hasMaxPublicSandboxes: undefined,
     };
   }
@@ -45,6 +46,14 @@ export const useWorkspaceLimits = (): WorkspaceLimitsReturn => {
     maxPublicProjects !== null &&
     publicProjectsQuantity >= maxPublicProjects;
 
+  const privateRepositoriesQuantity = usage.privateProjectsQuantity;
+  const maxPrivateRepositories = limits.maxPrivateProjects;
+
+  const hasMaxPrivateRepositories =
+    isFree === true &&
+    maxPrivateRepositories !== null &&
+    privateRepositoriesQuantity > maxPrivateRepositories;
+
   const publicSandboxesQuantity = usage.publicSandboxesQuantity;
   const maxPublicSandboxes = limits.maxPublicSandboxes;
 
@@ -58,6 +67,7 @@ export const useWorkspaceLimits = (): WorkspaceLimitsReturn => {
     hasMaxNumberOfEditors,
     numberOfEditorsIsOverTheLimit,
     hasMaxPublicRepositories,
+    hasMaxPrivateRepositories,
     hasMaxPublicSandboxes,
   };
 };
@@ -68,6 +78,7 @@ export type WorkspaceLimitsReturn =
       hasMaxNumberOfEditors: undefined;
       numberOfEditorsIsOverTheLimit: undefined;
       hasMaxPublicRepositories: undefined;
+      hasMaxPrivateRepositories: undefined;
       hasMaxPublicSandboxes: undefined;
     }
   | {
@@ -75,5 +86,6 @@ export type WorkspaceLimitsReturn =
       hasMaxNumberOfEditors: boolean;
       numberOfEditorsIsOverTheLimit: boolean;
       hasMaxPublicRepositories: boolean;
+      hasMaxPrivateRepositories: boolean;
       hasMaxPublicSandboxes: boolean;
     };

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Repositories/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Repositories/index.tsx
@@ -9,7 +9,7 @@ import { SelectionProvider } from 'app/pages/Dashboard/Components/Selection';
 import { Element } from '@codesandbox/components';
 import { useWorkspaceSubscription } from 'app/hooks/useWorkspaceSubscription';
 import { useWorkspaceLimits } from 'app/hooks/useWorkspaceLimits';
-import { MaxPublicReposFreeTeam, PrivateRepoFreeTeam } from './stripes';
+import { MaxReposFreeTeam, PrivateRepoFreeTeam } from './stripes';
 
 export const RepositoriesPage = () => {
   const params = useParams<{ path: string }>();
@@ -49,7 +49,10 @@ export const RepositoriesPage = () => {
   }, [path]);
 
   const { isFree } = useWorkspaceSubscription();
-  const { hasMaxPublicRepositories } = useWorkspaceLimits();
+  const {
+    hasMaxPublicRepositories,
+    hasMaxPrivateRepositories,
+  } = useWorkspaceLimits();
 
   const pageType: PageTypes = 'repositories';
   let selectedRepo:
@@ -103,7 +106,7 @@ export const RepositoriesPage = () => {
     if (viewMode === 'grid' && repoItems.length > 0) {
       repoItems.unshift({
         type: 'import-repository',
-        disabled: isFree && hasMaxPublicRepositories,
+        disabled: hasMaxPublicRepositories,
       });
     }
 
@@ -111,8 +114,7 @@ export const RepositoriesPage = () => {
   };
 
   const itemsToShow = getItemsToShow();
-  const readOnly =
-    isFree && (selectedRepo?.private || hasMaxPublicRepositories);
+  const isReadOnlyRepo = isFree && selectedRepo?.private;
 
   return (
     <SelectionProvider
@@ -130,17 +132,21 @@ export const RepositoriesPage = () => {
         showBetaBadge
         nestedPageType={pageType}
         selectedRepo={selectedRepo}
-        readOnly={readOnly}
+        readOnly={isReadOnlyRepo}
       />
 
-      {readOnly && (
+      {isReadOnlyRepo && (
         <Element paddingX={4} paddingY={2}>
           {selectedRepo?.private && <PrivateRepoFreeTeam />}
-          {hasMaxPublicRepositories && !selectedRepo && (
-            <MaxPublicReposFreeTeam />
-          )}
         </Element>
       )}
+
+      {!selectedRepo &&
+      (hasMaxPublicRepositories || hasMaxPrivateRepositories) ? (
+        <Element paddingX={4} paddingY={2}>
+          <MaxReposFreeTeam />
+        </Element>
+      ) : null}
 
       <VariableGrid page={pageType} items={itemsToShow} />
     </SelectionProvider>

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Repositories/stripes.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Repositories/stripes.tsx
@@ -57,7 +57,7 @@ export const PrivateRepoFreeTeam: React.FC = () => {
   );
 };
 
-export const MaxPublicReposFreeTeam: React.FC = () => {
+export const MaxReposFreeTeam: React.FC = () => {
   const { activeTeam } = useAppState();
   const { isEligibleForTrial } = useWorkspaceSubscription();
   const { isTeamAdmin, isPersonalSpace } = useWorkspaceAuthorization();


### PR DESCRIPTION
Added `hasMaxPrivateRepositories` property to `useWorkspaceLimits` hook, so we're now able to show the message stripe to notify users that the max amount of private repositories has been reached. This is only a restriction for free users.

<img width="1624" alt="Screenshot 2022-11-30 at 11 18 25" src="https://user-images.githubusercontent.com/7533849/204770320-ad821110-e05d-4e61-a8c4-2ee9ebb6c956.png">
