### PR TITLE
fix(sentry): Ensure continue action is not called when forking is not allowed

### DIFF
--- a/packages/app/src/app/overmind/factories.ts
+++ b/packages/app/src/app/overmind/factories.ts
@@ -128,14 +128,10 @@ export const withOwnedSandbox = <I>(
           sandboxId: sandbox.id,
         });
       } catch (e) {
-        const isAnonServerForkMessage = e.message.includes(
-          'server container as an anonymous user'
-        );
-
         // If we know the error is caused by an anonymous user trying to save a
         // file and fork a server sandbox, we don't want to show the vscode error
         // with the cancelAction and we don't want to continue either.
-        if (isAnonServerForkMessage) {
+        if (e.message === 'ERR_ANON_SSE_FORK') {
           return () => {};
         }
 

--- a/packages/app/src/app/overmind/factories.ts
+++ b/packages/app/src/app/overmind/factories.ts
@@ -112,6 +112,7 @@ export const withOwnedSandbox = <I>(
   const { state, actions } = context;
 
   const sandbox = state.editor.currentSandbox;
+
   if (sandbox) {
     if (
       typeof requiredPermission === 'undefined'
@@ -127,6 +128,17 @@ export const withOwnedSandbox = <I>(
           sandboxId: sandbox.id,
         });
       } catch (e) {
+        const isAnonServerForkMessage = e.message.includes(
+          'server container as an anonymous user'
+        );
+
+        // If we know the error is caused by an anonymous user trying to save a
+        // file and fork a server sandbox, we don't want to show the vscode error
+        // with the cancelAction and we don't want to continue either.
+        if (isAnonServerForkMessage) {
+          return () => {};
+        }
+
         return cancelAction(context, payload);
       }
     } else if (sandbox.isFrozen && state.editor.sessionFrozen) {

--- a/packages/app/src/app/overmind/namespaces/editor/internalActions.ts
+++ b/packages/app/src/app/overmind/namespaces/editor/internalActions.ts
@@ -446,9 +446,7 @@ export const forkSandbox = async (
     // when it tries to execute forkSandbox. When we just return instead of throwing the error
     // is not caught and "withOwnedSandbox" will run its "continueAction" which, in case of the
     // "codeSaved" function will continue to save code, with all kinds of actions and api calls.
-    throw new Error(
-      `Can't fork sandbox executed in a server container as an anonymous user`
-    );
+    throw new Error('ERR_ANON_SSE_FORK');
   }
 
   effects.analytics.track('Fork Sandbox', {

--- a/packages/app/src/app/overmind/namespaces/editor/internalActions.ts
+++ b/packages/app/src/app/overmind/namespaces/editor/internalActions.ts
@@ -434,11 +434,21 @@ export const forkSandbox = async (
     sandbox ? sandbox.template : null
   );
 
+  // If the user is not signed in and the sandbox is exectued in a server container
+  // we can't fork.
   if (!state.isLoggedIn && templateDefinition.isServer) {
+    // So we track this happens
     effects.analytics.track('Show Server Fork Sign In Modal');
+    // And open a modal (alert) to show a sign in button
     actions.modalOpened({ modal: 'forkServerModal' });
 
-    return;
+    // Throwing an error here ensures that it get's caught in the "withOwnedSandbox" function
+    // when it tries to execute forkSandbox. When we just return instead of throwing the error
+    // is not caught and "withOwnedSandbox" will run its "continueAction" which, in case of the
+    // "codeSaved" function will continue to save code, with all kinds of actions and api calls.
+    throw new Error(
+      `Can't fork sandbox executed in a server container as an anonymous user`
+    );
   }
 
   effects.analytics.track('Fork Sandbox', {


### PR DESCRIPTION
Should fix Sentry issue 3587048851.

### The culprit

The error had to do with an unauthorized API call (returned a `401`). The API was called when an anonymous user tried to save a file which resulted in CSB trying to stop it from being forked. This was done successfully, but the "save" action wasn't properly canceled after that. This PR changes that behaviour and throws an error rather than returning nothing to end up in a `catch` block - which then properly stops the save action from happening.

I've also made sure we don't trigger an "unknown" editor error while also showing the fork alert. The fork alert with sign in button should be enough.

### Before

https://user-images.githubusercontent.com/7533849/220662233-961e6e2c-7755-48d1-ad0b-3f460ebd8920.mov

### After

https://user-images.githubusercontent.com/7533849/220662297-c239a1fc-94a2-4648-9156-7b0d9360b538.mov
