### PR TITLE
fix(dashboard): Only close modal when modal is open

### DIFF
--- a/packages/app/src/app/components/CreateSandbox/CreateSandboxModal.tsx
+++ b/packages/app/src/app/components/CreateSandbox/CreateSandboxModal.tsx
@@ -60,10 +60,14 @@ export const CreateSandboxModal = () => {
   );
 
   useEffect(() => {
-    if (hasNavigated) {
+    if (hasNavigated && modals.newSandboxModal.isCurrent) {
       modalsActions.newSandboxModal.close();
     }
-  }, [hasNavigated, modalsActions.newSandboxModal]);
+  }, [
+    hasNavigated,
+    modals.newSandboxModal.isCurrent,
+    modalsActions.newSandboxModal,
+  ]);
 
   return (
     <ThemeProvider>


### PR DESCRIPTION
Closes XTD-634

Close modal was called for a modal which caused all modals to close. This extra check makes sure it's only called when necessary and the modal is actually open.