### PR TITLE
fix(vercel): Signing into vercel sometimes throws an error but still succeeds

### DIFF
--- a/packages/app/src/app/overmind/actions.ts
+++ b/packages/app/src/app/overmind/actions.ts
@@ -346,6 +346,11 @@ export const signInVercelClicked = async ({
   actions,
 }: Context) => {
   state.isLoadingVercel = true;
+
+  /**
+   * We're opening a browser popup here with the /auth/zeit page but then do a server
+   * side redirect to the Vercel sign in page. This only works on production, not locally.
+   */
   const popup = browser.openPopup('/auth/zeit', 'sign in');
   const data: { code: string } = await browser.waitForMessage('signin');
 
@@ -354,10 +359,22 @@ export const signInVercelClicked = async ({
   if (data && data.code) {
     try {
       state.user = await api.createVercelIntegration(data.code);
-      await actions.deployment.internal.getVercelUserDetails();
     } catch (error) {
       actions.internal.handleError({
-        message: 'Could not authorize with Vercel',
+        message: 'Not able to add a Vercel integration. Please try again.',
+        error,
+      });
+    }
+
+    try {
+      await actions.deployment.internal.getVercelUserDetails();
+
+      // Not sure if we ever reach the catch clause below because the error has already
+      // been caught in getVercelUserDetails.
+    } catch (error) {
+      actions.internal.handleError({
+        message:
+          'We were not able to fetch your Vercel user details. You should still be able to deploy to Vercel, please try again if needed.',
         error,
       });
     }

--- a/packages/app/src/app/overmind/namespaces/deployment/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/deployment/actions.ts
@@ -174,6 +174,7 @@ export const deployProductionClicked = async ({
 
   actions.deployment.getDeploys();
 };
+
 export const deploySandboxClicked = async ({
   actions,
   effects,
@@ -199,7 +200,8 @@ export const deploySandboxClicked = async ({
       }
     } catch (error) {
       actions.internal.handleError({
-        message: 'Could not authorize with Vercel',
+        message:
+          'We were not able to fetch your Vercel user details. You should still be able to deploy to Vercel, please try again if needed.',
         error,
       });
     }

--- a/packages/app/src/app/overmind/namespaces/deployment/internalActions.ts
+++ b/packages/app/src/app/overmind/namespaces/deployment/internalActions.ts
@@ -17,7 +17,8 @@ export const getVercelUserDetails = async ({
       state.user.integrations.zeit.email = vercelDetails.email;
     } catch (error) {
       actions.internal.handleError({
-        message: 'Could not authorize with Vercel',
+        message:
+          'We were not able to fetch your Vercel user details. You should still be able to deploy to Vercel, please try again if needed.',
         error,
       });
     }

--- a/packages/app/src/app/pages/VercelAuth/index.js
+++ b/packages/app/src/app/pages/VercelAuth/index.js
@@ -7,6 +7,11 @@ import {
 } from '@codesandbox/common/lib/utils/url-generator';
 import { Title } from 'app/components/Title';
 
+/**
+ * This component is insteresting. We're probably redirecting this page
+ * to the Vercel signin on the server. It doesn't do anything locally but
+ * does redirect on production.
+ */
 const VercelSignIn = () => {
   const [redirect, setRedirect] = useState(null);
   const [jwt] = useState(null);


### PR DESCRIPTION
Turns out that the error is actually thrown because we weren't able to fetch the user from Vercel, but we are still able to deploy to Vercel via the ingegration. Updated the messages to reflect this.