### PR TITLE
fix: remove unaccessed branches/repos from sorting

### DIFF
--- a/packages/app/src/app/overmind/namespaces/dashboard/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/dashboard/actions.ts
@@ -1990,9 +1990,15 @@ export const getRepositoriesByTeam = async (
       return;
     }
 
+    const accessedRepositories = repositories.filter(r => r.lastAccessedAt);
+    const unaccessedRepositories = repositories.filter(r => !r.lastAccessedAt);
+
     dashboard.repositoriesByTeamId = {
       ...dashboard.repositoriesByTeamId,
-      [teamId]: repositories.sort(sortByLastAccessed),
+      [teamId]: [
+        ...accessedRepositories.sort(sortByLastAccessed),
+        ...unaccessedRepositories,
+      ],
     };
 
     // If fetchCachedDataFirst was true, the initial call was made (faster), so we can

--- a/packages/app/src/app/pages/Dashboard/Content/routes/RepositoryBranches/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/RepositoryBranches/index.tsx
@@ -51,8 +51,16 @@ export const RepositoryBranchesPage = () => {
       return [{ type: 'skeleton-row' }, { type: 'skeleton-row' }];
     }
 
-    const branches = [...repositoryProject.branches];
-    const orderedBranches = branches.sort(sortByLastAccessed);
+    const accessedBranches = repositoryProject.branches.filter(
+      b => b.lastAccessedAt
+    );
+    const unaccessedBranches = repositoryProject.branches.filter(
+      b => !b.lastAccessedAt
+    );
+    const orderedBranches = [
+      ...accessedBranches.sort(sortByLastAccessed),
+      ...unaccessedBranches,
+    ];
 
     const branchItems: DashboardGridItem[] = orderedBranches.map(branch => ({
       type: 'branch',


### PR DESCRIPTION
Some branches/repositories come without a `lastAccessedAt` timestamp, which was breaking the sort algorithm and triggered different results in chrome and firefox.