### PR TITLE
fix: duplicate message when trial is close to expire

### DIFF
--- a/packages/app/src/app/pages/Dashboard/Sidebar/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Sidebar/index.tsx
@@ -308,6 +308,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
         {teamDataLoaded && showBottomMessage && (
           <Element css={{ margin: '24px', paddingTop: 0 }}>
             {isTeamAdmin &&
+              isFree &&
               (isEligibleForTrial ? (
                 <AdminStartTrial activeTeam={activeTeam} />
               ) : (


### PR DESCRIPTION
Before

<img width="258" alt="Screenshot 2022-12-29 at 12 04 41" src="https://user-images.githubusercontent.com/9945366/209936240-ca4ed260-3de2-4bb4-ad6d-ef419fcd38e7.png">

After

<img width="259" alt="Screenshot 2022-12-29 at 12 04 57" src="https://user-images.githubusercontent.com/9945366/209936250-249c95aa-c61f-48cf-9413-277673aa70c5.png">


