### PR TITLE
fix(privacy): Re-enable minimum privacy setting for personal pro

### DIFF
--- a/packages/app/src/app/pages/Dashboard/Content/routes/Settings/components/PermissionSettings.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Settings/components/PermissionSettings.tsx
@@ -27,6 +27,7 @@ export const PermissionSettings = () => {
   const {
     isTeamSpace,
     isTeamAdmin,
+    isAdmin,
     isPersonalSpace,
   } = useWorkspaceAuthorization();
 
@@ -67,7 +68,7 @@ export const PermissionSettings = () => {
 
       <Grid columnGap={12}>
         <Column span={[12, 12, 6]}>
-          <MinimumPrivacy disabled={isFree || !isTeamAdmin} />
+          <MinimumPrivacy disabled={isFree || !isAdmin} />
         </Column>
         {!isPersonalSpace && (
           <Column span={[12, 12, 6]}>


### PR DESCRIPTION
In the past personal pro users could update the minimum privacy, but after changing the conditional it seems that we disabled this. We used to check for `isTeamAdmin` but now we check for `isAdmin` which includes personal workspaces.

Some (pseudo) code from before using `isTeamAdmin` showing that personal pro workspaces shouldn't disable the minimum privacy setting:
```
if (isPersonalWorkspace) {
  if (!isPersonalPro) alert = true;
}

else if (!isTeamPro) alert = true;
else if (!isAdmin) alert = true;

[...]

<MinimumPrivacy disabled={Boolean(alert)} />
```