### PR TITLE
fix: don't try request when signed in and update template icons

### DIFF
--- a/packages/app/src/app/components/CreateSandbox/CreateSandbox.tsx
+++ b/packages/app/src/app/components/CreateSandbox/CreateSandbox.tsx
@@ -105,6 +105,7 @@ export const CreateSandbox: React.FC<CreateSandboxProps> = ({
   const teamTemplatesData = useTeamTemplates({
     isUser,
     teamId: activeTeamInfo?.id,
+    hasLogIn,
   });
 
   const officialTemplates =

--- a/packages/app/src/app/components/CreateSandbox/useTeamTemplates.ts
+++ b/packages/app/src/app/components/CreateSandbox/useTeamTemplates.ts
@@ -29,11 +29,13 @@ function getTeamTemplates(data: ListPersonalTemplatesQuery, teamId: string) {
 type UseTeamTemplatesParams = {
   isUser: boolean;
   teamId?: string;
+  hasLogIn: boolean;
 };
 
 export const useTeamTemplates = ({
   isUser,
   teamId,
+  hasLogIn,
 }: UseTeamTemplatesParams): State => {
   const { data, error } = useQuery<
     ListPersonalTemplatesQuery,
@@ -46,6 +48,7 @@ export const useTeamTemplates = ({
      */
     variables: {},
     fetchPolicy: 'cache-and-network',
+    skip: !hasLogIn,
   });
 
   if (error) {

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -76,7 +76,7 @@
     "semver": "^7.3.5",
     "sha1": "^1.1.1",
     "styled-components": "^5.2.0",
-    "template-icons": "^1.0.0",
+    "@codesandbox/template-icons": "^2.0.2",
     "typeface-inter": "^3.10.0"
   },
   "devDependencies": {

--- a/packages/common/src/templates/icons.ts
+++ b/packages/common/src/templates/icons.ts
@@ -28,7 +28,7 @@ import {
   UnibitIcon,
   DocusaurusIcon,
   SolidIcon,
-} from 'template-icons';
+} from '@codesandbox/template-icons';
 
 import {
   adonis,

--- a/packages/common/src/utils/getTemplateIcon.tsx
+++ b/packages/common/src/utils/getTemplateIcon.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ColorIcons as Icons } from 'template-icons';
+import { ColorIcons as Icons } from '@codesandbox/template-icons';
 import getColorIcons from '../templates/icons';
 
 function getUserIcon(

--- a/yarn.lock
+++ b/yarn.lock
@@ -32131,11 +32131,6 @@ tempfile@^2.0.0:
     temp-dir "^1.0.0"
     uuid "^3.0.1"
 
-template-icons@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/template-icons/-/template-icons-1.0.0.tgz#f6bd6d8e98c5057665d3f447e702924f0b1f8dfb"
-  integrity sha512-Uk5YycqkrB5nBqDrODBQt8tbpmEV6vNVXgDOlLiRYgL8FGyl1PLkV8mS9D+PB85cIHa5ZAOcI/iQfZcd1hvX9w==
-
 term-size@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/term-size/-/term-size-1.2.0.tgz#458b83887f288fc56d6fffbfad262e26638efa69"


### PR DESCRIPTION
- Anonymous users were seeing an error notification when opening /s, we now don't do the request if not signed in
- Our template icons were fetched from npm when I renamed the package, resulting in old icons