### PR TITLE
Maria/xtd 670

### DIFF
--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/GitHub/CreateRepo.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/GitHub/CreateRepo.tsx
@@ -12,7 +12,15 @@ import {
 import { useAppState, useActions } from 'app/overmind';
 import React, { ChangeEvent } from 'react';
 
-export const CreateRepo = () => {
+type CreateRepoProps = {
+  /**
+   * The prop overrides internals and disabled the whole section.
+   * Useful when there are no GitHub permissions but we still
+   * want to show the UI.
+   */
+  disabled?: boolean;
+};
+export const CreateRepo: React.FC<CreateRepoProps> = ({ disabled }) => {
   const {
     git: { createRepoClicked, repoTitleChanged },
     openCreateSandboxModal,
@@ -28,18 +36,29 @@ export const CreateRepo = () => {
 
   const createRepo = e => {
     e.preventDefault();
+
+    if (disabled) {
+      return;
+    }
+
     track('Export to GitHub Clicked');
     createRepoClicked();
   };
 
-  const disabled = Boolean(error) || !repoTitle || !isAllModulesSynced;
+  const disableImport =
+    Boolean(error) || !repoTitle || !isAllModulesSynced || disabled;
 
   return (
     <Collapsible
       title="Export to new GitHub repository"
-      defaultOpen={!currentSandbox.originalGit}
+      defaultOpen={!currentSandbox.originalGit && !disabled}
     >
-      <Element paddingX={2}>
+      <Element
+        css={{
+          opacity: disabled ? 0.6 : 1,
+        }}
+        paddingX={2}
+      >
         <Text variant="muted" marginBottom={2} block>
           Export the content of this sandbox to a new GitHub repository,
           allowing you to commit changes made on CodeSandbox to GitHub. If you
@@ -91,7 +110,7 @@ export const CreateRepo = () => {
             />
           </FormField>
           <Element paddingX={2}>
-            <Button type="submit" disabled={disabled} variant="secondary">
+            <Button type="submit" disabled={disableImport} variant="secondary">
               Create new repository on GitHub
             </Button>
           </Element>

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/GitHub/GithubLogin.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/GitHub/GithubLogin.tsx
@@ -18,6 +18,8 @@ export const GithubLogin = () => {
     },
   } = useAppState();
 
+  const privacyLabel = privacy === 0 ? 'public' : 'private';
+
   return (
     <Collapsible title="Adjust GitHub permissions" defaultOpen>
       <Stack css={{ padding: '0 12px' }} direction="vertical" gap={4}>
@@ -35,8 +37,8 @@ export const GithubLogin = () => {
             <Icon name="info" size={12} />
           </Element>
           <Text lineHeight="16px" size={12}>
-            CodeSandbox needs access to your public repositories in order to
-            link and/or export a public sandbox.
+            CodeSandbox needs access to your {privacyLabel} repositories in
+            order to link and/or export a {privacyLabel} sandbox.
           </Text>
         </Stack>
         <Button

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/GitHub/LinkSandbox.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/GitHub/LinkSandbox.tsx
@@ -4,9 +4,11 @@ import { Button, Collapsible, Element, Text } from '@codesandbox/components';
 import { useActions, useAppState } from 'app/overmind';
 
 type LinkSandboxProps = {
+  disabled?: boolean;
   upstreamSandbox: ForkedSandbox;
 };
 export const LinkSandbox: React.FC<LinkSandboxProps> = ({
+  disabled,
   upstreamSandbox,
 }) => {
   const {
@@ -18,8 +20,13 @@ export const LinkSandbox: React.FC<LinkSandboxProps> = ({
   } = useAppState();
 
   return (
-    <Collapsible title="Link to GitHub repository" defaultOpen>
-      <Element paddingX={2}>
+    <Collapsible title="Link to GitHub repository" defaultOpen={!disabled}>
+      <Element
+        css={{
+          opacity: disabled ? 0.6 : 1,
+        }}
+        paddingX={2}
+      >
         <Text variant="muted">If you wish to contribute back to</Text>{' '}
         {upstreamSandbox.git.username}/{upstreamSandbox.git.repo}
         <Text variant="muted">
@@ -27,8 +34,17 @@ export const LinkSandbox: React.FC<LinkSandboxProps> = ({
           you to create commits and open pull requests with this sandbox.
         </Text>
         <Button
+          // Using aria-disabled to have the affordance without
+          // affecting the styles.
+          aria-disabled={disabled}
           marginTop={4}
-          onClick={() => linkToGitSandbox(currentSandbox.id)}
+          onClick={() => {
+            if (disabled) {
+              return;
+            }
+
+            linkToGitSandbox(currentSandbox.id);
+          }}
           loading={isLinkingToGitSandbox}
         >
           Link Sandbox

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/GitHub/LinkSandbox.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/GitHub/LinkSandbox.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { ForkedSandbox } from '@codesandbox/common/lib/types';
+import { Button, Collapsible, Element, Text } from '@codesandbox/components';
+import { useActions, useAppState } from 'app/overmind';
+
+type LinkSandboxProps = {
+  upstreamSandbox: ForkedSandbox;
+};
+export const LinkSandbox: React.FC<LinkSandboxProps> = ({
+  upstreamSandbox,
+}) => {
+  const {
+    git: { linkToGitSandbox },
+  } = useActions();
+  const {
+    git: { isLinkingToGitSandbox },
+    editor: { currentSandbox },
+  } = useAppState();
+
+  return (
+    <Collapsible title="Link to GitHub repository" defaultOpen>
+      <Element paddingX={2}>
+        <Text variant="muted">If you wish to contribute back to</Text>{' '}
+        {upstreamSandbox.git.username}/{upstreamSandbox.git.repo}
+        <Text variant="muted">
+          , you can link this sandbox to the GitHub repository. This will allow
+          you to create commits and open pull requests with this sandbox.
+        </Text>
+        <Button
+          marginTop={4}
+          onClick={() => linkToGitSandbox(currentSandbox.id)}
+          loading={isLinkingToGitSandbox}
+        >
+          Link Sandbox
+        </Button>
+      </Element>
+    </Collapsible>
+  );
+};

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/GitHub/LinkSandbox.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/GitHub/LinkSandbox.tsx
@@ -34,9 +34,7 @@ export const LinkSandbox: React.FC<LinkSandboxProps> = ({
           you to create commits and open pull requests with this sandbox.
         </Text>
         <Button
-          // Using aria-disabled to have the affordance without
-          // affecting the styles.
-          aria-disabled={disabled}
+          disabled={disabled}
           marginTop={4}
           onClick={() => {
             if (disabled) {

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/GitHub/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/GitHub/index.tsx
@@ -210,38 +210,38 @@ export const GitHub = () => {
 
   // If there's a forkedFromSandbox we use that, otherwise we use the forkedTemplateSandbox
   const upstreamSandbox = forkedFromSandbox || forkedTemplateSandbox;
-  if (!originalGit && upstreamSandbox?.git) {
-    return (
-      <>
-        <LinkSandbox upstreamSandbox={upstreamSandbox} />
-        <CreateRepo />
-      </>
-    );
-  }
 
-  return originalGit ? (
+  return (
     <>
-      <Collapsible title="GitHub repository" defaultOpen>
-        <Element paddingX={2}>
-          <Link
-            target="_blank"
-            rel="noopener noreferrer"
-            href={githubRepoUrl(originalGit)}
-          >
-            <Stack gap={2} marginBottom={6} align="center">
-              <GitHubIcon width={20} />
-              <Text size={2}>
-                {originalGit.username}/{originalGit.repo}
-              </Text>
-            </Stack>
-          </Link>
-          {getText()}
-        </Element>
-      </Collapsible>
-      {getContent()}
+      {originalGit ? (
+        <>
+          <Collapsible title="GitHub repository" defaultOpen>
+            <Element paddingX={2}>
+              <Link
+                target="_blank"
+                rel="noopener noreferrer"
+                href={githubRepoUrl(originalGit)}
+              >
+                <Stack gap={2} marginBottom={6} align="center">
+                  <GitHubIcon width={20} />
+                  <Text size={2}>
+                    {originalGit.username}/{originalGit.repo}
+                  </Text>
+                </Stack>
+              </Link>
+              {getText()}
+            </Element>
+          </Collapsible>
+          {getContent()}
+        </>
+      ) : null}
+
+      {!originalGit && upstreamSandbox?.git ? (
+        <LinkSandbox upstreamSandbox={upstreamSandbox} />
+      ) : null}
+
+      {/* Always show create repo */}
       <CreateRepo />
     </>
-  ) : (
-    <CreateRepo />
   );
 };

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/GitHub/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/GitHub/index.tsx
@@ -1,7 +1,6 @@
 import { GitFileCompare, SandboxGitState } from '@codesandbox/common/lib/types';
 import { githubRepoUrl } from '@codesandbox/common/lib/utils/url-generator';
 import {
-  Button,
   Collapsible,
   Element,
   Link,
@@ -10,7 +9,7 @@ import {
   Stack,
   Text,
 } from '@codesandbox/components';
-import { useAppState, useActions } from 'app/overmind';
+import { useAppState } from 'app/overmind';
 import React from 'react';
 
 import { Changes } from './Changes';
@@ -42,6 +41,7 @@ import { ConflictType } from './types';
 import { getConflictIcon } from './utils/getConflictIcon';
 import { getConflictText } from './utils/getConflictsText';
 import { getConflictType } from './utils/getConflictType';
+import { LinkSandbox } from './LinkSandbox';
 
 export const GitHub = () => {
   const {
@@ -53,11 +53,9 @@ export const GitHub = () => {
       isFetching,
       isExported,
       pr,
-      isLinkingToGitSandbox,
     },
     editor: {
       currentSandbox: {
-        id,
         originalGit,
         baseGit,
         owned,
@@ -71,7 +69,6 @@ export const GitHub = () => {
     isLoggedIn,
     user,
   } = useAppState();
-  const actions = useActions();
 
   const changeCount = gitChanges
     ? gitChanges.added.length +
@@ -216,24 +213,7 @@ export const GitHub = () => {
   if (!originalGit && upstreamSandbox?.git) {
     return (
       <>
-        <Collapsible title="Link to GitHub repository" defaultOpen>
-          <Element paddingX={2}>
-            <Text variant="muted">If you wish to contribute back to</Text>{' '}
-            {upstreamSandbox.git.username}/{upstreamSandbox.git.repo}
-            <Text variant="muted">
-              , you can link this sandbox to the GitHub repository. This will
-              allow you to create commits and open pull requests with this
-              sandbox.
-            </Text>
-            <Button
-              marginTop={4}
-              onClick={() => actions.git.linkToGitSandbox(id)}
-              loading={isLinkingToGitSandbox}
-            >
-              Link Sandbox
-            </Button>
-          </Element>
-        </Collapsible>
+        <LinkSandbox upstreamSandbox={upstreamSandbox} />
         <CreateRepo />
       </>
     );


### PR DESCRIPTION
## Description

Updates the GitHub panel to show the actions even if there's no integration.
Fixes the GitHub login labels.
Updates the GitHub login in the deployments to ask the appropriate permissions.

- [ ] As a user without permissions for public repos in a public sandbox:

![localhost_3000_s_holy-field-4m26pv](https://user-images.githubusercontent.com/24959348/218649196-674780d7-9bae-49a1-b86a-457adcb9bd75.png)

- [ ] As a user without permissions for private repos in a private sandbox:

![localhost_3000_s_holy-field-4m26pv (1)](https://user-images.githubusercontent.com/24959348/218649242-75e2e2f3-f0c3-4279-8d9a-75d78de8b448.png)

It also handles public and private sandboxes in the deployments panel:

![localhost_3000_s_holy-field-4m26pv (2)](https://user-images.githubusercontent.com/24959348/218649989-941b0f2e-fc21-4244-84cd-f366e529a177.png)
