### PR TITLE
chore: add client headers for backend analytics

### DIFF
--- a/packages/app/src/app/components/CreateSandbox/utils/api.ts
+++ b/packages/app/src/app/components/CreateSandbox/utils/api.ts
@@ -100,6 +100,7 @@ export const importRepository: ImportRepositoryFn = ({
     headers: {
       Accept: 'application/json',
       'Content-Type': 'application/json',
+      'x-codesandbox-client': 'legacy-web',
       authorization: token ? `Bearer ${token}` : '',
     },
     method: 'POST',
@@ -132,6 +133,7 @@ export const validateRepositoryDestination: ValidateRepositoryDestinationFn = de
     headers: {
       Accept: 'application/json',
       'Content-Type': 'application/json',
+      'x-codesandbox-client': 'legacy-web',
       authorization: token ? `Bearer ${token}` : '',
     },
   })
@@ -174,6 +176,7 @@ export const forkRepository: ForkRepositoryFn = ({ source, destination }) => {
     headers: {
       Accept: 'application/json',
       'Content-Type': 'application/json',
+      'x-codesandbox-client': 'legacy-web',
       authorization: token ? `Bearer ${token}` : '',
     },
     method: 'POST',

--- a/packages/app/src/app/overmind/actions.ts
+++ b/packages/app/src/app/overmind/actions.ts
@@ -63,6 +63,11 @@ export const onInitializeOvermind = async (
   if (hasDevAuth) {
     gqlOptions.headers = () => ({
       Authorization: `Bearer ${localStorage.getItem('devJwt')}`,
+      'x-codesandbox-client': 'legacy-web',
+    });
+  } else {
+    gqlOptions.headers = () => ({
+      'x-codesandbox-client': 'legacy-web',
     });
   }
 

--- a/packages/app/src/app/overmind/effects/api/apiFactory.ts
+++ b/packages/app/src/app/overmind/effects/api/apiFactory.ts
@@ -36,13 +36,14 @@ export type ApiConfig = {
 };
 
 export default (config: ApiConfig) => {
-  const createHeaders = (provideJwt: () => string | null) =>
-    provideJwt()
+  const createHeaders = (provideJwt: () => string | null) => ({
+    'x-codesandbox-client': 'legacy-web',
+    ...(provideJwt()
       ? {
           Authorization: `Bearer ${provideJwt()}`,
         }
-      : {};
-
+      : {}),
+  });
   const api: Api = {
     get(path, params, options) {
       return axios

--- a/packages/app/src/embed/components/App/index.js
+++ b/packages/app/src/embed/components/App/index.js
@@ -163,6 +163,7 @@ export default class App extends React.PureComponent<
             headers: {
               'Content-Type': 'application/json',
               Authorization: `Bearer ${this.jwt()}`,
+              'x-codesandbox-client': 'legacy-embed',
             },
           }
         )
@@ -264,6 +265,7 @@ export default class App extends React.PureComponent<
         headers: {
           'Content-Type': 'application/json',
           Authorization: `Bearer ${jwt}`,
+          'x-codesandbox-client': 'legacy-embed',
         },
         body: JSON.stringify({
           id: this.state.sandbox.id,
@@ -301,6 +303,7 @@ export default class App extends React.PureComponent<
         headers: {
           'Content-Type': 'application/json',
           Authorization: `Bearer ${jwt}`,
+          'x-codesandbox-client': 'legacy-embed',
         },
       })
         .then(x => x.json())


### PR DESCRIPTION
This is a very basic change, but will help the backend team determine how the endpoints are used. Will follow-up with something similar on the codesandbox-applications side.