### PR TITLE
fix: redirect to default branch opposed to a new draft one

### DIFF
--- a/packages/app/src/app/components/CreateSandbox/Import/useForkAndRedirect.ts
+++ b/packages/app/src/app/components/CreateSandbox/Import/useForkAndRedirect.ts
@@ -1,5 +1,5 @@
 import { notificationState } from '@codesandbox/common/lib/utils/notifications';
-import { v2DraftBranchUrl } from '@codesandbox/common/lib/utils/url-generator';
+import { v2DefaultBranchUrl } from '@codesandbox/common/lib/utils/url-generator';
 import { NotificationStatus } from '@codesandbox/notifications';
 import { forkRepository } from '../utils/api';
 
@@ -7,7 +7,7 @@ export const useForkAndRedirect = () => {
   async function forkAndRedirect(...params: Parameters<typeof forkRepository>) {
     try {
       const response = await forkRepository(...params);
-      window.location.href = v2DraftBranchUrl(response.owner, response.repo);
+      window.location.href = v2DefaultBranchUrl(response.owner, response.repo);
     } catch (error) {
       notificationState.addNotification({
         message: JSON.stringify(error),

--- a/packages/app/src/app/components/CreateSandbox/Import/useImportAndRedirect.tsx
+++ b/packages/app/src/app/components/CreateSandbox/Import/useImportAndRedirect.tsx
@@ -1,5 +1,5 @@
 import { notificationState } from '@codesandbox/common/lib/utils/notifications';
-import { v2DraftBranchUrl } from '@codesandbox/common/lib/utils/url-generator';
+import { v2DefaultBranchUrl } from '@codesandbox/common/lib/utils/url-generator';
 import { NotificationStatus } from '@codesandbox/notifications';
 import { importRepository } from '../utils/api';
 
@@ -11,7 +11,7 @@ export const useImportAndRedirect = () => {
   ) {
     try {
       const response = await importRepository({ owner, name, csbTeamId });
-      window.location.href = v2DraftBranchUrl(response.owner, response.repo);
+      window.location.href = v2DefaultBranchUrl(response.owner, response.repo);
     } catch (error) {
       notificationState.addNotification({
         message: JSON.stringify(error),

--- a/packages/common/src/utils/url-generator.ts
+++ b/packages/common/src/utils/url-generator.ts
@@ -319,9 +319,11 @@ export const v2DefaultBranchUrl = (
 ) => {
   const searchParams = new URLSearchParams({
     ...qsObject,
-  });
+  }).toString();
 
-  return `${v2EditorUrl()}github/${owner}/${name}?${searchParams.toString()}`;
+  const queryString = searchParams ? `?${searchParams}` : '';
+
+  return `${v2EditorUrl()}github/${owner}/${name}${queryString}`;
 };
 
 export const v2DraftBranchUrl = (owner: string, name: string) => {


### PR DESCRIPTION
I already solved this in #7215 but this might go to prod faster. Doesn't make sense to create draft branches by default now that we have the seamless branching in production

Need to test the onboarding flow on the editor side