### PR TITLE
feat(privacy): Handle private sandbox forking and making public

### DIFF
--- a/packages/app/src/app/components/StripeMessages/FreeViewOnlyStripe.tsx
+++ b/packages/app/src/app/components/StripeMessages/FreeViewOnlyStripe.tsx
@@ -1,25 +1,37 @@
 import React from 'react';
+import styled from 'styled-components';
 import track from '@codesandbox/common/lib/utils/analytics';
 import { MessageStripe, Text } from '@codesandbox/components';
+import { useActions } from 'app/overmind';
 import { useWorkspaceAuthorization } from 'app/hooks/useWorkspaceAuthorization';
 
+const LinkButton = styled.button`
+  border: none;
+  background: none;
+  padding: 0;
+  color: inherit;
+  font-family: 'Inter', sans-serif;
+  text-decoration: underline;
+
+  &:hover {
+    color: white;
+  }
+`;
+
 export const FreeViewOnlyStripe = () => {
+  const { changeSandboxPrivacyToPublic } = useActions().workspace;
   const { isTeamAdmin } = useWorkspaceAuthorization();
 
   return (
     <MessageStripe>
-      {isTeamAdmin ? (
-        <span>
-          You are no longer in a <Text weight="bold">PRO account</Text>. This
-          sandbox is in view mode only. Upgrade your account for unlimited
-          sandboxes.
-        </span>
-      ) : (
-        <span>
-          You are no longer in a <Text weight="bold">PRO team</Text>. This
-          sandbox is in view mode only, contact your team admin to upgrade.
-        </span>
-      )}
+      <span>
+        You are no longer in a <Text weight="bold">PRO account</Text>. This
+        sandbox is in view mode only.{' '}
+        <LinkButton onClick={changeSandboxPrivacyToPublic}>
+          Make it public
+        </LinkButton>{' '}
+        or upgrade to <Text weight="bold">PRO</Text>.
+      </span>
       {isTeamAdmin ? (
         <MessageStripe.Action
           as="a"

--- a/packages/app/src/app/components/StripeMessages/FreeViewOnlyStripe.tsx
+++ b/packages/app/src/app/components/StripeMessages/FreeViewOnlyStripe.tsx
@@ -19,18 +19,20 @@ const LinkButton = styled.button`
 `;
 
 export const FreeViewOnlyStripe = () => {
-  const { changeSandboxPrivacyToPublic } = useActions().workspace;
+  const { sandboxPrivacyChanged } = useActions().workspace;
   const { isTeamAdmin } = useWorkspaceAuthorization();
+
+  const changeToPublic = () => {
+    sandboxPrivacyChanged({ privacy: 0, source: 'editor-view-only-stripe' });
+  };
 
   return (
     <MessageStripe>
       <span>
         You are no longer in a <Text weight="bold">PRO account</Text>. This
         sandbox is in view mode only.{' '}
-        <LinkButton onClick={changeSandboxPrivacyToPublic}>
-          Make it public
-        </LinkButton>{' '}
-        or upgrade to <Text weight="bold">PRO</Text>.
+        <LinkButton onClick={changeToPublic}>Make it public</LinkButton> or
+        upgrade to <Text weight="bold">PRO</Text>.
       </span>
       {isTeamAdmin ? (
         <MessageStripe.Action

--- a/packages/app/src/app/overmind/namespaces/workspace/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/workspace/actions.ts
@@ -305,7 +305,7 @@ export const sandboxPrivacyChanged = async (
     privacy,
     source = 'generic',
   }: {
-    privacy: 0 | 1 | 2;
+    privacy: /* public */ 0 | /* unlisted */ 1 | /* private */ 2;
     source?: string;
   }
 ) => {
@@ -313,72 +313,69 @@ export const sandboxPrivacyChanged = async (
     return;
   }
 
-  track('Sandbox - Update Privacy', {
-    privacy,
-    source,
-  });
+  track('Sandbox - Update Privacy', { privacy, source });
 
+  // Save oldPrivacy in case we need to reset
   const oldPrivacy = state.editor.currentSandbox.privacy;
+  // Optimistically update privacy
   state.editor.currentSandbox.privacy = privacy;
 
-  try {
-    const sandbox = await effects.api.updatePrivacy(
-      state.editor.currentSandbox.id,
-      privacy
-    );
-    state.editor.currentSandbox.previewSecret = sandbox.previewSecret;
-    state.editor.currentSandbox.privacy = privacy;
-
-    if (
-      getTemplate(state.editor.currentSandbox.template).isServer &&
-      ((oldPrivacy !== 2 && privacy === 2) ||
-        (oldPrivacy === 2 && privacy !== 2))
-    ) {
-      // Privacy changed from private to unlisted/public or other way around, restart
-      // the sandbox to notify containers
-      actions.server.restartContainer();
-    }
-  } catch (error) {
-    state.editor.currentSandbox.privacy = oldPrivacy;
-    actions.internal.handleError({
-      message: "We weren't able to update the sandbox privacy",
-      error,
-    });
-  }
-};
-
-export const changeSandboxPrivacyToPublic = async ({
-  actions,
-  effects,
-  state,
-}: Context) => {
-  effects.analytics.track('Sandbox - Update Privacy to public', {
-    source: 'editor',
-  });
-
-  try {
-    const sandboxId = state.editor.currentSandbox.id;
-
-    await effects.gql.mutations.changePrivacy({
-      sandboxIds: [sandboxId],
-      privacy: 0,
-    });
-
-    // Change new privacy in state
-    state.editor.currentSandbox.privacy = 0;
-    // Update editing restriction
+  // The rest endpoint doesn't allow free users and teams to change their privacy
+  // at all, so we have to use the gql mutation to update the privacy from private
+  // or unlisted to public.
+  if (privacy === 0) {
+    // Optimistically update editing restriction
     state.editor.currentSandbox.freePlanEditingRestricted = false;
 
-    if (getTemplate(state.editor.currentSandbox.template).isServer) {
-      // Privacy changed from private to unlisted/public or other way around, restart
-      // the sandbox to notify containers
-      actions.server.restartContainer();
+    try {
+      await effects.gql.mutations.changePrivacy({
+        sandboxIds: [state.editor.currentSandbox.id],
+        privacy: 0,
+      });
+
+      const { isServer } = getTemplate(state.editor.currentSandbox.template);
+      const isChangeFromPrivate = oldPrivacy === 2;
+
+      if (isServer && isChangeFromPrivate) {
+        actions.server.restartContainer();
+      }
+    } catch (error) {
+      // Reset previous state
+      state.editor.currentSandbox.privacy = oldPrivacy;
+      state.editor.currentSandbox.freePlanEditingRestricted = true;
+
+      actions.internal.handleError({
+        message: "We weren't able to update the sandbox privacy",
+        error,
+      });
     }
-  } catch (error) {
-    actions.internal.handleError({
-      message: "We weren't able to update the sandbox privacy",
-      error,
-    });
+  } else {
+    try {
+      const sandbox = await effects.api.updatePrivacy(
+        state.editor.currentSandbox.id,
+        privacy
+      );
+
+      state.editor.currentSandbox.previewSecret = sandbox.previewSecret;
+
+      const { isServer } = getTemplate(state.editor.currentSandbox.template);
+      const isChangeToPrivate = oldPrivacy !== 2 && privacy === 2;
+      const isChangeFromPrivate = oldPrivacy === 2 && privacy !== 2;
+
+      if (isServer && (isChangeToPrivate || isChangeFromPrivate)) {
+        // Privacy changed from private to unlisted/public or other way around, restart
+        // the sandbox to notify containers
+        actions.server.restartContainer();
+      }
+    } catch (error) {
+      // Reset previous state
+      state.editor.currentSandbox.privacy = oldPrivacy;
+
+      actions.internal.handleError({
+        message: "We weren't able to update the sandbox privacy",
+        error,
+      });
+    }
   }
 };
 

--- a/packages/app/src/app/pages/Sandbox/Editor/Header/Actions.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Header/Actions.tsx
@@ -5,6 +5,7 @@ import { useAppState, useActions } from 'app/overmind';
 import { UserMenu } from 'app/pages/common/UserMenu';
 import React, { useEffect, useState } from 'react';
 import { Notifications } from 'app/components/Notifications';
+import { useWorkspaceSubscription } from 'app/hooks/useWorkspaceSubscription';
 import track from '@codesandbox/common/lib/utils/analytics';
 
 import {
@@ -29,6 +30,65 @@ const TooltipButton = ({ tooltip, ...props }) => {
   );
 };
 
+type ForkActionProps = {
+  isPrimaryAction: boolean;
+  handleFork: (teamId: string) => void;
+  handleSignIn: () => void;
+};
+
+const ForkAction = ({
+  isPrimaryAction,
+  handleFork,
+  handleSignIn,
+}: ForkActionProps) => {
+  const {
+    user,
+    editor: { isForkingSandbox, currentSandbox },
+  } = useAppState();
+  const { isPro } = useWorkspaceSubscription();
+
+  const { privacy, permissions } = currentSandbox;
+  const isUnlistedOrPrivate = privacy === 1 || privacy === 2;
+  const preventSandboxLeaving = permissions?.preventSandboxLeaving;
+
+  const variant = isPrimaryAction ? 'primary' : 'secondary';
+
+  if (user) {
+    // If not pro and the sandbox is unlisted or private
+    if (!isPro && isUnlistedOrPrivate) {
+      return (
+        <TooltipButton
+          tooltip="You do not have permission to fork this sandbox"
+          variant={variant}
+          disabled
+        >
+          <ForkIcon css={css({ height: 3, marginRight: 1 })} /> Fork
+        </TooltipButton>
+      );
+    }
+
+    return (
+      <ForkButton user={user} forkClicked={handleFork} variant={variant} />
+    );
+  }
+
+  return (
+    <TooltipButton
+      tooltip={
+        preventSandboxLeaving
+          ? 'You do not have permission to fork this sandbox'
+          : null
+      }
+      loading={isForkingSandbox}
+      variant={variant}
+      onClick={handleSignIn}
+      disabled={preventSandboxLeaving}
+    >
+      <ForkIcon css={css({ height: 3, marginRight: 1 })} /> Fork
+    </TooltipButton>
+  );
+};
+
 export const Actions = () => {
   const {
     signInClicked,
@@ -43,7 +103,7 @@ export const Actions = () => {
     user,
     activeWorkspaceAuthorization,
     live: { isLive },
-    editor: { isForkingSandbox, currentSandbox },
+    editor: { currentSandbox },
   } = useAppState();
   const {
     id,
@@ -53,7 +113,6 @@ export const Actions = () => {
     description,
     likeCount,
     userLiked,
-    permissions,
   } = currentSandbox;
   const [fadeIn, setFadeIn] = useState(false);
 
@@ -171,29 +230,13 @@ export const Actions = () => {
         </Button>
       )}
 
-      {user ? (
-        <ForkButton
-          user={user}
-          forkClicked={teamId => forkSandboxClicked({ teamId })}
-          variant={primaryAction === 'Fork' ? 'primary' : 'secondary'}
-        />
-      ) : (
-        <TooltipButton
-          tooltip={
-            permissions.preventSandboxLeaving
-              ? 'You do not have permission to fork this sandbox'
-              : null
-          }
-          loading={isForkingSandbox}
-          variant={primaryAction === 'Fork' ? 'primary' : 'secondary'}
-          onClick={() => {
-            signInClicked({ onCancel: () => forkSandboxClicked({}) });
-          }}
-          disabled={permissions.preventSandboxLeaving}
-        >
-          <ForkIcon css={css({ height: 3, marginRight: 1 })} /> Fork
-        </TooltipButton>
-      )}
+      <ForkAction
+        isPrimaryAction={primaryAction === 'Fork'}
+        handleFork={teamId => forkSandboxClicked({ teamId })}
+        handleSignIn={() => {
+          signInClicked({ onCancel: () => forkSandboxClicked({}) });
+        }}
+      />
 
       <Button
         variant="secondary"

--- a/packages/app/src/app/pages/Sandbox/Editor/Header/Actions.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Header/Actions.tsx
@@ -54,7 +54,6 @@ const ForkAction = ({
   const variant = isPrimaryAction ? 'primary' : 'secondary';
 
   if (user) {
-    // If not pro and the sandbox is unlisted or private
     if (!isPro && isUnlistedOrPrivate) {
       return (
         <TooltipButton

--- a/packages/app/src/app/pages/Sandbox/Editor/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/index.tsx
@@ -120,7 +120,7 @@ export const Editor = ({ showNewSandboxModal }: EditorTypes) => {
     if (
       state.activeTeamInfo?.subscription?.status ===
         SubscriptionStatus.Unpaid ||
-      state.editor?.currentSandbox?.freePlanEditingRestricted
+      sandbox?.freePlanEditingRestricted
     ) {
       // Header height + MessageStripe
       return 3 * 16 + 42;
@@ -151,9 +151,7 @@ export const Editor = ({ showNewSandboxModal }: EditorTypes) => {
             {state.activeTeamInfo?.subscription?.status ===
               SubscriptionStatus.Unpaid && <PaymentPending />}
 
-            {state.editor?.currentSandbox?.freePlanEditingRestricted ? (
-              <FreeViewOnlyStripe />
-            ) : null}
+            {sandbox?.freePlanEditingRestricted ? <FreeViewOnlyStripe /> : null}
             <Header />
           </ComponentsThemeProvider>
         )}

--- a/packages/common/src/components/Preview/index.tsx
+++ b/packages/common/src/components/Preview/index.tsx
@@ -25,6 +25,10 @@ const DefaultWrapper = ({ children }) => children;
 export type Props = {
   sandbox: Sandbox;
   privacy?: number;
+  /**
+   * We only use preview secrets for private sandboxes (I think it is to identify the user in the
+   * preview, because that lives on csb.app and therefore doesn’t have the regular user cookie).
+   */
   previewSecret?: string;
   settings: Settings;
   customNpmRegistries: NpmRegistry[];


### PR DESCRIPTION
### Changes

- [x] Enabled switching private and unlisted to public from the dashboard (context menu) as a free user.
- [x] Disabled the fork button in the v1 editor based on pro status and sandbox privacy.
- [x] Added action to change sandbox privacy to free in editor message stripe

### Testing

Creating private sandboxes for free teams is pretty easy when you have another pro team. On the pro team create a draft and make it private. In the dashboard, fork the draft a couple of times if you want to have multiple private sandboxes available. Then, move the sandbox to a folder via the context menu and make sure to select a free team. The sandbox is now moved to a free team, with restrictions in place.

<details>
<summary>As a PRO user forking a private or unlisted sandbox works</summary>

##### From the dashboard:

1. Open the dashboard on the sandboxes page for a PRO user
2. Right click a private sandbox
3. Confirm the option to make the sandbox public exists
4. Confirm the option to fork the sandbox exists
5. Fork the sandbox

##### From the editor:

1. Open the dashboard on the sandboxes page for a PRO user
2. Open a private sandbox
3. Click fork button to fork the sandbox

The logic should be the same for unlisted sandboxes, but you can repeat the steps listed above to confirm if forking unlisted sandboxes still works.

</details>

<details>
<summary>As a FREE user forking a private sandbox is disabled</summary>

##### From the dashboard:

1. Open the dashboard on the sandboxes page for a FREE user
2. Right click a private sandbox
3. Confirm the option to fork the sandbox is disabled

##### From the editor:

1. Open the dashboard on the sandboxes page for a FREE user
2. Open a private sandbox
3. Confirm that the fork button is disabled

The logic should be the same for unlisted sandboxes, but you can repeat the steps listed above to confirm if forking unlisted sandboxes still works.

</details>

<details>
<summary>As a PRO or FREE user forking a public sandbox works</summary>

##### From the dashboard:

1. Open the dashboard on the sandboxes page for a PRO user
2. Right click a public sandbox
3. Confirm the options to make the sandbox private or unlisted exist
5. Confirm the option to fork the sandbox exists
6. Fork the sandbox

##### From the editor:

1. Open the dashboard on the sandboxes page for a PRO user
2. Open a public sandbox
3. Click fork button to fork the sandbox

The logic should be the same for PRO and FREE users, but you can repeat the steps listed above to confirm if it's working for both FREE and PRO users.

</details>

<details>
<summary>As a PRO or FREE user you can make a private sandbox public</summary>

##### From the dashboard (as pro and free):

1. Open the dashboard on the sandboxes page for a FREE user
2. Right click a private sandbox
3. Confirm the option to make the sandbox public exist
4. Make the sandbox public

##### From the editor (as free):

1. Open the dashboard on the sandboxes page for a FREE user
2. Open a private sandbox
3. Confirm that a message stripe is visible with an action to make the sandbox public
4. Click the button to make the sandbox public

</details>
