### PR TITLE
fix(pro): Stop using user.subscription and clean up uses

### DIFF
--- a/packages/app/src/app/overmind/effects/api/index.ts
+++ b/packages/app/src/app/overmind/effects/api/index.ts
@@ -58,29 +58,7 @@ export default {
 
     return response.jwt;
   },
-  createPatronSubscription(
-    token: string,
-    amount: number,
-    duration: 'monthly' | 'yearly',
-    coupon: string
-  ) {
-    return api.post<CurrentUser>('/users/current_user/subscription', {
-      subscription: {
-        amount,
-        coupon,
-        token,
-        duration,
-      },
-    });
-  },
-  updatePatronSubscription(amount: number, coupon: string) {
-    return api.patch<CurrentUser>('/users/current_user/subscription', {
-      subscription: {
-        amount,
-        coupon,
-      },
-    });
-  },
+  // We only use this function related to current_user/subscription
   cancelPatronSubscription() {
     return api.delete<CurrentUser>('/users/current_user/subscription');
   },

--- a/packages/app/src/app/overmind/internalActions.ts
+++ b/packages/app/src/app/overmind/internalActions.ts
@@ -28,7 +28,6 @@ export const initializeNewUser = async ({
   actions,
 }: Context) => {
   actions.dashboard.getTeams();
-  actions.internal.setPatronPrice();
   effects.analytics.identify('signed_in', true);
   effects.analytics.setUserId(state.user!.id, state.user!.email);
 
@@ -91,16 +90,6 @@ export const setStoredSettings = ({ state, effects }: Context) => {
   }
 
   Object.assign(state.preferences.settings, settings);
-};
-
-export const setPatronPrice = ({ state }: Context) => {
-  if (!state.user) {
-    return;
-  }
-
-  state.patron.price = state.user.subscription
-    ? Number(state.user.subscription.amount)
-    : 10;
 };
 
 export const showUserSurveyIfNeeded = ({

--- a/packages/app/src/app/overmind/state.ts
+++ b/packages/app/src/app/overmind/state.ts
@@ -20,7 +20,6 @@ export type PendingUserType = {
 } | null;
 
 type State = {
-  isPatron: boolean;
   isFirstVisit: boolean;
   isLoggedIn: boolean;
   hasLogIn: boolean;
@@ -82,13 +81,6 @@ export const state: State = {
   pendingUserId: null,
   pendingUser: null,
   isFirstVisit: false,
-  /**
-   * Important, only use this to see if someone has patron, you should not check this to see if someone
-   * has pro.
-   */
-  isPatron: derived(({ user }: State) =>
-    Boolean(user && user.subscription && user.subscription.since)
-  ),
   isLoggedIn: derived(({ hasLogIn: has, user }: State) => has && Boolean(user)),
   // TODO: Should not reference store directly here, rather initialize
   // the state with "onInitialize" setting the jwt

--- a/packages/app/src/app/pages/common/Modals/SurveyModal/index.tsx
+++ b/packages/app/src/app/pages/common/Modals/SurveyModal/index.tsx
@@ -4,12 +4,13 @@ import React, { FunctionComponent } from 'react';
 
 import { useAppState, useActions } from 'app/overmind';
 
+import { useWorkspaceSubscription } from 'app/hooks/useWorkspaceSubscription';
 import { Alert } from '../Common/Alert';
 
 export const SurveyModal: FunctionComponent = () => {
   const { modalClosed } = useActions();
-  const { isPatron, user, activeTeamInfo } = useAppState();
-  const isPro = Boolean(activeTeamInfo?.subscription);
+  const { user } = useAppState();
+  const { isPro, isPatron } = useWorkspaceSubscription();
 
   const initializeTypeform = (el?: HTMLDivElement) => {
     if (el) {


### PR DESCRIPTION
In rare cases user.subscription can be null for legacy subscriptions. Trying to access the page causes a crash. This is a quick fix but I'll make sure to look into why it can be null but the page can still be accessed. Decided with the BEOPS team that we want to clean up other old `user.subscription` values and use `activeTeamInfo.subscription` instead.

Fixes #7339
Closes XTD-608
