### PR TITLE
fix: share popup copy

### DIFF
--- a/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenus/CommunitySandboxMenu.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenus/CommunitySandboxMenu.tsx
@@ -33,7 +33,7 @@ export const CommunitySandboxMenu: React.FC<MenuProps> = ({ item }) => {
           window.open(`https://codesandbox.io${url}`, '_blank');
         }}
       >
-        Open Sandbox in New Tab
+        Open sandbox in a new tab
       </MenuItem>
       <MenuItem
         onSelect={() => {
@@ -43,14 +43,14 @@ export const CommunitySandboxMenu: React.FC<MenuProps> = ({ item }) => {
           });
         }}
       >
-        Fork Sandbox
+        Fork sandbox
       </MenuItem>
       <MenuItem
         onSelect={() => {
           effects.browser.copyToClipboard(`https://codesandbox.io${url}`);
         }}
       >
-        Copy Sandbox Link
+        Copy sandbox link
       </MenuItem>
     </Menu.ContextMenu>
   );

--- a/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenus/MasterMenu.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenus/MasterMenu.tsx
@@ -39,7 +39,7 @@ export const MasterMenu = ({ repo }: MasterMenuProps) => {
           )
         }
       >
-        View Master
+        View master
       </MenuItem>
       <MenuItem
         onSelect={() => {

--- a/packages/app/src/app/pages/Sandbox/Editor/Header/Collaborators/ButtonActions.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Header/Collaborators/ButtonActions.tsx
@@ -49,7 +49,11 @@ export const ButtonActions = () => {
       >
         Embed
       </Button>
-      <Button css={css({ width: 128 })} variant="secondary" onClick={copyLink}>
+      <Button
+        css={css({ width: 'initial' })}
+        variant="secondary"
+        onClick={copyLink}
+      >
         {linkCopied ? (
           <motion.div
             key="copied"
@@ -76,7 +80,7 @@ export const ButtonActions = () => {
             initial={mounted ? { scale: 0.8, opacity: 0.7 } : false}
             animate={{ scale: 1, opacity: 1 }}
           >
-            Copy Sandbox Link
+            Copy link
           </motion.div>
         )}
       </Button>


### PR DESCRIPTION
Before

<img width="404" alt="image" src="https://user-images.githubusercontent.com/9945366/213989753-804f4476-2801-4b16-b7a4-1f3640f25433.png">

After

<img width="440" alt="image" src="https://user-images.githubusercontent.com/9945366/213989664-ea8bbc71-edf1-4a28-8ead-097e137168ea.png">

Also changed some other copy messages I found that were all capital words