### PR TITLE
fix(editor): height when stripe message is dismissed

### DIFF
--- a/packages/app/src/app/components/StripeMessages/TrialWithoutPaymentInfo/TrialWithoutPaymentInfo.tsx
+++ b/packages/app/src/app/components/StripeMessages/TrialWithoutPaymentInfo/TrialWithoutPaymentInfo.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useLocation } from 'react-router-dom';
-import { differenceInDays, isBefore, startOfToday } from 'date-fns';
+import { differenceInDays, startOfToday } from 'date-fns';
 
 import { MessageStripe } from '@codesandbox/components';
 import { useCreateCustomerPortal } from 'app/hooks/useCreateCustomerPortal';
@@ -36,9 +36,13 @@ export const TrialWithoutPaymentInfo: React.FC<{ onDismiss: () => void }> = ({
   };
 
   const buildCopy = () => {
-    const firstSentence = `Your trial will expire in ${remainingTrialDays} ${pluralize(
-      { word: 'day', count: remainingTrialDays }
-    )}`;
+    const firstSentence =
+      remainingTrialDays === 0
+        ? 'Your trial expires today'
+        : `Your trial will expire in ${remainingTrialDays} ${pluralize({
+            word: 'day',
+            count: remainingTrialDays,
+          })}`;
 
     if (isTeamAdmin) {
       return `${firstSentence}. Add your payment details to continue with your subscription.`;

--- a/packages/app/src/app/components/StripeMessages/TrialWithoutPaymentInfo/TrialWithoutPaymentInfo.tsx
+++ b/packages/app/src/app/components/StripeMessages/TrialWithoutPaymentInfo/TrialWithoutPaymentInfo.tsx
@@ -4,17 +4,16 @@ import { differenceInDays, isBefore, startOfToday } from 'date-fns';
 
 import { MessageStripe } from '@codesandbox/components';
 import { useCreateCustomerPortal } from 'app/hooks/useCreateCustomerPortal';
-import { useAppState, useEffects } from 'app/overmind';
+import { useAppState } from 'app/overmind';
 import { useWorkspaceAuthorization } from 'app/hooks/useWorkspaceAuthorization';
 import { useWorkspaceSubscription } from 'app/hooks/useWorkspaceSubscription';
 import track from '@codesandbox/common/lib/utils/analytics';
 import { pluralize } from 'app/utils/pluralize';
 
-export const TrialWithoutPaymentInfo: React.FC = () => {
+export const TrialWithoutPaymentInfo: React.FC<{ onDismiss: () => void }> = ({
+  onDismiss,
+}) => {
   const { activeTeam } = useAppState();
-  const {
-    browser: { storage },
-  } = useEffects();
   const { pathname } = useLocation();
   const { isTeamAdmin } = useWorkspaceAuthorization();
   const { subscription } = useWorkspaceSubscription();
@@ -23,29 +22,9 @@ export const TrialWithoutPaymentInfo: React.FC = () => {
     createCustomerPortal,
   ] = useCreateCustomerPortal({ team_id: activeTeam, return_path: pathname });
 
-  const storageKey = `TRIAL_PAYMENT_INFO_REMINDER_${activeTeam}`;
-
-  const dismissedBannerAt = storage.get(storageKey)
-    ? new Date(storage.get(storageKey))
-    : null;
-
   const today = startOfToday();
   const trialEndDate = new Date(subscription?.trialEnd);
   const remainingTrialDays = differenceInDays(trialEndDate, today);
-
-  const [showBanner, setShowBanner] = React.useState<boolean>(
-    dismissedBannerAt ? isBefore(dismissedBannerAt, today) : true
-  );
-
-  const handleDismiss = () => {
-    track('Stripe banner - active trial dismiss payment reminder', {
-      codesandbox: 'V1',
-      event_source: 'UI',
-    });
-
-    storage.set(storageKey, today);
-    setShowBanner(false);
-  };
 
   const handleAction = () => {
     track('Stripe banner - active trial add payment details', {
@@ -59,32 +38,24 @@ export const TrialWithoutPaymentInfo: React.FC = () => {
   const buildCopy = () => {
     const firstSentence = `Your trial will expire in ${remainingTrialDays} ${pluralize(
       { word: 'day', count: remainingTrialDays }
-    )}.`;
+    )}`;
 
     if (isTeamAdmin) {
-      return `${firstSentence} Add your payment details to continue with your subscription.`;
+      return `${firstSentence}. Add your payment details to continue with your subscription.`;
     }
 
     return `${firstSentence}. Contact your team admin to add the payment details.`;
   };
 
   React.useEffect(() => {
-    if (!showBanner) {
-      return;
-    }
-
     track('Stripe banner - active trial seen payment reminder', {
       codesandbox: 'V1',
       event_source: 'UI',
     });
   }, []);
 
-  if (!showBanner) {
-    return null;
-  }
-
   return (
-    <MessageStripe corners="straight" variant="trial" onDismiss={handleDismiss}>
+    <MessageStripe corners="straight" variant="trial" onDismiss={onDismiss}>
       {buildCopy()}
       {isTeamAdmin ? (
         <MessageStripe.Action

--- a/packages/app/src/app/components/StripeMessages/TrialWithoutPaymentInfo/index.ts
+++ b/packages/app/src/app/components/StripeMessages/TrialWithoutPaymentInfo/index.ts
@@ -1,0 +1,2 @@
+export { TrialWithoutPaymentInfo } from './TrialWithoutPaymentInfo';
+export { useShowBanner } from './useShowBanner';

--- a/packages/app/src/app/components/StripeMessages/TrialWithoutPaymentInfo/useShowBanner.ts
+++ b/packages/app/src/app/components/StripeMessages/TrialWithoutPaymentInfo/useShowBanner.ts
@@ -20,8 +20,6 @@ export const useShowBanner = (): [boolean, () => void] => {
     ? new Date(storage.get(storageKey))
     : null;
 
-  console.log({ hasTrialWithoutPaymentInfo, dismissedBannerAt });
-
   const [showBanner, setShowBanner] = React.useState<boolean>(
     dismissedBannerAt ? isBefore(dismissedBannerAt, today) : true
   );
@@ -36,5 +34,5 @@ export const useShowBanner = (): [boolean, () => void] => {
     setShowBanner(false);
   };
 
-  return [false, dismissBanner];
+  return [hasTrialWithoutPaymentInfo && showBanner, dismissBanner];
 };

--- a/packages/app/src/app/components/StripeMessages/TrialWithoutPaymentInfo/useShowBanner.ts
+++ b/packages/app/src/app/components/StripeMessages/TrialWithoutPaymentInfo/useShowBanner.ts
@@ -1,0 +1,40 @@
+import React from 'react';
+import { useAppState, useEffects } from 'app/overmind';
+import { isBefore, startOfToday } from 'date-fns';
+import track from '@codesandbox/common/lib/utils/analytics';
+import { useWorkspaceSubscription } from 'app/hooks/useWorkspaceSubscription';
+
+export const useShowBanner = (): [boolean, () => void] => {
+  const { activeTeam } = useAppState();
+  const {
+    browser: { storage },
+  } = useEffects();
+  const { hasActiveTeamTrial, hasPaymentMethod } = useWorkspaceSubscription();
+
+  const hasTrialWithoutPaymentInfo = hasActiveTeamTrial && !hasPaymentMethod;
+
+  const storageKey = `TRIAL_PAYMENT_INFO_REMINDER_${activeTeam}`;
+
+  const today = startOfToday();
+  const dismissedBannerAt = storage.get(storageKey)
+    ? new Date(storage.get(storageKey))
+    : null;
+
+  console.log({ hasTrialWithoutPaymentInfo, dismissedBannerAt });
+
+  const [showBanner, setShowBanner] = React.useState<boolean>(
+    dismissedBannerAt ? isBefore(dismissedBannerAt, today) : true
+  );
+
+  const dismissBanner = () => {
+    track('Stripe banner - active trial dismiss payment reminder', {
+      codesandbox: 'V1',
+      event_source: 'UI',
+    });
+
+    storage.set(storageKey, today);
+    setShowBanner(false);
+  };
+
+  return [false, dismissBanner];
+};

--- a/packages/app/src/app/pages/Dashboard/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/index.tsx
@@ -28,6 +28,7 @@ import { SIDEBAR_WIDTH } from './Sidebar/constants';
 import { Content } from './Content';
 import { NUOCT22 } from '../SignIn/Onboarding';
 import { NewTeamModal } from './Components/NewTeamModal';
+import { useShowBanner } from 'app/components/StripeMessages/TrialWithoutPaymentInfo';
 
 const GlobalStyles = createGlobalStyle({
   body: { overflow: 'hidden' },
@@ -38,12 +39,12 @@ export const Dashboard: FunctionComponent = () => {
   const { hasLogIn, activeTeamInfo } = useAppState();
   const { browser, notificationToast } = useEffects();
   const actions = useActions();
-  const {
-    hasActiveTeamTrial,
-    hasPaymentMethod,
-    subscription,
-  } = useWorkspaceSubscription();
+  const { subscription } = useWorkspaceSubscription();
   const { trackVisit } = useDashboardVisit();
+  const [
+    showTrialWithoutPaymentInfoBanner,
+    dismissTrialWithoutPaymentInfoBanner,
+  ] = useShowBanner();
 
   // only used for mobile
   const [sidebarVisible, setSidebarVisibility] = React.useState(false);
@@ -108,8 +109,8 @@ export const Dashboard: FunctionComponent = () => {
 
   const hasUnpaidSubscription =
     subscription?.status === SubscriptionStatus.Unpaid;
-  const hasTrialWithoutPaymentInfo = hasActiveTeamTrial && !hasPaymentMethod;
-  const hasTopBarBanner = hasTrialWithoutPaymentInfo || hasUnpaidSubscription;
+  const hasTopBarBanner =
+    showTrialWithoutPaymentInfoBanner || hasUnpaidSubscription;
 
   useEffect(() => {
     if (!hasLogIn) {
@@ -152,7 +153,11 @@ export const Dashboard: FunctionComponent = () => {
         >
           <SkipNav.Link />
           {hasUnpaidSubscription && <PaymentPending />}
-          {hasTrialWithoutPaymentInfo && <TrialWithoutPaymentInfo />}
+          {showTrialWithoutPaymentInfoBanner && (
+            <TrialWithoutPaymentInfo
+              onDismiss={dismissTrialWithoutPaymentInfoBanner}
+            />
+          )}
           <Header onSidebarToggle={onSidebarToggle} />
           <Media
             query={theme.media

--- a/packages/app/src/app/pages/Dashboard/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/index.tsx
@@ -19,6 +19,7 @@ import {
   PaymentPending,
   TrialWithoutPaymentInfo,
 } from 'app/components/StripeMessages';
+import { useShowBanner } from 'app/components/StripeMessages/TrialWithoutPaymentInfo';
 import { useWorkspaceSubscription } from 'app/hooks/useWorkspaceSubscription';
 import { useDashboardVisit } from 'app/hooks/useDashboardVisit';
 import { SubscriptionStatus } from 'app/graphql/types';
@@ -28,7 +29,6 @@ import { SIDEBAR_WIDTH } from './Sidebar/constants';
 import { Content } from './Content';
 import { NUOCT22 } from '../SignIn/Onboarding';
 import { NewTeamModal } from './Components/NewTeamModal';
-import { useShowBanner } from 'app/components/StripeMessages/TrialWithoutPaymentInfo';
 
 const GlobalStyles = createGlobalStyle({
   body: { overflow: 'hidden' },

--- a/packages/app/src/app/pages/Sandbox/Editor/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/index.tsx
@@ -24,6 +24,7 @@ import styled, { ThemeProvider } from 'styled-components';
 import { SubscriptionStatus } from 'app/graphql/types';
 import { UpgradeSSEToV2Stripe } from 'app/components/StripeMessages/UpgradeSSEToV2';
 import { useWorkspaceSubscription } from 'app/hooks/useWorkspaceSubscription';
+import { useShowBanner } from 'app/components/StripeMessages/TrialWithoutPaymentInfo';
 import { MainWorkspace as Content } from './Content';
 import { Container } from './elements';
 import ForkFrozenSandboxModal from './ForkFrozenSandboxModal';
@@ -34,7 +35,6 @@ import getVSCodeTheme from './utils/get-vscode-theme';
 import { Workspace } from './Workspace';
 import { CommentsAPI } from './Workspace/screens/Comments/API';
 import { FixedSignInBanner } from './FixedSignInBanner';
-import { useShowBanner } from 'app/components/StripeMessages/TrialWithoutPaymentInfo';
 
 type EditorTypes = { showNewSandboxModal?: boolean };
 
@@ -185,6 +185,7 @@ export const Editor = ({ showNewSandboxModal }: EditorTypes) => {
           )}
 
           <div
+            key={getTopOffset()} // Force re-render when topOffset changes to avoid weird positioning.
             style={{
               position: 'fixed',
               left: hideNavigation ? 0 : 'calc(3.5rem + 1px)',

--- a/packages/app/src/app/pages/Sandbox/Editor/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/index.tsx
@@ -34,6 +34,7 @@ import getVSCodeTheme from './utils/get-vscode-theme';
 import { Workspace } from './Workspace';
 import { CommentsAPI } from './Workspace/screens/Comments/API';
 import { FixedSignInBanner } from './FixedSignInBanner';
+import { useShowBanner } from 'app/components/StripeMessages/TrialWithoutPaymentInfo';
 
 type EditorTypes = { showNewSandboxModal?: boolean };
 
@@ -61,13 +62,11 @@ export const Editor = ({ showNewSandboxModal }: EditorTypes) => {
     },
     customVSCodeTheme: null,
   });
-  const {
-    hasActiveTeamTrial,
-    hasPaymentMethod,
-    subscription,
-  } = useWorkspaceSubscription();
-
-  const hasTrialWithoutPaymentInfo = hasActiveTeamTrial && !hasPaymentMethod;
+  const { subscription } = useWorkspaceSubscription();
+  const [
+    showTrialWithoutPaymentInfoBanner,
+    dismissTrialWithoutPaymentInfoBanner,
+  ] = useShowBanner();
 
   useEffect(() => {
     let timeout;
@@ -129,7 +128,7 @@ export const Editor = ({ showNewSandboxModal }: EditorTypes) => {
     // Has MessageStripe
     if (
       subscription?.status === SubscriptionStatus.Unpaid ||
-      hasTrialWithoutPaymentInfo ||
+      showTrialWithoutPaymentInfoBanner ||
       sandbox?.freePlanEditingRestricted ||
       (state.hasLogIn && sandbox?.isSse)
     ) {
@@ -163,7 +162,11 @@ export const Editor = ({ showNewSandboxModal }: EditorTypes) => {
               <PaymentPending />
             )}
 
-            {hasTrialWithoutPaymentInfo && <TrialWithoutPaymentInfo />}
+            {showTrialWithoutPaymentInfoBanner && (
+              <TrialWithoutPaymentInfo
+                onDismiss={dismissTrialWithoutPaymentInfoBanner}
+              />
+            )}
 
             {sandbox?.freePlanEditingRestricted ? <FreeViewOnlyStripe /> : null}
             {state.hasLogIn && sandbox?.isSse ? <UpgradeSSEToV2Stripe /> : null}


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?

<!-- Is it a Bug fix, feature, docs update, ... -->

## What is the current behavior?

<!-- You can also link to an open issue here -->

![image](https://user-images.githubusercontent.com/24959348/222838786-91e4ccf2-aa22-4e23-afe6-c087214708a7.png)

Height is not re-calculated when the banner is dismissed.

## What is the new behavior?

<!-- if this is a feature change -->

https://user-images.githubusercontent.com/24959348/222838977-ede361a8-aec1-40da-b1a5-bccad33c9eba.mov

(Screen recording is laggy because the editor is quite sluggish in dev mode).

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Step A
2. Step B
3. Step C

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Testing <!-- We can only merge the PR if this is checked -->
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
