### PR TITLE
feat(upgrade): Append welcome=true to upgrade redirect URLs

### DIFF
--- a/packages/app/src/app/components/StripeMessages/UpgradeSSEToV2.tsx
+++ b/packages/app/src/app/components/StripeMessages/UpgradeSSEToV2.tsx
@@ -40,6 +40,9 @@ export const UpgradeSSEToV2Stripe = () => {
               id: sandboxId,
               alias,
               isV2: true,
+              query: {
+                welcome: 'true',
+              },
             });
 
             window.location.href = sandboxV2Url;
@@ -53,6 +56,9 @@ export const UpgradeSSEToV2Stripe = () => {
               id: forkedSandbox.id,
               alias: forkedSandbox.alias,
               isV2: true,
+              query: {
+                welcome: 'true',
+              },
             });
 
             window.location.href = sandboxV2Url;

--- a/packages/app/src/app/overmind/namespaces/git/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/git/actions.ts
@@ -175,6 +175,7 @@ export const createRepoClicked = async ({
     window.location.href = CSBProjectGitHubRepository({
       owner: git.username,
       repo: git.repo,
+      welcome: true,
     });
   } catch (error) {
     actions.internal.handleError({

--- a/packages/common/src/types/index.ts
+++ b/packages/common/src/types/index.ts
@@ -802,6 +802,7 @@ export type SandboxUrlSourceData = {
   alias?: string | null;
   git?: GitInfo | null;
   isV2?: boolean;
+  query?: Record<string, string>;
 };
 
 export type DevToolsTabPosition = {

--- a/packages/common/src/utils/url-generator.test.ts
+++ b/packages/common/src/utils/url-generator.test.ts
@@ -1,3 +1,4 @@
+import { sandboxUrl } from '../../lib/utils/url-generator';
 import { gitHubRepoPattern, gitHubToSandboxUrl } from './url-generator';
 
 const invalidUrls = [
@@ -42,6 +43,14 @@ describe('url-generator', () => {
       test(`validates ${inputUrl} as falsy`, () => {
         expect(gitHubRepoPattern.test(inputUrl)).toBeFalsy();
       });
+    });
+  });
+
+  describe('sandboxUrl', () => {
+    test(`handles query params`, () => {
+      expect(
+        sandboxUrl({ id: 'sandbox-id', isV2: true, query: { welcome: 'true' } })
+      ).toBe('/p/sandbox/sandbox-id?welcome=true');
     });
   });
 });

--- a/packages/common/src/utils/url-generator.ts
+++ b/packages/common/src/utils/url-generator.ts
@@ -112,11 +112,17 @@ export const sandboxUrl = (sandboxDetails: SandboxUrlSourceData) => {
     ? `${v2EditorUrl()}sandbox/`
     : editorUrl();
 
-  if (sandboxDetails.alias) {
-    return `${baseUrl}${sandboxDetails.alias}`;
+  let queryParams = '';
+
+  if (sandboxDetails.query) {
+    queryParams = `?${new URLSearchParams(sandboxDetails.query).toString()}`;
   }
 
-  return `${baseUrl}${sandboxDetails.id}`;
+  if (sandboxDetails.alias) {
+    return `${baseUrl}${sandboxDetails.alias}${queryParams}`;
+  }
+
+  return `${baseUrl}${sandboxDetails.id}${queryParams}`;
 };
 
 export const v2BranchUrl = (branchDetails: {

--- a/packages/common/src/utils/url-generator.ts
+++ b/packages/common/src/utils/url-generator.ts
@@ -14,15 +14,19 @@ const sandboxHost = {
 export const CSBProjectGitHubRepository = ({
   owner,
   repo,
+  welcome,
 }: {
   owner: string;
-  repo;
+  repo: string;
+  welcome: boolean;
 }) => {
   const origin = process.env.STAGING_API
     ? 'https://codesandbox.stream'
     : 'https://codesandbox.io';
 
-  return `${origin}/p/github/${owner}/${repo}?create=true`;
+  return `${origin}/p/github/${owner}/${repo}?create=true${
+    welcome ? '&welcome=true' : ''
+  }`;
 };
 
 const buildEncodedUri = (


### PR DESCRIPTION
## What kind of change does this PR introduce?

When upgrading from a V1 sandbox to a V2 repo/sandbox, we want to append `welcome=true` to the query params to show a nice modal on the other end.

There are two ways of using this - 
1. When you fork/upgrade using the new upgrade stripe.
2. When you export your sandbox to github and get redirect to V2.

## What is the current behavior?

The redirect URL does not contain `welcome=true`

## What is the new behavior?

The redirect URL contains `welcome=true`

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Testing <!-- We can only merge the PR if this is checked -->
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
