### PR TITLE
feat(dashboard/recent): hide upgrade banner on first visit

### DIFF
--- a/packages/app/src/app/hooks/useDashboardVisit.ts
+++ b/packages/app/src/app/hooks/useDashboardVisit.ts
@@ -11,14 +11,14 @@ type ReturnType = {
 export const useDashboardVisit = (): ReturnType => {
   const { browser } = useEffects();
   const [hasVisited, setHasVisited] = React.useState(() => {
-    const visitCount = browser.storage.get<VisitTracker>(KEY);
+    const visitCount = browser.storage.get<VisitTracker>(KEY) ?? 0;
     return visitCount > 1;
   });
 
   const trackVisit = () => {
-    const visitCount = browser.storage.get<VisitTracker>(KEY) || undefined;
+    const visitCount = browser.storage.get<VisitTracker>(KEY) ?? 0;
 
-    const updatedCount = (visitCount || 0) + 1;
+    const updatedCount = visitCount + 1;
     browser.storage.set(KEY, updatedCount);
     setHasVisited(updatedCount > 1);
   };

--- a/packages/app/src/app/hooks/useDashboardVisit.ts
+++ b/packages/app/src/app/hooks/useDashboardVisit.ts
@@ -2,7 +2,7 @@ import React from 'react';
 import { useEffects } from 'app/overmind';
 
 const KEY = 'DASHBOARD_VISIT';
-type VisitTracker = Record<string | number> | undefined;
+type VisitTracker = number | undefined;
 
 export const useDashboardVisit = (
   currentTeam: string
@@ -14,7 +14,7 @@ export const useDashboardVisit = (
   });
 
   const trackVisit = () => {
-    const visitCount = browser.storage.get<VisitCount>(KEY) || undefined;
+    const visitCount = browser.storage.get<VisitTracker>(KEY) || undefined;
 
     const updatedCount = (visitCount || 0) + 1;
     browser.storage.set(KEY, updatedCount);

--- a/packages/app/src/app/hooks/useDashboardVisit.ts
+++ b/packages/app/src/app/hooks/useDashboardVisit.ts
@@ -4,9 +4,7 @@ import { useEffects } from 'app/overmind';
 const KEY = 'DASHBOARD_VISIT';
 type VisitTracker = number | undefined;
 
-export const useDashboardVisit = (
-  currentTeam: string
-): [boolean, () => void] => {
+export const useDashboardVisit = (): [boolean, () => void] => {
   const { browser } = useEffects();
   const [hasVisited, setHasVisited] = React.useState(() => {
     const visitCount = browser.storage.get<VisitTracker>(KEY);

--- a/packages/app/src/app/hooks/useDashboardVisit.ts
+++ b/packages/app/src/app/hooks/useDashboardVisit.ts
@@ -3,8 +3,12 @@ import { useEffects } from 'app/overmind';
 
 const KEY = 'DASHBOARD_VISIT';
 type VisitTracker = number | undefined;
+type ReturnType = {
+  hasVisited: boolean;
+  trackVisit: () => void;
+};
 
-export const useDashboardVisit = (): [boolean, () => void] => {
+export const useDashboardVisit = (): ReturnType => {
   const { browser } = useEffects();
   const [hasVisited, setHasVisited] = React.useState(() => {
     const visitCount = browser.storage.get<VisitTracker>(KEY);
@@ -19,5 +23,5 @@ export const useDashboardVisit = (): [boolean, () => void] => {
     setHasVisited(updatedCount > 1);
   };
 
-  return [hasVisited, trackVisit];
+  return { hasVisited, trackVisit };
 };

--- a/packages/app/src/app/hooks/useDashboardVisit.ts
+++ b/packages/app/src/app/hooks/useDashboardVisit.ts
@@ -1,0 +1,25 @@
+import React from 'react';
+import { useEffects } from 'app/overmind';
+
+const KEY = 'DASHBOARD_VISIT';
+type VisitTracker = Record<string | number> | undefined;
+
+export const useDashboardVisit = (
+  currentTeam: string
+): [boolean, () => void] => {
+  const { browser } = useEffects();
+  const [hasVisited, setHasVisited] = React.useState(() => {
+    const visitCount = browser.storage.get<VisitTracker>(KEY);
+    return visitCount > 1;
+  });
+
+  const trackVisit = () => {
+    const visitCount = browser.storage.get<VisitCount>(KEY) || undefined;
+
+    const updatedCount = (visitCount || 0) + 1;
+    browser.storage.set(KEY, updatedCount);
+    setHasVisited(updatedCount > 1);
+  };
+
+  return [hasVisited, trackVisit];
+};

--- a/packages/app/src/app/pages/Dashboard/Components/UpgradeBanner/UpgradeBanner.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/UpgradeBanner/UpgradeBanner.tsx
@@ -18,6 +18,7 @@ import track from '@codesandbox/common/lib/utils/analytics';
 import { SUBSCRIPTION_DOCS_URLS } from 'app/constants';
 import { useWorkspaceAuthorization } from 'app/hooks/useWorkspaceAuthorization';
 import { useWorkspaceSubscription } from 'app/hooks/useWorkspaceSubscription';
+import { useDashboardVisit } from 'app/hooks/useDashboardVisit';
 
 const StyledTitle = styled(Text)`
   font-size: 24px;
@@ -71,8 +72,9 @@ export const UpgradeBanner: React.FC<UpgradeBannerProps> = ({ teamId }) => {
   );
   const { isTeamAdmin } = useWorkspaceAuthorization();
   const { isEligibleForTrial } = useWorkspaceSubscription();
+  const [hasVisited] = useDashboardVisit();
 
-  if (isBannerDismissed) {
+  if (isBannerDismissed || !hasVisited) {
     return null;
   }
 

--- a/packages/app/src/app/pages/Dashboard/Components/UpgradeBanner/UpgradeBanner.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/UpgradeBanner/UpgradeBanner.tsx
@@ -72,7 +72,7 @@ export const UpgradeBanner: React.FC<UpgradeBannerProps> = ({ teamId }) => {
   );
   const { isTeamAdmin } = useWorkspaceAuthorization();
   const { isEligibleForTrial } = useWorkspaceSubscription();
-  const [hasVisited] = useDashboardVisit();
+  const { hasVisited } = useDashboardVisit();
 
   if (isBannerDismissed || !hasVisited) {
     return null;

--- a/packages/app/src/app/pages/Dashboard/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/index.tsx
@@ -35,7 +35,7 @@ export const Dashboard: FunctionComponent = () => {
   const { browser, notificationToast } = useEffects();
   const actions = useActions();
   const { subscription } = useWorkspaceSubscription();
-  const [, trackVisit] = useDashboardVisit();
+  const { trackVisit } = useDashboardVisit();
 
   // only used for mobile
   const [sidebarVisible, setSidebarVisibility] = React.useState(false);

--- a/packages/app/src/app/pages/Dashboard/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/index.tsx
@@ -17,6 +17,7 @@ import css from '@styled-system/css';
 
 import { PaymentPending } from 'app/components/StripeMessages';
 import { useWorkspaceSubscription } from 'app/hooks/useWorkspaceSubscription';
+import { useDashboardVisit } from 'app/hooks/useDashboardVisit';
 import { SubscriptionStatus } from 'app/graphql/types';
 import { Header } from './Header';
 import { Sidebar } from './Sidebar';
@@ -34,6 +35,7 @@ export const Dashboard: FunctionComponent = () => {
   const { browser, notificationToast } = useEffects();
   const actions = useActions();
   const { subscription } = useWorkspaceSubscription();
+  const [, trackVisit] = useDashboardVisit();
 
   // only used for mobile
   const [sidebarVisible, setSidebarVisibility] = React.useState(false);
@@ -92,6 +94,10 @@ export const Dashboard: FunctionComponent = () => {
       });
     }
   }, [location.search, actions, activeTeamInfo, notificationToast]);
+
+  useEffect(() => {
+    trackVisit();
+  }, []);
 
   if (!hasLogIn) {
     return <Redirect to={signInPageUrl(location.pathname)} />;


### PR DESCRIPTION
Closes XTD-517.

Instead of using cookies, I decided to use the local storage following @tristandubbeld's suggestion here: https://github.com/codesandbox/codesandbox-client/pull/7243#discussion_r1050630876.

https://www.loom.com/share/e4b6610b135b4b7ba569568b6791fec2