### PR TITLE
chore: use Text truncate for existing cards

### DIFF
--- a/packages/app/src/app/pages/Dashboard/Components/Branch/BranchCard.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Branch/BranchCard.tsx
@@ -35,15 +35,7 @@ export const BranchCard: React.FC<BranchProps> = ({
           <Stack justify="space-between">
             <Stack direction="vertical" gap={1} css={{ overflow: 'hidden' }}>
               {showRepo && (
-                <Text
-                  css={{
-                    color: '#808080',
-                    whiteSpace: 'nowrap',
-                    overflow: 'hidden',
-                    textOverflow: 'ellipsis',
-                  }}
-                  size={12}
-                >
+                <Text color="#999" size={12} truncate>
                   {repository.owner}/{repository.name}
                 </Text>
               )}
@@ -54,26 +46,22 @@ export const BranchCard: React.FC<BranchProps> = ({
                 ) : (
                   <Icon color="#999999" name="branch" size={16} />
                 )}
-                <InteractiveOverlay.Item>
+                <InteractiveOverlay.Anchor
+                  href={isBeingRemoved ? undefined : branchUrl}
+                  aria-label={ariaLabel}
+                  onContextMenu={onContextMenu}
+                  css={{ overflow: 'hidden' }}
+                  {...props}
+                >
                   <Text
-                    as="a"
-                    aria-label={ariaLabel}
-                    href={isBeingRemoved ? undefined : branchUrl}
-                    css={{
-                      color: restricted ? '#999999' : '#E5E5E5',
-                      whiteSpace: 'nowrap',
-                      overflow: 'hidden',
-                      textOverflow: 'ellipsis',
-                      textDecoration: 'none',
-                    }}
+                    color={restricted ? '#999999' : '#E5E5E5'}
                     weight="medium"
                     size={13}
-                    onContextMenu={onContextMenu}
-                    {...props}
+                    truncate
                   >
                     {branchName}
                   </Text>
-                </InteractiveOverlay.Item>
+                </InteractiveOverlay.Anchor>
               </Stack>
             </Stack>
             <Stack css={{ height: '16px' }} align="center">

--- a/packages/app/src/app/pages/Dashboard/Components/SyncedSandbox/SyncedSandboxCard.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/SyncedSandbox/SyncedSandboxCard.tsx
@@ -19,15 +19,7 @@ export const SyncedSandboxCard = ({ name, path, url, ...props }) => {
           css={{ height: '100%' }}
         >
           <Stack direction="vertical" gap={1}>
-            <Text
-              css={{
-                color: '#808080',
-                whiteSpace: 'nowrap',
-                overflow: 'hidden',
-                textOverflow: 'ellipsis',
-              }}
-              size={12}
-            >
+            <Text color="#999" size={12} truncate>
               {props.owner}
             </Text>
             <Stack gap={2}>
@@ -36,19 +28,12 @@ export const SyncedSandboxCard = ({ name, path, url, ...props }) => {
                 <Link
                   to={url}
                   css={{
+                    display: 'flex',
+                    overflow: 'hidden',
                     textDecoration: 'none',
                   }}
                 >
-                  <Text
-                    weight="medium"
-                    size={13}
-                    css={{
-                      color: '#E5E5E5',
-                      whiteSpace: 'nowrap',
-                      overflow: 'hidden',
-                      textOverflow: 'ellipsis',
-                    }}
-                  >
+                  <Text weight="medium" size={13} truncate color="#E5E5E5">
                     {name}
                   </Text>
                 </Link>


### PR DESCRIPTION
Adding truncate on existing card implementations. Still need to rely on some overflows placed around certain elements, which I don't particularly dig, but I also don't see another solution in a fluid card sizing