### PR TITLE
feat: add trucate prop for Text component

### DIFF
--- a/packages/components/src/components/Text/index.tsx
+++ b/packages/components/src/components/Text/index.tsx
@@ -27,6 +27,7 @@ export interface ITextProps extends React.HTMLAttributes<HTMLSpanElement> {
   weight?: string;
   fontStyle?: string;
   block?: boolean;
+  truncate?: boolean;
   maxWidth?: number | string;
   variant?: 'body' | 'muted' | 'danger' | 'active';
   dateTime?: string;
@@ -44,6 +45,7 @@ export const Text = styled(Element).attrs(p => ({
     align,
     weight,
     block,
+    truncate,
     variant = 'body',
     maxWidth,
     lineHeight,
@@ -62,5 +64,6 @@ export const Text = styled(Element).attrs(p => ({
       maxWidth,
       fontFamily: fontFamilies[fontFamily],
       ...(maxWidth ? overflowStyles : {}),
+      ...(truncate ? overflowStyles : {}),
     })
 );

--- a/packages/components/src/components/Text/text.stories.tsx
+++ b/packages/components/src/components/Text/text.stories.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { Text } from '.';
+import { Icon } from '../Icon';
+import { Stack } from '../Stack';
 
 export default {
   title: 'components/Text',
@@ -70,4 +72,11 @@ export const Align = () => (
 
 export const MaxWidth = () => (
   <Text maxWidth={200}>this text will get cropped beyond 200px</Text>
+);
+
+export const Truncate = () => (
+  <Stack css={{ width: 200 }}>
+    <Icon name="branch" />
+    <Text truncate>This text will get cropped somewhere, over the rainbow</Text>
+  </Stack>
 );


### PR DESCRIPTION
`truncate` adds the overflow styles to avoid duplicating them in the new cards that are being redesigned