### PR TITLE
fix: pass search params to redirect after sign-in

### DIFF
--- a/packages/app/src/app/pages/Dashboard/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/index.tsx
@@ -111,7 +111,9 @@ export const Dashboard: FunctionComponent = () => {
   }, []);
 
   if (!hasLogIn) {
-    return <Redirect to={signInPageUrl(location.pathname)} />;
+    return (
+      <Redirect to={signInPageUrl(`${location.pathname}${location.search}`)} />
+    );
   }
 
   return (


### PR DESCRIPTION
The redirect to the dashboard on sign-in removed the search params from the URL thus not prompting the new team modal to open, this PR fixes it.

https://www.loom.com/share/502cf0b0bf3c4233add5e38a0b4596b6