### PR TITLE
feat(dashboard): update team members invitation modal

### DIFF
--- a/packages/app/src/app/components/dashboard/Textarea.tsx
+++ b/packages/app/src/app/components/dashboard/Textarea.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { Stack } from '@codesandbox/components';
 import { Label } from './Label';
 
-const StyledTextarea = styled.textarea`
+const StyledTextarea = styled.textarea<{ resize: boolean }>`
   padding: 12px 16px;
   background-color: #2a2a2a;
   font-family: 'Inter', sans-serif;
@@ -12,6 +12,7 @@ const StyledTextarea = styled.textarea`
   line-height: 24px;
   border: none;
   border-radius: 2px;
+  resize: ${props => (props.resize ? 'initial' : 'none')}
 
   &:hover {
     box-shadow: 0 0 0 2px #e5e5e51a;
@@ -26,11 +27,18 @@ interface TextareaProps extends TextareaHTMLAttributes<HTMLTextAreaElement> {
   id: string;
   label: string;
   name: string;
+  resize?: boolean;
 }
 
-export const Textarea = ({ id, label, name, ...restProps }: TextareaProps) => (
+export const Textarea = ({
+  id,
+  label,
+  name,
+  resize = true,
+  ...restProps
+}: TextareaProps) => (
   <Stack gap={2} direction="vertical">
     <Label htmlFor={id}>{label}</Label>
-    <StyledTextarea id={id} name={name} {...restProps} />
+    <StyledTextarea id={id} name={name} resize={resize} {...restProps} />
   </Stack>
 );

--- a/packages/app/src/app/components/dashboard/Textarea.tsx
+++ b/packages/app/src/app/components/dashboard/Textarea.tsx
@@ -12,7 +12,7 @@ const StyledTextarea = styled.textarea<{ resize: boolean }>`
   line-height: 24px;
   border: none;
   border-radius: 2px;
-  resize: ${props => (props.resize ? 'initial' : 'none')}
+  resize: ${props => (props.resize ? 'initial' : 'none')};
 
   &:hover {
     box-shadow: 0 0 0 2px #e5e5e51a;
@@ -36,9 +36,11 @@ export const Textarea = ({
   name,
   resize = true,
   ...restProps
-}: TextareaProps) => (
-  <Stack gap={2} direction="vertical">
-    <Label htmlFor={id}>{label}</Label>
-    <StyledTextarea id={id} name={name} resize={resize} {...restProps} />
-  </Stack>
-);
+}: TextareaProps) => {
+  return (
+    <Stack gap={2} direction="vertical">
+      <Label htmlFor={id}>{label}</Label>
+      <StyledTextarea id={id} name={name} resize={resize} {...restProps} />
+    </Stack>
+  );
+};

--- a/packages/app/src/app/hooks/useWorkspaceAuthorization.ts
+++ b/packages/app/src/app/hooks/useWorkspaceAuthorization.ts
@@ -28,11 +28,16 @@ export const useWorkspaceAuthorization = () => {
     isTeamSpace &&
     activeWorkspaceAuthorization === TeamMemberAuthorization.Write;
 
+  const isTeamViewer =
+    isTeamSpace &&
+    activeWorkspaceAuthorization === TeamMemberAuthorization.Read;
+
   return {
     isPersonalSpace,
     isTeamSpace,
     isTeamAdmin,
     isTeamEditor,
+    isTeamViewer,
     userRole: activeWorkspaceAuthorization,
   };
 };

