### PR TITLE
feat(tracking): "seen" event on PaymentPending banner

### DIFF
--- a/packages/app/src/app/components/StripeMessages/PaymentPending.tsx
+++ b/packages/app/src/app/components/StripeMessages/PaymentPending.tsx
@@ -22,10 +22,6 @@ export const PaymentPending: React.FC = () => {
     createCustomerPortal,
   ] = useCreateCustomerPortal({ team_id: activeTeam, return_path: pathname });
 
-  if (isDismissed) {
-    return null;
-  }
-
   const handleDismiss = () => {
     const event = hasExpiredTeamTrial
       ? 'expired trial dismiss'
@@ -67,6 +63,23 @@ export const PaymentPending: React.FC = () => {
         : 'Please update your payment details'
     }`;
   };
+
+  React.useEffect(() => {
+    if (isDismissed) {
+      return;
+    }
+
+    const event = hasExpiredTeamTrial ? 'expired trial seen' : 'unpaid - seen';
+
+    track(`Stripe banner - ${event}`, {
+      codesandbox: 'V1',
+      event_source: 'UI',
+    });
+  }, []);
+
+  if (isDismissed) {
+    return null;
+  }
 
   return (
     <MessageStripe variant="warning" onDismiss={handleDismiss}>


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?

<!-- Is it a Bug fix, feature, docs update, ... -->

Adds tracking to the PaymentPending banner.
- If the banner is shown because the trial has expired, track an event named "Stripe banner - expired trial seen"
- If the banner is shown because the subscription is unpaid, track an event named "Stripe banner - unpaid - seen"
