### PR TITLE
feat(XTD-348): Stripe success param

### DIFF
--- a/packages/app/src/app/hooks/useCreateCheckout.ts
+++ b/packages/app/src/app/hooks/useCreateCheckout.ts
@@ -14,6 +14,22 @@ type CheckoutOptions = {
   cancel_path?: string;
 };
 
+/**
+ * @param {string} pathNameAndSearch The pathname and search params you want to add the stripe
+ * success param to, for example  `/dashboard?workspace=xxxx`. Exclude the url base.
+ */
+const addStripeSuccessParam = (pathNameAndSearch: string): string => {
+  try {
+    const newUrl = new URL(pathNameAndSearch, window.location.origin);
+    newUrl.searchParams.append('stripe', 'success');
+
+    // Return only pathname and search
+    return `${newUrl.pathname}${newUrl.search}`;
+  } catch {
+    return pathNameAndSearch;
+  }
+};
+
 export const useCreateCheckout = (): [
   CheckoutStatus,
   (args: CheckoutOptions) => void
@@ -36,7 +52,7 @@ export const useCreateCheckout = (): [
       setStatus({ status: 'loading' });
 
       const payload = await api.stripeCreateCheckout({
-        success_path,
+        success_path: addStripeSuccessParam(success_path),
         cancel_path,
         team_id,
         recurring_interval,
@@ -93,7 +109,7 @@ export const useGetCheckoutURL = ({
       });
 
       const payload = await api.stripeCreateCheckout({
-        success_path,
+        success_path: addStripeSuccessParam(success_path),
         cancel_path,
         team_id,
         recurring_interval,

--- a/packages/app/src/app/pages/Dashboard/Components/UpgradeBanner/UpgradeBanner.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/UpgradeBanner/UpgradeBanner.tsx
@@ -19,6 +19,25 @@ import { useWorkspaceAuthorization } from 'app/hooks/useWorkspaceAuthorization';
 import { SUBSCRIPTION_DOCS_URLS } from 'app/constants';
 import { useWorkspaceSubscription } from 'app/hooks/useWorkspaceSubscription';
 
+// TODO: Move addStripeSuccessParam to a different file.
+// TODO: Implement everything that should happen when param is present.
+
+/**
+ * @param {string} pathNameAndSearch The pathname and search params you want to add the stripe
+ * success param to, for example  `/dashboard?workspace=xxxx`. Exclude the url base.
+ */
+const addStripeSuccessParam = (pathNameAndSearch: string) => {
+  try {
+    const newUrl = new URL(pathNameAndSearch, window.location.origin);
+    newUrl.searchParams.append('stripe', 'success');
+
+    // Return only param and search
+    return `${newUrl.pathname}${newUrl.search}`;
+  } catch {
+    return pathNameAndSearch;
+  }
+};
+
 const StyledTitle = styled(Text)`
   font-size: 24px;
   line-height: 32px;
@@ -136,7 +155,9 @@ export const UpgradeBanner: React.FC<UpgradeBannerProps> = ({ teamId }) => {
                         createCheckout({
                           team_id: teamId,
                           recurring_interval: 'month',
-                          success_path: dashboard.recent(teamId),
+                          success_path: addStripeSuccessParam(
+                            dashboard.recent(teamId)
+                          ),
                           cancel_path: dashboard.recent(teamId),
                         });
                       }}

--- a/packages/app/src/app/pages/Dashboard/Components/UpgradeBanner/UpgradeBanner.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/UpgradeBanner/UpgradeBanner.tsx
@@ -19,25 +19,6 @@ import { useWorkspaceAuthorization } from 'app/hooks/useWorkspaceAuthorization';
 import { SUBSCRIPTION_DOCS_URLS } from 'app/constants';
 import { useWorkspaceSubscription } from 'app/hooks/useWorkspaceSubscription';
 
-// TODO: Move addStripeSuccessParam to a different file.
-// TODO: Implement everything that should happen when param is present.
-
-/**
- * @param {string} pathNameAndSearch The pathname and search params you want to add the stripe
- * success param to, for example  `/dashboard?workspace=xxxx`. Exclude the url base.
- */
-const addStripeSuccessParam = (pathNameAndSearch: string) => {
-  try {
-    const newUrl = new URL(pathNameAndSearch, window.location.origin);
-    newUrl.searchParams.append('stripe', 'success');
-
-    // Return only param and search
-    return `${newUrl.pathname}${newUrl.search}`;
-  } catch {
-    return pathNameAndSearch;
-  }
-};
-
 const StyledTitle = styled(Text)`
   font-size: 24px;
   line-height: 32px;
@@ -155,9 +136,7 @@ export const UpgradeBanner: React.FC<UpgradeBannerProps> = ({ teamId }) => {
                         createCheckout({
                           team_id: teamId,
                           recurring_interval: 'month',
-                          success_path: addStripeSuccessParam(
-                            dashboard.recent(teamId)
-                          ),
+                          success_path: dashboard.recent(teamId),
                           cancel_path: dashboard.recent(teamId),
                         });
                       }}

--- a/packages/app/src/app/pages/Dashboard/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/index.tsx
@@ -75,7 +75,7 @@ export const Dashboard: FunctionComponent = () => {
         status: NotificationStatus.SUCCESS,
         title: 'Successfully activated subscription',
         message: isProDelayed
-          ? 'Please reload to update the dashboard'
+          ? 'Please reload to update the dashboard.'
           : undefined,
         actions: isProDelayed
           ? {

--- a/packages/app/src/app/pages/Dashboard/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/index.tsx
@@ -11,6 +11,7 @@ import {
   Element,
   SkipNav,
 } from '@codesandbox/components';
+import { NotificationStatus } from '@codesandbox/notifications/lib/state';
 import { createGlobalStyle, useTheme } from 'styled-components';
 import css from '@styled-system/css';
 
@@ -28,8 +29,8 @@ const GlobalStyles = createGlobalStyle({
 });
 
 export const Dashboard: FunctionComponent = () => {
-  const { hasLogIn } = useAppState();
-  const { browser } = useEffects();
+  const { hasLogIn, activeTeamInfo } = useAppState();
+  const { browser, notificationToast } = useEffects();
   const actions = useActions();
   const { subscription } = useWorkspaceSubscription();
 
@@ -53,12 +54,43 @@ export const Dashboard: FunctionComponent = () => {
   }, [browser.storage, actions]);
 
   const location = useLocation();
+
   useEffect(() => {
     const searchParams = new URLSearchParams(location.search);
+
     if (searchParams.get('workspace')) {
+      // Change workspace based on workspace param
       actions.setActiveTeam({ id: searchParams.get('workspace') });
     }
-  }, [location.search, actions]);
+
+    if (
+      activeTeamInfo &&
+      searchParams.get('stripe') &&
+      searchParams.get('stripe') === 'success'
+    ) {
+      const isProDelayed = activeTeamInfo.subscription === null;
+
+      // Show notification based on stripe success param
+      notificationToast.add({
+        status: NotificationStatus.SUCCESS,
+        title: 'Successfully activated subscription',
+        message: isProDelayed
+          ? 'Please reload to update the dashboard'
+          : undefined,
+        actions: isProDelayed
+          ? {
+              primary: {
+                label: 'Reload',
+                run: () => {
+                  actions.getActiveTeamInfo();
+                },
+                hideOnClick: true,
+              },
+            }
+          : undefined,
+      });
+    }
+  }, [location.search, actions, activeTeamInfo, notificationToast]);
 
   if (!hasLogIn) {
     return <Redirect to={signInPageUrl(location.pathname)} />;


### PR DESCRIPTION
Shows notification when a subscription through Stripe has been successful. Based on if the subscription webhook from Stripe came through fast enough we well show the user more information and an action.

### Testing

1. Open the dashboard with a team without trial
2. Start a trial
3. When redirected by Stripe, it should show a notification on the dashboard

Based on if your internet speed and device are faster than the webhook, you should see different notifications. When the webhook didn't come yet in you should see a refresh action in the notifications. To mock the refresh action notification, you can also open the dashboard for a team without trial and add `&stripe=success` to the url. To mock the notification without action, you can add `&stripe=success` to the url for a team that already has a subscription.

### Screenshots

**When webhook didn't come through yet**
<img width="1624" alt="image" src="https://user-images.githubusercontent.com/7533849/208461175-9ce8d0d0-7876-4104-b4c4-ff68b06f247a.png">

**When webhook came through and subscription is available**
<img width="1624" alt="image" src="https://user-images.githubusercontent.com/7533849/208461294-5115b5e6-4b24-4938-b679-8be78a8d4de3.png">