### PR TITLE
chore(graphql): Re-generate types and fix TS error

### DIFF
--- a/packages/app/src/app/graphql/types.ts
+++ b/packages/app/src/app/graphql/types.ts
@@ -102,6 +102,7 @@ export type Branch = {
   project: Project;
   /** Open pull requests from this head branch */
   pullRequests: Array<PullRequest>;
+  settings: BranchSettings;
   /** Information about the underlying git status of this branch */
   status: Maybe<Status>;
   /** Whether or not this branch exists on GitHub. Deduced from local information, so not guaranteed 100% accurate */
@@ -120,6 +121,12 @@ export type BranchLastCommit = {
   __typename?: 'BranchLastCommit';
   branchId: Scalars['String'];
   lastCommit: LastCommit;
+};
+
+/** Settings for this branch. Stored with the branch so does not incur an extra db query */
+export type BranchSettings = {
+  __typename?: 'BranchSettings';
+  protected: Scalars['Boolean'];
 };
 
 /** Subscription update about the underlying git status of a branch */
@@ -508,6 +515,7 @@ export type Limits = {
 
 export type MemberAuthorization = {
   authorization: TeamMemberAuthorization;
+  teamManager: Maybe<Scalars['Boolean']>;
   userId: Scalars['UUID4'];
 };
 
@@ -585,6 +593,27 @@ export type Project = {
   __typename?: 'Project';
   /** Whether the CodeSandbox GitHub App is installed */
   appInstalled: Scalars['Boolean'];
+  /**
+   * Combined permission of the current user on this project
+   *
+   * This includes permissions granted by the git provider, team membership, and any usage limits
+   * faced by the team. This field may be requested even for anonymous users, but the value will
+   * always be READ (or the project itself will fail to resolve).
+   */
+  authorization: ProjectAuthorization;
+  /**
+   * Get a CodeSandbox branch related to a particular Project by name
+   *
+   * Projects related to the same Repository may have different branches in CodeSandbox. Some
+   * branches may have been created in CodeSandbox and not yet pushed to the Git provider, and some
+   * may have been imported from the Git provider for some workspaces but not others.
+   *
+   * This field will look for a branch, by name, specifically related to the parent Project. If the
+   * branch does not exist for the parent Project, it will return `null`.
+   *
+   * Contribution branches are not supported by this field.
+   */
+  branchByName: Maybe<Branch>;
   /** Number of branches imported to CodeSandbox for this project. It is asynchronously updated when a create or delete happens. */
   branchCount: Scalars['Int'];
   /** Repository branches that have been imported to (or created in) CodeSandbox */
@@ -593,8 +622,6 @@ export type Project = {
   connections: Array<Connection>;
   /** Shortcut to retrieve the repository's default branch as it appears on CodeSandbox */
   defaultBranch: Branch;
-  /** @deprecated Use repository->description instead */
-  description: Maybe<Scalars['String']>;
   /** CodeSandbox ID for the project (specific to this repository-team pair) */
   id: Scalars['ID'];
   /** Timestamp of the last time the current user accessed one of this project's branches on CodeSandbox */
@@ -603,8 +630,6 @@ export type Project = {
   lastCommit: Maybe<LastCommit>;
   /** @deprecated Use repository->owner instead */
   owner: Scalars['String'];
-  /** @deprecated Use repository->private instead */
-  private: Scalars['Boolean'];
   /** Open pull requests from head branches in this repository */
   pullRequests: Array<PullRequest>;
   /** @deprecated Use repository->name instead */
@@ -628,6 +653,31 @@ export type Project = {
    */
   teams: Array<Team>;
 };
+
+/**
+ * Repository imported to a CodeSandbox team.
+ *
+ * Projects represent a git repository that has been imported to CodeSandbox for collaboration in a
+ * specific team. The assigned team is given by the `team` field. If no `team` is assigned, then the
+ * project is a read-only placeholder for anonymous users.
+ *
+ * A project `id` is unique to the repository-team pair, and should be used any time it is known.
+ * If the project is not known, then the repository `owner`/`name` pair, along with the team `id`,
+ * is roughly equivalent.
+ *
+ * To import a project, see the `importProject` mutation.
+ */
+export type ProjectBranchByNameArgs = {
+  name: Scalars['String'];
+};
+
+/** Combined permission for a project including git provider, team membership, and usage limits */
+export enum ProjectAuthorization {
+  Admin = 'ADMIN',
+  None = 'NONE',
+  Read = 'READ',
+  Write = 'WRITE',
+}
 
 export type ProSubscription = {
   __typename?: 'ProSubscription';
@@ -840,11 +890,56 @@ export type RootMutationType = {
    * ```
    */
   deleteProject: Scalars['Boolean'];
+  /**
+   * Remove a project from CodeSandbox using its CodeSandbox ID
+   *
+   * Unlike `mutation deleteProject`, this mutation supports deleting projects related to a
+   * repository that has been deleted and recreated with the same name. Otherwise, a matching
+   * project related to the latest known instance of a repository will be deleted.
+   *
+   * The target project must be team-assigned, and the user must have write access on that team.
+   *
+   * Does not affect other copies of the project related to the same repository in other teams, and
+   * does not affect the repository in the git provider. Branches related to the project will be
+   * removed, potentially losing uncommitted work-in-progress.
+   *
+   * Returns the scalar `true` on success, and errors otherwise.
+   *
+   * Example:
+   *
+   * ```gql
+   * mutation deleteProject(id: "9ff91681-5ae9-452c-abaa-f9bf7033d82c")
+   * ```
+   */
+  deleteProjectById: Scalars['Boolean'];
   /** Delete sandboxes */
   deleteSandboxes: Array<Sandbox>;
   deleteWorkspace: Scalars['String'];
   /** Enable beta-access for team and all members */
   enableTeamBetaAccess: Team;
+  /**
+   * Import an existing branch from a repository
+   *
+   * This endpoint allows users to import an existing branch from the git provider to CodeSandbox.
+   * To create a new branch on CodeSandbox that may not exist on the git provider, see `mutation
+   * createBranch`.
+   *
+   * A team ID is required for this mutation. To import an existing branch into a read-only project
+   * that is not team-associated, see `mutation importReadOnlyBranch`.
+   *
+   * Example (for `codesandbox/test-repo` branch `test-branch`):
+   *
+   * ```gql
+   * mutation importBranch(
+   *   provider: GITHUB,
+   *   owner: "codesandbox",
+   *   name: "test-repo",
+   *   branch: "test-branch",
+   *   team: "3e0a6cf9-af9c-4a7f-b4fb-1b2040e24a86"
+   * ) { id }
+   * ```
+   */
+  importBranch: Branch;
   /**
    * Import a repository to a specific team
    *
@@ -902,6 +997,8 @@ export type RootMutationType = {
    * ```
    */
   importReadOnlyProject: Project;
+  /** Increments the sandbox version and marks its screenshot as outdated. Requires `write_code` permission or above. */
+  incrementSandboxVersion: Scalars['String'];
   /** Invite someone to a team */
   inviteToTeam: Team;
   /** Invite someone to a team via email */
@@ -935,6 +1032,7 @@ export type RootMutationType = {
   revokeSandboxInvitation: Invitation;
   /** Revoke an invitation to a team */
   revokeTeamInvitation: Team;
+  setBranchProtection: Branch;
   /** Set the default authorization for any new members joining this workspace */
   setDefaultTeamMemberAuthorization: WorkspaceSandboxSettings;
   setPreventSandboxesExport: Array<Sandbox>;
@@ -1125,6 +1223,10 @@ export type RootMutationTypeDeleteProjectArgs = {
   team: Scalars['ID'];
 };
 
+export type RootMutationTypeDeleteProjectByIdArgs = {
+  id: Scalars['ID'];
+};
+
 export type RootMutationTypeDeleteSandboxesArgs = {
   sandboxIds: Array<Scalars['ID']>;
 };
@@ -1135,6 +1237,14 @@ export type RootMutationTypeDeleteWorkspaceArgs = {
 
 export type RootMutationTypeEnableTeamBetaAccessArgs = {
   teamId: Scalars['UUID4'];
+};
+
+export type RootMutationTypeImportBranchArgs = {
+  branch: Scalars['String'];
+  name: Scalars['String'];
+  owner: Scalars['String'];
+  provider: GitProvider;
+  team: Scalars['ID'];
 };
 
 export type RootMutationTypeImportProjectArgs = {
@@ -1155,6 +1265,10 @@ export type RootMutationTypeImportReadOnlyProjectArgs = {
   name: Scalars['String'];
   owner: Scalars['String'];
   provider: GitProvider;
+};
+
+export type RootMutationTypeIncrementSandboxVersionArgs = {
+  sandboxId: Scalars['ID'];
 };
 
 export type RootMutationTypeInviteToTeamArgs = {
@@ -1249,6 +1363,11 @@ export type RootMutationTypeRevokeSandboxInvitationArgs = {
 export type RootMutationTypeRevokeTeamInvitationArgs = {
   teamId: Scalars['UUID4'];
   userId: Scalars['UUID4'];
+};
+
+export type RootMutationTypeSetBranchProtectionArgs = {
+  branchId: Scalars['String'];
+  protected: Scalars['Boolean'];
 };
 
 export type RootMutationTypeSetDefaultTeamMemberAuthorizationArgs = {
@@ -1875,6 +1994,7 @@ export type User = {
 export type UserAuthorization = {
   __typename?: 'UserAuthorization';
   authorization: TeamMemberAuthorization;
+  teamManager: Scalars['Boolean'];
   userId: Scalars['UUID4'];
 };
 

--- a/packages/app/src/app/graphql/types.ts
+++ b/packages/app/src/app/graphql/types.ts
@@ -2651,7 +2651,7 @@ export type TeamFragmentDashboardFragment = { __typename?: 'Team' } & Pick<
     userAuthorizations: Array<
       { __typename?: 'UserAuthorization' } & Pick<
         UserAuthorization,
-        'userId' | 'authorization'
+        'userId' | 'authorization' | 'teamManager'
       >
     >;
     users: Array<

--- a/packages/app/src/app/overmind/effects/gql/dashboard/fragments.ts
+++ b/packages/app/src/app/overmind/effects/gql/dashboard/fragments.ts
@@ -127,6 +127,7 @@ export const teamFragmentDashboard = gql`
     userAuthorizations {
       userId
       authorization
+      teamManager
     }
 
     users {


### PR DESCRIPTION
Regenerating the types to be up to date. However, there was a type mismatch so I had to add the `teamManager` property to `userAuthorizations` a the `teamFragmentDashboard` fragment.