### PR TITLE
fix: template owner

### DIFF
--- a/packages/app/src/app/components/CreateSandbox/CreateSandbox.tsx
+++ b/packages/app/src/app/components/CreateSandbox/CreateSandbox.tsx
@@ -596,7 +596,7 @@ const TemplateInfo = ({ template }: TemplateInfoProps) => {
           {template.sandbox.title}
         </Text>
         <Text size={2} css={{ color: '#999', marginTop: '4px' }}>
-          {template.sandbox.collection?.team?.name}
+          {template.sandbox?.team?.name}
         </Text>
       </Stack>
       <Text size={2} css={{ color: '#999', lineHeight: '1.4' }}>

--- a/packages/app/src/app/components/CreateSandbox/SearchResults/SearchResultList.tsx
+++ b/packages/app/src/app/components/CreateSandbox/SearchResults/SearchResultList.tsx
@@ -57,9 +57,7 @@ const Results = (props: ResultsProps) => {
       source: {
         template: hit.template,
       },
-      collection: {
-        team: hit.team,
-      },
+      team: hit.team,
     },
   }));
 

--- a/packages/app/src/app/components/CreateSandbox/TemplateCard.tsx
+++ b/packages/app/src/app/components/CreateSandbox/TemplateCard.tsx
@@ -30,8 +30,9 @@ export const TemplateCard = ({
 
   const sandboxTitle = template.sandbox?.title || template.sandbox?.alias;
   const isV2 = template.sandbox?.isV2;
+
   const teamName =
-    template.sandbox?.collection?.team?.name ||
+    template.sandbox?.team?.name ||
     template.sandbox?.author?.username ||
     'GitHub';
 

--- a/packages/app/src/app/components/CreateSandbox/TemplateCard.tsx
+++ b/packages/app/src/app/components/CreateSandbox/TemplateCard.tsx
@@ -30,7 +30,10 @@ export const TemplateCard = ({
 
   const sandboxTitle = template.sandbox?.title || template.sandbox?.alias;
   const isV2 = template.sandbox?.isV2;
-  const teamName = template.sandbox?.collection?.team?.name;
+  const teamName =
+    template.sandbox?.collection?.team?.name ||
+    template.sandbox?.author?.username ||
+    'GitHub';
 
   return (
     <TemplateButton
@@ -92,7 +95,7 @@ export const TemplateCard = ({
 
           <Text size={2} css={{ color: '#999' }}>
             <VisuallyHidden>by </VisuallyHidden>
-            {teamName || 'GitHub'}
+            {teamName}
           </Text>
         </Stack>
       </Stack>

--- a/packages/app/src/app/components/CreateSandbox/queries.ts
+++ b/packages/app/src/app/components/CreateSandbox/queries.ts
@@ -14,10 +14,9 @@ const TEMPLATE_FRAGMENT = gql`
       insertedAt
       updatedAt
       isV2
-      collection {
-        team {
-          name
-        }
+
+      team {
+        name
       }
 
       author {

--- a/packages/app/src/app/components/CreateSandbox/utils/api.ts
+++ b/packages/app/src/app/components/CreateSandbox/utils/api.ts
@@ -55,7 +55,11 @@ const mapAPIResponseToTemplateInfo = (
       source: {
         template: sandbox.environment,
       },
-      collection: sandbox.collection,
+      // TODO: Update /official and /essential endpoints to return
+      // team -> name instead of collection -> team -> name
+      team: {
+        name: 'CodeSandbox',
+      },
       isV2: sandbox.v2,
       git: sandbox.git && {
         id: sandbox.git.id,

--- a/packages/app/src/app/graphql/types.ts
+++ b/packages/app/src/app/graphql/types.ts
@@ -611,6 +611,8 @@ export type Project = {
   repo: Scalars['String'];
   /** Git repository for the project, as it appears on the original git provider */
   repository: Repository;
+  /** Compute resources for the project, based on settings and team subscription */
+  resources: Resources;
   /**
    * Team to which this project is assigned
    *
@@ -714,6 +716,21 @@ export type Repository = GitHubRepository;
 
 /** GitHub webhook event about a repository. */
 export type RepositoryEvent = InstallationEvent;
+
+/**
+ * Available computing resources for the project
+ *
+ * These resources may be custom for a project, or they may be determined by the team's subscription.
+ */
+export type Resources = {
+  __typename?: 'Resources';
+  /** CPU core count */
+  cpu: Scalars['Int'];
+  /** RAM in Gi */
+  memory: Scalars['Int'];
+  /** Disk space in Gi */
+  storage: Scalars['Int'];
+};
 
 export type RootMutationType = {
   __typename?: 'RootMutationType';
@@ -1895,11 +1912,7 @@ export type TemplateFragment = { __typename?: 'Template' } & Pick<
         | 'updatedAt'
         | 'isV2'
       > & {
-          collection: Maybe<
-            { __typename?: 'Collection' } & {
-              team: Maybe<{ __typename?: 'Team' } & Pick<Team, 'name'>>;
-            }
-          >;
+          team: Maybe<{ __typename?: 'Team' } & Pick<Team, 'name'>>;
           author: Maybe<{ __typename?: 'User' } & Pick<User, 'username'>>;
           source: { __typename?: 'Source' } & Pick<Source, 'template'>;
         }


### PR DESCRIPTION
Changed the team name query for templates from `collection -> team -> name` to `team -> name` as sometimes templates are created in draft and moved to templates by the team, so they don't belong to any collection. Not sure why the query was originally like that.

This changes the `GitHub` fallback label under some of the templates to `CodeSandbox` or the correct owner (user or team)

Because `/official` and `/essential` are still two REST endpoints we use to show some of the templates in the create modal, I decided to hardcode `CodeSandbox` there for now, to have it show nice in prod and later we can update the endpoints.

Before

![image](https://user-images.githubusercontent.com/9945366/214022839-7b38a815-fb62-4081-a9e0-c0c903a4b412.png)
![image](https://user-images.githubusercontent.com/9945366/214023002-5d813d83-b2f4-4dcf-b93e-54684e2360dd.png)


After
![image](https://user-images.githubusercontent.com/9945366/214022421-1c6a7d0f-e38d-44a9-b6bb-a1ce9c7b128d.png)
![image](https://user-images.githubusercontent.com/9945366/214022316-df770613-bfd8-4e75-88a5-feb42b255d12.png)
