### PR TITLE
feat(dashboard): adds upgrade banner in personal workspaces

### DIFF
--- a/packages/app/src/app/graphql/types.ts
+++ b/packages/app/src/app/graphql/types.ts
@@ -109,6 +109,8 @@ export type Branch = {
   /** Open pull requests from this head branch */
   pullRequests: Array<PullRequest>;
   settings: BranchSettings;
+  /** The name of the branch the current branch was created from. Only available if this branch was created via CodeSandbox. */
+  sourceBranch: Maybe<Scalars['String']>;
   /** Information about the underlying git status of this branch */
   status: Maybe<Status>;
   /** Whether or not this branch exists on GitHub. Deduced from local information, so not guaranteed 100% accurate */
@@ -2768,7 +2770,7 @@ export type TeamFragmentDashboardFragment = { __typename?: 'Team' } & Pick<
     subscription: Maybe<
       { __typename?: 'ProSubscription' } & Pick<
         ProSubscription,
-        'origin' | 'type' | 'paymentProvider'
+        'origin' | 'type' | 'status' | 'paymentProvider'
       >
     >;
   };

--- a/packages/app/src/app/overmind/actions.ts
+++ b/packages/app/src/app/overmind/actions.ts
@@ -259,7 +259,8 @@ type ModalName =
   | 'minimumPrivacy'
   | 'addMemberToWorkspace'
   | 'legacyPayment'
-  | 'selectWorkspaceToUpgrade';
+  | 'selectWorkspaceToUpgrade'
+  | 'selectWorkspaceToStartTrial';
 
 export const modalOpened = (
   { state, effects }: Context,

--- a/packages/app/src/app/overmind/effects/gql/dashboard/fragments.ts
+++ b/packages/app/src/app/overmind/effects/gql/dashboard/fragments.ts
@@ -144,7 +144,7 @@ export const teamFragmentDashboard = gql`
       avatarUrl
     }
 
-    subscription {
+    subscription(includeCancelled: true) {
       origin
       type
       paymentProvider

--- a/packages/app/src/app/overmind/effects/gql/dashboard/fragments.ts
+++ b/packages/app/src/app/overmind/effects/gql/dashboard/fragments.ts
@@ -147,6 +147,7 @@ export const teamFragmentDashboard = gql`
     subscription(includeCancelled: true) {
       origin
       type
+      status
       paymentProvider
     }
   }

