### PR TITLE
fix(dashboard/repositories): silently fail get repos

### DIFF
--- a/packages/app/src/app/overmind/namespaces/dashboard/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/dashboard/actions.ts
@@ -1922,11 +1922,11 @@ export const getRepositoriesByTeam = async (
   const { activeTeam, dashboard } = state;
   const { bypassLoading = false } = options ?? {};
 
-  // If we should bypass the loading state, we don't need to make two
-  // queries (synced and unsynced) since the loading time won't be
-  // perceived by the user.
-  try {
-    if (!bypassLoading) {
+  // If we should show the loading state, we need to make two
+  // queries (synced and unsynced) since the waiting time to
+  // get up-to-date data from GitHub is too long.
+  if (!bypassLoading) {
+    try {
       dashboard.repositories = null;
 
       // First fetch data without syncing with GitHub
@@ -1943,10 +1943,16 @@ export const getRepositoriesByTeam = async (
       }
 
       dashboard.repositories = unsyncedRepositories.sort(sortByNameAscending);
+    } catch (error) {
+      effects.notificationToast.error(
+        'There was a problem getting your repositories'
+      );
     }
+  }
 
-    // Then fetch data synced with GitHub to make sure
-    // what we show is up-to-date.
+  // Fetch data synced with GitHub to make sure
+  // what we show is up-to-date.
+  try {
     const syncedRepositoriesData = await effects.gql.queries.getRepositoriesByTeam(
       {
         teamId: activeTeam,
@@ -1960,9 +1966,7 @@ export const getRepositoriesByTeam = async (
 
     dashboard.repositories = syncedRepositories.sort(sortByNameAscending);
   } catch (error) {
-    effects.notificationToast.error(
-      'There was a problem getting your repositories'
-    );
+    // Fail silently since this is a secondary request.
   }
 };
 

--- a/packages/app/src/app/overmind/namespaces/dashboard/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/dashboard/actions.ts
@@ -1966,7 +1966,14 @@ export const getRepositoriesByTeam = async (
 
     dashboard.repositories = syncedRepositories.sort(sortByNameAscending);
   } catch (error) {
-    // Fail silently since this is a secondary request.
+    if (!bypassLoading && error?.response?.status === 504) {
+      // Fail silently since this is a secondary request.
+      return;
+    }
+
+    effects.notificationToast.error(
+      'There was a problem getting your repositories'
+    );
   }
 };
 

--- a/packages/app/src/app/overmind/namespaces/dashboard/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/dashboard/actions.ts
@@ -1972,7 +1972,7 @@ export const getRepositoriesByTeam = async (
     }
 
     effects.notificationToast.error(
-      'There was a problem getting your repositories'
+      'There was a problem syncing your repositories with GitHub, data show might not be up to date'
     );
   }
 };

--- a/packages/app/src/app/overmind/namespaces/dashboard/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/dashboard/actions.ts
@@ -1972,7 +1972,7 @@ export const getRepositoriesByTeam = async (
     }
 
     effects.notificationToast.error(
-      'There was a problem syncing your repositories with GitHub, data show might not be up to date'
+      'There was a problem syncing your repositories with GitHub, data shown might not be up to date'
     );
   }
 };


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?

<!-- Is it a Bug fix, feature, docs update, ... -->

If the action to get repos is transparent (ie: first visibly fetch unsynced data and then silently fetch synced data), hide error notifications originating from a timeout because that can happen if there's too much data from GitHub.

- Turn on throttling to a slow network to make it easier to test
- Launch the dashboard
- Select a team with repos that have hundreds of branches
- See that the first call with unsynced data succeeds
- See that the second call with synced data throws a 504
