### PR TITLE
feat: remind users to add their payment details

### DIFF
--- a/packages/app/src/app/components/StripeMessages/TrialWithoutPaymentInfo.tsx
+++ b/packages/app/src/app/components/StripeMessages/TrialWithoutPaymentInfo.tsx
@@ -73,7 +73,7 @@ export const TrialWithoutPaymentInfo: React.FC = () => {
       return;
     }
 
-    track('Stripe banner - active trial dismiss payment reminde', {
+    track('Stripe banner - active trial seen payment reminder', {
       codesandbox: 'V1',
       event_source: 'UI',
     });

--- a/packages/app/src/app/components/StripeMessages/TrialWithoutPaymentInfo.tsx
+++ b/packages/app/src/app/components/StripeMessages/TrialWithoutPaymentInfo.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import { useLocation } from 'react-router-dom';
+import { differenceInDays, isBefore, startOfToday } from 'date-fns';
+
+import { MessageStripe } from '@codesandbox/components';
+import { useCreateCustomerPortal } from 'app/hooks/useCreateCustomerPortal';
+import { useAppState, useEffects } from 'app/overmind';
+import { useWorkspaceAuthorization } from 'app/hooks/useWorkspaceAuthorization';
+import { useWorkspaceSubscription } from 'app/hooks/useWorkspaceSubscription';
+import track from '@codesandbox/common/lib/utils/analytics';
+import { pluralize } from 'app/utils/pluralize';
+
+export const TrialWithoutPaymentInfo: React.FC = () => {
+  const { activeTeam } = useAppState();
+  const {
+    browser: { storage },
+  } = useEffects();
+  const { pathname } = useLocation();
+  const { isTeamAdmin } = useWorkspaceAuthorization();
+  const { subscription } = useWorkspaceSubscription();
+  const [
+    loadingCustomerPortal,
+    createCustomerPortal,
+  ] = useCreateCustomerPortal({ team_id: activeTeam, return_path: pathname });
+
+  const storageKey = `TRIAL_PAYMENT_INFO_REMINDER_${activeTeam}`;
+
+  const dismissedBannerAt = storage.get(storageKey)
+    ? new Date(storage.get(storageKey))
+    : null;
+
+  const today = startOfToday();
+  const trialEndDate = new Date(subscription?.trialEnd);
+  const remainingTrialDays = differenceInDays(trialEndDate, today);
+
+  const [showBanner, setShowBanner] = React.useState<boolean>(
+    dismissedBannerAt ? isBefore(dismissedBannerAt, today) : true
+  );
+
+  const handleDismiss = () => {
+    track('Stripe banner - active trial dismiss payment reminder', {
+      codesandbox: 'V1',
+      event_source: 'UI',
+    });
+
+    storage.set(storageKey, today);
+    setShowBanner(false);
+  };
+
+  const handleAction = () => {
+    track('Stripe banner - active trial add payment details', {
+      codesandbox: 'V1',
+      event_source: 'UI',
+    });
+
+    createCustomerPortal();
+  };
+
+  const buildCopy = () => {
+    const firstSentence = `Your trial will expire in ${remainingTrialDays} ${pluralize(
+      { word: 'day', count: remainingTrialDays }
+    )}.`;
+
+    if (isTeamAdmin) {
+      return `${firstSentence} Add your payment details to continue with your subscription.`;
+    }
+
+    return `${firstSentence}. Contact your team admin to add the payment details.`;
+  };
+
+  React.useEffect(() => {
+    if (!showBanner) {
+      return;
+    }
+
+    track('Stripe banner - active trial dismiss payment reminde', {
+      codesandbox: 'V1',
+      event_source: 'UI',
+    });
+  }, []);
+
+  if (!showBanner) {
+    return null;
+  }
+
+  return (
+    <MessageStripe variant="trial" onDismiss={handleDismiss}>
+      {buildCopy()}
+      {isTeamAdmin ? (
+        <MessageStripe.Action
+          loading={loadingCustomerPortal}
+          onClick={handleAction}
+        >
+          Add payment details
+        </MessageStripe.Action>
+      ) : null}
+    </MessageStripe>
+  );
+};

--- a/packages/app/src/app/components/StripeMessages/TrialWithoutPaymentInfo.tsx
+++ b/packages/app/src/app/components/StripeMessages/TrialWithoutPaymentInfo.tsx
@@ -84,7 +84,7 @@ export const TrialWithoutPaymentInfo: React.FC = () => {
   }
 
   return (
-    <MessageStripe variant="trial" onDismiss={handleDismiss}>
+    <MessageStripe corners="straight" variant="trial" onDismiss={handleDismiss}>
       {buildCopy()}
       {isTeamAdmin ? (
         <MessageStripe.Action

--- a/packages/app/src/app/components/StripeMessages/index.tsx
+++ b/packages/app/src/app/components/StripeMessages/index.tsx
@@ -1,2 +1,3 @@
-export { PaymentPending } from './PaymentPending';
 export { FreeViewOnlyStripe } from './FreeViewOnlyStripe';
+export { PaymentPending } from './PaymentPending';
+export { TrialWithoutPaymentInfo } from './TrialWithoutPaymentInfo';

--- a/packages/app/src/app/pages/Dashboard/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/index.tsx
@@ -99,7 +99,9 @@ export const Dashboard: FunctionComponent = () => {
     }
   }, [location.search, actions, activeTeamInfo, notificationToast]);
 
-  const hasTopBarBanner = subscription?.status === SubscriptionStatus.Unpaid;
+  const hasUnpaidSubscription =
+    subscription?.status === SubscriptionStatus.Unpaid;
+  const hasTopBarBanner = hasUnpaidSubscription;
 
   useEffect(() => {
     if (!hasLogIn) {
@@ -141,9 +143,7 @@ export const Dashboard: FunctionComponent = () => {
           })}
         >
           <SkipNav.Link />
-          {subscription?.status === SubscriptionStatus.Unpaid && (
-            <PaymentPending />
-          )}
+          {hasUnpaidSubscription && <PaymentPending />}
           <Header onSidebarToggle={onSidebarToggle} />
           <Media
             query={theme.media

--- a/packages/app/src/app/pages/Dashboard/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/index.tsx
@@ -15,7 +15,10 @@ import { NotificationStatus } from '@codesandbox/notifications/lib/state';
 import { createGlobalStyle, useTheme } from 'styled-components';
 import css from '@styled-system/css';
 
-import { PaymentPending } from 'app/components/StripeMessages';
+import {
+  PaymentPending,
+  TrialWithoutPaymentInfo,
+} from 'app/components/StripeMessages';
 import { useWorkspaceSubscription } from 'app/hooks/useWorkspaceSubscription';
 import { useDashboardVisit } from 'app/hooks/useDashboardVisit';
 import { SubscriptionStatus } from 'app/graphql/types';
@@ -35,7 +38,11 @@ export const Dashboard: FunctionComponent = () => {
   const { hasLogIn, activeTeamInfo } = useAppState();
   const { browser, notificationToast } = useEffects();
   const actions = useActions();
-  const { subscription } = useWorkspaceSubscription();
+  const {
+    hasActiveTeamTrial,
+    hasPaymentMethod,
+    subscription,
+  } = useWorkspaceSubscription();
   const { trackVisit } = useDashboardVisit();
 
   // only used for mobile
@@ -101,7 +108,8 @@ export const Dashboard: FunctionComponent = () => {
 
   const hasUnpaidSubscription =
     subscription?.status === SubscriptionStatus.Unpaid;
-  const hasTopBarBanner = hasUnpaidSubscription;
+  const hasTrialWithoutPaymentInfo = hasActiveTeamTrial && !hasPaymentMethod;
+  const hasTopBarBanner = hasTrialWithoutPaymentInfo || hasUnpaidSubscription;
 
   useEffect(() => {
     if (!hasLogIn) {
@@ -144,6 +152,7 @@ export const Dashboard: FunctionComponent = () => {
         >
           <SkipNav.Link />
           {hasUnpaidSubscription && <PaymentPending />}
+          {hasTrialWithoutPaymentInfo && <TrialWithoutPaymentInfo />}
           <Header onSidebarToggle={onSidebarToggle} />
           <Media
             query={theme.media

--- a/packages/components/src/components/MessageStripe/MessageStripe.stories.tsx
+++ b/packages/components/src/components/MessageStripe/MessageStripe.stories.tsx
@@ -28,6 +28,14 @@ export const WithoutAction = () => (
   </MessageStripe>
 );
 
+export const WithStraightCorners = () => (
+  <MessageStripe corners="straight" variant="trial">
+    You are no longer in a Pro team. This private repo is in view mode only.
+    Make it public or upgrade.
+    <MessageStripe.Action>Upgrade now</MessageStripe.Action>
+  </MessageStripe>
+);
+
 export const SpaceBetween = () => (
   <MessageStripe variant="trial" justify="space-between">
     There are some issues with your payment. Please update your payment details.

--- a/packages/components/src/components/MessageStripe/MessageStripe.tsx
+++ b/packages/components/src/components/MessageStripe/MessageStripe.tsx
@@ -10,6 +10,7 @@ import { IconButton } from '../IconButton';
 type ButtonVariant = React.ComponentProps<typeof Button>['variant'];
 
 type Variant = 'trial' | 'warning' | 'primary' | 'neutral';
+type Corners = 'rounded' | 'straight';
 
 const mapActionVariant: Record<Variant, ButtonVariant> = {
   trial: 'light',
@@ -69,13 +70,15 @@ const colorVariants: Record<Variant, string> = {
 
 interface MessageStripeProps {
   children: React.ReactNode;
-  variant?: Variant;
+  corners?: Corners;
   justify?: 'center' | 'space-between';
+  variant?: Variant;
   onDismiss?: () => void;
 }
 
 const MessageStripe = ({
   children,
+  corners = 'rounded', // Opposite of the value in v2 just to not cause regressions.
   variant = 'trial',
   justify = 'center',
   onDismiss,
@@ -115,7 +118,7 @@ const MessageStripe = ({
         backgroundColor: backgroundVariants[variant],
         color: colorVariants[variant],
         position: 'relative',
-        borderRadius: '4px',
+        borderRadius: { rounded: '4px', straight: 0 }[corners],
       }}
     >
       <Stack direction="horizontal" justify={justify} align="center" gap={2}>


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?

<!-- Is it a Bug fix, feature, docs update, ... -->

- Adds the `corners` prop to the `MessageStripe` component.
- Creates a new component `TrialWithoutPaymentInfo`
  - Adds it to the dashboard and to the editor

## What is the new behavior?

<!-- if this is a feature change -->

![localhost_3000_dashboard_settings_workspace=d8f69faa-e567-4b32-90d2-15bd48de5b88](https://user-images.githubusercontent.com/24959348/222599895-08c62300-cc25-413f-b923-7c87cf649ec9.png)

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Launch the dashboard
2. Open (or create) a team with an active trial and no payment info
3. The banner should be visible
4. The banner can be dismissed
5. If the banner was dismissed before the current day, it'll appear again
  - You can test this by opening the devtools, searching for the key `TRIAL_PAYMENT_INFO_REMINDER_${activeTeam}` and setting the date to the day before.

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Testing <!-- We can only merge the PR if this is checked -->
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