--- a/packages/app/src/app/pages/Dashboard/Components/UpgradeBanner/UpgradeBanner.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/UpgradeBanner/UpgradeBanner.tsx
@@ -92,7 +92,7 @@ export const UpgradeBanner: React.FC<UpgradeBannerProps> = ({ teamId }) => {
     >
       <Element css={{ overflow: 'hidden' }}>
         <StyledTitle color="#EDFFA5" weight="500" block>
-          {isEligibleForTrial ? 'Try Team Pro for free' : 'Upgrade to Pro'}
+          {isEligibleForTrial ? 'Try Team Pro for free' : 'Upgrade to Team Pro'}
         </StyledTitle>
         <Stack
           css={{

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Recent/RecentHeader.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Recent/RecentHeader.tsx
@@ -16,7 +16,7 @@ export const RecentHeader: React.FC<{ title: string }> = ({ title }) => {
     isPersonalSpace,
     isTeamViewer,
   } = useWorkspaceAuthorization();
-  const showUpgradeBanner = isFree && isTeamSpace;
+  const showUpgradeBanner = isPersonalSpace || (isFree && isTeamSpace);
 
   return (
     <Stack direction="vertical" gap={9}>

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Recent/RecentHeader.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Recent/RecentHeader.tsx
@@ -2,13 +2,12 @@ import track from '@codesandbox/common/lib/utils/analytics';
 import { CreateCard, Stack, Text } from '@codesandbox/components';
 import { useWorkspaceAuthorization } from 'app/hooks/useWorkspaceAuthorization';
 import { useWorkspaceSubscription } from 'app/hooks/useWorkspaceSubscription';
-import { useActions, useAppState } from 'app/overmind';
+import { useActions } from 'app/overmind';
 import { EmptyPage } from 'app/pages/Dashboard/Components/EmptyPage';
 import { UpgradeBanner } from 'app/pages/Dashboard/Components/UpgradeBanner';
 import React from 'react';
 
 export const RecentHeader: React.FC<{ title: string }> = ({ title }) => {
-  const { activeTeam } = useAppState();
   const actions = useActions();
   const { isFree } = useWorkspaceSubscription();
   const {
@@ -20,7 +19,7 @@ export const RecentHeader: React.FC<{ title: string }> = ({ title }) => {
 
   return (
     <Stack direction="vertical" gap={9}>
-      {showUpgradeBanner && <UpgradeBanner teamId={activeTeam} />}
+      {showUpgradeBanner && <UpgradeBanner />}
       <Text
         as="h1"
         css={{

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Recent/RecentHeader.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Recent/RecentHeader.tsx
@@ -24,7 +24,8 @@ export const RecentHeader: React.FC<{ title: string }> = ({ title }) => {
       t =>
         t.subscription &&
         t.subscription.type === SubscriptionType.TeamPro &&
-        t.subscription.status === SubscriptionStatus.Active
+        (t.subscription.status === SubscriptionStatus.Active ||
+          t.subscription.status === SubscriptionStatus.Trialing)
     ) === undefined;
   const showUpgradeBanner =
     (isPersonalSpace && allTeamsNotOnPro) || (isFree && isTeamSpace);

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Recent/RecentHeader.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Recent/RecentHeader.tsx
@@ -1,21 +1,33 @@
 import track from '@codesandbox/common/lib/utils/analytics';
 import { CreateCard, Stack, Text } from '@codesandbox/components';
+import { SubscriptionStatus, SubscriptionType } from 'app/graphql/types';
 import { useWorkspaceAuthorization } from 'app/hooks/useWorkspaceAuthorization';
 import { useWorkspaceSubscription } from 'app/hooks/useWorkspaceSubscription';
-import { useActions } from 'app/overmind';
+import { useActions, useAppState } from 'app/overmind';
 import { EmptyPage } from 'app/pages/Dashboard/Components/EmptyPage';
 import { UpgradeBanner } from 'app/pages/Dashboard/Components/UpgradeBanner';
 import React from 'react';
 
 export const RecentHeader: React.FC<{ title: string }> = ({ title }) => {
   const actions = useActions();
+  const {
+    dashboard: { teams },
+  } = useAppState();
   const { isFree } = useWorkspaceSubscription();
   const {
     isTeamSpace,
     isPersonalSpace,
     isTeamViewer,
   } = useWorkspaceAuthorization();
-  const showUpgradeBanner = isPersonalSpace || (isFree && isTeamSpace);
+  const allTeamsNotOnPro =
+    teams.find(
+      t =>
+        t.subscription &&
+        t.subscription.type === SubscriptionType.TeamPro &&
+        t.subscription.status === SubscriptionStatus.Active
+    ) === undefined;
+  const showUpgradeBanner =
+    (isPersonalSpace && allTeamsNotOnPro) || (isFree && isTeamSpace);
 
   return (
     <Stack direction="vertical" gap={9}>

--- a/packages/app/src/app/pages/common/Modals/SelectWorkspaceToStartTrial/index.tsx
+++ b/packages/app/src/app/pages/common/Modals/SelectWorkspaceToStartTrial/index.tsx
@@ -38,7 +38,7 @@ export const SelectWorkspaceToStartTrial: React.FC = () => {
   );
 
   return (
-    <Alert title="Choose a team to start a 14-day free trial">
+    <Alert title="Select a team to trial on pro">
       <Stack
         css={{
           marginBottom: '52px',
@@ -46,15 +46,6 @@ export const SelectWorkspaceToStartTrial: React.FC = () => {
         direction="vertical"
         gap={4}
       >
-        <Text
-          css={{
-            color: '#808080',
-            fontSize: '13px',
-            lineHeight: '19px',
-          }}
-        >
-          Team Pro trials are only available for teams.
-        </Text>
         {trialEligibleTeams.length > 0 ? (
           /**
            * This should always render because if there are no

--- a/packages/app/src/app/pages/common/Modals/SelectWorkspaceToStartTrial/index.tsx
+++ b/packages/app/src/app/pages/common/Modals/SelectWorkspaceToStartTrial/index.tsx
@@ -1,0 +1,166 @@
+import React from 'react';
+import {
+  Button,
+  Element,
+  Icon,
+  Select,
+  Stack,
+  Text,
+} from '@codesandbox/components';
+import track from '@codesandbox/common/lib/utils/analytics';
+
+import { useCreateCheckout } from 'app/hooks';
+import { useActions, useAppState } from 'app/overmind';
+import { TeamMemberAuthorization } from 'app/graphql/types';
+import { Alert } from '../Common/Alert';
+
+export const SelectWorkspaceToStartTrial: React.FC = () => {
+  const { dashboard, personalWorkspaceId, user } = useAppState();
+  const { openCreateTeamModal, modalClosed } = useActions();
+  const [checkout, createCheckout] = useCreateCheckout();
+
+  const trialEligibleTeams = dashboard.teams.filter(team => {
+    if (team.id === personalWorkspaceId || Boolean(team.subscription)) {
+      return false;
+    }
+
+    const teamAdmins = team.userAuthorizations
+      .filter(
+        ({ authorization }) => authorization === TeamMemberAuthorization.Admin
+      )
+      .map(({ userId }) => userId);
+
+    return teamAdmins.includes(user?.id);
+  });
+
+  const [selectedTeam, setSelectedTeam] = React.useState(
+    trialEligibleTeams[0]?.id
+  );
+
+  return (
+    <Alert title="Choose a team to start a 14-day free trial">
+      <Stack
+        css={{
+          marginBottom: '52px',
+        }}
+        direction="vertical"
+        gap={4}
+      >
+        <Text
+          css={{
+            color: '#808080',
+            fontSize: '13px',
+            lineHeight: '19px',
+          }}
+        >
+          Team Pro trials are only available for teams.
+        </Text>
+        {trialEligibleTeams.length > 0 ? (
+          /**
+           * This should always render because if there are no
+           * upgradeable teams, the CTA will directly open the modal.
+           */
+          <Select onChange={e => setSelectedTeam(e.target.value)}>
+            {trialEligibleTeams.map(team => (
+              <option key={team.id} value={team.id}>
+                {team.name}
+              </option>
+            ))}
+          </Select>
+        ) : (
+          <Text
+            css={{
+              color: '#808080',
+              fontSize: '13px',
+              lineHeight: '19px',
+            }}
+          >
+            You don&apos;t have any teams eligibe to start a Team Pro trial.{' '}
+            <Button
+              css={{
+                display: 'inline',
+                height: 'auto',
+                padding: 0,
+              }}
+              onClick={() => {
+                track('start team pro free trial - create team clicked', {
+                  codesandbox: 'V1',
+                  event_source: 'UI',
+                });
+
+                openCreateTeamModal();
+              }}
+              variant="link"
+              autoWidth
+            >
+              Create one and start a free trial.
+            </Button>
+          </Text>
+        )}
+      </Stack>
+      <Stack direction="vertical" gap={2}>
+        {checkout.status === 'error' && (
+          <Text
+            css={{
+              display: 'block',
+              marginTop: '2px',
+            }}
+            variant="danger"
+            size={12}
+          >
+            An error ocurred while trying to load the checkout.
+            <br /> Please try again.
+          </Text>
+        )}
+
+        <Stack gap={2} align="center" justify="flex-end">
+          <Button
+            onClick={() => {
+              track('start team pro free trial - modal closed', {
+                codesandbox: 'V1',
+                event_source: 'UI',
+              });
+              modalClosed();
+            }}
+            autoWidth
+            variant="ghost"
+          >
+            Cancel
+          </Button>
+          <Button
+            css={{
+              gap: '4px',
+              padding: '4px 24px',
+            }}
+            disabled={!selectedTeam}
+            loading={checkout.status === 'loading'}
+            variant="primary"
+            onClick={() => {
+              track('start team pro free trial - checkout clicked', {
+                codesandbox: 'V1',
+                event_source: 'UI',
+              });
+
+              createCheckout({
+                team_id: selectedTeam,
+                recurring_interval: 'month',
+                success_path: '/pro',
+                cancel_path: '/pro',
+              });
+            }}
+            autoWidth
+          >
+            Checkout
+            <Element
+              css={{
+                transform: 'rotate(270deg)',
+              }}
+            >
+              <Icon name="arrowDown" size={12} />
+            </Element>
+          </Button>
+        </Stack>
+      </Stack>
+    </Alert>
+  );
+};

--- a/packages/app/src/app/pages/common/Modals/index.tsx
+++ b/packages/app/src/app/pages/common/Modals/index.tsx
@@ -51,6 +51,7 @@ import { GithubPagesLogs } from './GithubPagesLogs';
 import { CropThumbnail } from './CropThumbnail';
 import { SubscriptionCancellationModal } from './SubscriptionCancellation';
 import { SelectWorkspaceToUpgrade } from './SelectWorkspaceToUpgrade';
+import { SelectWorkspaceToStartTrial } from './SelectWorkspaceToStartTrial';
 
 const modals = {
   preferences: {
@@ -216,6 +217,10 @@ const modals = {
   },
   selectWorkspaceToUpgrade: {
     Component: SelectWorkspaceToUpgrade,
+    width: 400,
+  },
+  selectWorkspaceToStartTrial: {
+    Component: SelectWorkspaceToStartTrial,
     width: 400,
   },
 };


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?

<!-- Is it a Bug fix, feature, docs update, ... -->

- Shows the `UpgradeBanner` in personal workspaces.
- Adjust the `UpgradeBanner` to inform about free trials for Team Pro.


## What is the new behavior?

<!-- if this is a feature change -->

![gv7jie-3000 preview csb app_dashboard_recent_workspace=f89f15e8-f5e1-48e9-8bc1-7104ff50fa53 (2)](https://user-images.githubusercontent.com/24959348/223220484-28381561-8cae-4b25-903b-c14c4df1d221.png)

![gv7jie-3000 preview csb app_dashboard_recent_workspace=f89f15e8-f5e1-48e9-8bc1-7104ff50fa53 (1)](https://user-images.githubusercontent.com/24959348/223220528-d78e0753-baed-45d2-b97d-51ea729753bf.png)


## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Visit the dashboard
  - Select your personal workspace if it's not already selected.
2. Refresh the page (the banner is designed to not appear the first time the dashboard is visited)
3. The banner should be visible, the CTA will:
  - Open a selection modal if any of the user's workspaces are eligible for a trial.
  - Open the new team modal if no workspace is eligible for a trial.

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Testing <!-- We can only merge the PR if this is checked -->
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
