### PR TITLE
Fix(sentry): Update fontfaceobserver to version with proper error handling

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -130,7 +130,7 @@
     "estree-walker": "^1.0.1",
     "expect": "^26.2.0",
     "file-saver": "^1.3.3",
-    "fontfaceobserver": "^2.0.13",
+    "fontfaceobserver": "^2.1.0",
     "framer-motion": "^1.8.4",
     "fuse.js": "^3.2.1",
     "glamor": "^2.20.25",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14965,9 +14965,10 @@ follow-redirects@^1.0.0, follow-redirects@^1.2.3:
   dependencies:
     debug "^3.0.0"
 
-fontfaceobserver@^2.0.13:
-  version "2.0.13"
-  resolved "https://registry.yarnpkg.com/fontfaceobserver/-/fontfaceobserver-2.0.13.tgz#47adbb343261eda98cb44db2152196ff124d3221"
+fontfaceobserver@^2.1.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/fontfaceobserver/-/fontfaceobserver-2.3.0.tgz#5fb392116e75d5024b7ec8e4f2ce92106d1488c8"
+  integrity sha512-6FPvD/IVyT4ZlNe7Wcn5Fb/4ChigpucKYSvD6a+0iMoLn2inpo711eyIcKjmDtE5XNcgAkSH9uN/nfAeZzHEfg==
 
 for-each@^0.3.3:
   version "0.3.3"


### PR DESCRIPTION
Should fix Sentry issue 1483077395.

### The culprit

The error was an `UnhandledRejection: Non-Error promise rejection`. A promise rejection was called with an object which had certain keys that pointed to a font. It turns out that it errored when trying to [load MonoLisa font when initializing the v1 editor](https://github.com/codesandbox/codesandbox-client/blob/master/packages/app/src/app/overmind/effects/vscode/index.ts#L217).

Digging around in [the `fontfaceobserver` package](https://www.npmjs.com/package/fontfaceobserver) I found that the class is constructed with the initial values visible in the Sentry error. It turns out that it was not properly handling errors and [passed an object instead of an Error instance](https://github.com/bramstein/fontfaceobserver/blob/v2.0.13/src/observer.js#L222) to the error handler. This [has been fixed in a PR](https://github.com/bramstein/fontfaceobserver/commit/eb705c28ada6d18a47e51ff0c05312345ad53962) which was [released with version `2.1.0`](https://github.com/bramstein/fontfaceobserver/compare/v2.0.13...v2.1.0).

### Testing

To test this you'll have to open a v1 Sandbox and make sure it loads properly, with the MonoLisa (monospace) font.