### PR TITLE
fix(settings): Add optional chaining to potentially undefined or null object

### DIFF
--- a/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/WorkspaceSettings.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/WorkspaceSettings.tsx
@@ -527,7 +527,7 @@ export const WorkspaceSettings = () => {
        * Soft limit for pro teams.
        */}
       {numberOfEditors > MAX_PRO_EDITORS &&
-        subscription.origin !== SubscriptionOrigin.Pilot && (
+        subscription?.origin !== SubscriptionOrigin.Pilot && (
           <MessageStripe justify="space-between">
             <span>
               You have over {MAX_PRO_EDITORS} editors. Upgrade to the


### PR DESCRIPTION
Fixes #7334. Subscription can be `null` or `undefined`. Feel free to merge this PR when approving!