### PR TITLE
fix: catch errors when upgrading sandboxes from v1 to v2

### DIFF
--- a/packages/app/src/app/hooks/useUpgradeFromV1ToV2.ts
+++ b/packages/app/src/app/hooks/useUpgradeFromV1ToV2.ts
@@ -22,45 +22,53 @@ export const useUpgradeFromV1ToV2 = (trackingLocation: string) => {
       }
 
       setIsLoading(true);
-      const sandboxId = state.editor.currentSandbox.id;
 
       track(`Editor - ${trackingLocation} Convert to Cloud Sandbox`, {
         owned: canConvert,
       });
 
-      if (canConvert) {
-        const alias = state.editor.currentSandbox.alias;
+      try {
+        const sandboxId = state.editor.currentSandbox.id;
 
-        await updateSandbox(sandboxId, {
-          v2: true,
-        });
+        if (canConvert) {
+          const alias = state.editor.currentSandbox.alias;
 
-        const sandboxV2Url = sandboxUrl({
-          id: sandboxId,
-          alias,
-          isV2: true,
-          query: {
-            welcome: 'true',
-          },
-        });
+          await updateSandbox(sandboxId, {
+            v2: true,
+          });
 
-        window.location.href = sandboxV2Url;
-      } else {
-        const forkedSandbox = await effects.api.forkSandbox(sandboxId, {
-          v2: true,
-          teamId: state.activeTeam,
-        });
+          const sandboxV2Url = sandboxUrl({
+            id: sandboxId,
+            alias,
+            isV2: true,
+            query: {
+              welcome: 'true',
+            },
+          });
 
-        const sandboxV2Url = sandboxUrl({
-          id: forkedSandbox.id,
-          alias: forkedSandbox.alias,
-          isV2: true,
-          query: {
-            welcome: 'true',
-          },
-        });
+          window.location.href = sandboxV2Url;
+        } else {
+          const forkedSandbox = await effects.api.forkSandbox(sandboxId, {
+            v2: true,
+            teamId: state.activeTeam,
+          });
 
-        window.location.href = sandboxV2Url;
+          const sandboxV2Url = sandboxUrl({
+            id: forkedSandbox.id,
+            alias: forkedSandbox.alias,
+            isV2: true,
+            query: {
+              welcome: 'true',
+            },
+          });
+
+          window.location.href = sandboxV2Url;
+        }
+      } catch (err) {
+        setIsLoading(false);
+        effects.notificationToast.error(
+          'Failed to convert to Cloud Sandbox. Please try again.'
+        );
       }
     },
   };


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?

<!-- Is it a Bug fix, feature, docs update, ... -->

Adds a `try/catch` block around the actions when upgrading a sandbox from v1 to v2. Add a toast notification if an error is thrown because this action can be triggered from a Stripe banner that doesn't have room for an error message.


https://user-images.githubusercontent.com/24959348/221061509-4316c702-eb02-4d5f-afd1-63771a25c269.mov

