### PR TITLE
fix(dashboard): empty likes spacing

### DIFF
--- a/packages/app/src/app/pages/Dashboard/Content/routes/Liked/EmptyLikes.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Liked/EmptyLikes.tsx
@@ -57,7 +57,7 @@ export const EmptyLikes: React.FC = () => {
         dangerouslySetInnerHTML={{ __html: DESCRIPTION }}
       />
       {pageState !== 'empty' ? (
-        <Stack css={{ flex: 1 }} direction="vertical" gap={6}>
+        <Stack css={{ flex: 1 }} direction="vertical" gap={4}>
           <EmptyPage.StyledGridTitle>
             Discover exciting projects
           </EmptyPage.StyledGridTitle>
@@ -65,7 +65,7 @@ export const EmptyLikes: React.FC = () => {
             css={{
               height: '100%',
               // Override the margins built-in the VariableGrid.
-              margin: `-28px -${GUTTER}px 0`,
+              margin: `0 -${GUTTER}px `,
             }}
           >
             <VariableGrid items={itemsToShow} page="liked" />


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?

<!-- Is it a Bug fix, feature, docs update, ... -->

Fixes a regression where there was no space between the title and the suggested sandboxes in the "empty likes" view.

![3blc21-3000 preview csb app_signin_continue=_dashboard_liked](https://user-images.githubusercontent.com/24959348/213573894-b7d89506-bff4-45c5-89c7-29537146e20e.png)

