### PR TITLE
feat(dashboard/components): ExternalCard: article and video variant

### DIFF
--- a/packages/components/src/components/ExternalCard/ArticleCard.tsx
+++ b/packages/components/src/components/ExternalCard/ArticleCard.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { Icon } from '../Icon';
+import {
+  StyledContent,
+  StyledDetails,
+  StyledTitle,
+  StyledWrapper,
+} from './elements';
+
+type Article = {
+  title: string;
+  thumbnail: string;
+  url: string;
+};
+
+type ArticleCardProps = { onClick?: () => void } & Article;
+
+export const ArticleCard: React.FC<ArticleCardProps> = ({
+  title,
+  thumbnail,
+  url,
+  ...props
+}) => {
+  return (
+    <StyledWrapper
+      as="a"
+      direction="vertical"
+      href={url}
+      target="_blank"
+      thumbnail={thumbnail}
+      {...props}
+    >
+      <StyledContent>
+        <StyledDetails>
+          <StyledTitle>{title}</StyledTitle>
+          <Icon
+            css={{
+              color: '#999999',
+              transform: 'rotate(270deg)',
+            }}
+            name="arrowDown"
+          />
+        </StyledDetails>
+      </StyledContent>
+    </StyledWrapper>
+  );
+};

--- a/packages/components/src/components/ExternalCard/ArticleCard.tsx
+++ b/packages/components/src/components/ExternalCard/ArticleCard.tsx
@@ -31,8 +31,8 @@ export const ArticleCard: React.FC<ArticleCardProps> = ({
       {...props}
     >
       <StyledContent>
-        <StyledDetails>
-          <StyledTitle>{title}</StyledTitle>
+        <StyledDetails gap={3}>
+          <StyledTitle clamp>{title}</StyledTitle>
           <Icon
             css={{
               color: '#999999',

--- a/packages/components/src/components/ExternalCard/VideoCard.tsx
+++ b/packages/components/src/components/ExternalCard/VideoCard.tsx
@@ -10,6 +10,7 @@ import {
 
 type Video = {
   duration: string;
+  durationLabel: string;
   title: string;
   thumbnail: string;
   url: string;
@@ -19,6 +20,7 @@ type VideoCardProps = { onClick?: () => void } & Video;
 
 export const VideoCard: React.FC<VideoCardProps> = ({
   duration,
+  durationLabel,
   title,
   thumbnail,
   url,
@@ -34,7 +36,7 @@ export const VideoCard: React.FC<VideoCardProps> = ({
       {...props}
     >
       <StyledContent>
-        <StyledDetails>
+        <StyledDetails gap={3}>
           <Stack
             align="center"
             css={{
@@ -49,8 +51,10 @@ export const VideoCard: React.FC<VideoCardProps> = ({
           >
             <Icon name="start" />
           </Stack>
-          <StyledTitle>{title}</StyledTitle>
-          <StyledTitle clamp={false}>{duration}</StyledTitle>
+          <StyledTitle clamp>{title}</StyledTitle>
+          <StyledTitle aria-label={durationLabel} clamp={false}>
+            {duration}
+          </StyledTitle>
         </StyledDetails>
       </StyledContent>
     </StyledWrapper>

--- a/packages/components/src/components/ExternalCard/VideoCard.tsx
+++ b/packages/components/src/components/ExternalCard/VideoCard.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { Icon } from '../Icon';
+import { Stack } from '../Stack';
+import {
+  StyledContent,
+  StyledDetails,
+  StyledTitle,
+  StyledWrapper,
+} from './elements';
+
+type Video = {
+  duration: string;
+  title: string;
+  thumbnail: string;
+  url: string;
+};
+
+type VideoCardProps = { onClick?: () => void } & Video;
+
+export const VideoCard: React.FC<VideoCardProps> = ({
+  duration,
+  title,
+  thumbnail,
+  url,
+  ...props
+}) => {
+  return (
+    <StyledWrapper
+      as="a"
+      direction="vertical"
+      href={url}
+      target="_blank"
+      thumbnail={thumbnail}
+      {...props}
+    >
+      <StyledContent>
+        <StyledDetails>
+          <Stack
+            align="center"
+            css={{
+              flexShrink: 0,
+              height: '32px',
+              width: '32px',
+              borderRadius: '50%',
+              background: 'rgba(255, 255, 255, 0.2)',
+              backdropFilter: 'blur(2.68809px)',
+            }}
+            justify="center"
+          >
+            <Icon name="start" />
+          </Stack>
+          <StyledTitle>{title}</StyledTitle>
+          <StyledTitle clamp={false}>{duration}</StyledTitle>
+        </StyledDetails>
+      </StyledContent>
+    </StyledWrapper>
+  );
+};

--- a/packages/components/src/components/ExternalCard/VideoCard.tsx
+++ b/packages/components/src/components/ExternalCard/VideoCard.tsx
@@ -40,16 +40,15 @@ export const VideoCard: React.FC<VideoCardProps> = ({
           <Stack
             align="center"
             css={{
+              padding: '8px',
               flexShrink: 0,
-              height: '32px',
-              width: '32px',
               borderRadius: '50%',
               background: 'rgba(255, 255, 255, 0.2)',
               backdropFilter: 'blur(2.68809px)',
             }}
             justify="center"
           >
-            <Icon name="start" />
+            <Icon css={{}} name="start" />
           </Stack>
           <StyledTitle clamp>{title}</StyledTitle>
           <StyledTitle aria-label={durationLabel} clamp={false}>

--- a/packages/components/src/components/ExternalCard/elements.ts
+++ b/packages/components/src/components/ExternalCard/elements.ts
@@ -8,7 +8,9 @@ export const StyledWrapper = styled(Stack)<{ thumbnail: string }>`
   height: 156px;
   width: 276px;
   background-color: #161616;
+  outline: none;
   border-radius: 4px;
+  border: 1px solid #161616;
   transition: background linear;
   transition-duration: 200ms;
 
@@ -32,8 +34,13 @@ export const StyledWrapper = styled(Stack)<{ thumbnail: string }>`
     background-color: #292929;
   }
 
-  :hover::after {
+  :hover::after,
+  :focus::after {
     transform: scale(1.02);
+  }
+
+  :focus-visible {
+    border-color: #9581ff;
   }
 `;
 StyledWrapper.defaultProps = {
@@ -58,6 +65,7 @@ export const StyledContent = styled(Stack)`
 `;
 
 export const StyledDetails = styled(Stack)`
+  width: 100%;
   margin: auto 24px 24px;
 `;
 StyledDetails.defaultProps = {

--- a/packages/components/src/components/ExternalCard/elements.ts
+++ b/packages/components/src/components/ExternalCard/elements.ts
@@ -3,6 +3,7 @@ import { Stack } from '../Stack';
 import { Text } from '../Text';
 
 export const StyledWrapper = styled(Stack)<{ thumbnail: string }>`
+  flex-direction: column;
   position: relative;
   overflow: hidden;
   height: 156px;
@@ -43,9 +44,6 @@ export const StyledWrapper = styled(Stack)<{ thumbnail: string }>`
     border-color: #9581ff;
   }
 `;
-StyledWrapper.defaultProps = {
-  direction: 'vertical',
-};
 
 export const StyledContent = styled(Stack)`
   position: absolute;
@@ -67,14 +65,11 @@ export const StyledContent = styled(Stack)`
 export const StyledDetails = styled(Stack)`
   width: 100%;
   margin: auto 24px 24px;
+  align-items: center;
+  justify-content: space-between;
 `;
-StyledDetails.defaultProps = {
-  align: 'center',
-  gap: 3,
-  justify: 'space-between',
-};
 
-export const StyledTitle = styled(Text)<{ clamp?: boolean }>`
+export const StyledTitle = styled(Text)<{ clamp: boolean }>`
   margin: 0;
   color: #ebebeb;
   font-size: 13px;
@@ -91,7 +86,3 @@ export const StyledTitle = styled(Text)<{ clamp?: boolean }>`
   -webkit-box-orient: vertical;
   `}
 `;
-StyledTitle.defaultProps = {
-  as: 'p',
-  clamp: true,
-};

--- a/packages/components/src/components/ExternalCard/elements.ts
+++ b/packages/components/src/components/ExternalCard/elements.ts
@@ -1,0 +1,83 @@
+import styled from 'styled-components';
+import { Stack } from '../Stack';
+import { Text } from '../Text';
+
+export const StyledWrapper = styled(Stack)<{ thumbnail: string }>`
+  position: relative;
+  overflow: hidden;
+  height: 156px;
+  width: 276px;
+  background: #999999;
+  border-radius: 4px;
+
+  &:after {
+    position: absolute;
+    content: '';
+    display: block;
+    width: 100%;
+    height: 100%;
+    top: 0;
+    left: 0;
+    background-image: url(${props => props.thumbnail});
+    background-size: cover;
+    background-position: center;
+    transform: scale(1);
+    transition: transform ease-in-out;
+    transition-duration: 100ms;
+  }
+
+  &:hover::after {
+    transform: scale(1.01);
+  }
+`;
+StyledWrapper.defaultProps = {
+  direction: 'vertical',
+};
+
+export const StyledContent = styled(Stack)`
+  position: absolute;
+  z-index: 1;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  left: 0;
+  display: flex;
+  background: linear-gradient(
+      0deg,
+      rgba(25, 25, 25, 0.3) 0%,
+      rgba(25, 25, 25, 0) 100%
+    ),
+    linear-gradient(0deg, rgba(25, 25, 25, 0.6) 0%, rgba(25, 25, 25, 0) 100%),
+    linear-gradient(0deg, rgba(25, 25, 25, 0.8) 0%, rgba(25, 25, 25, 0) 100%);
+`;
+
+export const StyledDetails = styled(Stack)`
+  margin: auto 24px 24px;
+`;
+StyledDetails.defaultProps = {
+  align: 'center',
+  gap: 3,
+  justify: 'space-between',
+};
+
+export const StyledTitle = styled(Text)<{ clamp?: boolean }>`
+  margin: 0;
+  color: #ebebeb;
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 16px;
+
+  ${props =>
+    props.clamp &&
+    `  
+  width: 100%;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  `}
+`;
+StyledTitle.defaultProps = {
+  as: 'p',
+  clamp: true,
+};

--- a/packages/components/src/components/ExternalCard/elements.ts
+++ b/packages/components/src/components/ExternalCard/elements.ts
@@ -6,8 +6,8 @@ export const StyledWrapper = styled(Stack)<{ thumbnail: string }>`
   flex-direction: column;
   position: relative;
   overflow: hidden;
-  height: 156px;
-  width: 276px;
+  width: 100%;
+  height: 100%;
   background-color: #161616;
   outline: none;
   border-radius: 4px;

--- a/packages/components/src/components/ExternalCard/elements.ts
+++ b/packages/components/src/components/ExternalCard/elements.ts
@@ -22,12 +22,12 @@ export const StyledWrapper = styled(Stack)<{ thumbnail: string }>`
     background-size: cover;
     background-position: center;
     transform: scale(1);
-    transition: transform ease-in-out;
-    transition-duration: 100ms;
+    transition: transform linear;
+    transition-duration: 200ms;
   }
 
   &:hover::after {
-    transform: scale(1.01);
+    transform: scale(1.02);
   }
 `;
 StyledWrapper.defaultProps = {

--- a/packages/components/src/components/ExternalCard/elements.ts
+++ b/packages/components/src/components/ExternalCard/elements.ts
@@ -7,10 +7,12 @@ export const StyledWrapper = styled(Stack)<{ thumbnail: string }>`
   overflow: hidden;
   height: 156px;
   width: 276px;
-  background: #999999;
+  background-color: #161616;
   border-radius: 4px;
+  transition: background linear;
+  transition-duration: 200ms;
 
-  &:after {
+  :after {
     position: absolute;
     content: '';
     display: block;
@@ -26,7 +28,11 @@ export const StyledWrapper = styled(Stack)<{ thumbnail: string }>`
     transition-duration: 200ms;
   }
 
-  &:hover::after {
+  :hover {
+    background-color: #292929;
+  }
+
+  :hover::after {
     transform: scale(1.02);
   }
 `;

--- a/packages/components/src/components/ExternalCard/index.stories.tsx
+++ b/packages/components/src/components/ExternalCard/index.stories.tsx
@@ -16,6 +16,7 @@ const article = {
 
 const video = {
   duration: '7:21',
+  durationLabel: '7 minutes, 21 seconds',
   title:
     "Updated pricing, Cloud sandboxes and more | What's new at CodeSandbox November 2022",
   url: 'https://www.youtube.com/watch?v=VDA41MYOYNI',

--- a/packages/components/src/components/ExternalCard/index.stories.tsx
+++ b/packages/components/src/components/ExternalCard/index.stories.tsx
@@ -23,8 +23,15 @@ const video = {
     'https://i.ytimg.com/vi/VDA41MYOYNI/hqdefault.jpg?sqp=-oaymwEcCNACELwBSFXyq4qpAw4IARUAAIhCGAFwAcABBg==&rs=AOn4CLDn88tm1ouxCTFFnhBdQ5zznDWfWg',
 };
 
+const thumbless = {
+  title: 'Uploading Static Files',
+  url:
+    'https://codesandbox.io/docs/learn/sandboxes/editors#uploading-static-files',
+  thumbnail: 'https://malformed-url.com',
+};
+
 export const ArticleVariant = () => <ArticleCard {...article} />;
 
-export const VideoVariant = () => <VideoCard {...video} />;
+export const ThumblessVariant = () => <ArticleCard {...thumbless} />;
 
-export const ThumblessVariant = () => <VideoCard {...video} thumbnail="" />;
+export const VideoVariant = () => <VideoCard {...video} />;

--- a/packages/components/src/components/ExternalCard/index.stories.tsx
+++ b/packages/components/src/components/ExternalCard/index.stories.tsx
@@ -1,6 +1,13 @@
 import React from 'react';
+import styled from 'styled-components';
 import { ArticleCard } from './ArticleCard';
 import { VideoCard } from './VideoCard';
+
+const StyledWraperGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  height: 154px;
+`;
 
 export default {
   title: 'components/facelift/ExternalCard',
@@ -31,8 +38,20 @@ const thumbless = {
   thumbnail: 'https://malformed-url.com',
 };
 
-export const ArticleVariant = () => <ArticleCard {...article} />;
+export const ArticleVariant = () => (
+  <StyledWraperGrid>
+    <ArticleCard {...article} />
+  </StyledWraperGrid>
+);
 
-export const ThumblessVariant = () => <ArticleCard {...thumbless} />;
+export const ThumblessVariant = () => (
+  <StyledWraperGrid>
+    <ArticleCard {...thumbless} />
+  </StyledWraperGrid>
+);
 
-export const VideoVariant = () => <VideoCard {...video} />;
+export const VideoVariant = () => (
+  <StyledWraperGrid>
+    <VideoCard {...video} />
+  </StyledWraperGrid>
+);

--- a/packages/components/src/components/ExternalCard/index.stories.tsx
+++ b/packages/components/src/components/ExternalCard/index.stories.tsx
@@ -26,3 +26,5 @@ const video = {
 export const ArticleVariant = () => <ArticleCard {...article} />;
 
 export const VideoVariant = () => <VideoCard {...video} />;
+
+export const ThumblessVariant = () => <VideoCard {...video} thumbnail="" />;

--- a/packages/components/src/components/ExternalCard/index.stories.tsx
+++ b/packages/components/src/components/ExternalCard/index.stories.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { ArticleCard } from './ArticleCard';
+import { VideoCard } from './VideoCard';
+
+export default {
+  title: 'components/facelift/ExternalCard',
+};
+
+const article = {
+  title: 'How to code your app using the CodeSandbox iPad IDE',
+  url:
+    'https://codesandbox.io/post/how-to-code-your-app-using-the-codesandbox-ipad-ide',
+  thumbnail:
+    'https://codesandbox.io/static/codesandbox-ipad-ide-cover-01937cea05823dd2253a6ad6e0823db5.png',
+};
+
+const video = {
+  duration: '7:21',
+  title:
+    "Updated pricing, Cloud sandboxes and more | What's new at CodeSandbox November 2022",
+  url: 'https://www.youtube.com/watch?v=VDA41MYOYNI',
+  thumbnail:
+    'https://i.ytimg.com/vi/VDA41MYOYNI/hqdefault.jpg?sqp=-oaymwEcCNACELwBSFXyq4qpAw4IARUAAIhCGAFwAcABBg==&rs=AOn4CLDn88tm1ouxCTFFnhBdQ5zznDWfWg',
+};
+
+export const ArticleVariant = () => <ArticleCard {...article} />;
+
+export const VideoVariant = () => <VideoCard {...video} />;

--- a/packages/components/src/components/ExternalCard/index.tsx
+++ b/packages/components/src/components/ExternalCard/index.tsx
@@ -1,0 +1,2 @@
+export { ArticleCard } from './ArticleCard';
+export { VideoCard } from './VideoCard';

--- a/packages/components/src/components/Icon/icons.tsx
+++ b/packages/components/src/components/Icon/icons.tsx
@@ -1230,3 +1230,18 @@ export const sandbox = props => (
     />
   </svg>
 );
+
+export const start = props => (
+  <Element
+    as="svg"
+    viewBox="0 0 16 16"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    {...props}
+  >
+    <path
+      d="M2 2.34612C2 1.3014 3.13971 0.656109 4.03554 1.19361L13.5196 6.88403C14.3896 7.40607 14.3896 8.66702 13.5196 9.18905L4.03554 14.8795C3.13971 15.417 2 14.7717 2 13.727V2.34612Z"
+      fill="currentColor"
+    />
+  </Element>
+);


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

Closes XTD-481.
Closes XTD-482.

## What kind of change does this PR introduce?

<!-- Is it a Bug fix, feature, docs update, ... -->

- Creates `VideoCard`;
- Creates `ArticleCard`;

They are placed in the components section to make visual testing easier with Storybook since this component will be integrated on an upcoming task.

|Article|Video|
|:-:|:-:|
|![Screen Shot 2022-12-07 at 18 23 01](https://user-images.githubusercontent.com/24959348/206299519-6b0ad7d0-8549-477c-be5b-9a3a8e563987.png)|![Screen Shot 2022-12-07 at 18 23 19](https://user-images.githubusercontent.com/24959348/206299527-620bbf84-2177-48a0-8d8c-284c5c00f11b.png)|
