### PR TITLE
feat(upgrade): Add terminal tab to client sandboxes for upgrade lever

### DIFF
--- a/packages/app/src/app/components/Preview/DevTools/TerminalUpgrade/elements.tsx
+++ b/packages/app/src/app/components/Preview/DevTools/TerminalUpgrade/elements.tsx
@@ -1,0 +1,15 @@
+import styled from 'styled-components';
+
+export const StyledTitle = styled.div`
+  display: flex;
+  align-items: center;
+  font-weight: 600;
+  font-size: 1rem;
+  color: ${props =>
+    props.theme.light ? 'rgba(0, 0, 0, 0.4)' : 'rgba(255, 255, 255, 0.4)'};
+  width: 100%;
+  padding: 1rem;
+  border-bottom: 2px solid;
+  border-color: ${props =>
+    props.theme.light ? 'rgba(0, 0, 0, 0.3)' : 'rgba(255, 255, 255, 0.3)'};
+`;

--- a/packages/app/src/app/components/Preview/DevTools/TerminalUpgrade/index.tsx
+++ b/packages/app/src/app/components/Preview/DevTools/TerminalUpgrade/index.tsx
@@ -62,7 +62,7 @@ export const TerminalUpgradeComponent: React.FC<StyledProps> = ({
                 paddingRight: '1rem',
               }}
             >
-              Yes, {canConvert ? 'convert' : 'fork'}
+              Yes, {canConvert ? 'convert' : 'fork and convert'}
             </Button>
             <Button
               as="a"
