### PR TITLE
fix: delayed repos fetch

### DIFF
--- a/packages/app/src/app/overmind/actions.ts
+++ b/packages/app/src/app/overmind/actions.ts
@@ -520,7 +520,6 @@ export const setActiveTeam = async (
 
   // reset dashboard data on team change
   state.dashboard.sandboxes = { ...DEFAULT_DASHBOARD_SANDBOXES };
-  state.dashboard.repositories = null;
   state.dashboard.contributions = null;
 
   actions.internal.replaceWorkspaceParameterInUrl();

--- a/packages/app/src/app/overmind/namespaces/dashboard/state.ts
+++ b/packages/app/src/app/overmind/namespaces/dashboard/state.ts
@@ -66,8 +66,15 @@ export type State = {
   };
   curatedAlbums: DashboardAlbum[];
   contributions: Branch[] | null;
-  /** v2 repositories (formerly projects) */
-  repositories: Repository[] | null;
+  /**
+   * v2 repositories (formerly projects)
+   * stores as a record of team id and repositories (or null).
+   * implemented this way to overcome an issue where the
+   * delayed synced repositories fetch on a previous team
+   * overrides the current team data.
+   * @see {@link https://linear.app/codesandbox/issue/XTD-375}
+   */
+  repositories: Record<string, Repository[] | null> | null;
   starredRepos: Array<{ owner: string; name: string }>;
   /**
    * Use these variables to track if items are being removed. This way


### PR DESCRIPTION
# Description

Remodels the state in a record of teams and their repositories. This way, because canceling pending promises when changing the active team is not possible to implement, we make sure the data doesn't get overridden when delayed fetches are finished.

# Test scenarios:

## 1. Repositories load as expected:

- Go to the repositories page
  - Expected: loading state is shown and then, if the fetch is successful, it shows the list of repos.
- Select a repo from the list
  - Expected: list of branches from the selected repo is shown w/o a loading state in between. 
- Navigate back to the list of repositories using the breadcrumbs.
  - Expected: list of repos is show w/o a loading state in between.
 
## 2. Single repository loads as expected:

- Select a repo from the list
- Refresh the page
  - Expected: same repo is shown w/ a loading state (it's the only repo fetched to get data faster)
- Navigate back to the list of repositories
  - Expected: list of repos is shown w/ a loading state in between (all the repos are fetched to show the expected data)

## 3. Navigating between teams:

- On a team with many repos with many branches, go to the list of repos
- See that the request to fetch synced repositories is still pending
- Navigate away to a team with fewer repos and fewer branches
- See the list of repos imported by the active team
  - Expected: once the repos request for the previously active team completes, the data doesn't override the current team's repositories. 

## 4. Removing a branch from a repository:

- Open the branch context menu and select "Remove branch from CodeSandbox"
  - Expected: branch card gets dimmed while the removal is happening.
  - If the removal is successful, the branch gets optimistically removed from the UI.

## 5. Removing a repository from a team:

- Open the repo context menu and select "Remove repository from CodeSandbox";
  - Expected: repo gets optimistically removed from the UI.