### PR TITLE
fix(import): Authorizing GitHub organizations via Account picker

### DIFF
--- a/packages/app/src/app/components/CreateSandbox/Import/AccountSelect.tsx
+++ b/packages/app/src/app/components/CreateSandbox/Import/AccountSelect.tsx
@@ -10,13 +10,11 @@ import {
 } from 'reakit/Menu';
 
 import { Stack, Text, Icon, Element } from '@codesandbox/components';
-import { useActions } from 'app/overmind';
 
 // In the new codebase this should be a Radix dropdown menu
 // https://www.radix-ui.com/docs/primitives/components/dropdown-menu
 // also, more composable if it were a design system component
 export const AccountSelect = ({ options, value, onChange }) => {
-  const { signInGithubClicked } = useActions();
   const menu = useMenuState();
 
   return (
@@ -62,8 +60,11 @@ export const AccountSelect = ({ options, value, onChange }) => {
           </Element>
           <StyledMenuItem
             {...menu}
+            as="a"
+            href="/auth/github/oauth-settings"
+            target="_blank"
+            rel="noopener noreferrer"
             onClick={() => {
-              signInGithubClicked('private_repos');
               menu.hide();
             }}
           >

--- a/packages/app/src/app/components/CreateSandbox/Import/AccountSelect.tsx
+++ b/packages/app/src/app/components/CreateSandbox/Import/AccountSelect.tsx
@@ -63,7 +63,7 @@ export const AccountSelect = ({ options, value, onChange }) => {
           <StyledMenuItem
             {...menu}
             onClick={() => {
-              signInGithubClicked('private_repos');
+              signInGithubClicked('write_org');
               menu.hide();
             }}
           >

--- a/packages/app/src/app/components/CreateSandbox/Import/AccountSelect.tsx
+++ b/packages/app/src/app/components/CreateSandbox/Import/AccountSelect.tsx
@@ -63,7 +63,7 @@ export const AccountSelect = ({ options, value, onChange }) => {
           <StyledMenuItem
             {...menu}
             onClick={() => {
-              signInGithubClicked('write_org');
+              signInGithubClicked('private_repos');
               menu.hide();
             }}
           >

--- a/packages/app/src/app/overmind/utils/auth.ts
+++ b/packages/app/src/app/overmind/utils/auth.ts
@@ -10,18 +10,13 @@ const GH_WORKING_SCOPES = ['workflow', 'read:org'].toString();
 // in public repos only (eg: open source maintainers)
 // don't need to grant access to their private repos
 // if they don't want to.
-const GH_REPO_SCOPE_OPTIONS = [
-  'private_repos',
-  'public_repos',
-  'write_org',
-] as const;
+const GH_REPO_SCOPE_OPTIONS = ['private_repos', 'public_repos'] as const;
 
 export type GHScopeOption = typeof GH_REPO_SCOPE_OPTIONS[number];
 
 export const MAP_GH_SCOPE_OPTIONS: Record<GHScopeOption, string> = {
   public_repos: GH_WORKING_SCOPES + ',public_repo',
   private_repos: GH_WORKING_SCOPES + ',repo',
-  write_org: GH_WORKING_SCOPES + ',write_org',
 };
 
 export type AuthOptions =

--- a/packages/app/src/app/overmind/utils/auth.ts
+++ b/packages/app/src/app/overmind/utils/auth.ts
@@ -10,13 +10,18 @@ const GH_WORKING_SCOPES = ['workflow', 'read:org'].toString();
 // in public repos only (eg: open source maintainers)
 // don't need to grant access to their private repos
 // if they don't want to.
-const GH_REPO_SCOPE_OPTIONS = ['private_repos', 'public_repos'] as const;
+const GH_REPO_SCOPE_OPTIONS = [
+  'private_repos',
+  'public_repos',
+  'write_org',
+] as const;
 
 export type GHScopeOption = typeof GH_REPO_SCOPE_OPTIONS[number];
 
 export const MAP_GH_SCOPE_OPTIONS: Record<GHScopeOption, string> = {
   public_repos: GH_WORKING_SCOPES + ',public_repo',
   private_repos: GH_WORKING_SCOPES + ',repo',
+  write_org: GH_WORKING_SCOPES + ',write_org',
 };
 
 export type AuthOptions =


### PR DESCRIPTION
Fixes XTD-755

Instead of using the "grant access to private repos" function we redirect to the GitHub OAuth application page. This ensures users will always be able to grant access to organizations, no matter if access is granted to private repos for other orgs already.