### PR TITLE
fix: don't show git templates in the template search

### DIFF
--- a/packages/app/src/app/components/CreateSandbox/SearchResults/SearchResults.tsx
+++ b/packages/app/src/app/components/CreateSandbox/SearchResults/SearchResults.tsx
@@ -60,12 +60,7 @@ export const SearchResults = ({
         <Configure
           query={search}
           hitsPerPage={50}
-          facetFilters={[
-            [
-              'custom_template.published: true',
-              'custom_template.published: false',
-            ],
-          ]}
+          facetFilters={['is_template: true', 'is_git: false']}
         />
 
         <Stack css={{ height: '100%' }} direction="vertical" gap={6}>


### PR DESCRIPTION
Git templates clutter the template search quite a bit. We have over 1.7M templates, of which 1.62M are git. They make the template search unusable. We now mark which template is git, and make sure to filter those out, as less than 1% of the git templates are really valuable.