@@ -90,7 +90,6 @@ export const TerminalUpgradeComponent: React.FC<StyledProps> = ({
 export const terminalUpgrade = {
   id: 'codesandbox.terminalUpgrade',
   title: 'Terminal',
-  // @ts-ignore  TODO: fix this
   Content: withTheme(TerminalUpgradeComponent),
   actions: [],
 };

--- a/packages/app/src/app/components/Preview/DevTools/TerminalUpgrade/index.tsx
+++ b/packages/app/src/app/components/Preview/DevTools/TerminalUpgrade/index.tsx
@@ -62,7 +62,7 @@ export const TerminalUpgradeComponent: React.FC<StyledProps> = ({
                 paddingRight: '1rem',
               }}
             >
-              Yes, convert
+              Yes, {canConvert ? 'convert' : 'fork'}
             </Button>
             <Button
               as="a"

--- a/packages/app/src/app/components/Preview/DevTools/TerminalUpgrade/index.tsx
+++ b/packages/app/src/app/components/Preview/DevTools/TerminalUpgrade/index.tsx
@@ -1,0 +1,96 @@
+import { Button, ThemeProvider, Text, Stack } from '@codesandbox/components';
+import React from 'react';
+import themeType from '@codesandbox/common/lib/theme';
+
+import { withTheme } from 'styled-components';
+import { useUpgradeFromV1ToV2 } from 'app/hooks/useUpgradeFromV1ToV2';
+import { DevToolProps } from '..';
+import { StyledTitle } from './elements';
+
+type StyledProps = DevToolProps & {
+  theme: typeof themeType & { light: boolean };
+};
+
+export const TerminalUpgradeComponent: React.FC<StyledProps> = ({
+  hidden,
+  theme,
+}) => {
+  const { perform, loading, canConvert } = useUpgradeFromV1ToV2();
+
+  if (hidden) {
+    return null;
+  }
+
+  return (
+    <ThemeProvider theme={theme.vscodeTheme}>
+      <Stack
+        direction="vertical"
+        css={{
+          width: '100%',
+        }}
+      >
+        <StyledTitle>Terminal</StyledTitle>
+        <Stack
+          direction="vertical"
+          css={{
+            padding: '1rem',
+          }}
+          gap={4}
+        >
+          <Text>
+            To use the terminal, you need to upgrade your Browser Sandbox into a
+            Cloud Sandbox.
+          </Text>
+          <Text>
+            {canConvert
+              ? `Do you want to convert it into a Cloud Sandbox?`
+              : `Do you want to fork into a Cloud Sandbox?`}
+          </Text>
+          <Stack
+            direction="horizontal"
+            gap={4}
+            css={{
+              justifyContent: 'start',
+            }}
+          >
+            <Button
+              onClick={perform}
+              loading={loading}
+              css={{
+                width: 'inherit',
+                paddingLeft: '1rem',
+                paddingRight: '1rem',
+              }}
+            >
+              Yes, convert
+            </Button>
+            <Button
+              as="a"
+              variant="link"
+              style={{
+                width: 'inherit',
+                display: 'flex',
+                alignItems: 'center',
+                backgroundColor: 'transparent',
+                color: 'mutedForeground',
+              }}
+              target="_blank"
+              rel="noreferrer noopener"
+              href="https://codesandbox.io/docs/learn/sandboxes/overview?tab=cloud"
+            >
+              Learn more
+            </Button>
+          </Stack>
+        </Stack>
+      </Stack>
+    </ThemeProvider>
+  );
+};
+
+export const terminalUpgrade = {
+  id: 'codesandbox.terminalUpgrade',
+  title: 'Terminal',
+  // @ts-ignore  TODO: fix this
+  Content: withTheme(TerminalUpgradeComponent),
+  actions: [],
+};

--- a/packages/app/src/app/components/Preview/DevTools/TerminalUpgrade/index.tsx
+++ b/packages/app/src/app/components/Preview/DevTools/TerminalUpgrade/index.tsx
@@ -15,7 +15,7 @@ export const TerminalUpgradeComponent: React.FC<StyledProps> = ({
   hidden,
   theme,
 }) => {
-  const { perform, loading, canConvert } = useUpgradeFromV1ToV2();
+  const { perform, loading, canConvert } = useUpgradeFromV1ToV2('Terminal Tab');
 
   if (hidden) {
     return null;

--- a/packages/app/src/app/components/Preview/DevTools/index.tsx
+++ b/packages/app/src/app/components/Preview/DevTools/index.tsx
@@ -13,6 +13,7 @@ import { problems } from './Problems';
 import { reactDevTools } from './React-Devtools';
 import { DevToolTabs } from './Tabs';
 import { terminal } from './Terminal';
+import { terminalUpgrade } from './TerminalUpgrade';
 import { tests } from './Tests';
 
 function unFocus(document, window) {
@@ -80,6 +81,7 @@ const VIEWS: IViews = {
   [tests.id]: tests,
   [terminal.id]: terminal,
   [reactDevTools.id]: reactDevTools,
+  [terminalUpgrade.id]: terminalUpgrade,
 };
 
 type Props = {

--- a/packages/app/src/app/components/StripeMessages/UpgradeSSEToV2.tsx
+++ b/packages/app/src/app/components/StripeMessages/UpgradeSSEToV2.tsx
@@ -1,19 +1,9 @@
-import React, { useState } from 'react';
-import { useEffects, useAppState } from 'app/overmind';
+import React from 'react';
 import { MessageStripe } from '@codesandbox/components';
-import { sandboxUrl } from '@codesandbox/common/lib/utils/url-generator';
-import { hasPermission } from '@codesandbox/common/lib/utils/permission';
-import track from '@codesandbox/common/lib/utils/analytics';
+import { useUpgradeFromV1ToV2 } from 'app/hooks/useUpgradeFromV1ToV2';
 
 export const UpgradeSSEToV2Stripe = () => {
-  const state = useAppState();
-  const effects = useEffects();
-  const [isLoading, setIsLoading] = useState(false);
-  const updateSandbox = useEffects().api.updateSandbox;
-  const canConvert = hasPermission(
-    state.editor.currentSandbox?.authorization,
-    'write_code'
-  );
+  const { perform, loading, canConvert } = useUpgradeFromV1ToV2();
 
   return (
     <MessageStripe variant="primary">
@@ -21,50 +11,7 @@ export const UpgradeSSEToV2Stripe = () => {
         This sandbox runs much faster in our new editor. Do you want to{' '}
         {canConvert ? 'convert' : 'fork'} it to a Cloud Sandbox?
       </span>
-      <MessageStripe.Action
-        loading={isLoading}
-        onClick={async () => {
-          setIsLoading(true);
-          const sandboxId = state.editor.currentSandbox.id;
-
-          track('Editor - Convert to Cloud Sandbox', { owned: canConvert });
-
-          if (canConvert) {
-            const alias = state.editor.currentSandbox.alias;
-
-            await updateSandbox(sandboxId, {
-              v2: true,
-            });
-
-            const sandboxV2Url = sandboxUrl({
-              id: sandboxId,
-              alias,
-              isV2: true,
-              query: {
-                welcome: 'true',
-              },
-            });
-
-            window.location.href = sandboxV2Url;
-          } else {
-            const forkedSandbox = await effects.api.forkSandbox(sandboxId, {
-              v2: true,
-              teamId: state.activeTeam,
-            });
-
-            const sandboxV2Url = sandboxUrl({
-              id: forkedSandbox.id,
-              alias: forkedSandbox.alias,
-              isV2: true,
-              query: {
-                welcome: 'true',
-              },
-            });
-
-            window.location.href = sandboxV2Url;
-          }
-        }}
-      >
+      <MessageStripe.Action loading={loading} onClick={perform}>
         Yes, Convert
       </MessageStripe.Action>
     </MessageStripe>

--- a/packages/app/src/app/components/StripeMessages/UpgradeSSEToV2.tsx
+++ b/packages/app/src/app/components/StripeMessages/UpgradeSSEToV2.tsx
@@ -3,7 +3,7 @@ import { MessageStripe } from '@codesandbox/components';
 import { useUpgradeFromV1ToV2 } from 'app/hooks/useUpgradeFromV1ToV2';
 
 export const UpgradeSSEToV2Stripe = () => {
-  const { perform, loading, canConvert } = useUpgradeFromV1ToV2();
+  const { perform, loading, canConvert } = useUpgradeFromV1ToV2('Top Bar');
 
   return (
     <MessageStripe variant="primary">

--- a/packages/app/src/app/hooks/useUpgradeFromV1ToV2.ts
+++ b/packages/app/src/app/hooks/useUpgradeFromV1ToV2.ts
@@ -17,7 +17,6 @@ export const useUpgradeFromV1ToV2 = () => {
   return {
     loading: isLoading,
     canConvert,
-
     perform: async () => {
       setIsLoading(true);
       const sandboxId = state.editor.currentSandbox.id;

--- a/packages/app/src/app/hooks/useUpgradeFromV1ToV2.ts
+++ b/packages/app/src/app/hooks/useUpgradeFromV1ToV2.ts
@@ -9,15 +9,18 @@ export const useUpgradeFromV1ToV2 = () => {
   const effects = useEffects();
   const [isLoading, setIsLoading] = useState(false);
   const updateSandbox = useEffects().api.updateSandbox;
-  const canConvert = hasPermission(
-    state.editor.currentSandbox?.authorization,
-    'write_code'
-  );
+  const canConvert = state.editor.currentSandbox
+    ? hasPermission(state.editor.currentSandbox.authorization, 'write_code')
+    : false;
 
   return {
     loading: isLoading,
     canConvert,
     perform: async () => {
+      if (!state.editor.currentSandbox) {
+        return;
+      }
+
       setIsLoading(true);
       const sandboxId = state.editor.currentSandbox.id;
 

--- a/packages/app/src/app/hooks/useUpgradeFromV1ToV2.ts
+++ b/packages/app/src/app/hooks/useUpgradeFromV1ToV2.ts
@@ -1,0 +1,63 @@
+import { useState } from 'react';
+import { useEffects, useAppState } from 'app/overmind';
+import { sandboxUrl } from '@codesandbox/common/lib/utils/url-generator';
+import { hasPermission } from '@codesandbox/common/lib/utils/permission';
+import track from '@codesandbox/common/lib/utils/analytics';
+
+export const useUpgradeFromV1ToV2 = () => {
+  const state = useAppState();
+  const effects = useEffects();
+  const [isLoading, setIsLoading] = useState(false);
+  const updateSandbox = useEffects().api.updateSandbox;
+  const canConvert = hasPermission(
+    state.editor.currentSandbox?.authorization,
+    'write_code'
+  );
+
+  return {
+    loading: isLoading,
+    canConvert,
+
+    perform: async () => {
+      setIsLoading(true);
+      const sandboxId = state.editor.currentSandbox.id;
+
+      track('Editor - Convert to Cloud Sandbox', { owned: canConvert });
+
+      if (canConvert) {
+        const alias = state.editor.currentSandbox.alias;
+
+        await updateSandbox(sandboxId, {
+          v2: true,
+        });
+
+        const sandboxV2Url = sandboxUrl({
+          id: sandboxId,
+          alias,
+          isV2: true,
+          query: {
+            welcome: 'true',
+          },
+        });
+
+        window.location.href = sandboxV2Url;
+      } else {
+        const forkedSandbox = await effects.api.forkSandbox(sandboxId, {
+          v2: true,
+          teamId: state.activeTeam,
+        });
+
+        const sandboxV2Url = sandboxUrl({
+          id: forkedSandbox.id,
+          alias: forkedSandbox.alias,
+          isV2: true,
+          query: {
+            welcome: 'true',
+          },
+        });
+
+        window.location.href = sandboxV2Url;
+      }
+    },
+  };
+};

--- a/packages/app/src/app/hooks/useUpgradeFromV1ToV2.ts
+++ b/packages/app/src/app/hooks/useUpgradeFromV1ToV2.ts
@@ -4,7 +4,7 @@ import { sandboxUrl } from '@codesandbox/common/lib/utils/url-generator';
 import { hasPermission } from '@codesandbox/common/lib/utils/permission';
 import track from '@codesandbox/common/lib/utils/analytics';
 
-export const useUpgradeFromV1ToV2 = () => {
+export const useUpgradeFromV1ToV2 = (trackingLocation: string) => {
   const state = useAppState();
   const effects = useEffects();
   const [isLoading, setIsLoading] = useState(false);
@@ -24,7 +24,9 @@ export const useUpgradeFromV1ToV2 = () => {
       setIsLoading(true);
       const sandboxId = state.editor.currentSandbox.id;
 
-      track('Editor - Convert to Cloud Sandbox', { owned: canConvert });
+      track(`Editor - ${trackingLocation} Convert to Cloud Sandbox`, {
+        owned: canConvert,
+      });
 
       if (canConvert) {
         const alias = state.editor.currentSandbox.alias;

--- a/packages/common/src/templates/helpers/react-template.ts
+++ b/packages/common/src/templates/helpers/react-template.ts
@@ -4,7 +4,11 @@ export class ReactTemplate extends Template {
   getViews(): ViewConfig[] {
     const REACT_VIEWS: ViewConfig[] = [
       {
-        views: [{ id: 'codesandbox.browser' }, { id: 'codesandbox.tests' }],
+        views: [
+          { id: 'codesandbox.browser' },
+          { id: 'codesandbox.tests' },
+          { id: 'codesandbox.terminalUpgrade' },
+        ],
       },
       {
         views: [

--- a/packages/common/src/templates/template.ts
+++ b/packages/common/src/templates/template.ts
@@ -58,7 +58,11 @@ export type ViewConfig = {
 
 const CLIENT_VIEWS: ViewConfig[] = [
   {
-    views: [{ id: 'codesandbox.browser' }, { id: 'codesandbox.tests' }],
+    views: [
+      { id: 'codesandbox.browser' },
+      { id: 'codesandbox.tests' },
+      { id: 'codesandbox.terminalUpgrade' },
+    ],
   },
   {
     views: [{ id: 'codesandbox.console' }, { id: 'codesandbox.problems' }],


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR adds a new devtool tab for client sandboxes. It is a upgrade lever to show users that they can have a terminal in V2. 
<img width="1333" alt="Screenshot 2023-02-03 at 11 25 32" src="https://user-images.githubusercontent.com/33638789/216592591-50ba4544-f6a2-4b5e-b31f-ed94e5b6691d.png">

<img width="1338" alt="Screenshot 2023-02-03 at 11 27 06" src="https://user-images.githubusercontent.com/33638789/216592602-27b086e3-2960-4ea4-8680-8ff3ca4ceb96.png">

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Testing <!-- We can only merge the PR if this is checked -->
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
