### PR TITLE
feat(Dashboard): discover button to the new discover page

### DIFF
--- a/packages/app/src/app/pages/Dashboard/Header/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Header/index.tsx
@@ -121,6 +121,22 @@ export const Header: React.FC<HeaderProps> = React.memo(
             Create
           </Button>
 
+          <Button
+            variant="ghost"
+            css={css({ width: 'auto' })}
+            onClick={() => {
+              window.open('http://codesandbox.io/discover', '_blank');
+            }}
+          >
+            <Icon
+              name="discover"
+              size={22}
+              title="New"
+              css={css({ paddingRight: 2 })}
+            />
+            Discover
+          </Button>
+
           {hasLogIn && <Notifications dashboard />}
         </Stack>
       </Stack>

--- a/packages/app/src/app/pages/Dashboard/Header/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Header/index.tsx
@@ -114,9 +114,9 @@ export const Header: React.FC<HeaderProps> = React.memo(
           >
             <Icon
               name="plus"
-              size={22}
+              size={16}
               title="New"
-              css={css({ paddingRight: 2 })}
+              css={{ marginRight: '8px' }}
             />
             Create
           </Button>
@@ -130,9 +130,9 @@ export const Header: React.FC<HeaderProps> = React.memo(
           >
             <Icon
               name="discover"
-              size={22}
+              size={16}
               title="New"
-              css={{ paddingRight: 2 }}
+              css={{ marginRight: '8px' }}
             />
             Discover
           </Button>

--- a/packages/app/src/app/pages/Dashboard/Header/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Header/index.tsx
@@ -132,7 +132,7 @@ export const Header: React.FC<HeaderProps> = React.memo(
               name="discover"
               size={22}
               title="New"
-              css={css({ paddingRight: 2 })}
+              css={{ paddingRight: 2 }}
             />
             Discover
           </Button>

--- a/packages/app/src/app/pages/Dashboard/Header/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Header/index.tsx
@@ -123,7 +123,7 @@ export const Header: React.FC<HeaderProps> = React.memo(
 
           <Button
             variant="ghost"
-            css={css({ width: 'auto' })}
+            autoWidth
             onClick={() => {
               window.open('http://codesandbox.io/discover', '_blank');
             }}

--- a/packages/app/src/app/pages/Dashboard/Sidebar/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Sidebar/index.tsx
@@ -197,7 +197,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
 
           {isPersonalSpace && (
             <RowItem
-              name="Shared With Me"
+              name="Shared with me"
               page="shared"
               path={dashboardUrls.shared(activeTeam)}
               icon="sharing"

--- a/packages/app/src/app/pages/Dashboard/Sidebar/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Sidebar/index.tsx
@@ -194,12 +194,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
             path={dashboardUrls.recent(activeTeam)}
             icon="clock"
           />
-          <RowItem
-            name="Discover"
-            page="discover"
-            path={dashboardUrls.discover(activeTeam)}
-            icon="discover"
-          />
+
           {isPersonalSpace && (
             <RowItem
               name="Shared With Me"

--- a/packages/app/src/app/pages/common/UserMenu/index.tsx
+++ b/packages/app/src/app/pages/common/UserMenu/index.tsx
@@ -31,12 +31,6 @@ export const UserMenu: FunctionComponent & {
         <Menu>
           {props.children}
           <Menu.List>
-            <Menu.Link href="http://codesandbox.io/discover">
-              <Stack align="center" gap={2}>
-                <Icon name="discover" size={16} />
-                <Text>Discover</Text>
-              </Stack>
-            </Menu.Link>
             <Menu.Link href={docsUrl()}>
               <Stack align="center" gap={2}>
                 <Icon name="documentation" size={16} />
@@ -81,13 +75,6 @@ export const UserMenu: FunctionComponent & {
             <Stack align="center" gap={2}>
               <Icon name="profile" size={16} />
               <Text>Profile</Text>
-            </Stack>
-          </Menu.Link>
-
-          <Menu.Link href="http://codesandbox.io/discover">
-            <Stack align="center" gap={2}>
-              <Icon name="discover" size={16} />
-              <Text>Discover</Text>
             </Stack>
           </Menu.Link>
 


### PR DESCRIPTION
### Remove the Discover button in the sidebar
This item is out of context in this place, all items here are relative to things owned by the user.

| Old      | New |
| ----------- | ----------- |
| <img width="279" alt="image" src="https://user-images.githubusercontent.com/2926010/219066219-f94e9f62-62dd-45d5-9dd3-a4c022d466dc.png">      | <img width="284" alt="image" src="https://user-images.githubusercontent.com/2926010/219066297-7c2c6bb5-3a32-43ee-9b89-af37baa2d119.png">       |


### Remove the Discover button in the user menu

| Old      | New |
| ----------- | ----------- |
| <img width="226" alt="image" src="https://user-images.githubusercontent.com/2926010/219067549-d35def37-1054-4082-9102-7151f32f430e.png">      | <img width="220" alt="image" src="https://user-images.githubusercontent.com/2926010/219067628-46696fcb-3431-42da-8dd0-b93123482111.png">       |



### Add Discover button in the header
Move to the new place promoting the new Discover page: https://codesandbox.io/discover

##### Old
<img width="1465" alt="image" src="https://user-images.githubusercontent.com/2926010/219067838-bce36308-17e8-4bc3-b060-5d9d43fc3326.png">

##### New
<img width="1465" alt="image" src="https://user-images.githubusercontent.com/2926010/219068006-bcc0927f-a7bf-4b44-adb2-13c63be14107.png">


