### PR TITLE
feat(dashboard): update pending payment banner

### DIFF
--- a/packages/app/src/app/components/StripeMessages/PaymentPending.tsx
+++ b/packages/app/src/app/components/StripeMessages/PaymentPending.tsx
@@ -25,46 +25,57 @@ export const PaymentPending: React.FC = () => {
     return null;
   }
 
-  const buildCopy = () => {
-    const description = {
-      trial: 'Your free trial has expired',
-      default: 'There are some issues with your payment',
-    };
-    const action = {
-      admin: 'Please update your payment details',
-      default: 'Please contact your team admin to update the payment details',
-    };
+  const handleDismiss = () => {
+    const event = hasExpiredTeamTrial
+      ? 'expired trial dismiss'
+      : 'unpaid - dismiss';
 
-    return `${hasExpiredTeamTrial ? description.trial : description.default}. ${
-      isTeamAdmin ? action.admin : action.default
-    }.`;
+    track(`Stripe banner - ${event}`, {
+      codesandbox: 'V1',
+      event_source: 'UI',
+    });
+
+    dismiss();
+  };
+
+  const handleAction = () => {
+    const event = hasExpiredTeamTrial
+      ? 'upgrade after expired trial'
+      : 'unpaid - update payment details';
+
+    track(`Stripe banner - ${event}`, {
+      codesandbox: 'V1',
+      event_source: 'UI',
+    });
+
+    createCustomerPortal();
+  };
+
+  const buildCopy = () => {
+    if (hasExpiredTeamTrial) {
+      return `Your trial has expired. ${
+        isTeamAdmin
+          ? 'Upgrade for the full CodeSandbox experience'
+          : 'Contact team admin to upgrade for the full Codesandbox Experience'
+      }.`;
+    }
+
+    return `There are some issues with your payment. ${
+      isTeamAdmin
+        ? 'Please contact your team admin to update the payment details'
+        : 'Please update your payment details'
+    }`;
   };
 
   return (
-    <MessageStripe
-      variant="warning"
-      onDismiss={() => {
-        track('Stripe banner - payment pending dismissed', {
-          codesandbox: 'V1',
-          event_source: 'UI',
-        });
-        dismiss();
-      }}
-    >
+    <MessageStripe variant="warning" onDismiss={handleDismiss}>
       {buildCopy()}
       {isTeamAdmin ? (
         <MessageStripe.Action
           loading={loadingCustomerPortal}
-          onClick={() => {
-            track('Stripe banner - payment pending update details clicked', {
-              codesandbox: 'V1',
-              event_source: 'UI',
-            });
-
-            createCustomerPortal();
-          }}
+          onClick={handleAction}
         >
-          Update payment
+          {hasExpiredTeamTrial ? 'Upgrade now' : 'Update payment'}
         </MessageStripe.Action>
       ) : null}
     </MessageStripe>

--- a/packages/app/src/app/components/StripeMessages/PaymentPending.tsx
+++ b/packages/app/src/app/components/StripeMessages/PaymentPending.tsx
@@ -14,8 +14,9 @@ export const PaymentPending: React.FC = () => {
   const { pathname } = useLocation();
   const { isTeamAdmin } = useWorkspaceAuthorization();
   const { hasExpiredTeamTrial } = useWorkspaceSubscription();
-  const key = `DASHBOARD_REPOSITORIES_PERMISSIONS_BANNER_${activeTeam}`;
-  const [isDismissed, dismiss] = useDismissible<typeof key>(key);
+  const [isDismissed, dismiss] = useDismissible(
+    `DASHBOARD_REPOSITORIES_PERMISSIONS_BANNER_${activeTeam}`
+  );
   const [
     loadingCustomerPortal,
     createCustomerPortal,

--- a/packages/app/src/app/components/StripeMessages/PaymentPending.tsx
+++ b/packages/app/src/app/components/StripeMessages/PaymentPending.tsx
@@ -5,34 +5,44 @@ import { useCreateCustomerPortal } from 'app/hooks/useCreateCustomerPortal';
 import { useAppState } from 'app/overmind';
 import { useLocation } from 'react-router-dom';
 import { useWorkspaceAuthorization } from 'app/hooks/useWorkspaceAuthorization';
+import { useWorkspaceSubscription } from 'app/hooks/useWorkspaceSubscription';
 
 export const PaymentPending: React.FC = () => {
   const { activeTeam } = useAppState();
   const { pathname } = useLocation();
   const { isTeamAdmin } = useWorkspaceAuthorization();
+  const { hasExpiredTeamTrial } = useWorkspaceSubscription();
   const [
     loadingCustomerPortal,
     createCustomerPortal,
   ] = useCreateCustomerPortal({ team_id: activeTeam, return_path: pathname });
 
-  if (isTeamAdmin) {
-    return (
-      <MessageStripe variant="warning">
-        There are some issues with your payment. Please update your payment
-        details.
+  const buildCopy = () => {
+    const description = {
+      trial: 'Your free trial has expired',
+      default: 'There are some issues with your payment',
+    };
+    const action = {
+      admin: 'Please update your payment details',
+      default: 'Please contact your team admin to update the payment details',
+    };
+
+    return `${hasExpiredTeamTrial ? description.trial : description.default}. ${
+      isTeamAdmin ? action.admin : action.default
+    }.`;
+  };
+
+  return (
+    <MessageStripe variant="warning">
+      {buildCopy()}
+      {isTeamAdmin ? (
         <MessageStripe.Action
           loading={loadingCustomerPortal}
           onClick={createCustomerPortal}
         >
           Update payment
         </MessageStripe.Action>
-      </MessageStripe>
-    );
-  }
-  return (
-    <MessageStripe variant="warning">
-      There are some issues with your payment. Please contact your team admin to
-      update your payment details.
+      ) : null}{' '}
     </MessageStripe>
   );
 };

--- a/packages/app/src/app/hooks/useDismissible.ts
+++ b/packages/app/src/app/hooks/useDismissible.ts
@@ -1,24 +1,12 @@
 import { useState } from 'react';
 import { useEffects } from 'app/overmind';
 
-/**
- * Localstorage keys used for dismissible modals and banners.
- */
-type DismissibleKeys<T extends string> =
-  | T
-  | 'DASHBOARD_RECENT_UPGRADE'
-  | 'DASHBOARD_REPOSITORIES_PERMISSIONS_BANNER';
+type Dismissibles = Partial<Record<string, true | string>>;
 
-type Dismissibles<T extends string> = Partial<
-  Record<DismissibleKeys<T>, true | string>
->;
-
-export const useDismissible = <T extends string>(
-  key: DismissibleKeys<T>
-): [boolean, () => void] => {
+export const useDismissible = (key: string): [boolean, () => void] => {
   const { browser } = useEffects();
   const [isDismissed, setIsDismissed] = useState(() => {
-    const dismissibles = browser.storage.get<Dismissibles<T>>('DISMISSIBLES');
+    const dismissibles = browser.storage.get<Dismissibles>('DISMISSIBLES');
     return dismissibles?.[key] === true;
   });
 
@@ -26,7 +14,7 @@ export const useDismissible = <T extends string>(
     // Getting the dismissibles again to make sure other instances aren't
     // overwritten after the hook initialised.
     const prevDismissibles =
-      browser.storage.get<Dismissibles<T>>('DISMISSIBLES') || {};
+      browser.storage.get<Dismissibles>('DISMISSIBLES') || {};
 
     browser.storage.set('DISMISSIBLES', {
       ...prevDismissibles,

--- a/packages/app/src/app/hooks/useDismissible.ts
+++ b/packages/app/src/app/hooks/useDismissible.ts
@@ -4,16 +4,21 @@ import { useEffects } from 'app/overmind';
 /**
  * Localstorage keys used for dismissible modals and banners.
  */
-type DismissibleKeys =
+type DismissibleKeys<T extends string> =
+  | T
   | 'DASHBOARD_RECENT_UPGRADE'
   | 'DASHBOARD_REPOSITORIES_PERMISSIONS_BANNER';
 
-type Dismissibles = Partial<Record<DismissibleKeys, true>>;
+type Dismissibles<T extends string> = Partial<
+  Record<DismissibleKeys<T>, true | string>
+>;
 
-export const useDismissible = (key: DismissibleKeys): [boolean, () => void] => {
+export const useDismissible = <T extends string>(
+  key: DismissibleKeys<T>
+): [boolean, () => void] => {
   const { browser } = useEffects();
   const [isDismissed, setIsDismissed] = useState(() => {
-    const dismissibles = browser.storage.get<Dismissibles>('DISMISSIBLES');
+    const dismissibles = browser.storage.get<Dismissibles<T>>('DISMISSIBLES');
     return dismissibles?.[key] === true;
   });
 
@@ -21,7 +26,7 @@ export const useDismissible = (key: DismissibleKeys): [boolean, () => void] => {
     // Getting the dismissibles again to make sure other instances aren't
     // overwritten after the hook initialised.
     const prevDismissibles =
-      browser.storage.get<Dismissibles>('DISMISSIBLES') || {};
+      browser.storage.get<Dismissibles<T>>('DISMISSIBLES') || {};
 
     browser.storage.set('DISMISSIBLES', {
       ...prevDismissibles,

--- a/packages/app/src/app/hooks/useWorkspaceSubscription.ts
+++ b/packages/app/src/app/hooks/useWorkspaceSubscription.ts
@@ -5,6 +5,7 @@ import {
   SubscriptionType,
 } from 'app/graphql/types';
 import { useAppState } from 'app/overmind';
+import { isBefore, startOfToday } from 'date-fns';
 import { useWorkspaceAuthorization } from './useWorkspaceAuthorization';
 
 export const useWorkspaceSubscription = (): WorkspaceSubscriptionReturn => {
@@ -27,14 +28,21 @@ export const useWorkspaceSubscription = (): WorkspaceSubscriptionReturn => {
   const isPro =
     subscription.status === SubscriptionStatus.Active ||
     subscription.status === SubscriptionStatus.Trialing;
-
   const isFree = !isPro;
+
+  const hasPaymentMethod = subscription.paymentMethodAttached;
+
   const hasActiveTeamTrial =
     isTeamSpace && subscription.status === SubscriptionStatus.Trialing;
 
-  const numberOfSeats = subscription.quantity || 1;
+  const today = startOfToday();
+  const hasExpiredTeamTrial =
+    isTeamSpace && // is a team
+    subscription.status !== SubscriptionStatus.Active && // the subscription isn't active
+    !hasPaymentMethod && // there's no payment method attached
+    isBefore(new Date(subscription.trialEnd), today); // the trial ended before today;
 
-  const hasPaymentMethod = subscription.paymentMethodAttached;
+  const numberOfSeats = subscription.quantity || 1;
 
   const isPatron =
     subscription.origin === SubscriptionOrigin.Legacy ||
@@ -51,8 +59,9 @@ export const useWorkspaceSubscription = (): WorkspaceSubscriptionReturn => {
     numberOfSeats,
     isPro,
     isFree,
-    isEligibleForTrial: false,
+    isEligibleForTrial: false, // Teams with an active or past subscription are not eligible for trial.
     hasActiveTeamTrial,
+    hasExpiredTeamTrial,
     hasPaymentMethod,
     isPatron,
     isPaddle,
@@ -67,6 +76,7 @@ const NO_WORKSPACE = {
   isFree: undefined,
   isEligibleForTrial: undefined,
   hasActiveTeamTrial: undefined,
+  hasExpiredTeamTrial: undefined,
   hasPaymentMethod: undefined,
   isPatron: undefined,
   isPaddle: undefined,
@@ -79,6 +89,7 @@ const NO_SUBSCRIPTION = {
   isPro: false,
   isFree: true,
   hasActiveTeamTrial: false,
+  hasExpiredTeamTrial: false,
   hasPaymentMethod: false,
   isPatron: false,
   isPaddle: false,
@@ -101,6 +112,7 @@ export type WorkspaceSubscriptionReturn =
       isFree: boolean;
       isEligibleForTrial: false;
       hasActiveTeamTrial: boolean;
+      hasExpiredTeamTrial: boolean;
       hasPaymentMethod: boolean;
       isPatron: boolean;
       isPaddle: boolean;


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?

<!-- Is it a Bug fix, feature, docs update, ... -->

- Adds the option to dismiss the banner.
- Adds a new field `hasExpiredTeamTrial` to the `useWorkspaceSubscription` hook.
- Updates the copy of the payment pending banner to handle expired trials.
- Adds tracking to the banner actions.

## What is the new behavior?

<!-- if this is a feature change -->

|Expired trial (non-admin)|
|:-:|
|![b9m0xn-3000 preview csb app_dashboard_recent_workspace=0035a776-40cc-40a4-847a-416f2006e254 (1)](https://user-images.githubusercontent.com/24959348/219499710-5bad3e2c-efd3-479f-b665-8c06fa55c8f1.png)|

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Launch the dashboard
2. Visit a team with an unpaid subscription

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
