### PR TITLE
chore: Remove references to legacy pricing

### DIFF
--- a/packages/app/src/app/overmind/effects/api/index.ts
+++ b/packages/app/src/app/overmind/effects/api/index.ts
@@ -632,14 +632,6 @@ export default {
       sandboxLimit: number;
     }>(`/sandboxes/limits`);
   },
-  legacyPrices() {
-    type Pricing = Record<
-      'pro' | 'teamPro',
-      Record<'month' | 'year', { currency: string; unitAmount: number }>
-    >;
-
-    return api.get<Pricing>(`/prices`);
-  },
   getPrices() {
     return api.get(`/prices`, undefined, undefined, true);
   },

--- a/packages/app/src/app/overmind/namespaces/pro/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/pro/actions.ts
@@ -4,9 +4,8 @@ import { SubscriptionInterval } from 'app/graphql/types';
 import { Step, PaymentSummary, PaymentPreview } from './types';
 
 export const pageMounted = withLoadApp(async ({ effects, state, actions }) => {
-  // We have to call the api effects directly rather than using an action because
-  // for some reason the actions don't work.
-  state.pro.legacyPrices = await effects.api.legacyPrices();
+  // We have to call the api effect directly rather than using an action because
+  // for some reason an action doesn't work.
   state.pro.prices = await effects.api.getPrices();
 
   // This action does work.

--- a/packages/app/src/app/overmind/namespaces/pro/state.ts
+++ b/packages/app/src/app/overmind/namespaces/pro/state.ts
@@ -1,10 +1,4 @@
-import {
-  Step,
-  PaymentSummary,
-  PaymentPreview,
-  LegacyPricing,
-  Pricing,
-} from './types';
+import { Step, PaymentSummary, PaymentPreview, Pricing } from './types';
 
 type State = {
   step: Step;
@@ -14,7 +8,6 @@ type State = {
   summary: PaymentSummary | null;
   paymentPreview: PaymentPreview | null;
   updatingSubscription: boolean;
-  legacyPrices: LegacyPricing | null;
   prices: Pricing | null;
 };
 
@@ -26,6 +19,5 @@ export const state: State = {
   summary: null,
   paymentPreview: null,
   updatingSubscription: false,
-  legacyPrices: null,
   prices: null,
 };

--- a/packages/app/src/app/overmind/namespaces/pro/types.ts
+++ b/packages/app/src/app/overmind/namespaces/pro/types.ts
@@ -3,11 +3,6 @@ export enum Step {
   ConfirmBillingInterval = 'ConfirmBillingInterval',
 }
 
-export type LegacyPricing = Record<
-  'pro' | 'teamPro',
-  Record<'month' | 'year', { currency: string; unitAmount: number }>
->;
-
 export type PaymentSummary = {
   unitPrice: number;
   unit: number;


### PR DESCRIPTION
There are still some references to legacy pricing, but those are in the old homepage pages, which we will remove in another PR.