### PR TITLE
Draft/nifty newton

### DIFF
--- a/packages/app/src/app/pages/Dashboard/Components/UpgradeBanner/UpgradeBanner.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/UpgradeBanner/UpgradeBanner.tsx
@@ -93,7 +93,7 @@ export const UpgradeBanner: React.FC<UpgradeBannerProps> = ({ teamId }) => {
     >
       <Element css={{ overflow: 'hidden' }}>
         <StyledTitle color="#EDFFA5" weight="500" block>
-          Upgrade to Pro
+          {isEligibleForTrial ? 'Try Team Pro for free' : 'Upgrade to Pro'}
         </StyledTitle>
         <Stack
           css={{
@@ -103,7 +103,9 @@ export const UpgradeBanner: React.FC<UpgradeBannerProps> = ({ teamId }) => {
         >
           <Stack direction="vertical" justify="space-between">
             <StyledTitle block>
-              Enjoy the full CodeSandbox experience.
+              {isEligibleForTrial
+                ? '14 days free trial. No credit card required.'
+                : 'Enjoy the full CodeSandbox experience.'}
             </StyledTitle>
             <Stack
               css={{

--- a/packages/app/src/app/pages/Dashboard/Components/UpgradeBanner/UpgradeBanner.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/UpgradeBanner/UpgradeBanner.tsx
@@ -37,8 +37,8 @@ type Feature = {
 };
 const FEATURES: Feature[] = [
   {
-    icon: 'profile',
-    label: 'Up to 20 editors',
+    icon: 'server',
+    label: '6GB RAM, 12GB Disk, 4 vCPUs',
   },
   {
     icon: 'npm',
@@ -57,8 +57,8 @@ const FEATURES: Feature[] = [
     label: 'Unlimited private repositories',
   },
   {
-    icon: 'server',
-    label: '6GB RAM, 12GB Disk, 4 vCPUs',
+    icon: 'profile',
+    label: 'Up to 20 editors',
   },
 ];
 


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?

Changes text for the home banner to highlight the lack of credit card requirements for trials

## What is the current behavior?
https://linear.app/codesandbox/issue/XTD-615/recent-banner


## What is the new behavior?
[x]Change headline text to Try Team Pro for free when trial is enabled 
   [x]show 'Upgrade to Pro' when trial is not enabled
[x]Change subtitle text to '14 days free trial. No credit card required'.
   [x]show 'Enjoy the full CodeSandbox experience' when trial is not enabled.
[x]Review text and order of features list

<img width="1223" alt="image" src="https://user-images.githubusercontent.com/20410256/214653952-d4fac489-eb0f-4af8-b32b-45636d827cbf.png">


## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

I viewed this on the preview

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Testing <!-- We can only merge the PR if this is checked -->
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
