### PR TITLE
fix: template icon for templates

### DIFF
--- a/packages/app/src/app/graphql/types.ts
+++ b/packages/app/src/app/graphql/types.ts
@@ -611,6 +611,8 @@ export type Project = {
   repo: Scalars['String'];
   /** Git repository for the project, as it appears on the original git provider */
   repository: Repository;
+  /** Compute resources for the project, based on settings and team subscription */
+  resources: Resources;
   /**
    * Team to which this project is assigned
    *
@@ -714,6 +716,21 @@ export type Repository = GitHubRepository;
 
 /** GitHub webhook event about a repository. */
 export type RepositoryEvent = InstallationEvent;
+
+/**
+ * Available computing resources for the project
+ *
+ * These resources may be custom for a project, or they may be determined by the team's subscription.
+ */
+export type Resources = {
+  __typename?: 'Resources';
+  /** CPU core count */
+  cpu: Scalars['Int'];
+  /** RAM in Gi */
+  memory: Scalars['Int'];
+  /** Disk space in Gi */
+  storage: Scalars['Int'];
+};
 
 export type RootMutationType = {
   __typename?: 'RootMutationType';
@@ -2450,7 +2467,9 @@ export type SandboxFragmentDashboardFragment = {
   | 'teamId'
 > & {
     source: { __typename?: 'Source' } & Pick<Source, 'template'>;
-    customTemplate: Maybe<{ __typename?: 'Template' } & Pick<Template, 'id'>>;
+    customTemplate: Maybe<
+      { __typename?: 'Template' } & Pick<Template, 'id' | 'iconUrl'>
+    >;
     forkedTemplate: Maybe<
       { __typename?: 'Template' } & Pick<Template, 'id' | 'color' | 'iconUrl'>
     >;

--- a/packages/app/src/app/overmind/effects/gql/dashboard/fragments.ts
+++ b/packages/app/src/app/overmind/effects/gql/dashboard/fragments.ts
@@ -25,6 +25,7 @@ export const sandboxFragmentDashboard = gql`
 
     customTemplate {
       id
+      iconUrl
     }
 
     forkedTemplate {

--- a/packages/app/src/app/pages/Dashboard/Components/Sandbox/TemplateIcon.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Sandbox/TemplateIcon.tsx
@@ -3,13 +3,18 @@ import { getTemplateIcon as commonTemplateIcon } from '@codesandbox/common/lib/u
 export const getTemplateIcon = (sandbox: {
   title?: string;
   forkedTemplate?: { iconUrl: string };
+  customTemplate?: { iconUrl: string };
   source: { template: string };
 }) => {
   if (!sandbox) return () => null;
 
+  // If the sandbox is a template, use that icon. Otherwise, use the icon
+  // of the forked template.
+  const template = sandbox.customTemplate || sandbox.forkedTemplate;
+
   const { UserIcon } = commonTemplateIcon(
     sandbox.title,
-    sandbox.forkedTemplate?.iconUrl,
+    template?.iconUrl,
     sandbox.source.template
   );
 


### PR DESCRIPTION
If a sandbox is a template, we should show that as the template icon. But right now we show the template icon it is forked from. This would fix that.