### PR TITLE
feat(pro): upsell team pro

### DIFF
--- a/packages/app/src/app/constants.ts
+++ b/packages/app/src/app/constants.ts
@@ -17,7 +17,6 @@ export interface Feature {
 }
 
 export const PERSONAL_FREE_FEATURES: Feature[] = [
-  { key: 'editors', label: '1 editor', highlighted: true },
   {
     key: 'limit_sandboxes',
     label: 'Unlimited public sandboxes',
@@ -32,7 +31,6 @@ export const PERSONAL_FREE_FEATURES: Feature[] = [
 ];
 
 export const PERSONAL_FEATURES: Feature[] = [
-  { key: 'editors', label: '1 editor', highlighted: true },
   {
     key: 'limit_sandboxes',
     label: 'Unlimited private sandboxes',
@@ -49,7 +47,6 @@ export const PERSONAL_FEATURES: Feature[] = [
 ];
 
 export const PERSONAL_FEATURES_WITH_PILLS: Feature[] = [
-  { key: 'editors', label: '1 editor', highlighted: true },
   {
     key: 'limit_sandboxes',
     label: 'Unlimited private sandboxes',
@@ -66,7 +63,6 @@ export const PERSONAL_FEATURES_WITH_PILLS: Feature[] = [
 ];
 
 export const TEAM_FREE_FEATURES: Feature[] = [
-  { key: 'editors', label: 'Up to 5 editors', highlighted: true },
   {
     key: 'limit_sandboxes',
     label: '20 public sandboxes',
@@ -82,7 +78,6 @@ export const TEAM_FREE_FEATURES: Feature[] = [
 ];
 
 export const TEAM_PRO_FEATURES: Feature[] = [
-  { key: 'editors', label: 'Up to 20 editors', highlighted: true },
   {
     key: 'limit_sandboxes',
     label: 'Unlimited private sandboxes',
@@ -99,7 +94,6 @@ export const TEAM_PRO_FEATURES: Feature[] = [
 ];
 
 export const TEAM_PRO_FEATURES_WITH_PILLS: Feature[] = [
-  { key: 'editors', label: 'Up to 20 editors', highlighted: true },
   {
     key: 'limit_sandboxes',
     label: 'Unlimited private sandboxes',
@@ -116,7 +110,6 @@ export const TEAM_PRO_FEATURES_WITH_PILLS: Feature[] = [
 ];
 
 export const ORG_FEATURES: Feature[] = [
-  { key: 'editors', label: 'Unlimited editors', highlighted: true },
   {
     key: 'limit_sandboxes',
     label: 'Unlimited private sandboxes',

--- a/packages/app/src/app/constants.ts
+++ b/packages/app/src/app/constants.ts
@@ -58,6 +58,7 @@ export const PERSONAL_FEATURES_WITH_PILLS: Feature[] = [
     key: 'limit_repositories',
     label: 'Unlimited private repositories',
   },
+  { key: 'npm', label: 'Public NPM packages' },
   { key: 'live_sessions', label: 'Live sessions' },
   { key: 'vm_mem', label: '6GB RAM', pill: '3x capacity' },
   { key: 'vm_cpu', label: '4vCPUs', pill: '2x faster' },

--- a/packages/app/src/app/constants.ts
+++ b/packages/app/src/app/constants.ts
@@ -13,10 +13,11 @@ export interface Feature {
   key: string;
   label: string;
   pill?: string;
+  highlighted?: boolean;
 }
 
 export const PERSONAL_FREE_FEATURES: Feature[] = [
-  { key: 'editors', label: '1 editor' },
+  { key: 'editors', label: '1 editor', highlighted: true },
   {
     key: 'limit_sandboxes',
     label: 'Unlimited public sandboxes',
@@ -31,7 +32,7 @@ export const PERSONAL_FREE_FEATURES: Feature[] = [
 ];
 
 export const PERSONAL_FEATURES: Feature[] = [
-  { key: 'editors', label: '1 editor' },
+  { key: 'editors', label: '1 editor', highlighted: true },
   {
     key: 'limit_sandboxes',
     label: 'Unlimited private sandboxes',
@@ -40,6 +41,7 @@ export const PERSONAL_FEATURES: Feature[] = [
     key: 'limit_repositories',
     label: 'Unlimited private repositories',
   },
+  { key: 'npm', label: 'Public NPM packages' },
   { key: 'live_sessions', label: 'Live sessions' },
   { key: 'vm_mem', label: '6GB RAM' },
   { key: 'vm_cpu', label: '4vCPUs' },
@@ -47,7 +49,7 @@ export const PERSONAL_FEATURES: Feature[] = [
 ];
 
 export const PERSONAL_FEATURES_WITH_PILLS: Feature[] = [
-  { key: 'editors', label: '1 editor' },
+  { key: 'editors', label: '1 editor', highlighted: true },
   {
     key: 'limit_sandboxes',
     label: 'Unlimited private sandboxes',
@@ -63,6 +65,7 @@ export const PERSONAL_FEATURES_WITH_PILLS: Feature[] = [
 ];
 
 export const TEAM_FREE_FEATURES: Feature[] = [
+  { key: 'editors', label: 'Up to 5 editors', highlighted: true },
   {
     key: 'limit_sandboxes',
     label: '20 public sandboxes',
@@ -71,7 +74,6 @@ export const TEAM_FREE_FEATURES: Feature[] = [
     key: 'limit_repositories',
     label: '3 public repositories',
   },
-  { key: 'editors', label: 'Up to 5 editors' },
   { key: 'npm', label: 'Public NPM packages' },
   { key: 'vm_mem', label: '2GB RAM' },
   { key: 'vm_cpu', label: '2vCPUs' },
@@ -79,6 +81,7 @@ export const TEAM_FREE_FEATURES: Feature[] = [
 ];
 
 export const TEAM_PRO_FEATURES: Feature[] = [
+  { key: 'editors', label: 'Up to 20 editors', highlighted: true },
   {
     key: 'limit_sandboxes',
     label: 'Unlimited private sandboxes',
@@ -87,7 +90,6 @@ export const TEAM_PRO_FEATURES: Feature[] = [
     key: 'limit_repositories',
     label: 'Unlimited private repositories',
   },
-  { key: 'editors', label: 'Up to 20 editors' },
   { key: 'npm', label: 'Private NPM packages' },
   { key: 'live_sessions', label: 'Live sessions' },
   { key: 'vm_mem', label: '6GB RAM' },
@@ -96,6 +98,7 @@ export const TEAM_PRO_FEATURES: Feature[] = [
 ];
 
 export const TEAM_PRO_FEATURES_WITH_PILLS: Feature[] = [
+  { key: 'editors', label: 'Up to 20 editors', highlighted: true },
   {
     key: 'limit_sandboxes',
     label: 'Unlimited private sandboxes',
@@ -104,7 +107,6 @@ export const TEAM_PRO_FEATURES_WITH_PILLS: Feature[] = [
     key: 'limit_repositories',
     label: 'Unlimited private repositories',
   },
-  { key: 'editors', label: 'Up to 20 editors' },
   { key: 'npm', label: 'Private NPM packages' },
   { key: 'live_sessions', label: 'Live sessions' },
   { key: 'vm_mem', label: '6GB RAM', pill: '3x capacity' },
@@ -113,6 +115,7 @@ export const TEAM_PRO_FEATURES_WITH_PILLS: Feature[] = [
 ];
 
 export const ORG_FEATURES: Feature[] = [
+  { key: 'editors', label: 'Unlimited editors', highlighted: true },
   {
     key: 'limit_sandboxes',
     label: 'Unlimited private sandboxes',
@@ -121,7 +124,6 @@ export const ORG_FEATURES: Feature[] = [
     key: 'limit_repositories',
     label: 'Unlimited private repositories',
   },
-  { key: 'editors', label: 'No editor limit' },
   { key: 'npm', label: 'Private NPM packages' },
   { key: 'live_sessions', label: 'Live sessions' },
   { key: 'vm_mem', label: 'Custom VM Specs' },

--- a/packages/app/src/app/overmind/actions.ts
+++ b/packages/app/src/app/overmind/actions.ts
@@ -258,7 +258,8 @@ type ModalName =
   | 'sandboxPicker'
   | 'minimumPrivacy'
   | 'addMemberToWorkspace'
-  | 'legacyPayment';
+  | 'legacyPayment'
+  | 'selectWorkspaceToUpgrade';
 
 export const modalOpened = (
   { state, effects }: Context,

--- a/packages/app/src/app/pages/Pro/Legacy.tsx
+++ b/packages/app/src/app/pages/Pro/Legacy.tsx
@@ -11,7 +11,9 @@ import { ConfirmBillingInterval } from './legacy-pages/ConfirmBillingInterval';
 import { PaymentSuccess } from './legacy-pages/PaymentSuccess';
 
 export const ProLegacy: React.FC = () => {
-  const { pageMounted } = useActions().pro;
+  const {
+    pro: { pageMounted },
+  } = useActions();
 
   React.useEffect(() => {
     pageMounted();

--- a/packages/app/src/app/pages/Pro/Upgrade.tsx
+++ b/packages/app/src/app/pages/Pro/Upgrade.tsx
@@ -120,6 +120,15 @@ export const ProUpgrade = () => {
         },
       };
 
+  // Used in the personal view if the account is free.
+  const upsellTeamProCta: CTA = {
+    text: 'Upgrade',
+    variant: 'highlight',
+    onClick: () => {
+      alert('foo');
+    },
+  };
+
   const teamProCta: CTA =
     isTeamAdmin && !hasCustomSubscription && isPro
       ? {
@@ -237,34 +246,61 @@ export const ProUpgrade = () => {
             </SubscriptionCard>
 
             {isPersonalSpace ? (
-              <SubscriptionCard
-                title="Personal Pro"
-                features={
-                  isPro ? PERSONAL_FEATURES : PERSONAL_FEATURES_WITH_PILLS
-                }
-                cta={personalProCta}
-                isHighlighted
-              >
-                <Stack gap={1} direction="vertical">
-                  <Text size={32} weight="500">
-                    {formatCurrency({
-                      currency: 'USD',
-                      amount: pro?.prices?.individual.year.usd / 12,
-                    })}
-                  </Text>
-                  <Text>
-                    <div>per month, billed anually</div>{' '}
-                    <div>
-                      or{' '}
+              <>
+                <SubscriptionCard
+                  title="Personal Pro"
+                  features={
+                    isPro ? PERSONAL_FEATURES : PERSONAL_FEATURES_WITH_PILLS
+                  }
+                  cta={personalProCta}
+                  isHighlighted
+                >
+                  <Stack gap={1} direction="vertical">
+                    <Text size={32} weight="500">
                       {formatCurrency({
                         currency: 'USD',
-                        amount: pro?.prices?.individual.month.usd,
-                      })}{' '}
-                      per month.
-                    </div>
-                  </Text>
-                </Stack>
-              </SubscriptionCard>
+                        amount: pro?.prices?.individual.year.usd / 12,
+                      })}
+                    </Text>
+                    <Text>
+                      <div>per month, billed anually</div>{' '}
+                      <div>
+                        or{' '}
+                        {formatCurrency({
+                          currency: 'USD',
+                          amount: pro?.prices?.individual.month.usd,
+                        })}{' '}
+                        per month.
+                      </div>
+                    </Text>
+                  </Stack>
+                </SubscriptionCard>
+                {isFree ? (
+                  <SubscriptionCard
+                    title="Team Pro"
+                    features={TEAM_PRO_FEATURES_WITH_PILLS}
+                    isHighlighted
+                    cta={upsellTeamProCta}
+                  >
+                    <Stack gap={1} direction="vertical">
+                      <Text size={32} weight="500">
+                        {formatCurrency({
+                          currency: 'USD',
+                          amount: pro?.prices?.team.year.usd / 12,
+                        })}
+                      </Text>
+                      <Text>
+                        per editor per month, billed anually, or{' '}
+                        {formatCurrency({
+                          currency: 'USD',
+                          amount: pro?.prices?.team.month.usd,
+                        })}{' '}
+                        per month.
+                      </Text>
+                    </Stack>
+                  </SubscriptionCard>
+                ) : null}
+              </>
             ) : (
               <>
                 <SubscriptionCard

--- a/packages/app/src/app/pages/Pro/Upgrade.tsx
+++ b/packages/app/src/app/pages/Pro/Upgrade.tsx
@@ -259,7 +259,10 @@ export const ProUpgrade = () => {
                       })}
                     </Text>
                     <StyledPricingDetailsText>
-                      <div>per month, billed anually</div>{' '}
+                      <div>
+                        per month
+                        <br />, billed anually
+                      </div>{' '}
                       <div>
                         or{' '}
                         {formatCurrency({
@@ -310,7 +313,8 @@ export const ProUpgrade = () => {
                       })}
                     </Text>
                     <StyledPricingDetailsText>
-                      per editor per month, billed anually, or{' '}
+                      per editor per month,
+                      <br /> billed anually, or{' '}
                       {formatCurrency({
                         currency: 'USD',
                         amount: pro?.prices?.team.month.usd,

--- a/packages/app/src/app/pages/Pro/Upgrade.tsx
+++ b/packages/app/src/app/pages/Pro/Upgrade.tsx
@@ -198,29 +198,25 @@ export const ProUpgrade = () => {
               personalWorkspaceId={personalWorkspaceId}
               activeTeamInfo={activeTeamInfo}
             />
-
-            <Text
-              as="h1"
-              fontFamily="everett"
-              size={48}
-              weight="500"
-              align="center"
-              lineHeight="56px"
-              margin={0}
-              css={{
-                maxWidth: '976px',
-                overflow: 'initial',
-                whiteSpace: 'wrap',
-              }}
-            >
-              {isPro && isPersonalSpace
-                ? 'You have an active Personal Pro subscription'
-                : null}
-              {isPro && isTeamSpace
-                ? 'You have an active Team Pro subscription'
-                : null}
-              {isFree ? 'Upgrade for Pro features' : null}
-            </Text>
+            <Element css={{ maxWidth: '976px', textAlign: 'center' }}>
+              <Text
+                as="h1"
+                fontFamily="everett"
+                size={48}
+                weight="500"
+                align="center"
+                lineHeight="56px"
+                margin={0}
+              >
+                {isPro && isPersonalSpace
+                  ? 'You have an active Personal Pro subscription'
+                  : null}
+                {isPro && isTeamSpace
+                  ? 'You have an active Team Pro subscription'
+                  : null}
+                {isFree ? 'Upgrade for Pro features' : null}
+              </Text>
+            </Element>
           </Stack>
 
           <Stack

--- a/packages/app/src/app/pages/Pro/Upgrade.tsx
+++ b/packages/app/src/app/pages/Pro/Upgrade.tsx
@@ -34,6 +34,7 @@ import { SubscriptionCard } from './components/SubscriptionCard';
 import type { CTA } from './components/SubscriptionCard';
 import { TeamSubscriptionOptions } from '../Dashboard/Components/TeamSubscriptionOptions/TeamSubscriptionOptions';
 import { NewTeamModal } from '../Dashboard/Components/NewTeamModal';
+import { StyledPricingDetailsText } from './components/elements';
 
 export const ProUpgrade = () => {
   const {
@@ -243,11 +244,11 @@ export const ProUpgrade = () => {
                 isPersonalSpace ? PERSONAL_FREE_FEATURES : TEAM_FREE_FEATURES
               }
             >
-              <Stack gap={1} direction="vertical" css={{ flexGrow: 1 }}>
+              <Stack gap={1} direction="vertical">
                 <Text size={32} weight="400">
                   $0
                 </Text>
-                <Text>forever</Text>
+                <StyledPricingDetailsText>forever</StyledPricingDetailsText>
               </Stack>
             </SubscriptionCard>
 
@@ -268,7 +269,7 @@ export const ProUpgrade = () => {
                         amount: pro?.prices?.individual.year.usd / 12,
                       })}
                     </Text>
-                    <Text>
+                    <StyledPricingDetailsText>
                       <div>per month, billed anually</div>{' '}
                       <div>
                         or{' '}
@@ -278,7 +279,7 @@ export const ProUpgrade = () => {
                         })}{' '}
                         per month.
                       </div>
-                    </Text>
+                    </StyledPricingDetailsText>
                   </Stack>
                 </SubscriptionCard>
                 <SubscriptionCard
@@ -294,14 +295,14 @@ export const ProUpgrade = () => {
                         amount: pro?.prices?.team.year.usd / 12,
                       })}
                     </Text>
-                    <Text>
+                    <StyledPricingDetailsText>
                       per editor per month, billed anually, or{' '}
                       {formatCurrency({
                         currency: 'USD',
                         amount: pro?.prices?.team.month.usd,
                       })}{' '}
                       per month.
-                    </Text>
+                    </StyledPricingDetailsText>
                   </Stack>
                 </SubscriptionCard>
               </>
@@ -340,14 +341,14 @@ export const ProUpgrade = () => {
                         amount: pro?.prices?.team.year.usd / 12,
                       })}
                     </Text>
-                    <Text>
+                    <StyledPricingDetailsText>
                       per editor per month, billed anually, or{' '}
                       {formatCurrency({
                         currency: 'USD',
                         amount: pro?.prices?.team.month.usd,
                       })}{' '}
                       per month.
-                    </Text>
+                    </StyledPricingDetailsText>
                   </Stack>
                 </SubscriptionCard>
 
@@ -384,14 +385,14 @@ export const ProUpgrade = () => {
                   }
                   isHighlighted={hasCustomSubscription}
                 >
-                  <Stack gap={1} direction="vertical" css={{ flexGrow: 1 }}>
+                  <Stack gap={1} direction="vertical">
                     <Text size={32} weight="400">
                       custom
                     </Text>
-                    <Text>
+                    <StyledPricingDetailsText>
                       <div>tailor-made plan.</div>
                       <div>bulk pricing for seats.</div>
-                    </Text>
+                    </StyledPricingDetailsText>
                   </Stack>
                 </SubscriptionCard>
               </>

--- a/packages/app/src/app/pages/Pro/Upgrade.tsx
+++ b/packages/app/src/app/pages/Pro/Upgrade.tsx
@@ -37,6 +37,7 @@ import { TeamSubscriptionOptions } from '../Dashboard/Components/TeamSubscriptio
 export const ProUpgrade = () => {
   const {
     pro: { pageMounted },
+    modalOpened,
     setActiveTeam,
   } = useActions();
   const {
@@ -125,7 +126,8 @@ export const ProUpgrade = () => {
     text: 'Upgrade',
     variant: 'highlight',
     onClick: () => {
-      alert('foo');
+      track('');
+      modalOpened({ modal: 'selectWorkspaceToUpgrade' });
     },
   };
 

--- a/packages/app/src/app/pages/Pro/Upgrade.tsx
+++ b/packages/app/src/app/pages/Pro/Upgrade.tsx
@@ -31,7 +31,7 @@ import { useWorkspaceSubscription } from 'app/hooks/useWorkspaceSubscription';
 import { Switcher } from './components/Switcher';
 import { SubscriptionPaymentProvider } from '../../graphql/types';
 import { SubscriptionCard } from './components/SubscriptionCard';
-import { UpsellTeamPro } from './components/UpsellTeamPro';
+import { UpsellTeamProCard } from './components/UpsellTeamProCard';
 import type { CTA } from './components/SubscriptionCard';
 import { StyledPricingDetailsText } from './components/elements';
 import { TeamSubscriptionOptions } from '../Dashboard/Components/TeamSubscriptionOptions/TeamSubscriptionOptions';
@@ -269,7 +269,7 @@ export const ProUpgrade = () => {
                     </StyledPricingDetailsText>
                   </Stack>
                 </SubscriptionCard>
-                <UpsellTeamPro />
+                <UpsellTeamProCard trackingLocation="subscription page" />
               </>
             ) : (
               <>

--- a/packages/app/src/app/pages/Pro/Upgrade.tsx
+++ b/packages/app/src/app/pages/Pro/Upgrade.tsx
@@ -126,7 +126,10 @@ export const ProUpgrade = () => {
     text: 'Upgrade',
     variant: 'highlight',
     onClick: () => {
-      track('');
+      track('subscription page - upsell team pro cta clicked', {
+        codesandbox: 'V1',
+        event_source: 'UI',
+      });
       modalOpened({ modal: 'selectWorkspaceToUpgrade' });
     },
   };
@@ -277,31 +280,29 @@ export const ProUpgrade = () => {
                     </Text>
                   </Stack>
                 </SubscriptionCard>
-                {isFree ? (
-                  <SubscriptionCard
-                    title="Team Pro"
-                    features={TEAM_PRO_FEATURES_WITH_PILLS}
-                    isHighlighted
-                    cta={upsellTeamProCta}
-                  >
-                    <Stack gap={1} direction="vertical">
-                      <Text size={32} weight="500">
-                        {formatCurrency({
-                          currency: 'USD',
-                          amount: pro?.prices?.team.year.usd / 12,
-                        })}
-                      </Text>
-                      <Text>
-                        per editor per month, billed anually, or{' '}
-                        {formatCurrency({
-                          currency: 'USD',
-                          amount: pro?.prices?.team.month.usd,
-                        })}{' '}
-                        per month.
-                      </Text>
-                    </Stack>
-                  </SubscriptionCard>
-                ) : null}
+                <SubscriptionCard
+                  title="Team Pro"
+                  features={TEAM_PRO_FEATURES_WITH_PILLS}
+                  isHighlighted
+                  cta={upsellTeamProCta}
+                >
+                  <Stack gap={1} direction="vertical">
+                    <Text size={32} weight="500">
+                      {formatCurrency({
+                        currency: 'USD',
+                        amount: pro?.prices?.team.year.usd / 12,
+                      })}
+                    </Text>
+                    <Text>
+                      per editor per month, billed anually, or{' '}
+                      {formatCurrency({
+                        currency: 'USD',
+                        amount: pro?.prices?.team.month.usd,
+                      })}{' '}
+                      per month.
+                    </Text>
+                  </Stack>
+                </SubscriptionCard>
               </>
             ) : (
               <>

--- a/packages/app/src/app/pages/Pro/Upgrade.tsx
+++ b/packages/app/src/app/pages/Pro/Upgrade.tsx
@@ -73,7 +73,12 @@ export const ProUpgrade = () => {
     }
   }, [hasLoadedApp, location, setActiveTeam, personalWorkspaceId, dashboard]);
 
-  const { isPersonalSpace, isTeamAdmin, isAdmin } = useWorkspaceAuthorization();
+  const {
+    isPersonalSpace,
+    isTeamSpace,
+    isTeamAdmin,
+    isAdmin,
+  } = useWorkspaceAuthorization();
   const { isFree, isPro } = useWorkspaceSubscription();
   // const isFree = false; // DEBUG
   // const isPro = true; // DEBUG
@@ -202,10 +207,19 @@ export const ProUpgrade = () => {
               align="center"
               lineHeight="56px"
               margin={0}
+              css={{
+                maxWidth: '976px',
+                overflow: 'initial',
+                whiteSpace: 'wrap',
+              }}
             >
-              {isPro
-                ? 'You have an active Pro subscription.'
-                : 'Upgrade for Pro features'}
+              {isPro && isPersonalSpace
+                ? 'You have an active Personal Pro subscription'
+                : null}
+              {isPro && isTeamSpace
+                ? 'You have an active Team Pro subscription'
+                : null}
+              {isFree ? 'Upgrade for Pro features' : null}
             </Text>
           </Stack>
 
@@ -259,12 +273,9 @@ export const ProUpgrade = () => {
                       })}
                     </Text>
                     <StyledPricingDetailsText>
+                      <div>per month,</div>
                       <div>
-                        per month
-                        <br />, billed anually
-                      </div>{' '}
-                      <div>
-                        or{' '}
+                        billed anually, or{' '}
                         {formatCurrency({
                           currency: 'USD',
                           amount: pro?.prices?.individual.month.usd,

--- a/packages/app/src/app/pages/Pro/Upgrade.tsx
+++ b/packages/app/src/app/pages/Pro/Upgrade.tsx
@@ -227,6 +227,7 @@ export const ProUpgrade = () => {
           >
             <SubscriptionCard
               title="Free plan"
+              subTitle="1 editor only"
               features={
                 isPersonalSpace ? PERSONAL_FREE_FEATURES : TEAM_FREE_FEATURES
               }
@@ -243,6 +244,7 @@ export const ProUpgrade = () => {
               <>
                 <SubscriptionCard
                   title="Personal Pro"
+                  subTitle="1 editor only"
                   features={
                     isPro ? PERSONAL_FEATURES : PERSONAL_FEATURES_WITH_PILLS
                   }
@@ -275,6 +277,7 @@ export const ProUpgrade = () => {
               <>
                 <SubscriptionCard
                   title="Team Pro"
+                  subTitle="Up to 20 editors"
                   features={
                     isPro ? TEAM_PRO_FEATURES : TEAM_PRO_FEATURES_WITH_PILLS
                   }
@@ -319,6 +322,7 @@ export const ProUpgrade = () => {
 
                 <SubscriptionCard
                   title="Organization"
+                  subTitle="Unlimited editors"
                   features={ORG_FEATURES}
                   cta={
                     hasCustomSubscription

--- a/packages/app/src/app/pages/Pro/Upgrade.tsx
+++ b/packages/app/src/app/pages/Pro/Upgrade.tsx
@@ -31,15 +31,15 @@ import { useWorkspaceSubscription } from 'app/hooks/useWorkspaceSubscription';
 import { Switcher } from './components/Switcher';
 import { SubscriptionPaymentProvider } from '../../graphql/types';
 import { SubscriptionCard } from './components/SubscriptionCard';
+import { UpsellTeamPro } from './components/UpsellTeamPro';
 import type { CTA } from './components/SubscriptionCard';
+import { StyledPricingDetailsText } from './components/elements';
 import { TeamSubscriptionOptions } from '../Dashboard/Components/TeamSubscriptionOptions/TeamSubscriptionOptions';
 import { NewTeamModal } from '../Dashboard/Components/NewTeamModal';
-import { StyledPricingDetailsText } from './components/elements';
 
 export const ProUpgrade = () => {
   const {
     pro: { pageMounted },
-    modalOpened,
     setActiveTeam,
   } = useActions();
   const {
@@ -122,19 +122,6 @@ export const ProUpgrade = () => {
           });
         },
       };
-
-  // Used in the personal view if the account is free.
-  const upsellTeamProCta: CTA = {
-    text: 'Upgrade',
-    variant: 'highlight',
-    onClick: () => {
-      track('subscription page - upsell team pro cta clicked', {
-        codesandbox: 'V1',
-        event_source: 'UI',
-      });
-      modalOpened({ modal: 'selectWorkspaceToUpgrade' });
-    },
-  };
 
   const teamProCta: CTA =
     isTeamAdmin && !hasCustomSubscription && isPro
@@ -282,29 +269,7 @@ export const ProUpgrade = () => {
                     </StyledPricingDetailsText>
                   </Stack>
                 </SubscriptionCard>
-                <SubscriptionCard
-                  title="Team Pro"
-                  features={TEAM_PRO_FEATURES_WITH_PILLS}
-                  isHighlighted
-                  cta={upsellTeamProCta}
-                >
-                  <Stack gap={1} direction="vertical">
-                    <Text size={32} weight="500">
-                      {formatCurrency({
-                        currency: 'USD',
-                        amount: pro?.prices?.team.year.usd / 12,
-                      })}
-                    </Text>
-                    <StyledPricingDetailsText>
-                      per editor per month, billed anually, or{' '}
-                      {formatCurrency({
-                        currency: 'USD',
-                        amount: pro?.prices?.team.month.usd,
-                      })}{' '}
-                      per month.
-                    </StyledPricingDetailsText>
-                  </Stack>
-                </SubscriptionCard>
+                <UpsellTeamPro />
               </>
             ) : (
               <>

--- a/packages/app/src/app/pages/Pro/components/SubscriptionCard.tsx
+++ b/packages/app/src/app/pages/Pro/components/SubscriptionCard.tsx
@@ -130,7 +130,12 @@ export const SubscriptionCard = ({
             justify="space-between"
             align="center"
           >
-            <Text css={{ padding: '8px 0' }}>{feature.label}</Text>
+            <Text
+              css={{ padding: '8px 0' }}
+              weight={feature.highlighted ? '700' : '400'}
+            >
+              {feature.label}
+            </Text>
             {feature.pill ? (
               <Badge variant="highlight">{feature.pill}</Badge>
             ) : null}
@@ -139,7 +144,7 @@ export const SubscriptionCard = ({
       </Stack>
       {
         // eslint-disable-next-line no-nested-ternary
-        'cta' in props ? (
+        'cta' in props && typeof props.cta !== 'undefined' ? (
           <StyledSubscriptionLink
             variant={props.cta.variant}
             {...(props.cta.href
@@ -154,7 +159,7 @@ export const SubscriptionCard = ({
           >
             {props.cta.isLoading ? 'Loading...' : props.cta.text}
           </StyledSubscriptionLink>
-        ) : 'customCta' in props ? (
+        ) : 'customCta' in props && typeof props.customCta !== 'undefined' ? (
           props.customCta
         ) : (
           <Element css={{ height: '48px' }} />

--- a/packages/app/src/app/pages/Pro/components/SubscriptionCard.tsx
+++ b/packages/app/src/app/pages/Pro/components/SubscriptionCard.tsx
@@ -114,11 +114,13 @@ export const SubscriptionCard = ({
         as="ul"
         direction="vertical"
         gap={1}
-        // Reset ul styles
         css={{
+          // Reset ul styles
           margin: 0,
           padding: 0,
           listStyle: 'none',
+          // Fill up space
+          flex: 1,
         }}
       >
         {features.map(feature => (

--- a/packages/app/src/app/pages/Pro/components/SubscriptionCard.tsx
+++ b/packages/app/src/app/pages/Pro/components/SubscriptionCard.tsx
@@ -82,6 +82,7 @@ export type CTA = CTABase & CTAOptional;
 
 type SubscriptionCardProps = {
   title: string;
+  subTitle: string;
   children: React.ReactNode;
   features: Feature[];
   isHighlighted?: boolean;
@@ -94,6 +95,7 @@ type SubscriptionCardProps = {
 
 export const SubscriptionCard = ({
   title,
+  subTitle,
   children,
   features,
   isHighlighted,
@@ -106,9 +108,12 @@ export const SubscriptionCard = ({
       gap={9}
       direction="vertical"
     >
-      <Text size={16} weight="500">
-        {title}
-      </Text>
+      <Stack direction="vertical" gap={1}>
+        <Text size={16} weight="500">
+          {title}
+        </Text>
+        <Text size={13}>{subTitle}</Text>
+      </Stack>
       {children}
       <Stack
         as="ul"

--- a/packages/app/src/app/pages/Pro/components/UpsellTeamPro.tsx
+++ b/packages/app/src/app/pages/Pro/components/UpsellTeamPro.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { useAppState, useActions } from 'app/overmind';
+import { Stack, Text } from '@codesandbox/components';
+import track from '@codesandbox/common/lib/utils/analytics';
+import { TEAM_PRO_FEATURES_WITH_PILLS } from 'app/constants';
+import { formatCurrency } from 'app/utils/currency';
+
+import { SubscriptionCard } from './SubscriptionCard';
+import type { CTA } from './SubscriptionCard';
+import { StyledPricingDetailsText } from './elements';
+
+export const UpsellTeamPro: React.FC = () => {
+  const { pro } = useAppState();
+  const { modalOpened } = useActions();
+
+  const upsellTeamProCta: CTA = {
+    text: 'Upgrade',
+    variant: 'highlight',
+    onClick: () => {
+      track('subscription page - upsell team pro cta clicked', {
+        codesandbox: 'V1',
+        event_source: 'UI',
+      });
+      modalOpened({ modal: 'selectWorkspaceToUpgrade' });
+    },
+  };
+
+  return (
+    <SubscriptionCard
+      title="Team Pro"
+      features={TEAM_PRO_FEATURES_WITH_PILLS}
+      isHighlighted
+      cta={upsellTeamProCta}
+    >
+      <Stack gap={1} direction="vertical">
+        <Text size={32} weight="500">
+          {formatCurrency({
+            currency: 'USD',
+            amount: pro?.prices?.team.year.usd / 12,
+          })}
+        </Text>
+        <StyledPricingDetailsText>
+          per editor per month, billed anually, or{' '}
+          {formatCurrency({
+            currency: 'USD',
+            amount: pro?.prices?.team.month.usd,
+          })}{' '}
+          per month.
+        </StyledPricingDetailsText>
+      </Stack>
+    </SubscriptionCard>
+  );
+};

--- a/packages/app/src/app/pages/Pro/components/UpsellTeamProCard.tsx
+++ b/packages/app/src/app/pages/Pro/components/UpsellTeamProCard.tsx
@@ -61,6 +61,7 @@ export const UpsellTeamProCard: React.FC<{ trackingLocation: string }> = ({
   return (
     <SubscriptionCard
       title="Team Pro"
+      subTitle="Up to 20 editors"
       features={TEAM_PRO_FEATURES_WITH_PILLS}
       isHighlighted
       cta={upsellTeamProCta}

--- a/packages/app/src/app/pages/Pro/components/UpsellTeamProCard.tsx
+++ b/packages/app/src/app/pages/Pro/components/UpsellTeamProCard.tsx
@@ -47,7 +47,7 @@ export const UpsellTeamProCard: React.FC<{ trackingLocation: string }> = ({
           },
         }
       : {
-          text: 'Create team',
+          text: 'Create team and Upgrade',
           variant: 'highlight',
           onClick: () => {
             track(`${trackingLocation} - upsell team pro create team clicked`, {

--- a/packages/app/src/app/pages/Pro/components/UpsellTeamProCard.tsx
+++ b/packages/app/src/app/pages/Pro/components/UpsellTeamProCard.tsx
@@ -9,7 +9,9 @@ import { SubscriptionCard } from './SubscriptionCard';
 import type { CTA } from './SubscriptionCard';
 import { StyledPricingDetailsText } from './elements';
 
-export const UpsellTeamPro: React.FC = () => {
+export const UpsellTeamProCard: React.FC<{ trackingLocation: string }> = ({
+  trackingLocation,
+}) => {
   const { pro } = useAppState();
   const { modalOpened } = useActions();
 
@@ -17,7 +19,7 @@ export const UpsellTeamPro: React.FC = () => {
     text: 'Upgrade',
     variant: 'highlight',
     onClick: () => {
-      track('subscription page - upsell team pro cta clicked', {
+      track(`${trackingLocation} - upsell team pro upgrade clicked`, {
         codesandbox: 'V1',
         event_source: 'UI',
       });

--- a/packages/app/src/app/pages/Pro/components/UpsellTeamProCard.tsx
+++ b/packages/app/src/app/pages/Pro/components/UpsellTeamProCard.tsx
@@ -74,7 +74,8 @@ export const UpsellTeamProCard: React.FC<{ trackingLocation: string }> = ({
           })}
         </Text>
         <StyledPricingDetailsText>
-          per editor per month, billed anually, or{' '}
+          per editor per month,
+          <br /> billed anually, or{' '}
           {formatCurrency({
             currency: 'USD',
             amount: pro?.prices?.team.month.usd,

--- a/packages/app/src/app/pages/Pro/components/elements.ts
+++ b/packages/app/src/app/pages/Pro/components/elements.ts
@@ -1,0 +1,11 @@
+import { Text } from '@codesandbox/components';
+import styled from 'styled-components';
+
+export const StyledPricingDetailsText = styled(Text)`
+  height: 32px; // Twice the line-height of the Text.
+  width: 100%;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+`;

--- a/packages/app/src/app/pages/Pro/legacy-pages/WorkspacePlanSelection.tsx
+++ b/packages/app/src/app/pages/Pro/legacy-pages/WorkspacePlanSelection.tsx
@@ -15,7 +15,9 @@ import {
   PERSONAL_FEATURES,
   TEAM_FREE_FEATURES,
   TEAM_PRO_FEATURES,
+  TEAM_PRO_FEATURES_WITH_PILLS,
 } from 'app/constants';
+import { formatCurrency } from 'app/utils/currency';
 import { Switcher } from '../components/Switcher';
 import { SubscriptionCard } from '../components/SubscriptionCard';
 import type { CTA } from '../components/SubscriptionCard';
@@ -45,6 +47,7 @@ export const WorkspacePlanSelection: React.FC = () => {
     activeTeam,
     activeTeamInfo,
     dashboard,
+    pro,
   } = useAppState();
   const {
     setActiveTeam,
@@ -96,6 +99,18 @@ export const WorkspacePlanSelection: React.FC = () => {
       modalOpened({ modal: 'legacyPayment' });
     },
     variant: 'light',
+  };
+
+  const upsellTeamProCta: CTA = {
+    text: 'Upgrade',
+    variant: 'highlight',
+    onClick: () => {
+      track('legacy subscription page - upsell team pro cta clicked', {
+        codesandbox: 'V1',
+        event_source: 'UI',
+      });
+      modalOpened({ modal: 'selectWorkspaceToUpgrade' });
+    },
   };
 
   const teamProCta: CTA =
@@ -183,31 +198,56 @@ export const WorkspacePlanSelection: React.FC = () => {
           </SubscriptionCard>
 
           {isPersonalSpace ? (
-            <SubscriptionCard
-              title={isPatron ? 'Patron' : 'Personal Pro'}
-              features={PERSONAL_FEATURES}
-              cta={personalProCta}
-              isHighlighted
-            >
-              <Stack gap={1} direction="vertical">
-                <Text size={32} weight="500">
-                  {`${subscription.currency || '$'}${subscription.unitPrice}`}
-                </Text>
-                {subscription.billingInterval ===
-                SubscriptionInterval.Yearly ? (
-                  <Text>
-                    charged annually on{' '}
-                    {format(new Date(subscription.nextBillDate), 'MMM dd')}
+            <>
+              <SubscriptionCard
+                title={isPatron ? 'Patron' : 'Personal Pro'}
+                features={PERSONAL_FEATURES}
+                cta={personalProCta}
+                isHighlighted
+              >
+                <Stack gap={1} direction="vertical">
+                  <Text size={32} weight="500">
+                    {`${subscription.currency || '$'}${subscription.unitPrice}`}
                   </Text>
-                ) : (
-                  <Text>
-                    charged on the{' '}
-                    {format(new Date(subscription.nextBillDate), 'do')} of each
-                    month
+                  {subscription.billingInterval ===
+                  SubscriptionInterval.Yearly ? (
+                    <Text>
+                      charged annually on{' '}
+                      {format(new Date(subscription.nextBillDate), 'MMM dd')}
+                    </Text>
+                  ) : (
+                    <Text>
+                      charged on the{' '}
+                      {format(new Date(subscription.nextBillDate), 'do')} of
+                      each month
+                    </Text>
+                  )}
+                </Stack>
+              </SubscriptionCard>
+              <SubscriptionCard
+                title="Team Pro"
+                features={TEAM_PRO_FEATURES_WITH_PILLS}
+                isHighlighted
+                cta={upsellTeamProCta}
+              >
+                <Stack gap={1} direction="vertical">
+                  <Text size={32} weight="500">
+                    {formatCurrency({
+                      currency: 'USD',
+                      amount: pro?.prices?.team.year.usd / 12,
+                    })}
                   </Text>
-                )}
-              </Stack>
-            </SubscriptionCard>
+                  <Text>
+                    per editor per month, billed anually, or{' '}
+                    {formatCurrency({
+                      currency: 'USD',
+                      amount: pro?.prices?.team.month.usd,
+                    })}{' '}
+                    per month.
+                  </Text>
+                </Stack>
+              </SubscriptionCard>
+            </>
           ) : (
             <SubscriptionCard
               title="Team Pro"

--- a/packages/app/src/app/pages/Pro/legacy-pages/WorkspacePlanSelection.tsx
+++ b/packages/app/src/app/pages/Pro/legacy-pages/WorkspacePlanSelection.tsx
@@ -171,6 +171,7 @@ export const WorkspacePlanSelection: React.FC = () => {
         >
           <SubscriptionCard
             title="Free plan"
+            subTitle="1 editor only"
             features={
               isPersonalSpace ? PERSONAL_FREE_FEATURES : TEAM_FREE_FEATURES
             }
@@ -188,6 +189,7 @@ export const WorkspacePlanSelection: React.FC = () => {
             <>
               <SubscriptionCard
                 title={isPatron ? 'Patron' : 'Personal Pro'}
+                subTitle="1 editor only"
                 features={PERSONAL_FEATURES}
                 cta={personalProCta}
                 isHighlighted
@@ -216,6 +218,7 @@ export const WorkspacePlanSelection: React.FC = () => {
           ) : (
             <SubscriptionCard
               title="Team Pro"
+              subTitle="Up to 20 editors"
               features={TEAM_PRO_FEATURES}
               cta={teamProCta}
               isHighlighted

--- a/packages/app/src/app/pages/Pro/legacy-pages/WorkspacePlanSelection.tsx
+++ b/packages/app/src/app/pages/Pro/legacy-pages/WorkspacePlanSelection.tsx
@@ -3,7 +3,7 @@ import { format } from 'date-fns';
 import { sortBy } from 'lodash-es';
 import { useLocation } from 'react-router-dom';
 import { VisuallyHidden } from 'reakit/VisuallyHidden';
-import { Stack, Text } from '@codesandbox/components';
+import { Element, Stack, Text } from '@codesandbox/components';
 import track from '@codesandbox/common/lib/utils/analytics';
 import { useAppState, useActions } from 'app/overmind';
 import { Step } from 'app/overmind/namespaces/pro/types';
@@ -145,28 +145,25 @@ export const WorkspacePlanSelection: React.FC = () => {
             activeTeamInfo={activeTeamInfo}
           />
 
-          <Text
-            as="h1"
-            fontFamily="everett"
-            size={48}
-            weight="500"
-            align="center"
-            lineHeight="56px"
-            margin={0}
-            css={{
-              maxWidth: '976px',
-              overflow: 'initial',
-              whiteSpace: 'wrap',
-            }}
-          >
-            {isPro && isPersonalSpace
-              ? 'You have an active Personal Pro subscription'
-              : null}
-            {isPro && isTeamSpace
-              ? 'You have an active Team Pro subscription'
-              : null}
-            {isFree ? 'Upgrade for Pro features' : null}
-          </Text>
+          <Element css={{ maxWidth: '976px', textAlign: 'center' }}>
+            <Text
+              as="h1"
+              fontFamily="everett"
+              size={48}
+              weight="500"
+              align="center"
+              lineHeight="56px"
+              margin={0}
+            >
+              {isPro && isPersonalSpace
+                ? 'You have an active Personal Pro subscription'
+                : null}
+              {isPro && isTeamSpace
+                ? 'You have an active Team Pro subscription'
+                : null}
+              {isFree ? 'Upgrade for Pro features' : null}
+            </Text>
+          </Element>
         </Stack>
         <Stack
           gap={2}

--- a/packages/app/src/app/pages/Pro/legacy-pages/WorkspacePlanSelection.tsx
+++ b/packages/app/src/app/pages/Pro/legacy-pages/WorkspacePlanSelection.tsx
@@ -21,6 +21,7 @@ import { formatCurrency } from 'app/utils/currency';
 import { Switcher } from '../components/Switcher';
 import { SubscriptionCard } from '../components/SubscriptionCard';
 import type { CTA } from '../components/SubscriptionCard';
+import { StyledPricingDetailsText } from '../components/elements';
 
 const getBillingText = ({
   quantity,
@@ -188,12 +189,12 @@ export const WorkspacePlanSelection: React.FC = () => {
               isPersonalSpace ? PERSONAL_FREE_FEATURES : TEAM_FREE_FEATURES
             }
           >
-            <Stack gap={1} direction="vertical" css={{ flexGrow: 1 }}>
+            <Stack gap={1} direction="vertical">
               <Text aria-hidden size={32} weight="400">
                 $0
               </Text>
               <VisuallyHidden>Zero dollar</VisuallyHidden>
-              <Text>forever</Text>
+              <StyledPricingDetailsText>forever</StyledPricingDetailsText>
             </Stack>
           </SubscriptionCard>
 
@@ -211,16 +212,16 @@ export const WorkspacePlanSelection: React.FC = () => {
                   </Text>
                   {subscription.billingInterval ===
                   SubscriptionInterval.Yearly ? (
-                    <Text>
+                    <StyledPricingDetailsText>
                       charged annually on{' '}
                       {format(new Date(subscription.nextBillDate), 'MMM dd')}
-                    </Text>
+                    </StyledPricingDetailsText>
                   ) : (
-                    <Text>
+                    <StyledPricingDetailsText>
                       charged on the{' '}
                       {format(new Date(subscription.nextBillDate), 'do')} of
                       each month
-                    </Text>
+                    </StyledPricingDetailsText>
                   )}
                 </Stack>
               </SubscriptionCard>
@@ -237,14 +238,14 @@ export const WorkspacePlanSelection: React.FC = () => {
                       amount: pro?.prices?.team.year.usd / 12,
                     })}
                   </Text>
-                  <Text>
+                  <StyledPricingDetailsText>
                     per editor per month, billed anually, or{' '}
                     {formatCurrency({
                       currency: 'USD',
                       amount: pro?.prices?.team.month.usd,
                     })}{' '}
                     per month.
-                  </Text>
+                  </StyledPricingDetailsText>
                 </Stack>
               </SubscriptionCard>
             </>

--- a/packages/app/src/app/pages/Pro/legacy-pages/WorkspacePlanSelection.tsx
+++ b/packages/app/src/app/pages/Pro/legacy-pages/WorkspacePlanSelection.tsx
@@ -228,7 +228,7 @@ export const WorkspacePlanSelection: React.FC = () => {
                   ${subscription.unitPrice}
                 </Text>
                 <Text>
-                  <div>per editor</div>
+                  <div>per editor{isTeamAdmin ? ',' : null}</div>
                   {isTeamAdmin ? (
                     <div>
                       {getBillingText({

--- a/packages/app/src/app/pages/Pro/legacy-pages/WorkspacePlanSelection.tsx
+++ b/packages/app/src/app/pages/Pro/legacy-pages/WorkspacePlanSelection.tsx
@@ -20,7 +20,7 @@ import { Switcher } from '../components/Switcher';
 import { SubscriptionCard } from '../components/SubscriptionCard';
 import type { CTA } from '../components/SubscriptionCard';
 import { StyledPricingDetailsText } from '../components/elements';
-import { UpsellTeamPro } from '../components/UpsellTeamPro';
+import { UpsellTeamProCard } from '../components/UpsellTeamProCard';
 
 const getBillingText = ({
   quantity,
@@ -211,7 +211,7 @@ export const WorkspacePlanSelection: React.FC = () => {
                   )}
                 </Stack>
               </SubscriptionCard>
-              <UpsellTeamPro />
+              <UpsellTeamProCard trackingLocation="legacy subscription page" />
             </>
           ) : (
             <SubscriptionCard

--- a/packages/app/src/app/pages/Pro/legacy-pages/WorkspacePlanSelection.tsx
+++ b/packages/app/src/app/pages/Pro/legacy-pages/WorkspacePlanSelection.tsx
@@ -15,13 +15,12 @@ import {
   PERSONAL_FEATURES,
   TEAM_FREE_FEATURES,
   TEAM_PRO_FEATURES,
-  TEAM_PRO_FEATURES_WITH_PILLS,
 } from 'app/constants';
-import { formatCurrency } from 'app/utils/currency';
 import { Switcher } from '../components/Switcher';
 import { SubscriptionCard } from '../components/SubscriptionCard';
 import type { CTA } from '../components/SubscriptionCard';
 import { StyledPricingDetailsText } from '../components/elements';
+import { UpsellTeamPro } from '../components/UpsellTeamPro';
 
 const getBillingText = ({
   quantity,
@@ -48,7 +47,6 @@ export const WorkspacePlanSelection: React.FC = () => {
     activeTeam,
     activeTeamInfo,
     dashboard,
-    pro,
   } = useAppState();
   const {
     setActiveTeam,
@@ -100,18 +98,6 @@ export const WorkspacePlanSelection: React.FC = () => {
       modalOpened({ modal: 'legacyPayment' });
     },
     variant: 'light',
-  };
-
-  const upsellTeamProCta: CTA = {
-    text: 'Upgrade',
-    variant: 'highlight',
-    onClick: () => {
-      track('legacy subscription page - upsell team pro cta clicked', {
-        codesandbox: 'V1',
-        event_source: 'UI',
-      });
-      modalOpened({ modal: 'selectWorkspaceToUpgrade' });
-    },
   };
 
   const teamProCta: CTA =
@@ -225,29 +211,7 @@ export const WorkspacePlanSelection: React.FC = () => {
                   )}
                 </Stack>
               </SubscriptionCard>
-              <SubscriptionCard
-                title="Team Pro"
-                features={TEAM_PRO_FEATURES_WITH_PILLS}
-                isHighlighted
-                cta={upsellTeamProCta}
-              >
-                <Stack gap={1} direction="vertical">
-                  <Text size={32} weight="500">
-                    {formatCurrency({
-                      currency: 'USD',
-                      amount: pro?.prices?.team.year.usd / 12,
-                    })}
-                  </Text>
-                  <StyledPricingDetailsText>
-                    per editor per month, billed anually, or{' '}
-                    {formatCurrency({
-                      currency: 'USD',
-                      amount: pro?.prices?.team.month.usd,
-                    })}{' '}
-                    per month.
-                  </StyledPricingDetailsText>
-                </Stack>
-              </SubscriptionCard>
+              <UpsellTeamPro />
             </>
           ) : (
             <SubscriptionCard

--- a/packages/app/src/app/pages/Pro/legacy-pages/WorkspacePlanSelection.tsx
+++ b/packages/app/src/app/pages/Pro/legacy-pages/WorkspacePlanSelection.tsx
@@ -55,10 +55,14 @@ export const WorkspacePlanSelection: React.FC = () => {
   } = useActions();
 
   const location = useLocation();
-  const { isPersonalSpace, isTeamAdmin } = useWorkspaceAuthorization();
+  const {
+    isPersonalSpace,
+    isTeamSpace,
+    isTeamAdmin,
+  } = useWorkspaceAuthorization();
   // const isPersonalSpace = false; // DEBUG
   // const isTeamAdmin = true; // DEBUG
-  const { subscription, isPatron } = useWorkspaceSubscription();
+  const { subscription, isPatron, isPro, isFree } = useWorkspaceSubscription();
 
   // Based on the 'type' search param we redirect to the personal pro page if
   // it's not yet active.
@@ -149,8 +153,19 @@ export const WorkspacePlanSelection: React.FC = () => {
             align="center"
             lineHeight="56px"
             margin={0}
+            css={{
+              maxWidth: '976px',
+              overflow: 'initial',
+              whiteSpace: 'wrap',
+            }}
           >
-            You have an active Pro subscription.
+            {isPro && isPersonalSpace
+              ? 'You have an active Personal Pro subscription'
+              : null}
+            {isPro && isTeamSpace
+              ? 'You have an active Team Pro subscription'
+              : null}
+            {isFree ? 'Upgrade for Pro features' : null}
           </Text>
         </Stack>
         <Stack

--- a/packages/app/src/app/pages/common/Modals/SelectWorkspaceToUpgrade/index.tsx
+++ b/packages/app/src/app/pages/common/Modals/SelectWorkspaceToUpgrade/index.tsx
@@ -18,9 +18,8 @@ export const SelectWorkspaceToUpgrade: React.FC = () => {
   const { dashboard, personalWorkspaceId, user } = useAppState();
   const { openCreateTeamModal, modalClosed } = useActions();
   const [checkout, createCheckout] = useCreateCheckout();
-  const [selectedTeam, setSelectedTeam] = React.useState(undefined);
 
-  const teamsToShow = dashboard.teams.filter(team => {
+  const upgradeableTeams = dashboard.teams.filter(team => {
     if (
       team.id === personalWorkspaceId ||
       team.subscription?.type === SubscriptionType.TeamPro
@@ -37,11 +36,9 @@ export const SelectWorkspaceToUpgrade: React.FC = () => {
     return teamAdmins.includes(user?.id);
   });
 
-  React.useEffect(() => {
-    if (!selectedTeam) {
-      setSelectedTeam(teamsToShow[0]?.id);
-    }
-  }, [selectedTeam, teamsToShow]);
+  const [selectedTeam, setSelectedTeam] = React.useState(
+    upgradeableTeams[0]?.id
+  );
 
   return (
     <Alert title="Choose a team to upgrade">
@@ -61,9 +58,9 @@ export const SelectWorkspaceToUpgrade: React.FC = () => {
         >
           Team Pro plan is only available for teams.
         </Text>
-        {teamsToShow.length > 0 ? (
+        {upgradeableTeams.length > 0 ? (
           <Select onChange={e => setSelectedTeam(e.target.value)}>
-            {teamsToShow.map(team => (
+            {upgradeableTeams.map(team => (
               <option key={team.id} value={team.id}>
                 {team.name}
               </option>

--- a/packages/app/src/app/pages/common/Modals/SelectWorkspaceToUpgrade/index.tsx
+++ b/packages/app/src/app/pages/common/Modals/SelectWorkspaceToUpgrade/index.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { Button, Element, Icon, Stack, Text } from '@codesandbox/components';
+import track from '@codesandbox/common/lib/utils/analytics';
+
+import { useCreateCheckout } from 'app/hooks';
+import { useActions, useAppState } from 'app/overmind';
+import { Alert } from '../Common/Alert';
+
+export const SelectWorkspaceToUpgrade: React.FC = () => {
+  const { activeTeam } = useAppState();
+  const { modalClosed } = useActions();
+  const [checkout, createCheckout] = useCreateCheckout();
+
+  return (
+    <Alert title="Choose a team to upgrade">
+      <Text>Team Pro plan is only available for teams.</Text>
+      {checkout.status === 'error' && (
+        <Text marginBottom={8} variant="danger" size={12}>
+          An error ocurred while trying to load the checkout. Please try again.
+        </Text>
+      )}
+      <Stack
+        css={{
+          marginTop: '52px',
+        }}
+        gap={2}
+        align="center"
+        justify="flex-end"
+      >
+        <Button
+          onClick={() => {
+            track('');
+            modalClosed();
+          }}
+          autoWidth
+          variant="ghost"
+        >
+          Cancel
+        </Button>
+        <Button
+          css={{
+            gap: '4px',
+          }}
+          loading={checkout.status === 'loading'}
+          variant="primary"
+          onClick={() => {
+            track('Live Session - upgrade clicked', {
+              codesandbox: 'V1',
+              event_source: 'UI',
+            });
+
+            createCheckout({
+              team_id: activeTeam,
+              recurring_interval: 'month',
+              // success_path: sandboxUrl({ id }),
+              // cancel_path: sandboxUrl({ id }),
+            });
+          }}
+          autoWidth
+        >
+          Checkout
+          <Element
+            css={{
+              transform: 'rotate(270deg)',
+            }}
+          >
+            <Icon name="arrowDown" size={12} />
+          </Element>
+        </Button>
+      </Stack>
+    </Alert>
+  );
+};

--- a/packages/app/src/app/pages/common/Modals/SelectWorkspaceToUpgrade/index.tsx
+++ b/packages/app/src/app/pages/common/Modals/SelectWorkspaceToUpgrade/index.tsx
@@ -82,13 +82,10 @@ export const SelectWorkspaceToUpgrade: React.FC = () => {
                 padding: 0,
               }}
               onClick={() => {
-                track(
-                  'subscription page - upsell team pro create team clicked',
-                  {
-                    codesandbox: 'V1',
-                    event_source: 'UI',
-                  }
-                );
+                track('upsell team pro - create team clicked', {
+                  codesandbox: 'V1',
+                  event_source: 'UI',
+                });
 
                 openCreateTeamModal();
               }}
@@ -118,7 +115,7 @@ export const SelectWorkspaceToUpgrade: React.FC = () => {
         <Stack gap={2} align="center" justify="flex-end">
           <Button
             onClick={() => {
-              track('subscription page - upsell team pro modal closed', {
+              track('upsell team pro - modal closed', {
                 codesandbox: 'V1',
                 event_source: 'UI',
               });
@@ -138,7 +135,7 @@ export const SelectWorkspaceToUpgrade: React.FC = () => {
             loading={checkout.status === 'loading'}
             variant="primary"
             onClick={() => {
-              track('subscription page - upsell team pro checkout clicked', {
+              track('upsell team pro - checkout clicked', {
                 codesandbox: 'V1',
                 event_source: 'UI',
               });

--- a/packages/app/src/app/pages/common/Modals/SelectWorkspaceToUpgrade/index.tsx
+++ b/packages/app/src/app/pages/common/Modals/SelectWorkspaceToUpgrade/index.tsx
@@ -59,6 +59,10 @@ export const SelectWorkspaceToUpgrade: React.FC = () => {
           Team Pro plan is only available for teams.
         </Text>
         {upgradeableTeams.length > 0 ? (
+          /**
+           * This should always render because if there are no
+           * upgradeable teams, the CTA will directly open the modal.
+           */
           <Select onChange={e => setSelectedTeam(e.target.value)}>
             {upgradeableTeams.map(team => (
               <option key={team.id} value={team.id}>

--- a/packages/app/src/app/pages/common/Modals/SelectWorkspaceToUpgrade/index.tsx
+++ b/packages/app/src/app/pages/common/Modals/SelectWorkspaceToUpgrade/index.tsx
@@ -1,72 +1,136 @@
 import React from 'react';
-import { Button, Element, Icon, Stack, Text } from '@codesandbox/components';
+import {
+  Button,
+  Element,
+  Icon,
+  Select,
+  Stack,
+  Text,
+} from '@codesandbox/components';
 import track from '@codesandbox/common/lib/utils/analytics';
 
 import { useCreateCheckout } from 'app/hooks';
 import { useActions, useAppState } from 'app/overmind';
+import { SubscriptionType, TeamMemberAuthorization } from 'app/graphql/types';
 import { Alert } from '../Common/Alert';
 
 export const SelectWorkspaceToUpgrade: React.FC = () => {
-  const { activeTeam } = useAppState();
+  const { dashboard, personalWorkspaceId, user } = useAppState();
   const { modalClosed } = useActions();
   const [checkout, createCheckout] = useCreateCheckout();
+  const [selectedTeam, setSelectedTeam] = React.useState(undefined);
+
+  const teamsToShow = dashboard.teams.filter(team => {
+    if (
+      team.id === personalWorkspaceId ||
+      team.subscription?.type === SubscriptionType.TeamPro
+    ) {
+      return false;
+    }
+
+    const teamAdmins = team.userAuthorizations
+      .filter(
+        ({ authorization }) => authorization === TeamMemberAuthorization.Admin
+      )
+      .map(({ userId }) => userId);
+
+    return teamAdmins.includes(user?.id);
+  });
+
+  React.useEffect(() => {
+    if (!selectedTeam) {
+      setSelectedTeam(teamsToShow[0].id);
+    }
+  }, [selectedTeam, teamsToShow]);
 
   return (
     <Alert title="Choose a team to upgrade">
-      <Text>Team Pro plan is only available for teams.</Text>
-      {checkout.status === 'error' && (
-        <Text marginBottom={8} variant="danger" size={12}>
-          An error ocurred while trying to load the checkout. Please try again.
-        </Text>
-      )}
       <Stack
         css={{
-          marginTop: '52px',
+          marginBottom: '52px',
         }}
-        gap={2}
-        align="center"
-        justify="flex-end"
+        direction="vertical"
+        gap={4}
       >
-        <Button
-          onClick={() => {
-            track('');
-            modalClosed();
-          }}
-          autoWidth
-          variant="ghost"
-        >
-          Cancel
-        </Button>
-        <Button
+        <Text
           css={{
-            gap: '4px',
+            color: '#808080',
+            fontSize: '13px',
+            lineHeight: '19px',
           }}
-          loading={checkout.status === 'loading'}
-          variant="primary"
-          onClick={() => {
-            track('Live Session - upgrade clicked', {
-              codesandbox: 'V1',
-              event_source: 'UI',
-            });
-
-            createCheckout({
-              team_id: activeTeam,
-              recurring_interval: 'month',
-              // success_path: sandboxUrl({ id }),
-              // cancel_path: sandboxUrl({ id }),
-            });
-          }}
-          autoWidth
         >
-          Checkout
-          <Element
+          Team Pro plan is only available for teams.
+        </Text>
+        <Select onChange={e => setSelectedTeam(e.target.value)}>
+          {teamsToShow.map(team => (
+            <option key={team.id} value={team.id}>
+              {team.name}
+            </option>
+          ))}
+        </Select>
+      </Stack>
+      <Stack direction="vertical" gap={2}>
+        {checkout.status === 'error' && (
+          <Text
             css={{
-              transform: 'rotate(270deg)',
+              display: 'block',
+              marginTop: '2px',
             }}
+            variant="danger"
+            size={12}
           >
-            <Icon name="arrowDown" size={12} />
-          </Element>
-        </Button>
+            An error ocurred while trying to load the checkout.
+            <br /> Please try again.
+          </Text>
+        )}
+
+        <Stack gap={2} align="center" justify="flex-end">
+          <Button
+            onClick={() => {
+              track('Pro page - upsell team pro modal closed', {
+                codesandbox: 'V1',
+                event_source: 'UI',
+              });
+              modalClosed();
+            }}
+            autoWidth
+            variant="ghost"
+          >
+            Cancel
+          </Button>
+          <Button
+            css={{
+              gap: '4px',
+              padding: '4px 24px',
+            }}
+            disabled={!selectedTeam}
+            loading={checkout.status === 'loading'}
+            variant="primary"
+            onClick={() => {
+              track('Pro page - upsell team pro checkout clicked', {
+                codesandbox: 'V1',
+                event_source: 'UI',
+              });
+
+              createCheckout({
+                team_id: selectedTeam,
+                recurring_interval: 'month',
+                success_path: '/pro',
+                cancel_path: '/pro',
+              });
+            }}
+            autoWidth
+          >
+            Checkout
+            <Element
+              css={{
+                transform: 'rotate(270deg)',
+              }}
+            >
+              <Icon name="arrowDown" size={12} />
+            </Element>
+          </Button>
+        </Stack>
       </Stack>
     </Alert>
   );

--- a/packages/app/src/app/pages/common/Modals/index.tsx
+++ b/packages/app/src/app/pages/common/Modals/index.tsx
@@ -50,6 +50,7 @@ import { NotFoundBranchModal } from './NotFoundBranchModal';
 import { GithubPagesLogs } from './GithubPagesLogs';
 import { CropThumbnail } from './CropThumbnail';
 import { SubscriptionCancellationModal } from './SubscriptionCancellation';
+import { SelectWorkspaceToUpgrade } from './SelectWorkspaceToUpgrade';
 
 const modals = {
   preferences: {
@@ -212,6 +213,10 @@ const modals = {
   subscriptionCancellation: {
     Component: SubscriptionCancellationModal,
     width: 444,
+  },
+  selectWorkspaceToUpgrade: {
+    Component: SelectWorkspaceToUpgrade,
+    width: 400,
   },
 };
 


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?

<!-- Is it a Bug fix, feature, docs update, ... -->

Adds a third card listing "Team Pro" benefits on the `/pro` page even if the selected workspace is personal.

## What is the current behavior?

<!-- You can also link to an open issue here -->

<img width="1792" alt="Screen Shot 2023-03-01 at 00 07 21" src="https://user-images.githubusercontent.com/24959348/222034939-6deb4a68-bf87-4d2a-9358-7ef14701ea82.png">

## What is the new behavior?

<!-- if this is a feature change -->

https://user-images.githubusercontent.com/24959348/222035716-f98028ac-2e05-40db-8c4e-2f6eb01801e8.mov

If no _upgradeable_ teams are available, open the create team flow:

![image](https://user-images.githubusercontent.com/24959348/222271958-d6cbd978-fe2b-4538-a0ff-fc6da6ffe573.png)


## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Visit https://llqorv-3000.preview.csb.app/pro
2. Select your personal workspace
3. A third card upselling Team Pro should be visible

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Testing <!-- We can only merge the PR if this is checked -->
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
