### PR TITLE
fix: allow dynamic imports in cjs node_modules

### DIFF
--- a/packages/app/src/sandbox/eval/transpilers/babel/ast/syntax-info.ts
+++ b/packages/app/src/sandbox/eval/transpilers/babel/ast/syntax-info.ts
@@ -88,6 +88,9 @@ export function getSyntaxInfoFromCode(code: string, path: string): SyntaxInfo {
     get esm() {
       return isESModule(code);
     },
+    get dynamicImports() {
+      return code.includes('import(')
+    }
   };
 
   if (path.endsWith('.min.js')) {
@@ -95,6 +98,7 @@ export function getSyntaxInfoFromCode(code: string, path: string): SyntaxInfo {
     return {
       jsx: false,
       esm: false,
+      dynamicImports: false,
     };
   }
 

--- a/packages/app/src/sandbox/eval/transpilers/babel/ast/syntax-info.ts
+++ b/packages/app/src/sandbox/eval/transpilers/babel/ast/syntax-info.ts
@@ -14,16 +14,21 @@ const ESM_TYPES: Set<string> = new Set([
 export interface SyntaxInfo {
   jsx: boolean;
   esm: boolean;
+  dynamicImports: boolean;
 }
 
 export function getSyntaxInfoFromAst(ast: ESTreeAST): SyntaxInfo {
-  const syntaxInfo: SyntaxInfo = { jsx: false, esm: false };
+  const syntaxInfo: SyntaxInfo = {
+    jsx: false,
+    esm: false,
+    dynamicImports: false,
+  };
 
   walk(ast.program, {
     enter(node) {
       // TODO: Figure out if we can exit the walk entirely
       // Just skip everything if we already know it's esm and jsx
-      if (syntaxInfo.jsx && syntaxInfo.esm) {
+      if (syntaxInfo.jsx && syntaxInfo.esm && syntaxInfo.dynamicImports) {
         this.skip();
         return;
       }
@@ -39,6 +44,11 @@ export function getSyntaxInfoFromAst(ast: ESTreeAST): SyntaxInfo {
 
       if (node.type === n.JSXElement) {
         syntaxInfo.jsx = true;
+        this.skip();
+      }
+
+      if (node.type === n.ImportExpression) {
+        syntaxInfo.dynamicImports = true;
         this.skip();
       }
     },

--- a/packages/app/src/sandbox/eval/transpilers/babel/ast/syntax.ts
+++ b/packages/app/src/sandbox/eval/transpilers/babel/ast/syntax.ts
@@ -35,6 +35,7 @@ export const Syntax = {
   ImportDefaultSpecifier: 'ImportDefaultSpecifier' as 'ImportDefaultSpecifier',
   ImportNamespaceSpecifier: 'ImportNamespaceSpecifier' as 'ImportNamespaceSpecifier',
   ImportSpecifier: 'ImportSpecifier' as 'ImportSpecifier',
+  ImportExpression: 'ImportExpression' as 'ImportExpression',
   LabeledStatement: 'LabeledStatement' as 'LabeledStatement',
   Literal: 'Literal' as 'Literal',
   LogicalExpression: 'LogicalExpression' as 'LogicalExpression',

--- a/packages/app/src/sandbox/eval/transpilers/babel/index.ts
+++ b/packages/app/src/sandbox/eval/transpilers/babel/index.ts
@@ -115,9 +115,11 @@ class BabelTranspiler extends WorkerTranspiler {
         const syntaxInfo = getSyntaxInfoFromAst(ast);
         if (!syntaxInfo.jsx) {
           // If the code is ESM we transform it to commonjs and return it
-          if (syntaxInfo.esm) {
+          if (syntaxInfo.esm || syntaxInfo.dynamicImports) {
             measure(`esconvert-${path}`);
-            convertEsModule(ast);
+            if (syntaxInfo.esm) {
+              convertEsModule(ast);
+            }
             // We collect requires instead of doing this in convertESModule as some modules also use require
             // Which is actually invalid but we probably don't wanna break anyone's code if it works in other bundlers...
             const deps = collectDependenciesFromAST(ast);


### PR DESCRIPTION
## What kind of change does this PR introduce?

Ensures we transpile dynamic imports in commonjs node modules, this is probably not valid JavaScript, but we should support it regardless.

Fixes #7357
