### PR TITLE
fix(permissions): typo

### DIFF
--- a/packages/app/src/app/pages/common/Modals/PreferencesModal/Integrations/GitHubPermissions.tsx
+++ b/packages/app/src/app/pages/common/Modals/PreferencesModal/Integrations/GitHubPermissions.tsx
@@ -84,17 +84,17 @@ const Details: React.FC = () => {
               <ComboButton.Item
                 onSelect={() => signInGithubClicked('private_repos')}
               >
-                Autorize access to all repositories{' '}
+                Authorize access to all repositories{' '}
               </ComboButton.Item>
               <ComboButton.Item
                 onSelect={() => signInGithubClicked('public_repos')}
               >
-                Autorize access only to public repositories{' '}
+                Authorize access only to public repositories{' '}
               </ComboButton.Item>
             </>
           }
         >
-          Autorize access to all repositories{' '}
+          Authorize access to all repositories{' '}
         </ComboButton>
       </Stack>
     );


### PR DESCRIPTION
`Autorize` (which is the correct spelling in 🇧🇷 ) -> `Authorize` 🤦🏽‍♀️ 