### PR TITLE
fix: sidebar height when banner is visible

### DIFF
--- a/packages/app/src/app/pages/Dashboard/Sidebar/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Sidebar/index.tsx
@@ -17,7 +17,6 @@ import { WorkspaceSelect } from 'app/components/WorkspaceSelect';
 import { getDaysUntil } from 'app/utils/dateTime';
 import { useWorkspaceAuthorization } from 'app/hooks/useWorkspaceAuthorization';
 import { useWorkspaceSubscription } from 'app/hooks/useWorkspaceSubscription';
-import { SubscriptionStatus } from 'app/graphql/types';
 import { ContextMenu } from './ContextMenu';
 import { DashboardBaseFolder } from '../types';
 import { Position } from '../Components/Selection';
@@ -35,11 +34,13 @@ const DAYS_LEFT_TO_SHOW_UPGRADE_MESSAGE = 5;
 
 interface SidebarProps {
   visible: boolean;
+  hasTopBarBanner?: boolean;
   onSidebarToggle: () => void;
 }
 
 export const Sidebar: React.FC<SidebarProps> = ({
   visible,
+  hasTopBarBanner,
   onSidebarToggle,
 }) => {
   const history = useHistory();
@@ -114,8 +115,6 @@ export const Sidebar: React.FC<SidebarProps> = ({
   const showDaysLeftMessage =
     trialDaysLeft !== null &&
     trialDaysLeft <= DAYS_LEFT_TO_SHOW_UPGRADE_MESSAGE;
-
-  const hasTopBarBanner = subscription?.status === SubscriptionStatus.Unpaid;
 
   return (
     <SidebarContext.Provider value={{ onSidebarToggle, menuState }}>

--- a/packages/app/src/app/pages/Dashboard/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/index.tsx
@@ -172,16 +172,20 @@ export const Dashboard: FunctionComponent = () => {
                 >
                   <Sidebar
                     visible={sidebarVisible}
+                    hasTopBarBanner={hasTopBarBanner}
                     onSidebarToggle={onSidebarToggle}
                   />
                 </Element>
               ) : (
                 <Element
                   id="desktop-sidebar"
-                  css={css({ display: ['none', 'none', 'block'] })}
+                  css={css({
+                    display: ['none', 'none', 'block'],
+                  })}
                 >
                   <Sidebar
                     visible
+                    hasTopBarBanner={hasTopBarBanner}
                     onSidebarToggle={() => {
                       /* do nothing */
                     }}


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

Part of XTD-803.

## What kind of change does this PR introduce?

<!-- Is it a Bug fix, feature, docs update, ... -->

Account for the topbar banner in the sidebar height.

## What is the current behavior?

<!-- You can also link to an open issue here -->

Content at the bottom of the sidebar touches the bounds/is cut off.

![Screen Shot 2023-03-16 at 13 36 21](https://user-images.githubusercontent.com/24959348/225689762-1f065927-f473-4b0c-a9d7-2f6da04ecf23.png)

## What is the new behavior?

<!-- if this is a feature change -->

https://user-images.githubusercontent.com/24959348/225689171-e071ce5e-3e26-4110-aea7-104cc1274bb4.mov

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Testing <!-- We can only merge the PR if this is checked -->
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->

