### PR TITLE
fix(sse): Update message and disable forking for free teams

### DIFF
--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/NotOwnedSandboxInfo/Summary.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/NotOwnedSandboxInfo/Summary.tsx
@@ -26,9 +26,6 @@ import {
 } from '@codesandbox/components';
 import css from '@styled-system/css';
 
-// Comment to trigger the CI that keeps on failing on manual restart, without there
-// being actual issues.
-
 import { BookmarkTemplateButton } from './BookmarkTemplateButton';
 import { GitHubIcon } from '../GitHub/Icons';
 
@@ -173,7 +170,7 @@ export const Summary = () => {
           <Stack as="section" direction="vertical" gap={4} paddingX={2}>
             {!isPro && isUnlistedOrPrivate ? (
               <Text variant="muted" size={3}>
-                This is {privacy === 1 ? 'a private' : 'an unlisted'} sandbox.{' '}
+                This is {privacy === 2 ? 'a private' : 'an unlisted'} sandbox.{' '}
                 <Link href="/pro" css={{ color: 'white' }}>
                   Upgrade to{' '}
                   <Element as="span" css={{ textTransform: 'uppercase' }}>

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/NotOwnedSandboxInfo/Summary.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/NotOwnedSandboxInfo/Summary.tsx
@@ -26,6 +26,9 @@ import {
 } from '@codesandbox/components';
 import css from '@styled-system/css';
 
+// Comment to trigger the CI that keeps on failing on manual restart, without there
+// being actual issues.
+
 import { BookmarkTemplateButton } from './BookmarkTemplateButton';
 import { GitHubIcon } from '../GitHub/Icons';
 

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/NotOwnedSandboxInfo/Summary.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/NotOwnedSandboxInfo/Summary.tsx
@@ -10,6 +10,7 @@ import {
 import getTemplateDefinition from '@codesandbox/common/lib/templates';
 import { getTemplateIcon } from '@codesandbox/common/lib/utils/getTemplateIcon';
 import { TeamAvatar } from 'app/components/TeamAvatar';
+import { useWorkspaceSubscription } from 'app/hooks/useWorkspaceSubscription';
 
 import {
   Element,
@@ -47,13 +48,16 @@ export const Summary = () => {
     forkedTemplateSandbox,
     tags,
     team,
+    privacy,
   } = currentSandbox;
   const {
     editor: { forkSandboxClicked },
   } = useActions();
+  const { isPro } = useWorkspaceSubscription();
 
   const isForked = forkedFromSandbox || forkedTemplateSandbox;
   const { url: templateUrl } = getTemplateDefinition(template);
+  const isUnlistedOrPrivate = privacy === 1 || privacy === 2;
 
   return (
     <Collapsible
@@ -164,13 +168,29 @@ export const Summary = () => {
 
         {!author && currentSandbox.git ? (
           <Stack as="section" direction="vertical" gap={4} paddingX={2}>
-            <Text variant="muted" size={3}>
-              This sandbox is in sync with{' '}
-              <Text weight="bold">{currentSandbox.git.branch}</Text> on GitHub.
-              You have to fork to make changes
-            </Text>
+            {!isPro && isUnlistedOrPrivate ? (
+              <Text variant="muted" size={3}>
+                You are on a free team and this is a{' '}
+                {privacy === 1 ? 'private' : 'unlisted'}
+                sandbox.{' '}
+                <Link href="/pro" css={{ color: 'white' }}>
+                  Upgrade to{' '}
+                  <Element as="span" css={{ textTransform: 'uppercase' }}>
+                    pro
+                  </Element>
+                </Link>{' '}
+                to fork this sandbox.
+              </Text>
+            ) : (
+              <Text variant="muted" size={3}>
+                This sandbox is in sync with{' '}
+                <Text weight="bold">{currentSandbox.git.branch}</Text> on
+                GitHub. You have to fork to make changes
+              </Text>
+            )}
             <Button
               variant="primary"
+              disabled={!isPro && isUnlistedOrPrivate}
               loading={isForkingSandbox}
               onClick={() => forkSandboxClicked({})}
             >

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/NotOwnedSandboxInfo/Summary.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/NotOwnedSandboxInfo/Summary.tsx
@@ -173,9 +173,7 @@ export const Summary = () => {
           <Stack as="section" direction="vertical" gap={4} paddingX={2}>
             {!isPro && isUnlistedOrPrivate ? (
               <Text variant="muted" size={3}>
-                You are on a free team and this is a{' '}
-                {privacy === 1 ? 'private' : 'unlisted'}
-                sandbox.{' '}
+                This is {privacy === 1 ? 'a private' : 'an unlisted'} sandbox.{' '}
                 <Link href="/pro" css={{ color: 'white' }}>
                   Upgrade to{' '}
                   <Element as="span" css={{ textTransform: 'uppercase' }}>
@@ -188,7 +186,7 @@ export const Summary = () => {
               <Text variant="muted" size={3}>
                 This sandbox is in sync with{' '}
                 <Text weight="bold">{currentSandbox.git.branch}</Text> on
-                GitHub. You have to fork to make changes
+                GitHub. You have to fork to make changes.
               </Text>
             )}
             <Button


### PR DESCRIPTION
Closes XTD-646

Makes sure that all the fork buttons are disabled, as it is not possible to fork a private SSE sandbox on a free team. Disabling the editor still needs to be done, but the flag we use for this (`free_plan_editing_restricted`) always returns `false` for SSE sandboxes. I've asked to look into this with the BEOPS team.

Update: We're disabling the editor in another iteration. I've created various Linear tickets for this.

### Screenshot

<img width="1248" alt="image" src="https://user-images.githubusercontent.com/7533849/216019561-0433818e-3782-410f-b593-e679147616f5.png">
