### PR TITLE
feat(cloud sandboxes): Banner for upgrading to V2

### DIFF
--- a/packages/app/src/app/components/StripeMessages/UpgradeSSEToV2.tsx
+++ b/packages/app/src/app/components/StripeMessages/UpgradeSSEToV2.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useEffects, useAppState } from 'app/overmind';
 import { MessageStripe } from '@codesandbox/components';
 import { sandboxUrl } from '@codesandbox/common/lib/utils/url-generator';
@@ -7,24 +7,26 @@ import { hasPermission } from '@codesandbox/common/lib/utils/permission';
 export const UpgradeSSEToV2Stripe = () => {
   const state = useAppState();
   const effects = useEffects();
+  const [isLoading, setIsLoading] = useState(false);
   const updateSandbox = useEffects().api.updateSandbox;
+  const canConvert = hasPermission(
+    state.editor.currentSandbox?.authorization,
+    'write_code'
+  );
 
   return (
     <MessageStripe variant="primary">
       <span>
-        This sandbox runs much faster in our new Editor. Do you want to convert
-        it to a Cloud Sandbox?
+        This sandbox runs much faster in our new editor. Do you want to{' '}
+        {canConvert ? 'convert' : 'fork'} it to a Cloud Sandbox?
       </span>
       <MessageStripe.Action
+        loading={isLoading}
         onClick={async () => {
+          setIsLoading(true);
           const sandboxId = state.editor.currentSandbox.id;
 
-          if (
-            hasPermission(
-              state.editor.currentSandbox.authorization,
-              'write_code'
-            )
-          ) {
+          if (canConvert) {
             const alias = state.editor.currentSandbox.alias;
 
             await updateSandbox(sandboxId, {

--- a/packages/app/src/app/components/StripeMessages/UpgradeSSEToV2.tsx
+++ b/packages/app/src/app/components/StripeMessages/UpgradeSSEToV2.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { useEffects, useAppState } from 'app/overmind';
+import { MessageStripe } from '@codesandbox/components';
+import { sandboxUrl } from '@codesandbox/common/lib/utils/url-generator';
+
+export const UpgradeSSEToV2Stripe = () => {
+  const state = useAppState();
+  const updateSandbox = useEffects().api.updateSandbox;
+
+  return (
+    <MessageStripe variant="primary">
+      <span>
+        This sandbox runs much faster in our new Editor. Do you want to convert
+        it to a Cloud Sandbox?
+      </span>
+      <MessageStripe.Action
+        onClick={async () => {
+          const sandboxId = state.editor.currentSandbox.id;
+          const alias = state.editor.currentSandbox.alias;
+
+          await updateSandbox(sandboxId, {
+            v2: true,
+          });
+
+          const sandboxV2Url = sandboxUrl({
+            id: sandboxId,
+            alias,
+            isV2: true,
+          });
+
+          window.location.href = sandboxV2Url;
+        }}
+      >
+        Yes, Convert
+      </MessageStripe.Action>
+    </MessageStripe>
+  );
+};

--- a/packages/app/src/app/pages/Sandbox/Editor/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/index.tsx
@@ -122,7 +122,7 @@ export const Editor = ({ showNewSandboxModal }: EditorTypes) => {
       state.activeTeamInfo?.subscription?.status ===
         SubscriptionStatus.Unpaid ||
       sandbox?.freePlanEditingRestricted ||
-      sandbox?.isSse
+      (state.hasLogIn && sandbox?.isSse)
     ) {
       // Header height + MessageStripe
       return 3 * 16 + 42;
@@ -154,7 +154,7 @@ export const Editor = ({ showNewSandboxModal }: EditorTypes) => {
               SubscriptionStatus.Unpaid && <PaymentPending />}
 
             {sandbox?.freePlanEditingRestricted ? <FreeViewOnlyStripe /> : null}
-            {sandbox?.isSse ? <UpgradeSSEToV2Stripe /> : null}
+            {state.hasLogIn && sandbox?.isSse ? <UpgradeSSEToV2Stripe /> : null}
             <Header />
           </ComponentsThemeProvider>
         )}

--- a/packages/app/src/app/pages/Sandbox/Editor/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/index.tsx
@@ -21,6 +21,7 @@ import SplitPane from 'react-split-pane';
 import styled, { ThemeProvider } from 'styled-components';
 
 import { SubscriptionStatus } from 'app/graphql/types';
+import { UpgradeSSEToV2Stripe } from 'app/components/StripeMessages/UpgradeSSEToV2';
 import { MainWorkspace as Content } from './Content';
 import { Container } from './elements';
 import ForkFrozenSandboxModal from './ForkFrozenSandboxModal';
@@ -120,7 +121,8 @@ export const Editor = ({ showNewSandboxModal }: EditorTypes) => {
     if (
       state.activeTeamInfo?.subscription?.status ===
         SubscriptionStatus.Unpaid ||
-      sandbox?.freePlanEditingRestricted
+      sandbox?.freePlanEditingRestricted ||
+      sandbox?.isSse
     ) {
       // Header height + MessageStripe
       return 3 * 16 + 42;
@@ -152,6 +154,7 @@ export const Editor = ({ showNewSandboxModal }: EditorTypes) => {
               SubscriptionStatus.Unpaid && <PaymentPending />}
 
             {sandbox?.freePlanEditingRestricted ? <FreeViewOnlyStripe /> : null}
+            {sandbox?.isSse ? <UpgradeSSEToV2Stripe /> : null}
             <Header />
           </ComponentsThemeProvider>
         )}

--- a/packages/components/src/components/MessageStripe/MessageStripe.tsx
+++ b/packages/components/src/components/MessageStripe/MessageStripe.tsx
@@ -6,7 +6,7 @@ import { Button } from '../Button';
 import { Text } from '../Text';
 import { IconButton } from '../IconButton';
 
-type Variant = 'trial' | 'warning';
+type Variant = 'trial' | 'warning' | 'primary';
 
 interface MessageActionProps
   extends Omit<React.ComponentProps<typeof Button>, 'variant'> {
@@ -22,7 +22,11 @@ export const MessageAction = ({
   return (
     <Element as="div" css={{ flexShrink: 0 }}>
       <Button
-        variant={({ trial: 'light', warning: 'dark' } as const)[variant]}
+        variant={
+          ({ trial: 'light', warning: 'dark', primary: 'dark' } as const)[
+            variant
+          ]
+        }
         {...buttonProps}
       >
         {children}
@@ -34,11 +38,13 @@ export const MessageAction = ({
 const backgroundVariants: Record<Variant, string> = {
   trial: '#644ED7',
   warning: '#F7CC66',
+  primary: 'button.background',
 };
 
 const colorVariants: Record<Variant, string> = {
   trial: 'inherit',
   warning: '#0E0E0E',
+  primary: 'button.foreground',
 };
 
 interface MessageStripeProps {

--- a/yarn.lock
+++ b/yarn.lock
@@ -32131,6 +32131,11 @@ tempfile@^2.0.0:
     temp-dir "^1.0.0"
     uuid "^3.0.1"
 
+template-icons@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/template-icons/-/template-icons-1.0.0.tgz#f6bd6d8e98c5057665d3f447e702924f0b1f8dfb"
+  integrity sha512-Uk5YycqkrB5nBqDrODBQt8tbpmEV6vNVXgDOlLiRYgL8FGyl1PLkV8mS9D+PB85cIHa5ZAOcI/iQfZcd1hvX9w==
+
 term-size@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/term-size/-/term-size-1.2.0.tgz#458b83887f288fc56d6fffbfad262e26638efa69"


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR adds a new banner at the top of SSE sandboxes giving the opportunity for users to upgrade their sandbox into a V2 cloud sandbox. If they do not have "write_code" permissions, it will instead fork it into a V2 cloud sandbox.

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Testing <!-- We can only merge the PR if this is checked -->
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