--- a/packages/app/src/app/pages/Dashboard/Components/NewTeamModal/TeamMembers.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/NewTeamModal/TeamMembers.tsx
@@ -178,6 +178,7 @@ export const TeamMembers: React.FC<{
         >
           <Stack gap={4} direction="vertical">
             <Textarea
+              aria-describedby="invitees-role"
               id="member"
               label="Invite team members (Insert emails separated by a comma)"
               name="members"
@@ -214,6 +215,7 @@ export const TeamMembers: React.FC<{
             css={{
               margin: 0,
             }}
+            id="invitees-role"
             align="center"
             as="p"
             size={2}

--- a/packages/app/src/app/pages/Dashboard/Components/NewTeamModal/TeamMembers.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/NewTeamModal/TeamMembers.tsx
@@ -185,9 +185,7 @@ export const TeamMembers: React.FC<{
               onChange={e => {
                 setAddressesString(e.target.value);
               }}
-              css={{
-                resize: 'none',
-              }}
+              resize={false}
               rows={3}
               autoFocus
               required

--- a/packages/app/src/app/pages/Dashboard/Components/NewTeamModal/TeamMembers.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/NewTeamModal/TeamMembers.tsx
@@ -142,97 +142,134 @@ export const TeamMembers: React.FC<{
   };
 
   return (
-    <Stack
-      align="center"
-      direction="vertical"
-      gap={4}
-      css={{
-        paddingTop: '60px',
-        paddingBottom: '40px',
-        maxWidth: '370px',
-        width: '100%',
-      }}
-    >
-      <Text
-        as="h2"
-        size={32}
-        weight="500"
-        align="center"
-        css={{
-          margin: 0,
-          color: '#ffffff',
-          fontFamily: 'Everett, sans-serif',
-          lineHeight: '42px',
-          letterSpacing: '-0.01em',
-        }}
-      >
-        {activeTeamInfo.name}
-      </Text>
+    <>
       <Stack
-        as="form"
-        onSubmit={handleSubmit}
+        align="center"
         direction="vertical"
         gap={6}
-        css={{ width: '100%' }}
+        css={{
+          paddingTop: '60px',
+          paddingBottom: '40px',
+          maxWidth: '370px',
+          width: '100%',
+        }}
       >
-        <Textarea
-          label="Invite team members (Insert emails separated by a comma)"
-          name="members"
-          id="member"
-          autoFocus
-          required
-          rows={3}
-          value={addressesString}
-          onChange={e => {
-            setAddressesString(e.target.value);
+        <Text
+          as="h2"
+          size={32}
+          weight="500"
+          align="center"
+          css={{
+            margin: 0,
+            color: '#ffffff',
+            fontFamily: 'Everett, sans-serif',
+            lineHeight: '42px',
+            letterSpacing: '-0.01em',
           }}
-        />
-        {invalidEmails && invalidEmails.length > 0 ? (
-          <Text size={2} variant="danger">
-            {invalidEmails.length > 1
-              ? 'There seem to be errors in some email addresses, '
-              : 'Email is invalid, '}
-            please review: {formatInvalidEmails(invalidEmails)}
-          </Text>
-        ) : null}
+        >
+          {activeTeamInfo.name}
+        </Text>
+        <Stack
+          as="form"
+          onSubmit={handleSubmit}
+          direction="vertical"
+          gap={6}
+          css={{ width: '100%' }}
+        >
+          <Stack gap={4} direction="vertical">
+            <Textarea
+              id="member"
+              label="Invite team members (Insert emails separated by a comma)"
+              name="members"
+              value={addressesString}
+              onChange={e => {
+                setAddressesString(e.target.value);
+              }}
+              css={{
+                resize: 'none',
+              }}
+              rows={3}
+              autoFocus
+              required
+            />
 
-        {inviteError ? (
-          <Text size={2} variant="danger">
-            {inviteError}
-          </Text>
-        ) : null}
+            {invalidEmails && invalidEmails.length > 0 ? (
+              <Text size={2} variant="danger">
+                {invalidEmails.length > 1
+                  ? 'There seem to be errors in some email addresses, '
+                  : 'Email is invalid, '}
+                please review: {formatInvalidEmails(invalidEmails)}
+              </Text>
+            ) : null}
 
-        <StyledButton loading={inviteLoading} type="submit">
-          Invite members
-        </StyledButton>
+            {inviteError ? (
+              <Text size={2} variant="danger">
+                {inviteError}
+              </Text>
+            ) : null}
+
+            <StyledButton loading={inviteLoading} type="submit">
+              Invite members
+            </StyledButton>
+          </Stack>
+          <Text
+            css={{
+              margin: 0,
+            }}
+            align="center"
+            as="p"
+            size={2}
+            variant="muted"
+          >
+            Team members will be invited as{' '}
+            <Text color="#C2C2C2">
+              {
+                // The modal is visible only to admins and editors.
+                {
+                  [TeamMemberAuthorization.Admin]: 'editors',
+                  [TeamMemberAuthorization.Write]: 'viewers',
+                }[activeWorkspaceAuthorization]
+              }
+            </Text>
+            .
+          </Text>
+        </Stack>
       </Stack>
-      {hideSkip ? null : (
+      <Stack
+        css={{
+          width: '100%',
+          padding: '48px 56px',
+          justifyContent: 'space-between',
+        }}
+      >
         <Button
-          onClick={() => {
-            track('New Team - Skip Team Invite', {
-              codesandbox: 'V1',
-              event_source: 'UI',
-            });
-            onComplete();
-          }}
+          css={{ width: 'auto' }}
+          onClick={copyTeamInviteLink}
           variant="link"
         >
-          Skip
+          <Icon
+            size={12}
+            style={{ marginRight: 8 }}
+            name={linkCopied ? 'simpleCheck' : 'link'}
+          />
+          {linkCopied ? 'Link Copied!' : 'Copy Invite URL'}
         </Button>
-      )}
-
-      <Button
-        onClick={copyTeamInviteLink}
-        style={{ marginTop: 48 }}
-        variant="link"
-      >
-        <Icon
-          size={12}
-          style={{ marginRight: 8 }}
-          name={linkCopied ? 'simpleCheck' : 'link'}
-        />
-        {linkCopied ? 'Link Copied!' : 'Copy Invite URL'}
-      </Button>
-    </Stack>
+        {hideSkip ? null : (
+          <Button
+            css={{ width: 'auto' }}
+            onClick={() => {
+              track('New Team - Skip Team Invite', {
+                codesandbox: 'V1',
+                event_source: 'UI',
+              });
+              onComplete();
+            }}
+            variant="link"
+          >
+            Skip
+          </Button>
+        )}
+      </Stack>
+    </>
   );
 };

--- a/packages/app/src/app/pages/Dashboard/Components/NewTeamModal/TeamMembers.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/NewTeamModal/TeamMembers.tsx
@@ -239,8 +239,8 @@ export const TeamMembers: React.FC<{
         css={{
           width: '100%',
           padding: '48px 56px',
-          justifyContent: 'space-between',
         }}
+        justify={hideSkip ? 'center' : 'space-between'}
       >
         <Button
           css={{ width: 'auto' }}

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Recent/RecentHeader.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Recent/RecentHeader.tsx
@@ -11,7 +11,11 @@ export const RecentHeader: React.FC<{ title: string }> = ({ title }) => {
   const { activeTeam } = useAppState();
   const actions = useActions();
   const { isFree } = useWorkspaceSubscription();
-  const { isTeamSpace } = useWorkspaceAuthorization();
+  const {
+    isTeamSpace,
+    isPersonalSpace,
+    isTeamViewer,
+  } = useWorkspaceAuthorization();
   const showUpgradeBanner = isFree && isTeamSpace;
 
   return (
@@ -57,7 +61,7 @@ export const RecentHeader: React.FC<{ title: string }> = ({ title }) => {
             actions.openCreateSandboxModal({ initialTab: 'import' });
           }}
         />
-        {isTeamSpace ? (
+        {isTeamSpace && !isTeamViewer ? (
           <CreateCard
             icon="addMember"
             title="Invite team members"
@@ -73,7 +77,8 @@ export const RecentHeader: React.FC<{ title: string }> = ({ title }) => {
               });
             }}
           />
-        ) : (
+        ) : null}
+        {isPersonalSpace ? (
           <CreateCard
             icon="team"
             title="Create a team"
@@ -86,7 +91,7 @@ export const RecentHeader: React.FC<{ title: string }> = ({ title }) => {
               actions.openCreateTeamModal();
             }}
           />
-        )}
+        ) : null}
       </EmptyPage.StyledGrid>
     </Stack>
   );


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?

<!-- Is it a Bug fix, feature, docs update, ... -->

- Hides the `Invite members` card on the recent page for members who are viewers of the team.
- Adds copy to the invitation modal explaining the role of invitees.
- UI adjustments.

|Admins|Editors|
|:-:|:-:|
|![ut8gkw-3000 preview csb app_dashboard_recent_workspace=cab9e635-ec49-4c82-806c-c521babd3a6c (1)](https://user-images.githubusercontent.com/24959348/213560557-d493a05d-bfd9-4a34-baf7-51c3f7991cdc.png)|![ut8gkw-3000 preview csb app_dashboard_recent_workspace=cab9e635-ec49-4c82-806c-c521babd3a6c (2)](https://user-images.githubusercontent.com/24959348/213560587-ba152b21-0826-4ca9-8b94-79997b67ea38.png)|