### PR TITLE
feat(workspace-scopes): Add temporary workspace scopes message to recent page

### DIFF
--- a/packages/app/src/app/pages/Dashboard/Components/Repository/stripes.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Repository/stripes.tsx
@@ -113,7 +113,8 @@ export const MaxReposFreeTeam: React.FC = () => {
 
 export const TemporaryWarningForWorkspaceScopesMigration: React.FC<{
   onDismiss?: () => void;
-}> = ({ onDismiss }) => {
+  variant?: 'repository' | 'branch';
+}> = ({ onDismiss, variant = 'repository' }) => {
   return (
     <MessageStripe
       justify="space-between"
@@ -121,8 +122,8 @@ export const TemporaryWarningForWorkspaceScopesMigration: React.FC<{
       variant="neutral"
     >
       <Text>
-        Is your repository gone? It is not deleted, but needs to be re-imported
-        due to a change. Please{' '}
+        Can&apos;t find a {variant}? It is not deleted, but needs to be
+        re-imported due to a change. Please{' '}
         <Link
           css={{ textDecoration: 'underline', fontWeight: 'bold' }}
           href="https://www.loom.com/share/a7a7a44e7ef547358ab5696d6d328156"
@@ -134,5 +135,3 @@ export const TemporaryWarningForWorkspaceScopesMigration: React.FC<{
     </MessageStripe>
   );
 };
-
-//

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Recent/RecentContent.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Recent/RecentContent.tsx
@@ -1,3 +1,6 @@
+import React from 'react';
+import styled from 'styled-components';
+
 import { Element, Stack, Text } from '@codesandbox/components';
 import { useAppState } from 'app/overmind';
 import { Branch } from 'app/pages/Dashboard/Components/Branch';
@@ -16,8 +19,8 @@ import {
   DashboardSandbox,
   PageTypes,
 } from 'app/pages/Dashboard/types';
-import React from 'react';
-import styled from 'styled-components';
+import { TemporaryWarningForWorkspaceScopesMigration } from 'app/pages/Dashboard/Components/Repository/stripes';
+import { useDismissible } from 'app/hooks';
 import { DocumentationRow } from './DocumentationRow';
 import { RecentHeader } from './RecentHeader';
 
@@ -66,6 +69,10 @@ export const RecentContent: React.FC<RecentContentProps> = ({
     activeTeam,
     dashboard: { viewMode },
   } = useAppState();
+  const [
+    dismissedWorkspaceScopesMigrationMessage,
+    dismissWorkspaceScopesMigrationMessage,
+  ] = useDismissible('DASHBOARD_RECENT_WORKSPACE_SCOPES_MIGRATION_MESSAGE');
   const page: PageTypes = 'recent';
 
   return (
@@ -78,6 +85,14 @@ export const RecentContent: React.FC<RecentContentProps> = ({
           </Text>
           <ViewOptions />
         </Stack>
+
+        {!dismissedWorkspaceScopesMigrationMessage ? (
+          <TemporaryWarningForWorkspaceScopesMigration
+            variant="branch"
+            onDismiss={dismissWorkspaceScopesMigrationMessage}
+          />
+        ) : null}
+
         <SelectionProvider
           activeTeamId={activeTeam}
           page={page}


### PR DESCRIPTION
We were already showing a message to users on the repositories page, but users might also miss their branches on the recent page.

Closes XTD-753

---

Changed the text from
> Is your repository gone? It is not deleted, but needs to be re-imported due to a change.

to

> Can't find a repository? It is not deleted, but needs to be re-imported due to a change.

---

Updated the message to use either `branch` or `repository` in the text.

---

<img width="1624" alt="image" src="https://user-images.githubusercontent.com/7533849/222399547-cc86014c-bfa1-4a62-9187-434beb819e57.png">
