### PR TITLE
fix(import): extract owner and repo from input

### DIFF
--- a/packages/app/src/app/components/CreateSandbox/Import/utils.test.ts
+++ b/packages/app/src/app/components/CreateSandbox/Import/utils.test.ts
@@ -5,6 +5,7 @@ const VALID_REPOS = [
   'http://github.com/owner/repo',
   'http://www.github.com/owner/repo',
   'https://github.com/owner/repo',
+  'https://github.com/owner/repo/',
   'https://www.github.com/owner/repo',
   'www.github.com/owner/repo',
   'https://github.com/owner/repo.git',
@@ -15,6 +16,7 @@ const VALID_REPOS = [
 const INVALID_REPOS = [
   'github.com/',
   'github.com/user/',
+  'github.com/user/repo/path/to/file',
   'http://github.com/',
   'http://github.com/user/',
   'http://www.github.com/',
@@ -35,9 +37,45 @@ describe('getOwnerAndRepoFromInput', () => {
     });
   });
 
+  test('owner/repo-dash returns an owner and repo', () => {
+    expect(getOwnerAndRepoFromInput('owner/repo-dash')).toEqual({
+      owner: 'owner',
+      repo: 'repo-dash',
+    });
+  });
+
+  test('owner/repo.dot returns an owner and repo', () => {
+    expect(getOwnerAndRepoFromInput('owner/repo.dot')).toEqual({
+      owner: 'owner',
+      repo: 'repo.dot',
+    });
+  });
+
+  test('https://github.com/owner/repo.com returns an owner and repo', () => {
+    expect(
+      getOwnerAndRepoFromInput('https://github.com/owner/repo.com')
+    ).toEqual({
+      owner: 'owner',
+      repo: 'repo.com',
+    });
+  });
+
+  test('https://github.com/owner/repo-dash returns an owner and repo', () => {
+    expect(
+      getOwnerAndRepoFromInput('https://github.com/owner/repo-dash')
+    ).toEqual({
+      owner: 'owner',
+      repo: 'repo-dash',
+    });
+  });
+
   INVALID_REPOS.forEach(possibleRepo => {
     test(`${possibleRepo} returns null`, () => {
       expect(getOwnerAndRepoFromInput(possibleRepo)).toBeNull();
     });
+  });
+
+  test('owner/repo/branch returns null', () => {
+    expect(getOwnerAndRepoFromInput('owner/repo/branch')).toBeNull();
   });
 });

--- a/packages/app/src/app/components/CreateSandbox/Import/utils.ts
+++ b/packages/app/src/app/components/CreateSandbox/Import/utils.ts
@@ -1,29 +1,62 @@
 import { findBestMatch } from 'string-similarity';
 import { State } from './useGithubOrganizations';
 
-// Will match: git@github.com:owner/repository.git
-const REGEX_SSH = /git@github\.com:(?<owner>[\w-]+)\/(?<repo>[\w-]+)\.git$/i;
-// Will match: http(s)://github.com/owner/repo(.git)
-const REGEX_HTTPS = /http(s?):\/\/github\.com\/(?<owner>[\w-]+)\/(?<repo>[\w-]+)(\.git)?$/i;
-// Will match: www.github.com/owner/repo and github.com/owner/repo
-const REGEX_PROTOCOLLESS = /(www\.)?github\.com\/(?<owner>[\w-]+)\/(?<repo>[\w-]+)$/i;
-// Will match: owner/repo
-const REGEX_PLAIN = /(?<owner>[\w-]+)\/(?<repo>[\w-]+)$/i;
+const REGEX_PLAIN = /(?<owner>^\w+)(?<slash>\/)(?<repo>[\w.-]+$)/g;
 
 export const getOwnerAndRepoFromInput = (input: string) => {
-  const match =
-    REGEX_SSH.exec(input) ||
-    REGEX_HTTPS.exec(input) ||
-    REGEX_PROTOCOLLESS.exec(input) ||
-    REGEX_PLAIN.exec(input);
+  let sanitizedInput = input.replace(/\s/, '');
 
-  if (!match) {
+  // Invalidate if input is empty.
+  if (!sanitizedInput) {
     return null;
   }
 
-  const { owner, repo } = match.groups as { owner: string; repo: string };
+  // If it starts with "www.", "github.com" or "http(s?)://", it
+  // should be an url.
+  if (sanitizedInput.match(/(^www.)|(^github.com)|(^http(s?):\/\/)/g)) {
+    try {
+      // If the input doesn't start with "http(s?)://", add it so
+      // the new URL constructor.
+      const parsedUrl = new URL(
+        /^(?!https?:\/\/)/g.test(sanitizedInput)
+          ? `https://${sanitizedInput}`
+          : sanitizedInput
+      );
 
-  return { owner, repo };
+      // Remove slashes from the beginning and end of the
+      // pathname before splitting it, also remove ".git".
+      const pathnameParts = parsedUrl.pathname
+        .replace(/^\/|(\/$)|(\.git$)/g, '')
+        .split('/');
+
+      // If the pathname is correctly formed (owner/repo),
+      // the length should equal 2.
+      if (pathnameParts.length !== 2) {
+        throw new Error('Invalid pathanme.');
+      }
+
+      return { owner: pathnameParts[0], repo: pathnameParts[1] };
+    } catch (error) {
+      return null;
+    }
+  }
+
+  // Check if the input is a SSH clone url.
+  if (sanitizedInput.startsWith('git@')) {
+    // If it's the case, extract the owner and repo
+    // to be returned in the next step.
+    sanitizedInput = sanitizedInput.replace(/^git@github.com:|(\.git$)/g, '');
+  }
+
+  // Check if the input matches "owner/repo".
+  if (sanitizedInput.match(REGEX_PLAIN)) {
+    const matches = REGEX_PLAIN.exec(sanitizedInput);
+    return matches?.groups
+      ? { owner: matches.groups.owner, repo: matches.groups.repo }
+      : null;
+  }
+
+  return null;
 };
 
 export const getGihubOrgMatchingCsbTeam = (


### PR DESCRIPTION
Updates the `getOwnerAndRepoFromInput` to handle more cases. I tried getting rid of the most complex regular expressions because they can make maintainability harder, instead, it checks some cases separately.

- [ ] Import a repo with an URL ending in a trailing slash, eg (`https://github.com/codesandbox/codesandbox-client/`) 
- [ ] Import a repo with a dot (`.`) in the repo name, eg (`https://github.com/tailwindlabs/tailwindcss.com`)
- [ ] Import a repo in the format `owner/repo`