### PR TITLE
feat(create-new): Close create sandbox modal when navigating to a different page

### DIFF
--- a/packages/app/src/app/components/CreateSandbox/CreateSandboxModal.tsx
+++ b/packages/app/src/app/components/CreateSandbox/CreateSandboxModal.tsx
@@ -2,7 +2,7 @@ import { ThemeProvider } from '@codesandbox/components';
 import Modal from 'app/components/Modal';
 import { useAppState, useActions } from 'app/overmind';
 import { DELETE_ME_COLLECTION } from 'app/overmind/namespaces/dashboard/types';
-import * as React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { useLocation } from 'react-router-dom';
 
 import { COLUMN_MEDIA_THRESHOLD, CreateSandbox } from './CreateSandbox';
@@ -33,15 +33,37 @@ function getImplicitCollectionIdFromFolder(
 }
 
 const collectionPathRegex = /^.*dashboard\/sandboxes/;
+
+const useHasNavigated = ({ pathname }: ReturnType<typeof useLocation>) => {
+  const previousLocationRef = useRef<string>();
+
+  useEffect(() => {
+    previousLocationRef.current = pathname;
+  }, [pathname]);
+
+  if (previousLocationRef.current === pathname) {
+    return true;
+  }
+
+  return false;
+};
+
 export const CreateSandboxModal = () => {
   const { modals, dashboard } = useAppState();
   const { modals: modalsActions } = useActions();
-
   const location = useLocation();
+  const hasNavigated = useHasNavigated(location);
+
   const implicitCollection = getImplicitCollectionIdFromFolder(
     location.pathname,
     dashboard.allCollections
   );
+
+  useEffect(() => {
+    if (hasNavigated) {
+      modalsActions.newSandboxModal.close();
+    }
+  }, [hasNavigated, modalsActions.newSandboxModal]);
 
   return (
     <ThemeProvider>


### PR DESCRIPTION
### What kind of change does this PR introduce?

When navigation to a different url through the client side route change (`react-router` `Link`) the create new modal will now be closed.

### What is the current behavior?

Modal will persist when navigating.

### What is the new behavior?

Modal will close when navigating.

### Testing

1. Log in and navigate to the dashboard
2. Select a free team
3. Open the create new modal on the import tab
4. Try to import a private repository
5. Follow the link to the pro page in the error message
6. Modal should be closed