### PR TITLE
fix: dashboard search loading and URL

### DIFF
--- a/packages/app/src/app/pages/Dashboard/Content/routes/Search/searchItems.ts
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Search/searchItems.ts
@@ -16,28 +16,38 @@ const useSearchedSandboxes = (query: string) => {
     | (SandboxFragmentDashboardFragment | SidebarCollectionDashboardFragment)[]
     | null
   >(null);
+  const [searchIndex, setSearchindex] = React.useState<Fuse<
+    SandboxFragmentDashboardFragment | SidebarCollectionDashboardFragment,
+    unknown
+  > | null>(null);
 
   useEffect(() => {
     actions.dashboard.getPage(sandboxesTypes.SEARCH);
   }, [actions.dashboard, state.activeTeam]);
 
+  useEffect(
+    () => {
+      setSearchindex(calculateSearchIndex(state.dashboard, state.activeTeam));
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [
+      state.dashboard.sandboxes.SEARCH,
+      state.dashboard.repositories,
+      state.activeTeam,
+    ]
+  );
+
   useEffect(() => {
-    const index = searchIndex(state.dashboard, state.activeTeam);
-    if (index) {
-      setFoundResults(index.search(query));
+    if (searchIndex) {
+      setFoundResults(searchIndex.search(query));
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    query,
-    searchIndex,
-    state.dashboard.sandboxes.SEARCH,
-    state.dashboard.repositories,
-  ]);
+  }, [query, searchIndex]);
 
   return foundResults;
 };
 
-const searchIndex = (dashboard: any, activeTeam: string) => {
+const calculateSearchIndex = (dashboard: any, activeTeam: string) => {
   const sandboxes = dashboard.sandboxes.SEARCH;
   if (sandboxes == null) {
     return null;

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Search/searchItems.ts
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Search/searchItems.ts
@@ -27,7 +27,12 @@ const useSearchedSandboxes = (query: string) => {
       setFoundResults(index.search(query));
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [query, searchIndex]);
+  }, [
+    query,
+    searchIndex,
+    state.dashboard.sandboxes.SEARCH,
+    state.dashboard.repositories,
+  ]);
 
   return foundResults;
 };

--- a/packages/app/src/app/pages/Dashboard/Header/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Header/index.tsx
@@ -126,8 +126,9 @@ const SearchInputGroup = () => {
 
   const onChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setQuery(event.target.value);
-
-    if (event.target.value.length >= 2) debouncedSearch(event.target.value);
+    if (event.target.value.length >= 1) {
+      debouncedSearch(event.target.value);
+    }
     if (!event.target.value) {
       history.push(dashboardUrls.sandboxes('/', activeTeam));
     }


### PR DESCRIPTION
Fixes three things:

1. Whenever we would do a search, we would fetch sandboxes but not update the search after the fetch is done. This made it look like search is broken, because you always get 0 results back (for your first few searches).
2. When you have a search with 1 character, it would lead you to an empty search page with no search query. It should search instead.
3. When you empty the search bar, it would also lead you to an empty search page. You should go to the dashboard overview instead.

Also improves efficiency of searching, before we used to recalculate the index for every new query. Now we recalculate the search index only if the data changes.