### PR TITLE
fix: vercel integration

### DIFF
--- a/packages/app/src/app/pages/VercelAuth/index.js
+++ b/packages/app/src/app/pages/VercelAuth/index.js
@@ -15,7 +15,9 @@ const VercelSignIn = () => {
   useEffect(() => {
     if (document.location.search.match(/\?code=(.*)/)) {
       // eslint-disable-next-line
-      const [_, code] = document.location.search.match(/\?code=(.*)/);
+      const queryParams = new URLSearchParams(document.location.search);
+      const code = queryParams.get('code');
+
       if (window.opener) {
         if (window.opener.location.origin === window.location.origin) {
           window.opener.postMessage(

--- a/packages/app/src/app/pages/VercelAuth/index.js
+++ b/packages/app/src/app/pages/VercelAuth/index.js
@@ -13,10 +13,10 @@ const VercelSignIn = () => {
   const [error, setError] = useState(null);
 
   useEffect(() => {
-    if (document.location.search.match(/\?code=(.*)/)) {
-      const queryParams = new URLSearchParams(document.location.search);
-      const code = queryParams.get('code');
+    const queryParams = new URLSearchParams(document.location.search);
+    const code = queryParams.get('code');
 
+    if (code) {
       if (window.opener) {
         if (window.opener.location.origin === window.location.origin) {
           window.opener.postMessage(

--- a/packages/app/src/app/pages/VercelAuth/index.js
+++ b/packages/app/src/app/pages/VercelAuth/index.js
@@ -14,7 +14,6 @@ const VercelSignIn = () => {
 
   useEffect(() => {
     if (document.location.search.match(/\?code=(.*)/)) {
-      // eslint-disable-next-line
       const queryParams = new URLSearchParams(document.location.search);
       const code = queryParams.get('code');
 


### PR DESCRIPTION
The vercel callback passes multiple params with the newer integration, so this is fixed by taking the code value only from the query string