### PR TITLE
fix(vue): Use the correct id for vue compiler to ensure correct hmr logic

### DIFF
--- a/packages/vue3-transpiler/src/index.ts
+++ b/packages/vue3-transpiler/src/index.ts
@@ -18,7 +18,6 @@ import { selectBlock } from './select';
 import { genHotReloadCode } from './hotReload';
 import { genCSSModulesCode } from './cssModules';
 import { formatError } from './formatError';
-import { v4 as uuid } from 'uuid';
 
 import vueTemplateLoader from './transpilers/template-loader';
 import vueStylePostLoader from './transpilers/style-post-loader';
@@ -91,7 +90,7 @@ export default function loader(
   // module id for scoped CSS & hot-reload
   const rawShortFilePath = path
     .relative(rootContext || process.cwd(), resourcePath)
-    .replace(/^(\.\.[\/\\])+/, '');
+    .replace(/^(\.\.[/\\])+/, '');
   const shortFilePath = rawShortFilePath.replace(/\\/g, '/') + resourceQuery;
   const id = hash(isProduction ? shortFilePath + '\n' + source : shortFilePath);
 
@@ -111,7 +110,7 @@ export default function loader(
       // eslint-disable-next-line no-multi-assign
       script = (descriptor as any).scriptCompiled = compileScript(descriptor, {
         babelParserPlugins: options.babelParserPlugins,
-        id: uuid(),
+        id,
       });
     } catch (e) {
       loaderContext.emitError(e);

--- a/packages/vue3-transpiler/src/templateLoader.ts
+++ b/packages/vue3-transpiler/src/templateLoader.ts
@@ -3,7 +3,6 @@ import { LoaderContext } from 'sandpack-core';
 import loaderUtils from 'sandpack-core/lib/transpiler/utils/loader-utils';
 import { compileTemplate, TemplateCompiler } from 'vue3-browser-compiler';
 import { WarningStructure } from 'sandpack-core/lib/transpiler/utils/worker-warning-handler';
-import { v4 as uuid } from 'uuid';
 
 import { VueLoaderOptions } from './index';
 import { formatError } from './formatError';
@@ -23,7 +22,8 @@ function TemplateLoader(source: string, loaderContext: LoaderContext) {
     {}) as VueLoaderOptions;
 
   const query = qs.parse(loaderContext.resourceQuery.slice(1));
-  const scopeId = query.scoped ? `data-v-${query.id}` : null;
+  const id: string = `${query.id}`;
+  const scopeId = query.scoped ? `data-v-${id}` : null;
 
   let compiler: TemplateCompiler | undefined;
   if (typeof options.compiler === 'string') {
@@ -34,7 +34,7 @@ function TemplateLoader(source: string, loaderContext: LoaderContext) {
   }
 
   const compiled = compileTemplate({
-    id: uuid(),
+    id,
     source,
     inMap,
     filename: loaderContext.path,


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?

<!-- Is it a Bug fix, feature, docs update, ... -->

Vue transpiler should use the hash of filename/query as the id, not a uuid, I assume it's because of hmr and replacing the correct element.

Haven't been able to break the current logic so not sure where this would show, but best to stay in sync with the vue plugins the maintainer of vue wrote.

Some vite code for reference: https://github.com/vitejs/vite/blob/main/packages/plugin-vue/src/template.ts#L109

Update: Tested a bunch of things, doesn't seem to be making a difference, but at least it should be faster and perhaps they don't use the id's for script yet? (also wouldn't be very semver compatible if they changed this now)

## What is the current behavior?

<!-- You can also link to an open issue here -->

Uses uuid for hmr

## What is the new behavior?

<!-- if this is a feature change -->

Uses filename hash

