### PR TITLE
feat(invite): conditional authorization

### DIFF
--- a/packages/app/src/app/pages/Dashboard/Components/NewTeamModal/TeamMembers.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/NewTeamModal/TeamMembers.tsx
@@ -36,7 +36,7 @@ export const TeamMembers: React.FC<{
   hideSkip?: boolean;
   onComplete: () => void;
 }> = ({ hideSkip, onComplete }) => {
-  const { activeTeamInfo } = useAppState();
+  const { activeTeamInfo, activeWorkspaceAuthorization } = useAppState();
   const actions = useActions();
   const { gql } = useEffects();
   const { copyToClipboard } = useEffects().browser;
@@ -114,7 +114,10 @@ export const TeamMembers: React.FC<{
         await gql.mutations.inviteToTeamViaEmail({
           teamId: activeTeamInfo.id,
           email: addressesString,
-          authorization: TeamMemberAuthorization.Write,
+          authorization:
+            activeWorkspaceAuthorization === TeamMemberAuthorization.Admin
+              ? TeamMemberAuthorization.Write
+              : TeamMemberAuthorization.Read,
         });
         setInviteLoading(false);
 


### PR DESCRIPTION
Instead of removing the call to action, I updated the internals of the invitation to make the role of invitees based on the current user's role.

- If the user is an admin, the role of invitees is "write".
- If the user's role is other than admin, the role of invitees is "read".