### PR TITLE
fix(typecheck): Remove emitDeclarationOnly flag

### DIFF
--- a/packages/template-icons/tsconfig.json
+++ b/packages/template-icons/tsconfig.json
@@ -7,7 +7,6 @@
     "lib": ["es6", "dom", "es2017.object", "es2017.sharedmemory"],
     "outDir": "lib",
     "declaration": true,
-    "emitDeclarationOnly": true,
     "allowJs": false,
     "jsx": "preserve",
     "resolveJsonModule": true,


### PR DESCRIPTION
Removes `emitDeclarationOnly` flag as it conflicts with `--noEmit` when running `tsc`.