### PR TITLE
fix(dependencies): show right version in version dropdown

### DIFF
--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Explorer/Dependencies/Dependency/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Explorer/Dependencies/Dependency/index.tsx
@@ -189,7 +189,7 @@ export const Dependency = ({
           {versions.length === 0 ? null : (
             <Select
               css={{ width: '80px' }}
-              value={versionFromDropdown}
+              value={versionFromDropdown || dependencies[dependency]}
               onChange={e => onRefresh(dependency, e.target.value)}
             >
               {versionFromDropdown === undefined && (

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Explorer/Dependencies/Dependency/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Explorer/Dependencies/Dependency/index.tsx
@@ -118,6 +118,10 @@ export const Dependency = ({
     return null;
   }
 
+  const versionFromDropdown = versions.find(
+    v => v === dependencies[dependency]
+  );
+
   return (
     <>
       <ListAction
@@ -185,9 +189,14 @@ export const Dependency = ({
           {versions.length === 0 ? null : (
             <Select
               css={{ width: '80px' }}
-              value={versions.find(v => v === dependencies[dependency])}
+              value={versionFromDropdown}
               onChange={e => onRefresh(dependency, e.target.value)}
             >
+              {versionFromDropdown === undefined && (
+                <option key={dependencies[dependency]}>
+                  {dependencies[dependency]}
+                </option>
+              )}
               {versions.map(a => (
                 <option key={a}>{a}</option>
               ))}


### PR DESCRIPTION
If you've configured a version for a dependency in `package.json` that doesn't match the version list, we randomly select a version from the version selector. Like here:

![image](https://user-images.githubusercontent.com/587016/207291755-14f0a069-8287-451c-a75c-1659b808d5de.png)

That's a bit confusing. With this change, we add the dependency that's in package.json to the list in case it's not in the list, so you'll get a view like this:

<img width="462" alt="image" src="https://user-images.githubusercontent.com/587016/207291663-037a2263-ad3b-4a81-a25f-1f4047b0a77d.png">
