### PR TITLE
fix(ComboButton): focus styles

### DIFF
--- a/packages/components/src/components/Button/button.stories.tsx
+++ b/packages/components/src/components/Button/button.stories.tsx
@@ -36,6 +36,15 @@ export const Disabled = () => (
     <Button disabled variant="danger">
       Go live
     </Button>
+    <Button disabled variant="light">
+      Light variant
+    </Button>
+    <Button disabled variant="dark">
+      Dark variant
+    </Button>
+    <Button disabled variant="trial">
+      Trial variant
+    </Button>
   </Stack>
 );
 
@@ -52,6 +61,15 @@ export const Loading = () => (
     </Button>
     <Button loading variant="danger">
       Go live
+    </Button>
+    <Button loading variant="light">
+      Light variant
+    </Button>
+    <Button loading variant="dark">
+      Dark variant
+    </Button>
+    <Button loading variant="trial">
+      Trial variant
     </Button>
   </Stack>
 );

--- a/packages/components/src/components/Button/button.stories.tsx
+++ b/packages/components/src/components/Button/button.stories.tsx
@@ -16,6 +16,9 @@ export const Variants = () => (
     <Button variant="secondary">Save as Template</Button>
     <Button variant="link">Open sandbox</Button>
     <Button variant="danger">Go live</Button>
+    <Button variant="light">Light variant</Button>
+    <Button variant="dark">Dark variant</Button>
+    <Button variant="trial">Trial variant</Button>
   </Stack>
 );
 

