### PR TITLE
fix(pro): Undefined user crash and update CTA when eligible for trial

### DIFF
--- a/packages/app/src/app/pages/Pro/Upgrade.tsx
+++ b/packages/app/src/app/pages/Pro/Upgrade.tsx
@@ -68,7 +68,7 @@ export const ProUpgrade = () => {
   }, [hasLoadedApp, location, setActiveTeam, personalWorkspaceId, dashboard]);
 
   const { isPersonalSpace, isTeamAdmin, isAdmin } = useWorkspaceAuthorization();
-  const { isFree, isPro } = useWorkspaceSubscription();
+  const { isFree, isPro, isEligibleForTrial } = useWorkspaceSubscription();
   // const isFree = false; // DEBUG
   // const isPro = true; // DEBUG
 
@@ -107,7 +107,7 @@ export const ProUpgrade = () => {
         isLoading: isCustomerPortalLoading,
       }
     : {
-        text: 'Proceed to checkout',
+        text: isEligibleForTrial ? 'Start free trial' : 'Proceed to checkout',
         href: checkout.state === 'READY' ? checkout.url : undefined, // TODO: Fallback?
         variant: 'highlight',
         isLoading: checkout.state === 'LOADING',
@@ -137,7 +137,7 @@ export const ProUpgrade = () => {
           isLoading: isCustomerPortalLoading,
         }
       : {
-          text: 'Proceed to checkout',
+          text: isEligibleForTrial ? 'Start free trial' : 'Proceed to checkout',
           href: checkout.state === 'READY' ? checkout.url : undefined, // TODO: Fallback?
           variant: 'highlight',
           isLoading: checkout.state === 'LOADING',

--- a/packages/app/src/app/pages/Pro/components/Switcher.tsx
+++ b/packages/app/src/app/pages/Pro/components/Switcher.tsx
@@ -50,8 +50,9 @@ export const Switcher: React.FC<{
             if (!workspace) return null;
 
             const isAdmin =
-              workspace.userAuthorizations.find(team => team.userId === user.id)
-                .authorization === TeamMemberAuthorization.Admin;
+              workspace.userAuthorizations.find(
+                team => team.userId === user?.id
+              )?.authorization === TeamMemberAuthorization.Admin;
 
             const isPro = [
               SubscriptionType.TeamPro,


### PR DESCRIPTION
Found a bug that when visiting `/pro` directly made the application crash because `user` was still `undefined`. Also changed the CTA text when the user is eligible for trial to start a trial rather than "proceed to checkout".