### PR TITLE
fix: select and focus state for cards and list items

### DIFF
--- a/packages/app/src/app/pages/Dashboard/Components/Folder/FolderListItem.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Folder/FolderListItem.tsx
@@ -56,7 +56,7 @@ export const FolderListItem = ({
           cursor: 'default',
           backgroundColor: selected ? 'purpleOpaque' : 'list.hoverBackground',
         },
-        ':has(button:hover)': {
+        ':has(button:hover), :has(button:focus-visible)': {
           backgroundColor: 'transparent',
         },
         width: '100%',
@@ -65,8 +65,8 @@ export const FolderListItem = ({
         borderBottomColor: 'grays.600',
       })}
     >
-      <Grid css={{ width: 'calc(100% - 26px - 8px)' }}>
-        <Column span={[12, 5, 5]}>
+      <Grid css={{ width: 'calc(100% - 26px - 8px)' }} columnGap={4}>
+        <Column span={[12, 7, 6]}>
           <Stack gap={4} align="center" marginLeft={2}>
             <Stack
               as="div"
@@ -104,7 +104,7 @@ export const FolderListItem = ({
             </Stack>
           </Stack>
         </Column>
-        <Column span={[0, 4, 4]} as={Stack} align="center">
+        <Column span={[0, 2, 3]} as={Stack} align="center">
           {!isNewFolder ? (
             <Text size={3} block variant={selected ? 'body' : 'muted'}>
               {numberOfSandboxes || 0}{' '}

--- a/packages/app/src/app/pages/Dashboard/Components/Sandbox/SandboxCard.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Sandbox/SandboxCard.tsx
@@ -247,9 +247,10 @@ export const SandboxCard = ({
         position: 'relative',
         width: '100%',
         height: 240,
+        outline: 'none',
         backgroundColor: selected ? '#292929' : '#1D1D1D',
         border: '1px solid',
-        borderColor: selected ? '#242424' : 'transparent',
+        borderColor: selected ? '#9581FF' : 'transparent',
         borderRadius: '4px',
         overflow: 'hidden',
         transition: 'background ease-in-out',
@@ -262,7 +263,7 @@ export const SandboxCard = ({
           backgroundColor: '#1D1D1D',
         },
         ':focus-visible': {
-          borderColor: '#242424',
+          borderColor: '#9581FF',
         },
       }}
     >

--- a/packages/app/src/app/pages/Dashboard/Components/Sandbox/SandboxListItem.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Sandbox/SandboxListItem.tsx
@@ -58,7 +58,7 @@ export const SandboxListItem = ({
         cursor: 'default',
         backgroundColor: selected ? 'purpleOpaque' : 'list.hoverBackground',
       },
-      ':has(button:hover)': {
+      ':has(button:hover), :has(button:focus-visible)': {
         backgroundColor: 'transparent',
       },
     })}
@@ -69,6 +69,7 @@ export const SandboxListItem = ({
         alignItems: 'center',
         width: '100%',
         height: '100%',
+        outline: 'none',
       })}
       onClick={onClick}
       onDoubleClick={onDoubleClick}

--- a/packages/app/src/app/pages/Dashboard/Components/Sandbox/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Sandbox/index.tsx
@@ -275,6 +275,7 @@ const GenericSandbox = ({ isScrolling, item, page }: GenericSandboxProps) => {
           ...baseInteractions,
           // Recent page does not support selection
           'data-selection-id': sandbox.id,
+          tabIndex: '0',
           onClick,
           onMouseDown,
           onDoubleClick,


### PR DESCRIPTION
A few fixes on the selected and focused states for sandbox cards and list items. Including the alignment of list item columns and some fixes for focusing the more button.

Selection
![image](https://user-images.githubusercontent.com/9945366/207840022-67226d40-e8df-4787-8fc0-058e53e327e6.png)

![image](https://user-images.githubusercontent.com/9945366/207840124-f62db7fe-c325-474f-9cef-9e043d9d3e21.png)
