### PR TITLE
Update Team overview style

### DIFF
--- a/packages/app/src/app/components/UserSearchInput/UserSearchInput.tsx
+++ b/packages/app/src/app/components/UserSearchInput/UserSearchInput.tsx
@@ -104,7 +104,7 @@ export const UserSearchInput = ({
           <InputWithoutTypes
             {...props}
             {...getInputProps({
-              placeholder: 'Enter username or email',
+              placeholder: 'Enter username or email to invite team member',
             })}
             autoFocus
             spellcheck="false"

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/WorkspaceSettings.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/WorkspaceSettings.tsx
@@ -586,8 +586,8 @@ export const WorkspaceSettings = () => {
                   right: 2,
                 })}
               >
-                <Text variant="muted">{ROLES_TEXT_MAP[newMemberRole]}</Text>
-                <Icon name="caret" size={8} marginLeft={1} />
+                <Text> {ROLES_TEXT_MAP[newMemberRole]}</Text>
+                <Icon name="chevronDown" size={8} marginLeft={1} />
               </Menu.Button>
               <Menu.List>
                 {rolesThatUserCanInvite.map(role => (
@@ -613,7 +613,7 @@ export const WorkspaceSettings = () => {
             loading={inviteLoading}
             style={{ width: 'auto', marginLeft: 8 }}
           >
-            Add Member
+            Add team member
           </Button>
 
           <Button
@@ -621,6 +621,12 @@ export const WorkspaceSettings = () => {
             onClick={onCopyInviteUrl}
             style={{ width: 'auto', marginLeft: 8 }}
           >
+            <Icon
+              name="link"
+              size={20}
+              title="URL"
+              css={css({ paddingRight: 2 })}
+            />
             Copy Invite URL
           </Button>
         </Stack>

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/WorkspaceSettings.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/WorkspaceSettings.tsx
@@ -327,7 +327,9 @@ export const WorkspaceSettings = () => {
               <Stack justify="flex-end">
                 <Button
                   variant="link"
-                  css={{ width: 100 }}
+                  css={{
+                    width: 100,
+                  }}
                   disabled={loading}
                   onClick={() => setEditing(false)}
                 >
@@ -619,7 +621,14 @@ export const WorkspaceSettings = () => {
           <Button
             variant="secondary"
             onClick={onCopyInviteUrl}
-            style={{ width: 'auto', marginLeft: 8 }}
+            css={css({
+              width: 'auto',
+              marginLeft: 2,
+              color: '#999',
+              ':hover': {
+                color: '#f5f5f5',
+              },
+            })}
           >
             <Icon
               name="link"

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Settings/components/MemberList.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Settings/components/MemberList.tsx
@@ -69,7 +69,9 @@ export const MemberList: React.FC<MemberListProps> = ({
                 css={{ height: '100%', width: '100%' }}
               >
                 <Avatar user={user} />
-                <Text size={3}>{user.username}</Text>
+                <Text size={3} style={{ color: 'white' }}>
+                  {user.username}
+                </Text>
               </Stack>
             </Column>
             <Column span={6}>
@@ -82,12 +84,14 @@ export const MemberList: React.FC<MemberListProps> = ({
                   <Menu>
                     <Menu.Button
                       style={{ paddingLeft: 0, paddingRight: 0 }}
-                      css={css({ fontSize: 3, fontWeight: 'normal' })}
+                      css={css({
+                        fontSize: 3,
+                        fontWeight: 'normal',
+                        color: 'grays.200',
+                      })}
                     >
-                      <Text variant="muted">
-                        {permissionMap[getPermission(user)]}
-                      </Text>
-                      <Icon name="caret" size={8} marginLeft={1} />
+                      <Text>{permissionMap[getPermission(user)]}</Text>
+                      <Icon name="chevronDown" size={8} marginLeft={1} />
                     </Menu.Button>
                     <Menu.List>
                       {permissionActions.map(action => (
@@ -119,7 +123,7 @@ export const MemberList: React.FC<MemberListProps> = ({
                   <Menu>
                     <Menu.IconButton
                       name="more"
-                      size={9}
+                      size={14}
                       title="Member options"
                     />
                     <Menu.List>


### PR DESCRIPTION
[New]

- Change color of username
- Change color of editable role
- Change size of more options
- Add link icon to `Copy invite URL` button
- Update copy
- Change dropdown icons to `chevronDown`

<img width="983" alt="Screen Shot 2023-03-01 at 15 55 40" src="https://user-images.githubusercontent.com/93996574/222237489-df5c5ccc-9fa1-44bb-b8c4-d62bb5e26c5e.png">

[Old]
<img width="984" alt="Screen Shot 2023-03-01 at 15 57 13" src="https://user-images.githubusercontent.com/93996574/222237765-32c3f623-fb73-40e1-90d3-23b46d663182.png">