### PR TITLE
fix: explicit redirect to default branch after import

### DIFF
--- a/packages/app/src/app/graphql/types.ts
+++ b/packages/app/src/app/graphql/types.ts
@@ -3357,7 +3357,9 @@ export type ImportProjectMutationVariables = Exact<{
 }>;
 
 export type ImportProjectMutation = { __typename?: 'RootMutationType' } & {
-  importProject: { __typename?: 'Project' } & Pick<Project, 'id'>;
+  importProject: { __typename?: 'Project' } & Pick<Project, 'id'> & {
+      defaultBranch: { __typename?: 'Branch' } & Pick<Branch, 'name'>;
+    };
 };
 
 export type DeleteProjectMutationVariables = Exact<{

--- a/packages/app/src/app/overmind/effects/gql/dashboard/mutations.ts
+++ b/packages/app/src/app/overmind/effects/gql/dashboard/mutations.ts
@@ -695,6 +695,9 @@ export const importProject: Query<
   mutation importProject($owner: String!, $name: String!, $teamId: ID!) {
     importProject(provider: GITHUB, owner: $owner, name: $name, team: $teamId) {
       id
+      defaultBranch {
+        name
+      }
     }
   }
 `;

--- a/packages/app/src/app/overmind/namespaces/dashboard/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/dashboard/actions.ts
@@ -14,10 +14,7 @@ import {
   CuratedAlbumByIdQueryVariables,
   ProjectFragment,
 } from 'app/graphql/types';
-import {
-  v2BranchUrl,
-  v2DefaultBranchUrl,
-} from '@codesandbox/common/lib/utils/url-generator';
+import { v2BranchUrl } from '@codesandbox/common/lib/utils/url-generator';
 import { notificationState } from '@codesandbox/common/lib/utils/notifications';
 import { NotificationStatus } from '@codesandbox/notifications';
 import {
@@ -2265,15 +2262,16 @@ export const importGitHubRepository = async (
   }
 
   try {
-    await effects.gql.mutations.importProject({
+    const result = await effects.gql.mutations.importProject({
       name,
       owner,
       teamId: activeTeam,
     });
 
-    window.location.href = v2DefaultBranchUrl({
+    window.location.href = v2BranchUrl({
       owner,
       repoName: name,
+      branchName: result.importProject.defaultBranch.name,
       workspaceId: activeTeam,
       importFlag: true,
     });

--- a/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenus/RepositoryMenu.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenus/RepositoryMenu.tsx
@@ -4,7 +4,7 @@ import { Menu } from '@codesandbox/components';
 import { ProjectFragment } from 'app/graphql/types';
 import {
   dashboard,
-  v2DefaultBranchUrl,
+  v2BranchUrl,
 } from '@codesandbox/common/lib/utils/url-generator';
 import { useActions, useAppState } from 'app/overmind';
 import { quotes } from 'app/utils/quotes';
@@ -44,9 +44,10 @@ export const RepositoryMenu: React.FC<RepositoryMenuProps> = ({
     name: repository.name,
   });
 
-  const defaultBranchUrl = v2DefaultBranchUrl({
+  const defaultBranchUrl = v2BranchUrl({
     owner: repository.owner,
     repoName: repository.name,
+    branchName: repository.defaultBranch,
     workspaceId: assignedTeam?.id,
   });
 


### PR DESCRIPTION
Imports were redirecting to the project without the branch in the URL, so the editor was doing the inference and changing the workspace when a PRO one was found instead of the one passed in the URL.