### PR TITLE
fix(dashboard): Align recent page grid columns

### DIFF
--- a/packages/app/src/app/pages/Dashboard/Components/EmptyPage/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/EmptyPage/index.tsx
@@ -1,6 +1,11 @@
 import { Element, Stack, Text } from '@codesandbox/components';
 import styled from 'styled-components';
-import { GRID_MAX_WIDTH, GUTTER } from '../VariableGrid/constants';
+import {
+  GRID_MAX_WIDTH,
+  GUTTER,
+  ITEM_HEIGHT_GRID,
+  ITEM_MIN_WIDTH,
+} from '../VariableGrid/constants';
 
 const StyledWrapper = styled(Stack)`
   overflow: auto;
@@ -32,8 +37,8 @@ const StyledGrid = styled(Element)`
   display: grid;
   list-style: none;
   gap: 16px;
-  grid-template-columns: repeat(auto-fill, minmax(268px, 1fr));
-  grid-auto-rows: minmax(156px, 1fr);
+  grid-template-columns: repeat(auto-fill, minmax(${ITEM_MIN_WIDTH}px, 1fr));
+  grid-auto-rows: minmax(${ITEM_HEIGHT_GRID}px, 1fr);
 `;
 
 const StyledGridTitle = styled(Text)`


### PR DESCRIPTION
Aligns the "create" buttons and the information cards with the recent sandboxes and branch cards.

### Linear

Closes XTD-564

### Screenshots

<img width="953" alt="image" src="https://user-images.githubusercontent.com/7533849/214057073-ddb0229d-9aee-4645-af94-f183a6ceecf2.png">