--- a/packages/components/src/components/Button/index.tsx
+++ b/packages/components/src/components/Button/index.tsx
@@ -9,7 +9,8 @@ const variantStyles = {
   primary: {
     backgroundColor: 'button.background',
     color: 'button.foreground',
-    ':hover:not(:disabled)': {
+
+    ':hover:not(:disabled), :focus:not(:disabled)': {
       // hoverBackground is polyfilled and uses a gradient
       // so we use background and not backgroundColor
 
@@ -18,38 +19,27 @@ const variantStyles = {
       // TODO @sid: extend our system to make background work as well
       background: theme => theme.colors.button.hoverBackground,
     },
-    ':focus:not(:disabled)': {
-      // we use the same colors for hover and focus
-      // but we add an active state to give
-      background: theme => theme.colors.button.hoverBackground,
-    },
   },
   secondary: {
     backgroundColor: 'secondaryButton.background',
     color: 'secondaryButton.foreground',
-    // same technique as primary
-    ':hover:not(:disabled)': {
-      background: theme => theme.colors.secondaryButton.hoverBackground,
-    },
-    ':focus:not(:disabled)': {
+
+    ':hover:not(:disabled), :focus:not(:disabled)': {
       background: theme => theme.colors.secondaryButton.hoverBackground,
     },
   },
   link: {
     backgroundColor: 'transparent',
     color: 'mutedForeground',
-    // same technique as primary
-    ':hover:not(:disabled)': {
-      color: 'foreground',
-    },
-    ':focus:not(:disabled)': {
+
+    ':hover:not(:disabled), :focus:not(:disabled)': {
       color: 'foreground',
     },
   },
   ghost: {
     backgroundColor: 'transparent',
     color: 'mutedForeground',
-    // same technique as primary
+
     ':hover:not(:disabled), :focus:not(:disabled)': {
       color: 'foreground',
       backgroundColor: '#E5E5E51A',
@@ -58,11 +48,8 @@ const variantStyles = {
   danger: {
     backgroundColor: 'dangerButton.background',
     color: 'dangerButton.foreground',
-    // same technique as primary
-    ':hover:not(:disabled)': {
-      background: theme => theme.colors.dangerButton.hoverBackground,
-    },
-    ':focus:not(:disabled)': {
+
+    ':hover:not(:disabled), :focus:not(:disabled)': {
       background: theme => theme.colors.dangerButton.hoverBackground,
     },
   },
@@ -70,7 +57,7 @@ const variantStyles = {
     backgroundColor: '#FFFFFF',
     color: '#0E0E0E',
 
-    ':hover': {
+    ':hover:not(:disabled), :focus:not(:disabled)': {
       backgroundColor: '#E0E0E0', // three up in the gray scale (gray[400])
     },
   },
@@ -78,7 +65,7 @@ const variantStyles = {
     backgroundColor: '#0E0E0E',
     color: '#FFFFFF',
 
-    ':hover': {
+    ':hover:not(:disabled), :focus:not(:disabled)': {
       backgroundColor: '#252525', // three down in the black scale (black[500])
     },
   },
@@ -86,7 +73,7 @@ const variantStyles = {
     backgroundColor: '#644ED7',
     color: '#FFFFFF',
 
-    ':hover': {
+    ':hover:not(:disabled), :focus:not(:disabled)': {
       backgroundColor: '#7B61FF',
     },
   },
@@ -107,10 +94,11 @@ const commonStyles = {
   lineHeight: '16px', // trust the height
   border: 'none',
   borderRadius: '4px',
-  transition: 'background .3s, color .3s',
+  transition: 'background .3s, color .3s, box-shadow .3s',
   textDecoration: 'none',
 
   ':focus': {
+    boxShadow: `0 0 0 1px #AC9CFF`,
     outline: 'none',
   },
   ':active:not(:disabled)': {

--- a/packages/components/src/components/ComboButton/ComboButton.stories.tsx
+++ b/packages/components/src/components/ComboButton/ComboButton.stories.tsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import { Element } from '../Element';
+import { Stack } from '../Stack';
 import { ComboButton } from './ComboButton';
 
 export default {
@@ -7,19 +9,39 @@ export default {
 };
 
 export const BaseVariant = () => (
-  <ComboButton
-    onClick={() => alert('onClick')}
-    options={
-      <>
-        <ComboButton.Item onSelect={() => {}} disabled>
-          Disabled button
-        </ComboButton.Item>
-        <ComboButton.Item onSelect={() => alert('onSelect')}>
-          Enabled button
-        </ComboButton.Item>
-      </>
-    }
-  >
-    Hello
-  </ComboButton>
+  <Element padding={4}>
+    <Stack direction="vertical" gap={4}>
+      <ComboButton
+        onClick={() => alert('onClick')}
+        options={
+          <>
+            <ComboButton.Item onSelect={() => {}} disabled>
+              Disabled button
+            </ComboButton.Item>
+            <ComboButton.Item onSelect={() => alert('onSelect')}>
+              Enabled button
+            </ComboButton.Item>
+          </>
+        }
+      >
+        Primary
+      </ComboButton>
+      <ComboButton
+        onClick={() => alert('onClick')}
+        options={
+          <>
+            <ComboButton.Item onSelect={() => {}} disabled>
+              Disabled button
+            </ComboButton.Item>
+            <ComboButton.Item onSelect={() => alert('onSelect')}>
+              Enabled button
+            </ComboButton.Item>
+          </>
+        }
+        variant="trial"
+      >
+        Trial
+      </ComboButton>
+    </Stack>
+  </Element>
 );

--- a/packages/components/src/components/ComboButton/ComboButton.tsx
+++ b/packages/components/src/components/ComboButton/ComboButton.tsx
@@ -39,6 +39,12 @@ const ComboButton = ({
           lineHeight: 1,
           letterSpacing: '-0.02em',
           flex: fillSpace ? 1 : 'initial',
+          position: 'relative',
+
+          '&:focus': {
+            // Allow box-shadow to appear on the right side.
+            zIndex: 1,
+          },
           ...customStyles,
         }}
         variant={variant}


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?

<!-- Is it a Bug fix, feature, docs update, ... -->

Turns out, some variants  (`light`, `dark` and `trial`) of the `Button` were missing focus states. So I adjusted the background and added the border using the [Design System](https://www.figma.com/file/8BBHbEXBqKclOyarnViclf/Design-System-v2.0?node-id=446-636&t=8gjgf6MN9GHAkQ5x-4) as reference:

<img width="203" alt="Screen Shot 2023-03-08 at 16 59 18" src="https://user-images.githubusercontent.com/24959348/223833505-2bf55660-88f4-4955-ad1b-7ffbd877419c.png">

With the `Button` fixed, it was only a matter of adjusting the `z-index` to make the focus work properly in the `ComboButton`:

https://user-images.githubusercontent.com/24959348/223834684-f681af21-8583-416d-bb57-a83ceab81652.mov

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Open storybook
2. Check `?path=/story/components-button--variants`
3. Check `?path=/story/components-facelift-combobutton--base-variant`

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation (Storybook)
- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
