### PR TITLE
fix(upgrade): Pass correct property to fork api call

### DIFF
--- a/packages/app/src/app/components/StripeMessages/UpgradeSSEToV2.tsx
+++ b/packages/app/src/app/components/StripeMessages/UpgradeSSEToV2.tsx
@@ -42,7 +42,7 @@ export const UpgradeSSEToV2Stripe = () => {
             window.location.href = sandboxV2Url;
           } else {
             const forkedSandbox = await effects.api.forkSandbox(sandboxId, {
-              isV2: true,
+              v2: true,
               teamId: state.activeTeam,
             });
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

I was passing the incorrect value into the fork api endpoint. It was not properly converting the sandbox into V2.

## What is the current behavior?

It would redirect to the v2 fork of the sandbox, but if you re-opened it from the dashboard it would be v1.

## What is the new behavior?

The newly forked sandbox will always be v2

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Testing <!-- We can only merge the PR if this is checked -->
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
