### PR TITLE
fix(icons): Rename remix to remix-starter to fix icon

### DIFF
--- a/packages/common/src/templates/index.ts
+++ b/packages/common/src/templates/index.ts
@@ -100,7 +100,7 @@ export type TemplateType =
   | 'docusaurus'
   | 'babel-repl'
   | 'esm-react'
-  | 'remix'
+  | 'remix-starter'
   | 'solid';
 
 export default function getDefinition(theme?: TemplateType | null) {

--- a/packages/common/src/templates/remix.ts
+++ b/packages/common/src/templates/remix.ts
@@ -2,7 +2,7 @@ import Template from './template';
 import { decorateSelector } from '../utils/decorate-selector';
 
 export default new Template(
-  'remix',
+  'remix-starter',
   'Remix',
   'https://remix.run/',
   'https://github.com/remix-run',


### PR DESCRIPTION
The name of the Remix template was named `remix-starter` so I changed the name to fix the icon. It currently shows the React icon though, so we should update that.

### Testing

1. Open the create new modal
2. Click through all the tabs to see if it doesn't crash
3. In the official templates, there should be a Remix template with a React icon