### PR TITLE
fix(legacy-pro): default to dollar when currency is unavailable

### DIFF
--- a/packages/app/src/app/pages/Pro/legacy-pages/WorkspacePlanSelection.tsx
+++ b/packages/app/src/app/pages/Pro/legacy-pages/WorkspacePlanSelection.tsx
@@ -191,7 +191,7 @@ export const WorkspacePlanSelection: React.FC = () => {
             >
               <Stack gap={1} direction="vertical">
                 <Text size={32} weight="500">
-                  {`${subscription.currency}${subscription.unitPrice}`}
+                  {`${subscription.currency || '$'}${subscription.unitPrice}`}
                 </Text>
                 {subscription.billingInterval ===
                 SubscriptionInterval.Yearly ? (


### PR DESCRIPTION
Fixes an error where we render `null`:

<img width="564" alt="image" src="https://user-images.githubusercontent.com/7533849/214923232-5ade6a79-50a2-4436-8957-1dd27d8a572f.png">
