### PR TITLE
feat(dashboard): replace api call w/ gql mutation to delete branches

### DIFF
--- a/packages/app/src/app/graphql/types.ts
+++ b/packages/app/src/app/graphql/types.ts
@@ -3126,6 +3126,15 @@ export type UpdateAlbumMutation = { __typename?: 'RootMutationType' } & {
   updateAlbum: { __typename?: 'Album' } & Pick<Album, 'id'>;
 };
 
+export type DeleteBranchMutationVariables = Exact<{
+  branchId: Scalars['String'];
+}>;
+
+export type DeleteBranchMutation = { __typename?: 'RootMutationType' } & Pick<
+  RootMutationType,
+  'deleteBranch'
+>;
+
 export type RecentlyDeletedPersonalSandboxesQueryVariables = Exact<{
   [key: string]: never;
 }>;

--- a/packages/app/src/app/overmind/effects/api/index.ts
+++ b/packages/app/src/app/overmind/effects/api/index.ts
@@ -680,9 +680,6 @@ export default {
       `/teams/${teamId}/customer_portal?return_path=${return_path}`
     );
   },
-  removeBranchFromRepository(owner: string, repo: string, branch: string) {
-    return api.delete(`/beta/sandboxes/github/${owner}/${repo}/${branch}`);
-  },
   removeRepositoryFromTeam(owner: string, repo: string, teamId: string) {
     return api.delete(`/beta/repos/link/github/${owner}/${repo}/${teamId}`);
   },

--- a/packages/app/src/app/overmind/effects/gql/dashboard/mutations.ts
+++ b/packages/app/src/app/overmind/effects/gql/dashboard/mutations.ts
@@ -81,6 +81,8 @@ import {
   UpdateAlbumMutationVariables,
   CreateAlbumMutation,
   CreateAlbumMutationVariables,
+  DeleteBranchMutation,
+  DeleteBranchMutationVariables,
 } from 'app/graphql/types';
 import { gql, Query } from 'overmind-graphql';
 
@@ -677,5 +679,14 @@ export const updateAlbum: Query<
     updateAlbum(id: $id, title: $title) {
       id
     }
+  }
+`;
+
+export const deleteBranch: Query<
+  DeleteBranchMutation,
+  DeleteBranchMutationVariables
+> = gql`
+  mutation deleteBranch($branchId: String!) {
+    deleteBranch(id: $branchId)
   }
 `;

--- a/packages/app/src/app/overmind/namespaces/dashboard/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/dashboard/actions.ts
@@ -2126,7 +2126,7 @@ export const removeBranchFromRepository = async (
   dashboard.removingBranch = { id };
 
   try {
-    await effects.api.removeBranchFromRepository(owner, repoName, name);
+    await effects.gql.mutations.deleteBranch({ branchId: id });
 
     // Clean the branch references from all possible locations in the state
     // 1. Repository with branches


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

Closes XTD-529.

## What kind of change does this PR introduce?

<!-- Is it a Bug fix, feature, docs update, ... -->

Replaces the previous API call that would remove a branch from a repo with a gql mutation that deletes a branch given the id. With this new method, we can delete contribution branches even if the parent repo has been deleted.

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Launch the dashboard
2. Click on "remove branch from CodeSandbox" in any branch card
3. Branch should be removed as expected

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
