### PR TITLE
fix(pro): Make personal team user team admin by default

### DIFF
--- a/packages/app/src/app/hooks/useWorkspaceAuthorization.ts
+++ b/packages/app/src/app/hooks/useWorkspaceAuthorization.ts
@@ -21,8 +21,9 @@ export const useWorkspaceAuthorization = () => {
   const isTeamSpace = activeTeam !== null && !isPersonalSpace;
 
   const isTeamAdmin =
-    isTeamSpace &&
-    activeWorkspaceAuthorization === TeamMemberAuthorization.Admin;
+    (isTeamSpace &&
+      activeWorkspaceAuthorization === TeamMemberAuthorization.Admin) ||
+    isPersonalSpace;
 
   const isTeamEditor =
     isTeamSpace &&

--- a/packages/app/src/app/hooks/useWorkspaceAuthorization.ts
+++ b/packages/app/src/app/hooks/useWorkspaceAuthorization.ts
@@ -27,9 +27,7 @@ export const useWorkspaceAuthorization = () => {
 
   const isTeamSpace = activeTeam !== null && !isPersonalSpace;
 
-  const isTeamAdmin =
-    isTeamSpace &&
-    activeWorkspaceAuthorization === TeamMemberAuthorization.Admin;
+  const isTeamAdmin = isTeamSpace && isAdmin;
 
   const isTeamEditor =
     isTeamSpace &&

--- a/packages/app/src/app/hooks/useWorkspaceAuthorization.ts
+++ b/packages/app/src/app/hooks/useWorkspaceAuthorization.ts
@@ -15,15 +15,21 @@ export const useWorkspaceAuthorization = () => {
   const isPersonalSpace = activeTeam === personalWorkspaceId;
 
   /**
+   * User states
+   */
+
+  const isAdmin =
+    activeWorkspaceAuthorization === TeamMemberAuthorization.Admin;
+
+  /**
    * Team states
    */
 
   const isTeamSpace = activeTeam !== null && !isPersonalSpace;
 
   const isTeamAdmin =
-    (isTeamSpace &&
-      activeWorkspaceAuthorization === TeamMemberAuthorization.Admin) ||
-    isPersonalSpace;
+    isTeamSpace &&
+    activeWorkspaceAuthorization === TeamMemberAuthorization.Admin;
 
   const isTeamEditor =
     isTeamSpace &&
@@ -39,6 +45,7 @@ export const useWorkspaceAuthorization = () => {
     isTeamAdmin,
     isTeamEditor,
     isTeamViewer,
+    isAdmin,
     userRole: activeWorkspaceAuthorization,
   };
 };

--- a/packages/app/src/app/pages/Pro/Upgrade.tsx
+++ b/packages/app/src/app/pages/Pro/Upgrade.tsx
@@ -67,7 +67,7 @@ export const ProUpgrade = () => {
     }
   }, [hasLoadedApp, location, setActiveTeam, personalWorkspaceId, dashboard]);
 
-  const { isPersonalSpace, isTeamAdmin } = useWorkspaceAuthorization();
+  const { isPersonalSpace, isTeamAdmin, isAdmin } = useWorkspaceAuthorization();
   const { isFree, isPro } = useWorkspaceSubscription();
   // const isFree = false; // DEBUG
   // const isPro = true; // DEBUG
@@ -80,7 +80,7 @@ export const ProUpgrade = () => {
   const hasCustomSubscription = false;
 
   const checkout = useGetCheckoutURL({
-    team_id: isTeamAdmin && isFree ? activeTeam : undefined,
+    team_id: isAdmin && isFree ? activeTeam : undefined,
     success_path: dashboardUrls.settings(activeTeam),
     cancel_path: '/pro',
     // recurring_interval: 'year', // TODO: defaulting to year does not enable the interval switch in stripe


### PR DESCRIPTION
When creating the checkout URL on the pro page we check if the user is a team admin, but this was only true for team spaces. Changed it to make sure we have an `isAdmin` property unrelated to personal or teams, but just to the user.