### PR TITLE
fix(pro): Legacy user.subscription can be null

### DIFF
--- a/packages/app/src/app/pages/Pro/legacy-pages/WorkspacePlanSelection.tsx
+++ b/packages/app/src/app/pages/Pro/legacy-pages/WorkspacePlanSelection.tsx
@@ -186,7 +186,7 @@ export const WorkspacePlanSelection: React.FC = () => {
           {isPersonalSpace ? (
             <SubscriptionCard
               title={
-                user.subscription.plan === 'patron' ? 'Patron' : 'Personal Pro'
+                user.subscription?.plan === 'patron' ? 'Patron' : 'Personal Pro'
               }
               features={PERSONAL_FEATURES}
               cta={personalProCta}
@@ -194,17 +194,17 @@ export const WorkspacePlanSelection: React.FC = () => {
             >
               <Stack gap={1} direction="vertical">
                 <Text size={32} weight="500">
-                  ${user.subscription.amount}
+                  ${user.subscription?.amount}
                 </Text>
-                {user.subscription.duration === 'yearly' ? (
+                {user.subscription?.duration === 'yearly' ? (
                   <Text>
                     charged annually on{' '}
-                    {format(new Date(user.subscription.since), 'MMM dd')}
+                    {format(new Date(user.subscription?.since), 'MMM dd')}
                   </Text>
                 ) : (
                   <Text>
                     charged on the{' '}
-                    {format(new Date(user.subscription.since), 'do')} of each
+                    {format(new Date(user.subscription?.since), 'do')} of each
                     month
                   </Text>
                 )}


### PR DESCRIPTION
Fixes #7339.

In rare cases `user.subscription` can be null for legacy subscriptions. Trying to access the page causes a crash. This is a quick fix but I'll make sure to look into why it can be `null` but the page can still be accessed.