### PR TITLE
feat: add createBranch mutation instead of editor redirect

### DIFF
--- a/packages/app/src/app/components/CreateSandbox/Import/ImportInfo.tsx
+++ b/packages/app/src/app/components/CreateSandbox/Import/ImportInfo.tsx
@@ -1,9 +1,6 @@
 import React from 'react';
 import { Element, Icon, Link, Stack, Text } from '@codesandbox/components';
-import {
-  v2DraftBranchUrl,
-  v2DefaultBranchUrl,
-} from '@codesandbox/common/lib/utils/url-generator';
+import { v2DefaultBranchUrl } from '@codesandbox/common/lib/utils/url-generator';
 import { GithubRepoToImport } from './types';
 
 export const ImportInfo: React.FC<{ githubRepo: GithubRepoToImport }> = ({
@@ -43,6 +40,10 @@ export const ImportInfo: React.FC<{ githubRepo: GithubRepoToImport }> = ({
       </Stack>
 
       <Stack direction="vertical" gap={4}>
+        {/* 
+        TODO: Replace the link to contribution branch creation in the editor
+              with the proper mutation to create a contribution branch before
+              redirecting to the editor
         <Link
           css={{ color: '#808080', display: 'flex', gap: '8px' }}
           href={v2DraftBranchUrl({
@@ -54,7 +55,7 @@ export const ImportInfo: React.FC<{ githubRepo: GithubRepoToImport }> = ({
           <Text as="span" size={2}>
             Create contribution branch
           </Text>
-        </Link>
+        </Link> */}
 
         <Link
           css={{ color: '#808080', display: 'flex', gap: '8px' }}

--- a/packages/app/src/app/graphql/types.ts
+++ b/packages/app/src/app/graphql/types.ts
@@ -88,6 +88,12 @@ export type Branch = {
   connections: Array<Connection>;
   /** Whether this branch is a contribution branch made by a read-only user */
   contribution: Scalars['Boolean'];
+  /**
+   * Whether the current user is the owner of this contribution branch. Can be
+   *     used to override project-level `READ` authorization. Always returns `false` if the
+   *     current branch is not a contribution branch.
+   */
+  contributionOwner: Scalars['Boolean'];
   /** Alphanumeric short ID of the branch, for use with Pitcher */
   id: Scalars['String'];
   /** Timestamp of the last time the current user accessed this branch on CodeSandbox */
@@ -838,6 +844,27 @@ export type RootMutationType = {
   /** Create a collection */
   createCollection: Collection;
   createComment: Comment;
+  /**
+   * Create a contribution branch on a non-team-assinged project.
+   *
+   * This endpoint allows users to create a contribution branch on a read-only
+   * project. This branch will only be created on CodeSandbox and the branch will
+   * be a _contribution branch_, which will automatically fork a new repository
+   * andproject on the first commit.
+   *
+   * A team ID is not accepted for this mutation. To create a branch on a team-assigned project, see `mutation createBranch`.
+   *
+   * Example (for `codesandbox/test-repo` branch `test-branch`):
+   *
+   * ```gql
+   * mutation createContributionBranch(
+   *   provider: GITHUB,
+   *   owner: "codesandbox",
+   *   name: "test-repo",
+   * ) { id }
+   * ```
+   */
+  createContributionBranch: Branch;
   /** Create or Update a private registry */
   createOrUpdatePrivateNpmRegistry: PrivateRegistry;
   createPreviewComment: Comment;
@@ -915,8 +942,6 @@ export type RootMutationType = {
   /** Delete sandboxes */
   deleteSandboxes: Array<Sandbox>;
   deleteWorkspace: Scalars['String'];
-  /** Enable beta-access for team and all members */
-  enableTeamBetaAccess: Team;
   /**
    * Import an existing branch from a repository
    *
@@ -1161,6 +1186,13 @@ export type RootMutationTypeCreateCommentArgs = {
   userReferences: Maybe<Array<UserReference>>;
 };
 
+export type RootMutationTypeCreateContributionBranchArgs = {
+  from: Maybe<Scalars['String']>;
+  name: Scalars['String'];
+  owner: Scalars['String'];
+  provider: GitProvider;
+};
+
 export type RootMutationTypeCreateOrUpdatePrivateNpmRegistryArgs = {
   authType: Maybe<AuthType>;
   enabledScopes: Array<Scalars['String']>;
@@ -1232,10 +1264,6 @@ export type RootMutationTypeDeleteSandboxesArgs = {
 };
 
 export type RootMutationTypeDeleteWorkspaceArgs = {
-  teamId: Scalars['UUID4'];
-};
-
-export type RootMutationTypeEnableTeamBetaAccessArgs = {
   teamId: Scalars['UUID4'];
 };
 
@@ -1538,8 +1566,6 @@ export type RootQueryType = {
    */
   branchByName: Branch;
   curatedAlbums: Array<Album>;
-  /** @deprecated Field no longer supported */
-  featureFlags: Array<FeatureFlag>;
   /** Get git repo and related V1 sandboxes */
   git: Maybe<Git>;
   /**
@@ -1576,7 +1602,8 @@ export type RootQueryType = {
    */
   project: Maybe<Project>;
   /**
-   * Get all projects for the given repository accessible by the current user.
+   * Get all projects for the given repository accessible by the current user. Returns an empty list
+   * if no such projects are available, or no version of this project has been imported yet.
    *
    * Projects are identified by repository-team pairs. For public repositories, there may also be a
    * single project that does not have an associated team. This query returns all of the projects
@@ -1800,7 +1827,7 @@ export type Sandbox = {
   screenshotOutdated: Scalars['Boolean'];
   screenshotUrl: Maybe<Scalars['String']>;
   source: Source;
-  team: Maybe<Team>;
+  team: Maybe<TeamPreview>;
   teamId: Maybe<Scalars['UUID4']>;
   title: Maybe<Scalars['String']>;
   updatedAt: Scalars['String'];
@@ -1874,8 +1901,6 @@ export enum SubscriptionType {
 export type Team = {
   __typename?: 'Team';
   avatarUrl: Maybe<Scalars['String']>;
-  /** @deprecated Deprecated for open beta */
-  beta: Scalars['Boolean'];
   bookmarkedTemplates: Array<Template>;
   collections: Array<Collection>;
   creatorId: Maybe<Scalars['UUID4']>;
@@ -1951,6 +1976,15 @@ export enum TeamMemberAuthorization {
   /** Permission create and edit team sandboxes (in addition to read). */
   Write = 'WRITE',
 }
+
+export type TeamPreview = {
+  __typename?: 'TeamPreview';
+  avatarUrl: Maybe<Scalars['String']>;
+  description: Maybe<Scalars['String']>;
+  id: Scalars['UUID4'];
+  name: Scalars['String'];
+  shortid: Scalars['String'];
+};
 
 export type TeamUsage = {
   __typename?: 'TeamUsage';
@@ -2032,7 +2066,9 @@ export type TemplateFragment = { __typename?: 'Template' } & Pick<
         | 'updatedAt'
         | 'isV2'
       > & {
-          team: Maybe<{ __typename?: 'Team' } & Pick<Team, 'name'>>;
+          team: Maybe<
+            { __typename?: 'TeamPreview' } & Pick<TeamPreview, 'name'>
+          >;
           author: Maybe<{ __typename?: 'User' } & Pick<User, 'username'>>;
           source: { __typename?: 'Source' } & Pick<Source, 'template'>;
         }
@@ -2681,7 +2717,7 @@ export type TemplateFragmentDashboardFragment = {
             'id' | 'username' | 'commitSha' | 'path' | 'repo' | 'branch'
           >
         >;
-        team: Maybe<{ __typename?: 'Team' } & Pick<Team, 'name'>>;
+        team: Maybe<{ __typename?: 'TeamPreview' } & Pick<TeamPreview, 'name'>>;
         author: Maybe<{ __typename?: 'User' } & Pick<User, 'username'>>;
         source: { __typename?: 'Source' } & Pick<Source, 'template'>;
       } & SandboxFragmentDashboardFragment
@@ -3343,6 +3379,16 @@ export type DeleteBranchMutation = { __typename?: 'RootMutationType' } & Pick<
   RootMutationType,
   'deleteBranch'
 >;
+
+export type CreateBranchMutationVariables = Exact<{
+  owner: Scalars['String'];
+  name: Scalars['String'];
+  teamId: Scalars['ID'];
+}>;
+
+export type CreateBranchMutation = { __typename?: 'RootMutationType' } & {
+  createBranch: { __typename?: 'Branch' } & Pick<Branch, 'id' | 'name'>;
+};
 
 export type RecentlyDeletedPersonalSandboxesQueryVariables = Exact<{
   [key: string]: never;

--- a/packages/app/src/app/overmind/effects/gql/dashboard/mutations.ts
+++ b/packages/app/src/app/overmind/effects/gql/dashboard/mutations.ts
@@ -87,6 +87,8 @@ import {
   DeleteProjectMutationVariables,
   DeleteBranchMutation,
   DeleteBranchMutationVariables,
+  CreateBranchMutation,
+  CreateBranchMutationVariables,
 } from 'app/graphql/types';
 import { gql, Query } from 'overmind-graphql';
 
@@ -712,5 +714,17 @@ export const deleteBranch: Query<
 > = gql`
   mutation deleteBranch($branchId: String!) {
     deleteBranch(id: $branchId)
+  }
+`;
+
+export const createBranch: Query<
+  CreateBranchMutation,
+  CreateBranchMutationVariables
+> = gql`
+  mutation createBranch($owner: String!, $name: String!, $teamId: ID!) {
+    createBranch(provider: GITHUB, owner: $owner, name: $name, team: $teamId) {
+      id
+      name
+    }
   }
 `;

--- a/packages/app/src/app/overmind/namespaces/dashboard/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/dashboard/actions.ts
@@ -2343,8 +2343,6 @@ export const createDraftBranch = async (
 
     const branchName = response.createBranch.name;
 
-    state.dashboard.creatingBranch = false;
-
     window.location.href = v2BranchUrl({
       workspaceId: teamId,
       owner,

--- a/packages/app/src/app/overmind/namespaces/dashboard/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/dashboard/actions.ts
@@ -2323,3 +2323,31 @@ export const forkGitHubRepository = async (
     });
   }
 };
+
+export const createDraftBranch = async (
+  { effects }: Context,
+  { owner, name, teamId }: { owner: string; name: string; teamId: string }
+) => {
+  try {
+    const response = await effects.gql.mutations.createBranch({
+      name,
+      owner,
+      teamId,
+    });
+
+    const branchName = response.createBranch.name;
+
+    window.location.href = v2BranchUrl({
+      workspaceId: teamId,
+      owner,
+      repoName: name,
+      branchName,
+    });
+  } catch (error) {
+    notificationState.addNotification({
+      message: JSON.stringify(error),
+      title: 'Failed to create branch',
+      status: NotificationStatus.ERROR,
+    });
+  }
+};

--- a/packages/app/src/app/overmind/namespaces/dashboard/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/dashboard/actions.ts
@@ -2325,10 +2325,16 @@ export const forkGitHubRepository = async (
 };
 
 export const createDraftBranch = async (
-  { effects }: Context,
+  { state, effects }: Context,
   { owner, name, teamId }: { owner: string; name: string; teamId: string }
 ) => {
+  if (state.dashboard.creatingBranch) {
+    return;
+  }
+
   try {
+    state.dashboard.creatingBranch = true;
+
     const response = await effects.gql.mutations.createBranch({
       name,
       owner,
@@ -2336,6 +2342,8 @@ export const createDraftBranch = async (
     });
 
     const branchName = response.createBranch.name;
+
+    state.dashboard.creatingBranch = false;
 
     window.location.href = v2BranchUrl({
       workspaceId: teamId,

--- a/packages/app/src/app/overmind/namespaces/dashboard/state.ts
+++ b/packages/app/src/app/overmind/namespaces/dashboard/state.ts
@@ -95,6 +95,7 @@ export type State = {
    */
   removingRepository: { owner: string; name: string } | null;
   removingBranch: { id: string } | null;
+  creatingBranch: boolean;
 };
 
 export const DEFAULT_DASHBOARD_SANDBOXES: DashboardSandboxStructure = {
@@ -214,4 +215,5 @@ export const state: State = {
   starredRepos: [],
   removingRepository: null,
   removingBranch: null,
+  creatingBranch: false,
 };

--- a/packages/app/src/app/pages/Dashboard/Components/Header/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Header/index.tsx
@@ -10,7 +10,6 @@ import {
   SkeletonText,
 } from '@codesandbox/components';
 import css from '@styled-system/css';
-import { v2DraftBranchUrl } from '@codesandbox/common/lib/utils/url-generator';
 import { Breadcrumbs, BreadcrumbProps } from '../Breadcrumbs';
 import { FilterOptions } from '../Filters/FilterOptions';
 import { ViewOptions } from '../Filters/ViewOptions';
@@ -188,25 +187,18 @@ export const Header = ({
           dashboard.viewMode === 'list' &&
           selectedRepo && (
             <Button
-              as={readOnly ? undefined : 'a'}
-              href={v2DraftBranchUrl({
-                owner: selectedRepo.owner,
-                repoName: selectedRepo.name,
-                workspaceId: selectedRepo.assignedTeamId,
-              })}
-              variant="link"
+              onClick={() => {
+                dashboardActions.createDraftBranch({
+                  owner: selectedRepo.owner,
+                  name: selectedRepo.name,
+                  teamId: selectedRepo.assignedTeamId,
+                });
+              }}
+              variant="ghost"
               css={css({
-                display: 'flex',
-                alignItems: 'center',
-                textDecoration: 'none',
                 fontSize: 2,
                 color: 'mutedForeground',
                 width: 'auto',
-                transition: `color ease-in`,
-                transitionDuration: theme => theme.speeds[2],
-                '&:hover': {
-                  color: '#e5e5e5',
-                },
               })}
               disabled={readOnly}
             >

--- a/packages/app/src/app/pages/Dashboard/Components/Repository/stripes.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Repository/stripes.tsx
@@ -1,10 +1,10 @@
-import { MessageStripe } from '@codesandbox/components';
+import { MessageStripe, Link, Text } from '@codesandbox/components';
 import track from '@codesandbox/common/lib/utils/analytics';
 import { dashboard as dashboardUrls } from '@codesandbox/common/lib/utils/url-generator';
 import { useWorkspaceSubscription } from 'app/hooks/useWorkspaceSubscription';
 import { useWorkspaceAuthorization } from 'app/hooks/useWorkspaceAuthorization';
 import React from 'react';
-import { Link, useLocation } from 'react-router-dom';
+import { Link as RouterLink, useLocation } from 'react-router-dom';
 import { useGetCheckoutURL } from 'app/hooks/useCreateCheckout';
 import { useAppState } from 'app/overmind';
 
@@ -40,7 +40,7 @@ export const PrivateRepoFreeTeam: React.FC = () => {
                 href: checkout.url,
               }
             : {
-                as: Link,
+                as: RouterLink,
                 to: '/pro',
               })}
           onClick={() => {
@@ -110,3 +110,24 @@ export const MaxReposFreeTeam: React.FC = () => {
     </MessageStripe>
   );
 };
+
+export const TemporaryWarningForWorkspaceScopesMigration: React.FC<{
+  onDismiss?: () => void;
+}> = ({ onDismiss }) => {
+  return (
+    <MessageStripe
+      justify="space-between"
+      onDismiss={onDismiss}
+      variant="neutral"
+    >
+      <Text>
+        Is your repository gone? It is not deleted, but needs to be re-imported
+        due to a change. If you miss any work in progress, please{' '}
+        <Link href="https://codesandbox.io/support">contact us</Link> to recover
+        it
+      </Text>
+    </MessageStripe>
+  );
+};
+
+//

--- a/packages/app/src/app/pages/Dashboard/Components/Repository/stripes.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Repository/stripes.tsx
@@ -122,14 +122,14 @@ export const TemporaryWarningForWorkspaceScopesMigration: React.FC<{
     >
       <Text>
         Is your repository gone? It is not deleted, but needs to be re-imported
-        due to a change. If you miss any work in progress, please{' '}
+        due to a change. Please{' '}
         <Link
           css={{ textDecoration: 'underline', fontWeight: 'bold' }}
-          href="https://codesandbox.io/support"
+          href="https://www.loom.com/share/a7a7a44e7ef547358ab5696d6d328156"
         >
-          contact us
-        </Link>{' '}
-        to recover it
+          watch this video for more details
+        </Link>
+        .
       </Text>
     </MessageStripe>
   );

--- a/packages/app/src/app/pages/Dashboard/Components/Repository/stripes.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Repository/stripes.tsx
@@ -123,8 +123,13 @@ export const TemporaryWarningForWorkspaceScopesMigration: React.FC<{
       <Text>
         Is your repository gone? It is not deleted, but needs to be re-imported
         due to a change. If you miss any work in progress, please{' '}
-        <Link href="https://codesandbox.io/support">contact us</Link> to recover
-        it
+        <Link
+          css={{ textDecoration: 'underline', fontWeight: 'bold' }}
+          href="https://codesandbox.io/support"
+        >
+          contact us
+        </Link>{' '}
+        to recover it
       </Text>
     </MessageStripe>
   );

--- a/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenus/RepositoryMenu.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenus/RepositoryMenu.tsx
@@ -5,7 +5,6 @@ import { ProjectFragment } from 'app/graphql/types';
 import {
   dashboard,
   v2DefaultBranchUrl,
-  v2DraftBranchUrl,
 } from '@codesandbox/common/lib/utils/url-generator';
 import { useActions, useAppState } from 'app/overmind';
 import { quotes } from 'app/utils/quotes';
@@ -44,11 +43,7 @@ export const RepositoryMenu: React.FC<RepositoryMenuProps> = ({
     owner: repository.owner,
     name: repository.name,
   });
-  const branchFromDefaultUrl = v2DraftBranchUrl({
-    owner: repository.owner,
-    repoName: repository.name,
-    workspaceId: assignedTeam?.id,
-  });
+
   const defaultBranchUrl = v2DefaultBranchUrl({
     owner: repository.owner,
     repoName: repository.name,
@@ -85,7 +80,13 @@ export const RepositoryMenu: React.FC<RepositoryMenuProps> = ({
       <Menu.Divider />
 
       <MenuItem
-        onSelect={() => window.open(branchFromDefaultUrl, '_blank')}
+        onSelect={() => {
+          actions.dashboard.createDraftBranch({
+            owner: repository.owner,
+            name: repository.name,
+            teamId: assignedTeam?.id,
+          });
+        }}
         disabled={restricted}
       >
         Create branch

--- a/packages/app/src/app/pages/Dashboard/Components/VariableGrid/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/VariableGrid/index.tsx
@@ -5,7 +5,6 @@ import { Element, Stack, Text, Link } from '@codesandbox/components';
 import css from '@styled-system/css';
 import { VariableSizeGrid, areEqual } from 'react-window';
 import AutoSizer from 'react-virtualized-auto-sizer';
-import { v2DraftBranchUrl } from '@codesandbox/common/lib/utils/url-generator';
 import { Sandbox } from '../Sandbox';
 import { NewMasterSandbox } from '../Sandbox/NewMasterSandbox';
 import { Folder } from '../Folder';
@@ -151,15 +150,7 @@ const ComponentForTypes: IComponentForTypes = {
   branch: ({ item, page }) => <Branch page={page} {...item} />,
   repository: ({ item }) => <Repository {...item} />,
   'new-branch': ({ item }) => (
-    <ActionCard
-      href={v2DraftBranchUrl({
-        owner: item.repo.owner,
-        repoName: item.repo.name,
-        workspaceId: item.workspaceId,
-      })}
-      icon="plus"
-      disabled={item.disabled}
-    >
+    <ActionCard onClick={item.onClick} icon="plus" disabled={item.disabled}>
       Create branch
     </ActionCard>
   ),

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Repositories/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Repositories/index.tsx
@@ -8,7 +8,10 @@ import { SelectionProvider } from 'app/pages/Dashboard/Components/Selection';
 import { Element } from '@codesandbox/components';
 import { useWorkspaceLimits } from 'app/hooks/useWorkspaceLimits';
 import { useGitHuPermissions } from 'app/hooks/useGitHubPermissions';
-import { MaxReposFreeTeam } from 'app/pages/Dashboard/Components/Repository/stripes';
+import {
+  MaxReposFreeTeam,
+  TemporaryWarningForWorkspaceScopesMigration,
+} from 'app/pages/Dashboard/Components/Repository/stripes';
 import { RestrictedPublicReposImport } from 'app/pages/Dashboard/Components/shared/RestrictedPublicReposImport';
 import { useDismissible } from 'app/hooks';
 import { EmptyRepositories } from './EmptyRepositories';
@@ -21,6 +24,13 @@ export const RepositoriesPage = () => {
   } = useAppState();
   const [dismissedPermissionsBanner, dismissPermissionsBanner] = useDismissible(
     'DASHBOARD_REPOSITORIES_PERMISSIONS_BANNER'
+  );
+
+  const [
+    dismissedWorkspaceScopesMigrationMessage,
+    dismissWorkspaceScopesMigrationMessage,
+  ] = useDismissible(
+    'DASHBOARD_REPOSITORIES_WORKSPACE_SCOPES_MIGRATION_MESSAGE'
   );
 
   const teamRepos = repositoriesByTeamId[activeTeam] || undefined;
@@ -86,6 +96,14 @@ export const RepositoriesPage = () => {
         showBetaBadge
         title="All repositories"
       />
+
+      {!dismissedWorkspaceScopesMigrationMessage ? (
+        <Element paddingLeft={4} paddingRight={6} paddingY={4}>
+          <TemporaryWarningForWorkspaceScopesMigration
+            onDismiss={dismissWorkspaceScopesMigrationMessage}
+          />
+        </Element>
+      ) : null}
 
       {hasMaxPublicRepositories || hasMaxPrivateRepositories ? (
         <Element paddingLeft={4} paddingRight={6} paddingY={4}>

--- a/packages/app/src/app/pages/Dashboard/Content/routes/RepositoryBranches/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/RepositoryBranches/index.tsx
@@ -99,6 +99,13 @@ export const RepositoryBranchesPage = () => {
         workspaceId: repositoryProject?.team?.id,
         repo: { owner, name },
         disabled: isFree && repositoryProject.repository.private,
+        onClick: () => {
+          actions.dashboard.createDraftBranch({
+            owner,
+            name,
+            teamId: repositoryProject?.team?.id,
+          });
+        },
       });
     }
 

--- a/packages/app/src/app/pages/Dashboard/types.ts
+++ b/packages/app/src/app/pages/Dashboard/types.ts
@@ -148,6 +148,7 @@ export type DashboardNewBranch = {
   };
   workspaceId?: string;
   disabled?: boolean;
+  onClick: () => void;
 };
 
 export type DashboardRepository = {

--- a/packages/common/src/utils/url-generator.ts
+++ b/packages/common/src/utils/url-generator.ts
@@ -350,16 +350,3 @@ export const v2DefaultBranchUrl = (params: {
 }) => {
   return v2EditorBranchUrl(params);
 };
-
-export const v2DraftBranchUrl = (params: {
-  owner: string;
-  repoName: string;
-  workspaceId?: string;
-  importFlag?: boolean;
-  source?: string;
-}) => {
-  return v2EditorBranchUrl({
-    ...params,
-    createDraftBranch: true,
-  });
-};

--- a/packages/components/src/components/MessageStripe/MessageStripe.tsx
+++ b/packages/components/src/components/MessageStripe/MessageStripe.tsx
@@ -9,12 +9,13 @@ import { IconButton } from '../IconButton';
 
 type ButtonVariant = React.ComponentProps<typeof Button>['variant'];
 
-type Variant = 'trial' | 'warning' | 'primary';
+type Variant = 'trial' | 'warning' | 'primary' | 'neutral';
 
 const mapActionVariant: Record<Variant, ButtonVariant> = {
   trial: 'light',
   warning: 'dark',
   primary: 'dark',
+  neutral: 'primary',
 };
 
 interface MessageActionProps
@@ -56,12 +57,14 @@ const backgroundVariants: Record<Variant, string> = {
   trial: '#644ED7',
   warning: '#F7CC66',
   primary: 'button.background',
+  neutral: '#1D1D1D',
 };
 
 const colorVariants: Record<Variant, string> = {
   trial: 'inherit',
   warning: '#0E0E0E',
   primary: 'button.foreground',
+  neutral: '#e5e5e5',
 };
 
 interface MessageStripeProps {
@@ -122,7 +125,7 @@ const MessageStripe = ({
           <Element css={{ position: 'absolute', right: '16px' }}>
             <IconButton
               onClick={onDismiss}
-              css={{ color: variant === 'trial' ? '#F5F5F5' : '#0E0E0E' }}
+              css={{ color: colorVariants[variant] }}
               name="cross"
               title="Dismiss"
             />


### PR DESCRIPTION
Starting with the workspace scopes phase 2 PR, the editor no longer supports the `create=true` query to create a draft branch.

Hence, this PR replaces the use of the create=true with a mutation to create the draft branch and then redirect to it.

Note: The contribution branch creation might be a bit more tricky to solve, so I just commented it out for now. A linear task will explain the changes needed for that.

Closes XTD-549