### PR TITLE
fix(dashboard): create/edit team name

### DIFF
--- a/packages/app/src/app/overmind/namespaces/dashboard/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/dashboard/actions.ts
@@ -1097,16 +1097,14 @@ export const createTeam = async (
     teamName: string;
   }
 ) => {
-  try {
-    effects.analytics.track('Team - Create Team', { dashboardVersion: 2 });
-    const { createTeam: newTeam } = await effects.gql.mutations.createTeam({
-      name: teamName,
-    });
-    state.dashboard.teams = [...state.dashboard.teams, newTeam];
-    actions.setActiveTeam({ id: newTeam.id });
-  } catch {
-    effects.notificationToast.error('There was a problem creating your team');
-  }
+  // Do not try/catch to let errors propagate to `TeamInfo` that will
+  // then handle it by showing a notification if creating a team fails.
+  effects.analytics.track('Team - Create Team', { dashboardVersion: 2 });
+  const { createTeam: newTeam } = await effects.gql.mutations.createTeam({
+    name: teamName,
+  });
+  state.dashboard.teams = [...state.dashboard.teams, newTeam];
+  actions.setActiveTeam({ id: newTeam.id });
 };
 
 export const revokeTeamInvitation = async (

--- a/packages/app/src/app/pages/Dashboard/Components/NewTeamModal/TeamInfo.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/NewTeamModal/TeamInfo.tsx
@@ -12,19 +12,18 @@ export const TeamInfo: React.FC<{ onComplete: () => void }> = ({
   const { dashboard } = useAppState();
   const actions = useActions();
   const [loading, setLoading] = useState(false);
-  const [name, setName] = useState('');
+  const [existingTeamError, setExistingTeamError] = useState(false);
 
   const onSubmit = async event => {
     event.preventDefault();
-    const teamName = event.target.name.value;
+    const teamName = event.target.name.value?.trim();
 
-    if (teamName && teamName.trim()) {
+    if (teamName) {
       track('New Team - Create Team', {
         codesandbox: 'V1',
         event_source: 'UI',
       });
 
-      event.target.name.setCustomValidity('');
       setLoading(true);
       try {
         await actions.dashboard.createTeam({
@@ -40,16 +39,22 @@ export const TeamInfo: React.FC<{ onComplete: () => void }> = ({
 
   const handleInput = e => {
     const { value } = e.target;
-    setName(value.trim());
 
-    if (value && value.trim()) {
+    // Get the input and remove any whitespace from both ends.
+    const trimmedName = value?.trim() ?? '';
+
+    // Validate if the name input is filled with whitespaces.
+    if (trimmedName) {
       e.target.setCustomValidity('');
     } else {
       e.target.setCustomValidity('Team name is required.');
     }
-  };
 
-  const error = Boolean(dashboard.teams.find(team => team.name === name));
+    // Check if there's any team with the same name.
+    setExistingTeamError(
+      Boolean(dashboard.teams.find(team => team.name === trimmedName))
+    );
+  };
 
   return (
     <Stack
@@ -114,10 +119,9 @@ export const TeamInfo: React.FC<{ onComplete: () => void }> = ({
           required
           autoFocus
           onChange={handleInput}
-          value={name}
         />
 
-        {error && (
+        {existingTeamError && (
           <Text size={2} variant="danger">
             Name already taken, please choose a new name.
           </Text>
@@ -125,7 +129,7 @@ export const TeamInfo: React.FC<{ onComplete: () => void }> = ({
 
         <StyledButton
           loading={loading}
-          disabled={loading || error}
+          disabled={loading || existingTeamError}
           type="submit"
         >
           Create Team

--- a/packages/app/src/app/pages/Dashboard/Components/NewTeamModal/TeamInfo.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/NewTeamModal/TeamInfo.tsx
@@ -12,6 +12,7 @@ export const TeamInfo: React.FC<{ onComplete: () => void }> = ({
   const { dashboard } = useAppState();
   const actions = useActions();
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
   const [existingTeamError, setExistingTeamError] = useState(false);
 
   const onSubmit = async event => {
@@ -24,14 +25,16 @@ export const TeamInfo: React.FC<{ onComplete: () => void }> = ({
         event_source: 'UI',
       });
 
+      setError(null);
       setLoading(true);
       try {
         await actions.dashboard.createTeam({
           teamName,
         });
-        setLoading(false);
         onComplete();
       } catch {
+        setError('There was a problem creating your team');
+      } finally {
         setLoading(false);
       }
     }
@@ -124,6 +127,12 @@ export const TeamInfo: React.FC<{ onComplete: () => void }> = ({
         {existingTeamError && (
           <Text size={2} variant="danger">
             Name already taken, please choose a new name.
+          </Text>
+        )}
+
+        {error && (
+          <Text size={2} variant="danger">
+            {error}
           </Text>
         )}
 

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/WorkspaceSettings.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/WorkspaceSettings.tsx
@@ -112,10 +112,30 @@ export const WorkspaceSettings = () => {
     });
   };
 
+  const handleTeamNameChange = event => {
+    const { value } = event.target;
+
+    // Get the input and remove any whitespace from both ends.
+    const trimmedName = value?.trim() ?? '';
+
+    // Validate if the name input is filled with whitespaces.
+    if (trimmedName) {
+      event.target.setCustomValidity('');
+    } else {
+      event.target.setCustomValidity('Team name is required.');
+    }
+  };
+
   const onSubmit = async event => {
     event.preventDefault();
-    const name = event.target.name.value;
-    const description = event.target.description.value;
+
+    const name = event.target.name.value?.trim();
+    const description = event.target.description.value?.trim();
+
+    if (!name) {
+      return;
+    }
+
     setLoading(true);
     try {
       await actions.dashboard.setTeamInfo({
@@ -286,6 +306,7 @@ export const WorkspaceSettings = () => {
                     required
                     defaultValue={team.name}
                     placeholder="Enter team name"
+                    onChange={handleTeamNameChange}
                   />
                   <Textarea
                     name="description"

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/WorkspaceSettings.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/WorkspaceSettings.tsx
@@ -59,7 +59,11 @@ const ROLES_TEXT_MAP = {
 export const WorkspaceSettings = () => {
   const actions = useActions();
   const effects = useEffects();
-  const { user: currentUser, activeTeamInfo: team } = useAppState();
+  const {
+    user: currentUser,
+    activeTeamInfo: team,
+    dashboard: { teams },
+  } = useAppState();
 
   const [editing, setEditing] = useState(false);
   const [loading, setLoading] = useState(false);
@@ -119,10 +123,14 @@ export const WorkspaceSettings = () => {
     const trimmedName = value?.trim() ?? '';
 
     // Validate if the name input is filled with whitespaces.
-    if (trimmedName) {
-      event.target.setCustomValidity('');
-    } else {
+    if (!trimmedName) {
       event.target.setCustomValidity('Team name is required.');
+    } else if (teams.find(t => t.name === trimmedName)) {
+      event.target.setCustomValidity(
+        'Name already taken, please choose a new name.'
+      );
+    } else {
+      event.target.setCustomValidity('');
     }
   };
 

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/WorkspaceSettings.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/WorkspaceSettings.tsx
@@ -145,16 +145,14 @@ export const WorkspaceSettings = () => {
     }
 
     setLoading(true);
-    try {
-      await actions.dashboard.setTeamInfo({
-        name,
-        description,
-        file,
-      });
-      setEditing(false);
-    } finally {
-      setLoading(false);
-    }
+    // no try/catch because setTeamInfo dispatches
+    // a notification toast on error.
+    await actions.dashboard.setTeamInfo({
+      name,
+      description,
+      file,
+    });
+    setEditing(false);
   };
 
   const [inviteValue, setInviteValue] = useState('');


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

Closes XTD-609.

## What kind of change does this PR introduce?

<!-- Is it a Bug fix, feature, docs update, ... -->

- Allows whitespace in team names when creating a new team.
- Fixes whitespace behavior in team names when editing an existing team.

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

### Create team:

- [ ] It's possible to create a team with spaces in the name (eg: `my team`)
- [ ] It's not possible to create a team with only spaces in the name (eg: `   `)
- [ ] It's not possible to create a team if the user is already part of a team with the same name

### Edit team:

- [ ] It's possible to edit a team with spaces in the name (eg: `my team`)
- [ ] It's not possible to edit a team with only spaces in the name (eg: `   `)
- [ ] It's not possible to edit a team if the user is already part of a team with the same name