### PR TITLE
fix(dashboard): Gracefully change to personal workspace

### DIFF
--- a/packages/app/src/app/overmind/actions.ts
+++ b/packages/app/src/app/overmind/actions.ts
@@ -539,7 +539,11 @@ export const setActiveTeam = async (
         const res = await effects.gql.queries.getPersonalWorkspaceId({});
         personalWorkspaceId = res.me?.personalWorkspaceId;
       }
+
       if (personalWorkspaceId) {
+        // This toast was triggered when the getTeam query inside getActiveTeamInfo
+        // failed due to an invalid workspace id in the url or localStorage. We now
+        // check for id validity when initializing.
         effects.notificationToast.add({
           title: 'Could not find current workspace',
           message: "We've switched you to your personal workspace",
@@ -563,6 +567,9 @@ export const getActiveTeamInfo = async ({
     await actions.internal.setActiveTeamFromUrlOrStore();
   }
 
+  // The getTeam query below used to fail because we weren't sure if the id in
+  // the localStorage or url was valid. We check this now when initializing the
+  // team, so this shouldn't error anymore.
   const team = await effects.gql.queries.getTeam({
     teamId: state.activeTeam,
   });

--- a/packages/app/src/app/overmind/actions.ts
+++ b/packages/app/src/app/overmind/actions.ts
@@ -75,7 +75,7 @@ export const onInitializeOvermind = async (
   effects.gql.initialize(gqlOptions, () => effects.live.socket);
 
   if (state.hasLogIn) {
-    await actions.internal.setActiveTeamFromUrlOrStore();
+    await actions.internal.setActiveWorkspaceFromUrlOrStore();
   }
 
   effects.notifications.initialize({
@@ -564,7 +564,7 @@ export const getActiveTeamInfo = async ({
   actions,
 }: Context) => {
   if (!state.activeTeam) {
-    await actions.internal.setActiveTeamFromUrlOrStore();
+    await actions.internal.setActiveWorkspaceFromUrlOrStore();
   }
 
   // The getTeam query below used to fail because we weren't sure if the id in

--- a/packages/app/src/app/overmind/internalActions.ts
+++ b/packages/app/src/app/overmind/internalActions.ts
@@ -595,8 +595,9 @@ const INVALID_ID_TITLE = 'Workspace not recognized.';
 const INVALID_ID_MESSAGE =
   "The workspace in the URL or stored in your browser is unknown. We've automatically switched to your personal workspace.";
 
-// Rename to initializeTeam (because we also use personalWorkspaceId);
-export const setActiveTeamFromUrlOrStore = async ({
+// TODO we could rename the function to initializeTeam (because we also use
+// personalWorkspaceId);
+export const setActiveWorkspaceFromUrlOrStore = async ({
   actions,
   effects,
 }: Context) => {

--- a/packages/app/src/app/pages/Dashboard/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/index.tsx
@@ -63,6 +63,9 @@ export const Dashboard: FunctionComponent = () => {
 
     if (searchParams.get('workspace')) {
       // Change workspace based on workspace param
+
+      // TODO: We might want to update this because this is also triggered in
+      // overmind already? We can check if it is triggered multiple times.
       actions.setActiveTeam({ id: searchParams.get('workspace') });
     }
 


### PR DESCRIPTION
Closes XTD-632
Closes XTD-630
Closes XTD-631

#### Before

https://user-images.githubusercontent.com/7533849/215761133-8d62ea0e-cabd-4030-85fa-97221828bb3f.mov

#### After

1. First we show that the application gracefully changes to the personal workspace when no id is present in the url or `localStorage`. No message is shown.

2. We then show behaviour when the suggested id is wrong. We change to the personal workspace and make sure we're not trying to fetch any data with the wrong id. We also notify the user that the "saved" id is wrong and we've activated the personal workspace.

3. We than show the same behaviour, but with an existing team id the user does not have access to. This behaves the same way as described above.

4. And finally we use the url with a wrong team id. This behaves the same way as described above.

https://user-images.githubusercontent.com/7533849/215761249-705b7656-4130-4b77-9969-7c1e80f6959f.mov


