### PR TITLE
fix(dashboard): Import link with right URL and close modal after navigation

### DIFF
--- a/packages/app/src/app/components/CreateSandbox/CreateSandboxModal.tsx
+++ b/packages/app/src/app/components/CreateSandbox/CreateSandboxModal.tsx
@@ -2,7 +2,7 @@ import { ThemeProvider } from '@codesandbox/components';
 import Modal from 'app/components/Modal';
 import { useAppState, useActions } from 'app/overmind';
 import { DELETE_ME_COLLECTION } from 'app/overmind/namespaces/dashboard/types';
-import React, { useEffect, useRef } from 'react';
+import React from 'react';
 import { useLocation } from 'react-router-dom';
 
 import { COLUMN_MEDIA_THRESHOLD, CreateSandbox } from './CreateSandbox';
@@ -34,36 +34,15 @@ function getImplicitCollectionIdFromFolder(
 
 const collectionPathRegex = /^.*dashboard\/sandboxes/;
 
-const useHasNavigated = ({ pathname }: ReturnType<typeof useLocation>) => {
-  const previousLocationRef = useRef<string>();
-
-  useEffect(() => {
-    previousLocationRef.current = pathname;
-  }, [pathname]);
-
-  if (previousLocationRef.current === pathname) {
-    return true;
-  }
-
-  return false;
-};
-
 export const CreateSandboxModal = () => {
   const { modals, dashboard } = useAppState();
   const { modals: modalsActions } = useActions();
   const location = useLocation();
-  const hasNavigated = useHasNavigated(location);
 
   const implicitCollection = getImplicitCollectionIdFromFolder(
     location.pathname,
     dashboard.allCollections
   );
-
-  useEffect(() => {
-    if (hasNavigated) {
-      modalsActions.newSandboxModal.close();
-    }
-  }, [hasNavigated, modalsActions.newSandboxModal]);
 
   return (
     <ThemeProvider>

--- a/packages/app/src/app/components/CreateSandbox/Import/importLimits.tsx
+++ b/packages/app/src/app/components/CreateSandbox/Import/importLimits.tsx
@@ -100,38 +100,42 @@ export const PrivateRepoFreeTeam: React.FC = () => {
     cancel_path: pathname,
   });
 
-  const checkoutURL = React.useMemo(() => {
-    if (isTeamAdmin || isPersonalSpace) {
-      if (checkout.state === 'READY') {
-        return checkout.url;
-      }
-      return '/pro';
-    }
+  let checkoutURL: string;
 
-    return isEligibleForTrial
+  if (isTeamAdmin || isPersonalSpace) {
+    if (checkout.state === 'READY') {
+      checkoutURL = checkout.url;
+    } else {
+      checkoutURL = '/pro';
+    }
+  } else {
+    // Not team admin or personal workspace points to docs
+    checkoutURL = isEligibleForTrial
       ? '/docs/learn/plan-billing/trials'
       : '/docs/learn/introduction/workspace#managing-teams-and-subscriptions';
-  }, [checkout, isEligibleForTrial, isTeamAdmin, isPersonalSpace]);
+  }
+
+  const isDashboardLink = checkoutURL.startsWith('/pro');
 
   return (
     <>
       The free plan only allows public repos. For private repositories,{' '}
       <StyledLink
-        {...(checkoutURL.startsWith('/pro')
+        {...(isDashboardLink
           ? {
-              as: 'a',
-              href: checkoutURL,
+              as: RouterLink,
+              to: `${checkoutURL}?utm_source=dashboard_import_limits`,
             }
           : {
-              as: RouterLink,
-              to: '/pro?utm_source=dashboard_import_limits',
+              as: 'a',
+              href: checkoutURL, // goes to either /docs or Stripe
             })}
         css={{
           padding: 0,
         }}
         color="#FFFFFF"
         onClick={() => {
-          if (checkoutURL.startsWith('/pro')) {
+          if (isDashboardLink) {
             modals.newSandboxModal.close();
           }
 


### PR DESCRIPTION
Closes XTD-634

And this time for real. I've reverted the buggy behaviour that was supposed to close modals on navigation, as it wasn't necessary. I found that the logic to generate the URL and close the create new modal was behaving weird. The "upgrade to pro" URL shows up when a free team tries to import a private repository.

<img width="711" alt="image" src="https://user-images.githubusercontent.com/7533849/215873829-964a6f97-6d0a-482f-b58f-8ff98bb8e414.png">

The link can either point to `/pro`, `/docs/*` or Stripe. When it's pointing to `/pro` it stays on the "dashboard" pages and uses a React Router link to navigate. This is done client side, so modals won't close. Adding an `onClick` where we close the modal for this case fixes this.

- The link is pointing to `/pro` when the user is **admin and the stripe URL hasn't been generated yet**
- The link is pointing to `/docs` when the user is **not admin and not on a personal space**
- The link is pointing to Stripe when the user is **admin and the stripe URL is generated**

Generating the Stripe URL happens async and takes time.

### Proof that the modal closes

https://user-images.githubusercontent.com/7533849/215874494-801c92ee-6b6c-499e-b8f2-5b3ad0ea48f5.mov

### Proof that the create team modal shows up

https://user-images.githubusercontent.com/7533849/215875593-94172615-c924-4930-af1c-06fd5f23ac80.mov
