### PR TITLE
feat(dashboard): support opening new team modal from the url

### DIFF
--- a/packages/app/src/app/pages/Dashboard/Content/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/index.tsx
@@ -1,5 +1,11 @@
 import React, { useEffect } from 'react';
-import { Route, Switch, Redirect, withRouter } from 'react-router-dom';
+import {
+  Route,
+  Switch,
+  Redirect,
+  withRouter,
+  useLocation,
+} from 'react-router-dom';
 import { Element } from '@codesandbox/components';
 import { dashboard as dashboardUrls } from '@codesandbox/common/lib/utils/url-generator';
 import css from '@styled-system/css';
@@ -25,6 +31,13 @@ import { RepositoryBranchesPage } from './routes/RepositoryBranches';
 export const Content = withRouter(({ history }) => {
   const { dashboard } = useActions();
   const { activeTeam } = useAppState();
+  const { search } = useLocation();
+
+  const mapFromSearchParams = {};
+  const searchParams = new URLSearchParams(search);
+  searchParams.forEach((value, key) => {
+    mapFromSearchParams[key] = value;
+  });
 
   useEffect(() => {
     dashboard.dashboardMounted();
@@ -90,7 +103,7 @@ export const Content = withRouter(({ history }) => {
           to="/dashboard/sandboxes/:path*"
         />
         <Redirect from="/dashboard/always-on" to="/dashboard/recent" />
-        <Redirect to={dashboardUrls.recent(activeTeam)} />
+        <Redirect to={dashboardUrls.recent(activeTeam, mapFromSearchParams)} />
       </Switch>
     </Element>
   );

--- a/packages/app/src/app/pages/Dashboard/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/index.tsx
@@ -100,6 +100,13 @@ export const Dashboard: FunctionComponent = () => {
   }, [location.search, actions, activeTeamInfo, notificationToast]);
 
   useEffect(() => {
+    const searchParams = new URLSearchParams(location.search);
+    if (JSON.parse(searchParams.get('create_team'))) {
+      actions.openCreateTeamModal();
+    }
+  }, [actions, location.search]);
+
+  useEffect(() => {
     trackVisit();
   }, []);
 

--- a/packages/common/src/utils/url-generator/dashboard.test.ts
+++ b/packages/common/src/utils/url-generator/dashboard.test.ts
@@ -1,0 +1,41 @@
+import * as dashboard from './dashboard';
+
+const teamId = 'foo-bar-123';
+
+describe('dashboard url generator', () => {
+  test('sandboxes', () => {
+    expect(dashboard.sandboxes('/path', teamId)).toBe(
+      '/dashboard/sandboxes/path?workspace=foo-bar-123'
+    );
+  });
+
+  test('recent', () => {
+    expect(dashboard.recent(teamId)).toBe(
+      '/dashboard/recent?workspace=foo-bar-123'
+    );
+  });
+
+  test('recent with extra params', () => {
+    expect(dashboard.recent(teamId, { create_team: 'true' })).toBe(
+      '/dashboard/recent?workspace=foo-bar-123&create_team=true'
+    );
+  });
+
+  test('search', () => {
+    expect(dashboard.search('foo', teamId)).toBe(
+      '/dashboard/search?workspace=foo-bar-123&query=foo'
+    );
+  });
+
+  test('discover', () => {
+    expect(dashboard.discover(teamId, 'album-1')).toBe(
+      '/dashboard/discover/album-1?workspace=foo-bar-123'
+    );
+  });
+
+  test('discoverSearch', () => {
+    expect(dashboard.discoverSearch('foo', teamId)).toBe(
+      '/dashboard/discover/search?workspace=foo-bar-123&query=foo'
+    );
+  });
+});

--- a/packages/common/src/utils/url-generator/dashboard.ts
+++ b/packages/common/src/utils/url-generator/dashboard.ts
@@ -51,8 +51,29 @@ export const syncedSandboxes = (teamId?: string | null) =>
 export const templates = (teamId?: string | null) =>
   appendTeamIdQueryParam(`${DASHBOARD_URL_PREFIX}/templates`, teamId);
 
-export const recent = (teamId?: string | null) =>
-  appendTeamIdQueryParam(`${DASHBOARD_URL_PREFIX}/recent`, teamId);
+export const recent = (
+  teamId?: string | null,
+  extraParams?: Record<string, string>
+) => {
+  let recentUrl = appendTeamIdQueryParam(
+    `${DASHBOARD_URL_PREFIX}/recent`,
+    teamId
+  );
+
+  if (extraParams && Object.keys(extraParams).length > 0) {
+    const params = new URLSearchParams(extraParams);
+
+    if (recentUrl.includes('?')) {
+      recentUrl += '&';
+    } else {
+      recentUrl += '?';
+    }
+
+    recentUrl += params.toString();
+  }
+
+  return recentUrl;
+};
 
 export const deleted = (teamId?: string | null) =>
   appendTeamIdQueryParam(`${DASHBOARD_URL_PREFIX}/deleted`, teamId);


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?

<!-- Is it a Bug fix, feature, docs update, ... -->

Makes the new team modal appear when opening `dashboard?create_team=true`.

## What is the new behavior?

<!-- if this is a feature change -->

https://www.loom.com/share/eac98b5064794efdb8f99f22fd7008a1

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Go to `/dashboard?create_team=true`.
2. The URL will change to `/dashboard?workspace={id}&create_team=true`
3. The create team modal will open automatically.

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Testing <!-- We can only merge the PR if this is checked -->
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
