### PR TITLE
feat(pro): Update upsell links on personal free spaces

### DIFF
--- a/packages/app/src/app/components/CreateSandbox/Import/PrivateRepoFreeTeam.tsx
+++ b/packages/app/src/app/components/CreateSandbox/Import/PrivateRepoFreeTeam.tsx
@@ -10,7 +10,7 @@ import { getEventName } from './utils';
 
 export const PrivateRepoFreeTeam: React.FC = () => {
   const { isEligibleForTrial } = useWorkspaceSubscription();
-  const { isTeamAdmin } = useWorkspaceAuthorization();
+  const { isTeamAdmin, isPersonalSpace } = useWorkspaceAuthorization();
   const { pathname } = useLocation();
   const { modals } = useActions();
 
@@ -19,9 +19,10 @@ export const PrivateRepoFreeTeam: React.FC = () => {
     cancel_path: pathname,
   });
 
-  const ctaUrl =
-    checkoutUrl ??
-    '/docs/learn/introduction/workspace#managing-teams-and-subscriptions';
+  const ctaUrl = isPersonalSpace
+    ? '/pro'
+    : checkoutUrl ??
+      '/docs/learn/introduction/workspace#managing-teams-and-subscriptions';
   const isDashboardLink = ctaUrl.startsWith('/');
 
   return (

--- a/packages/app/src/app/components/StripeMessages/FreeViewOnlyStripe.tsx
+++ b/packages/app/src/app/components/StripeMessages/FreeViewOnlyStripe.tsx
@@ -20,7 +20,7 @@ const LinkButton = styled.button`
 
 export const FreeViewOnlyStripe = () => {
   const { sandboxPrivacyChanged } = useActions().workspace;
-  const { isTeamAdmin } = useWorkspaceAuthorization();
+  const { isPersonalSpace, isTeamAdmin } = useWorkspaceAuthorization();
 
   const changeToPublic = () => {
     sandboxPrivacyChanged({ privacy: 0, source: 'editor-view-only-stripe' });
@@ -34,7 +34,7 @@ export const FreeViewOnlyStripe = () => {
         <LinkButton onClick={changeToPublic}>Make it public</LinkButton> or
         upgrade to <Text weight="bold">PRO</Text>.
       </span>
-      {isTeamAdmin ? (
+      {isPersonalSpace || isTeamAdmin ? (
         <MessageStripe.Action
           as="a"
           href="/pro"

--- a/packages/app/src/app/pages/Dashboard/Components/Repository/stripes.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Repository/stripes.tsx
@@ -18,7 +18,7 @@ const getEventName = (isEligibleForTrial: boolean, isAdmin: boolean) => {
 
 export const PrivateRepoFreeTeam: React.FC = () => {
   const { isEligibleForTrial } = useWorkspaceSubscription();
-  const { isAdmin } = useWorkspaceAuthorization();
+  const { isAdmin, isPersonalSpace } = useWorkspaceAuthorization();
   const { pathname } = useLocation();
 
   const checkoutUrl = useGetCheckoutURL({
@@ -26,9 +26,11 @@ export const PrivateRepoFreeTeam: React.FC = () => {
     cancel_path: pathname,
   });
 
+  const ctaURl = isPersonalSpace ? '/pro' : checkoutUrl;
+
   return (
     <MessageStripe
-      justify={checkoutUrl ? 'space-between' : 'center'}
+      justify={ctaURl ? 'space-between' : 'center'}
       variant="trial"
     >
       This repository is in view mode only. Upgrade your account for unlimited
@@ -38,11 +40,11 @@ export const PrivateRepoFreeTeam: React.FC = () => {
           {...(checkoutUrl.startsWith('/')
             ? {
                 as: RouterLink,
-                to: checkoutUrl,
+                to: ctaURl,
               }
             : {
                 as: 'a',
-                href: checkoutUrl,
+                href: ctaURl,
               })}
           onClick={() => {
             track(getEventName(isEligibleForTrial, isAdmin), {

--- a/packages/app/src/app/pages/common/Modals/LiveSessionRestricted/index.tsx
+++ b/packages/app/src/app/pages/common/Modals/LiveSessionRestricted/index.tsx
@@ -21,7 +21,7 @@ export const LiveSessionRestricted: React.FC = () => {
       currentSandbox: { id },
     },
   } = useAppState();
-  const { isAdmin } = useWorkspaceAuthorization();
+  const { isAdmin, isPersonalSpace } = useWorkspaceAuthorization();
   const { isEligibleForTrial } = useWorkspaceSubscription();
 
   const checkoutUrl = useGetCheckoutURL({
@@ -48,27 +48,33 @@ export const LiveSessionRestricted: React.FC = () => {
           >
             Learn more
           </Button>
-          <Button
-            variant="primary"
-            onClick={() => {
-              if (isEligibleForTrial) {
-                const event = 'Live Session - trial clicked';
-                track(
-                  isAdmin ? event : `${event} - As non-admin`,
-                  EVENT_PARAMS
-                );
-              } else {
-                track('Live Session - upgrade clicked', EVENT_PARAMS);
-              }
+          {isPersonalSpace ? (
+            <Button as="a" href="/pro" variant="primary" autoWidth>
+              Upgrade to Pro
+            </Button>
+          ) : (
+            <Button
+              variant="primary"
+              onClick={() => {
+                if (isEligibleForTrial) {
+                  const event = 'Live Session - trial clicked';
+                  track(
+                    isAdmin ? event : `${event} - As non-admin`,
+                    EVENT_PARAMS
+                  );
+                } else {
+                  track('Live Session - upgrade clicked', EVENT_PARAMS);
+                }
 
-              window.location.href = checkoutUrl;
-            }}
-            autoWidth
-          >
-            <Text>
-              {isEligibleForTrial ? 'Start free trial' : 'Upgrade to Pro'}
-            </Text>
-          </Button>
+                window.location.href = checkoutUrl;
+              }}
+              autoWidth
+            >
+              <Text>
+                {isEligibleForTrial ? 'Start free trial' : 'Upgrade to Pro'}
+              </Text>
+            </Button>
+          )}
         </Stack>
       ) : (
         <Stack direction="vertical" gap={6}>


### PR DESCRIPTION
This PR updates a few links and upgrade CTAs to point to the pro page rather than directly to Stripe, for personal workspaces. This way the users will be made aware that team pro exists too.