### PR TITLE
fix(dashboard): bottom being cut if stripe banner is visible at the top

### DIFF
--- a/packages/app/src/app/pages/Dashboard/Sidebar/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Sidebar/index.tsx
@@ -128,7 +128,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
         css={css({
           width: SIDEBAR_WIDTH,
           zIndex: 3,
-          paddingTop: '23px',
+          paddingTop: '24px',
           // We set sidebar as absolute so that content can
           // take 100% width, this helps us enable dragging
           // sandboxes onto the sidebar more freely.

--- a/packages/app/src/app/pages/Dashboard/Sidebar/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Sidebar/index.tsx
@@ -17,6 +17,7 @@ import { WorkspaceSelect } from 'app/components/WorkspaceSelect';
 import { getDaysUntil } from 'app/utils/dateTime';
 import { useWorkspaceAuthorization } from 'app/hooks/useWorkspaceAuthorization';
 import { useWorkspaceSubscription } from 'app/hooks/useWorkspaceSubscription';
+import { SubscriptionStatus } from 'app/graphql/types';
 import { ContextMenu } from './ContextMenu';
 import { DashboardBaseFolder } from '../types';
 import { Position } from '../Components/Selection';
@@ -114,6 +115,8 @@ export const Sidebar: React.FC<SidebarProps> = ({
     trialDaysLeft !== null &&
     trialDaysLeft <= DAYS_LEFT_TO_SHOW_UPGRADE_MESSAGE;
 
+  const hasTopBarBanner = subscription?.status === SubscriptionStatus.Unpaid;
+
   return (
     <SidebarContext.Provider value={{ onSidebarToggle, menuState }}>
       <Stack
@@ -128,12 +131,16 @@ export const Sidebar: React.FC<SidebarProps> = ({
         css={css({
           width: SIDEBAR_WIDTH,
           zIndex: 3,
-          paddingTop: '24px',
+          marginTop: '24px',
+          paddingBottom: '32px',
           // We set sidebar as absolute so that content can
           // take 100% width, this helps us enable dragging
           // sandboxes onto the sidebar more freely.
           position: 'absolute',
-          height: 'calc(100% - 48px)',
+          // 100vh - topbar height - (banner height or 0) - padding bottom
+          height: `calc(100vh - 60px - ${
+            hasTopBarBanner ? '44' : '0'
+          }px - 32px)`,
         })}
       >
         <Stack direction="horizontal">
@@ -307,7 +314,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
         </List>
 
         {teamDataLoaded && isFree ? (
-          <Element css={{ margin: '24px', paddingTop: 0 }}>
+          <Element css={{ margin: 'auto 24px 0' }}>
             {isTeamAdmin && isEligibleForTrial ? (
               <AdminStartTrial activeTeam={activeTeam} />
             ) : null}
@@ -323,7 +330,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
         ) : null}
 
         {teamDataLoaded && showDaysLeftMessage ? (
-          <Element css={{ margin: '24px', paddingTop: 0 }}>
+          <Element css={{ margin: 'auto 24px 0' }}>
             <TrialExpiring
               activeTeam={activeTeam}
               cancelAtPeriodEnd={subscription?.cancelAtPeriodEnd}

--- a/packages/app/src/app/pages/Dashboard/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/index.tsx
@@ -95,6 +95,8 @@ export const Dashboard: FunctionComponent = () => {
     }
   }, [location.search, actions, activeTeamInfo, notificationToast]);
 
+  const hasTopBarBanner = subscription?.status === SubscriptionStatus.Unpaid;
+
   useEffect(() => {
     trackVisit();
   }, []);
@@ -160,7 +162,8 @@ export const Dashboard: FunctionComponent = () => {
             as="main"
             css={css({
               width: '100%',
-              height: 'calc(100vh - 48px)',
+              // 100vh - (topbar height - gap between topbar and content) - (banner height or 0)
+              height: `calc(100vh - 32px - ${hasTopBarBanner ? '44' : '0'}px)`,
               paddingLeft: [0, 0, SIDEBAR_WIDTH + 24],
             })}
           >

--- a/packages/app/src/app/pages/Dashboard/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/index.tsx
@@ -111,68 +111,61 @@ export const Dashboard: FunctionComponent = () => {
         <Stack
           direction="vertical"
           css={css({
+            position: 'relative',
             fontFamily: "'Inter', sans-serif",
             backgroundColor: 'sideBar.background',
             color: 'sideBar.foreground',
-            width: '100vw',
-            minHeight: '100vh',
+            width: '100%',
+            height: '100%',
           })}
         >
           <SkipNav.Link />
           {subscription?.status === SubscriptionStatus.Unpaid && (
-            <Element
-              css={{
-                paddingBottom: '8px', // Using padding because the margin will get overridden to 0
-              }}
-            >
-              <PaymentPending />
-            </Element>
+            <PaymentPending />
           )}
           <Header onSidebarToggle={onSidebarToggle} />
-          <Stack css={{ flexGrow: 1 }}>
-            <Media
-              query={theme.media
-                .lessThan(theme.sizes.medium)
-                .replace('@media ', '')}
-            >
-              {match =>
-                match ? (
-                  <Element
-                    id="mobile-sidebar"
-                    css={css({ display: ['block', 'block', 'none'] })}
-                  >
-                    <Sidebar
-                      visible={sidebarVisible}
-                      onSidebarToggle={onSidebarToggle}
-                    />
-                  </Element>
-                ) : (
-                  <Element
-                    id="desktop-sidebar"
-                    css={css({ display: ['none', 'none', 'block'] })}
-                  >
-                    <Sidebar
-                      visible
-                      onSidebarToggle={() => {
-                        /* do nothing */
-                      }}
-                    />
-                  </Element>
-                )
-              }
-            </Media>
+          <Media
+            query={theme.media
+              .lessThan(theme.sizes.medium)
+              .replace('@media ', '')}
+          >
+            {match =>
+              match ? (
+                <Element
+                  id="mobile-sidebar"
+                  css={css({ display: ['block', 'block', 'none'] })}
+                >
+                  <Sidebar
+                    visible={sidebarVisible}
+                    onSidebarToggle={onSidebarToggle}
+                  />
+                </Element>
+              ) : (
+                <Element
+                  id="desktop-sidebar"
+                  css={css({ display: ['none', 'none', 'block'] })}
+                >
+                  <Sidebar
+                    visible
+                    onSidebarToggle={() => {
+                      /* do nothing */
+                    }}
+                  />
+                </Element>
+              )
+            }
+          </Media>
 
-            <Element
-              as="main"
-              css={css({
-                width: '100%',
-                height: 'calc(100vh - 48px)',
-                paddingLeft: [0, 0, SIDEBAR_WIDTH + 24],
-              })}
-            >
-              <Content />
-            </Element>
-          </Stack>
+          <Element
+            as="main"
+            css={css({
+              width: '100%',
+              height: 'calc(100vh - 48px)',
+              paddingLeft: [0, 0, SIDEBAR_WIDTH + 24],
+            })}
+          >
+            <Content />
+          </Element>
         </Stack>
       </DndProvider>
       <NewTeamModal />

--- a/packages/app/src/app/pages/Sandbox/Editor/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/index.tsx
@@ -125,7 +125,7 @@ export const Editor = ({ showNewSandboxModal }: EditorTypes) => {
       (state.hasLogIn && sandbox?.isSse)
     ) {
       // Header height + MessageStripe
-      return 3 * 16 + 42;
+      return 3 * 16 + 44;
     }
 
     // Header height


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?

<!-- Is it a Bug fix, feature, docs update, ... -->

Manually calculate the height based on whether the stripe banner is visible or not. Because of some absolutely positioned elements, it's hard to simplify this since doesn't follow a proper flow layout.

## What is the current behavior?

<!-- You can also link to an open issue here -->

<img width="1163" alt="Screen Shot 2023-02-01 at 02 05 41" src="https://user-images.githubusercontent.com/24959348/215956230-62fc419a-b328-437e-939f-08160a78c4b3.png">

## What is the new behavior?

<!-- if this is a feature change -->

|Desktop|
|:-:|
|![ur44et-3000 preview csb app_dashboard_recent_workspace=47968439-c1ee-494c-a6e1-ec7ea18ab162 (2)](https://user-images.githubusercontent.com/24959348/215956143-b98a812e-ff19-40f7-b3c1-a38d4de3bb05.png)|

|Mobile - Sidebar closed|Mobile - Sidebar open|
|:-:|:-:|
|![ur44et-3000 preview csb app_dashboard_recent_workspace=47968439-c1ee-494c-a6e1-ec7ea18ab162 (1)](https://user-images.githubusercontent.com/24959348/215955982-e689e35d-06f9-4ae3-b57b-a619513e5130.png)|![ur44et-3000 preview csb app_dashboard_recent_workspace=47968439-c1ee-494c-a6e1-ec7ea18ab162](https://user-images.githubusercontent.com/24959348/215955938-b8f8d610-f01f-4f0f-a1b9-b862c2308ab6.png)|

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Launch the dashboard
2. Open a team w/ an unpaid subscription

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Testing <!-- We can only merge the PR if this is checked -->
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
