### PR TITLE
feat(live): add restricted go live feature flag and view message

### DIFF
--- a/packages/app/src/app/overmind/actions.ts
+++ b/packages/app/src/app/overmind/actions.ts
@@ -254,6 +254,7 @@ type ModalName =
   | 'signInForTemplates'
   | 'userSurvey'
   | 'liveSessionConfirm'
+  | 'liveSessionRestricted'
   | 'sandboxPicker'
   | 'minimumPrivacy'
   | 'addMemberToWorkspace'

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Live/NotLive/Owner.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Live/NotLive/Owner.tsx
@@ -11,16 +11,32 @@ export const Owner: FunctionComponent = () => {
   const { live, modalOpened } = useActions();
   const { isPro } = useWorkspaceSubscription();
   const {
-    editor: {
-      currentSandbox: { id },
-      isAllModulesSynced,
-    },
+    editor: { currentSandbox, isAllModulesSynced },
     live: { isLoading },
   } = useAppState();
 
+  const id = currentSandbox.id;
+  const restrictions = currentSandbox?.restrictions;
+
   const handleGoLive = () => {
+    // Check the liveSessionsRestricted flag has been toggled. We can remove this
+    // after we're sure it is turned on.
+    if (typeof restrictions?.liveSessionsRestricted !== 'undefined') {
+      if (restrictions.liveSessionsRestricted) {
+        // Show modal that its restricted
+        modalOpened({ modal: 'liveSessionRestricted' });
+      } else {
+        live.createLiveClicked(id);
+      }
+
+      return;
+    }
+
+    // If liveSessionsRestricted flag has been toggled we can remove the logic
+    // below and rely on that instead.
     if (isPro) {
       live.createLiveClicked(id);
+
       return;
     }
 

--- a/packages/app/src/app/pages/common/Modals/LiveSessionRestricted/index.tsx
+++ b/packages/app/src/app/pages/common/Modals/LiveSessionRestricted/index.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import { Button, Stack, Text } from '@codesandbox/components';
+import { sandboxUrl } from '@codesandbox/common/lib/utils/url-generator';
+import track from '@codesandbox/common/lib/utils/analytics';
+
+import { useWorkspaceAuthorization } from 'app/hooks/useWorkspaceAuthorization';
+import { useCreateCheckout } from 'app/hooks';
+import { useWorkspaceSubscription } from 'app/hooks/useWorkspaceSubscription';
+import { useAppState } from 'app/overmind';
+import { SUBSCRIPTION_DOCS_URLS } from 'app/constants';
+import { Alert } from '../Common/Alert';
+
+export const LiveSessionRestricted: React.FC = () => {
+  const {
+    activeTeam,
+    editor: {
+      currentSandbox: { id },
+    },
+  } = useAppState();
+  const [checkout, createCheckout] = useCreateCheckout();
+  const { isAdmin } = useWorkspaceAuthorization();
+  const { isEligibleForTrial } = useWorkspaceSubscription();
+
+  return (
+    <Alert title="Upgrade to Pro to start a Live Session">
+      {checkout.status === 'error' && (
+        <Text marginBottom={8} variant="danger" size={12}>
+          An error ocurred while trying to load the checkout. Please try again.
+        </Text>
+      )}
+
+      {isAdmin ? (
+        <Stack gap={2} align="center" justify="flex-end">
+          <Button
+            as="a"
+            variant="link"
+            href={
+              isEligibleForTrial
+                ? SUBSCRIPTION_DOCS_URLS.teams.trial
+                : SUBSCRIPTION_DOCS_URLS.teams.non_trial
+            }
+            onClick={() => {
+              track('Live Session - learn more clicked', {
+                codesandbox: 'V1',
+                event_source: 'UI',
+              });
+            }}
+            autoWidth
+          >
+            Learn more
+          </Button>
+          <Button
+            loading={checkout.status === 'loading'}
+            variant="primary"
+            onClick={() => {
+              track('Live Session - upgrade clicked', {
+                codesandbox: 'V1',
+                event_source: 'UI',
+              });
+
+              createCheckout({
+                team_id: activeTeam,
+                recurring_interval: 'month',
+                success_path: sandboxUrl({ id }),
+                cancel_path: sandboxUrl({ id }),
+              });
+            }}
+            autoWidth
+          >
+            <Text>
+              {isEligibleForTrial ? 'Start free trial' : 'Upgrade to Pro'}
+            </Text>
+          </Button>
+        </Stack>
+      ) : (
+        <Stack direction="vertical" gap={6}>
+          <Text as="p" variant="muted" css={{ marginTop: 0 }}>
+            Contact your team admin to upgrade.
+          </Text>
+          <Stack justify="flex-end">
+            <Button
+              as="a"
+              variant="secondary"
+              href={
+                isEligibleForTrial
+                  ? SUBSCRIPTION_DOCS_URLS.teams.trial
+                  : SUBSCRIPTION_DOCS_URLS.teams.non_trial
+              }
+              onClick={() => {
+                track('Live Session - learn more clicked', {
+                  codesandbox: 'V1',
+                  event_source: 'UI',
+                });
+              }}
+              autoWidth
+            >
+              Learn more
+            </Button>
+          </Stack>
+        </Stack>
+      )}
+    </Alert>
+  );
+};

--- a/packages/app/src/app/pages/common/Modals/index.tsx
+++ b/packages/app/src/app/pages/common/Modals/index.tsx
@@ -23,6 +23,7 @@ import { FeedbackModal } from './FeedbackModal';
 import { ForkServerModal } from './ForkServerModal';
 import { LiveSessionEnded } from './LiveSessionEnded';
 import { LiveSessionConfirm } from './LiveSessionConfirm';
+import { LiveSessionRestricted } from './LiveSessionRestricted';
 import { LiveVersionMismatch } from './LiveSessionVersionMismatch';
 import { NetlifyLogs } from './NetlifyLogs';
 import { PickSandboxModal } from './PickSandboxModal';
@@ -149,6 +150,10 @@ const modals = {
   },
   liveSessionConfirm: {
     Component: LiveSessionConfirm,
+    width: 400,
+  },
+  liveSessionRestricted: {
+    Component: LiveSessionRestricted,
     width: 400,
   },
   liveVersionMismatch: {

--- a/packages/common/src/types/index.ts
+++ b/packages/common/src/types/index.ts
@@ -508,6 +508,14 @@ export type Sandbox = {
     preventSandboxLeaving: boolean;
     preventSandboxExport: boolean;
   };
+  // New restrictions object. Remove the optional from the properties
+  // when resrcitions are deployed to production.
+  restrictions?: {
+    freePlanEditingRestricted?: boolean;
+    liveSessionsRestricted?: boolean;
+  };
+  // Legacy freePlanEditingRestricted. We can remove this when the
+  // restrictions above have been implemented.
   freePlanEditingRestricted: boolean;
 };
 


### PR DESCRIPTION
Closes XTD-711

Adds the recently added `restrictions` object with `liveSessionsRestricted` flag to the types, and use it to view a message when going live is restricted.

### Testing

Open the team "free-team" on stream. This team should have the feature flag enabled, and go live restricted. Go to any sandbox and press go live, either as editor or admin. A message should pop up.

### Video
As an admin.

https://user-images.githubusercontent.com/7533849/220380810-985670dc-05bc-440a-bbd7-fb5750a6508e.mov

### Screenshot
As non-admin.

<img width="1624" alt="image" src="https://user-images.githubusercontent.com/7533849/220381846-7e6a5991-0aec-4f6b-bda5-f30a0bbacf28.png">
