### PR TITLE
feat(trial): Mid-trial reminder modal

### DIFF
--- a/packages/app/src/app/graphql/types.ts
+++ b/packages/app/src/app/graphql/types.ts
@@ -2885,6 +2885,15 @@ export type ProjectWithBranchesFragment = { __typename?: 'Project' } & {
   team: Maybe<{ __typename?: 'Team' } & Pick<Team, 'id'>>;
 };
 
+export type TeamLimitsFragment = { __typename?: 'TeamLimits' } & Pick<
+  TeamLimits,
+  | 'maxEditors'
+  | 'maxPrivateProjects'
+  | 'maxPrivateSandboxes'
+  | 'maxPublicProjects'
+  | 'maxPublicSandboxes'
+>;
+
 export type _CreateTeamMutationVariables = Exact<{
   name: Scalars['String'];
 }>;
@@ -3865,6 +3874,17 @@ export type RepositoryByDetailsQueryVariables = Exact<{
 
 export type RepositoryByDetailsQuery = { __typename?: 'RootQueryType' } & {
   project: Maybe<{ __typename?: 'Project' } & ProjectWithBranchesFragment>;
+};
+
+export type LimitsQueryVariables = Exact<{ [key: string]: never }>;
+
+export type LimitsQuery = { __typename?: 'RootQueryType' } & {
+  limits: { __typename?: 'Limits' } & {
+    personalFree: { __typename?: 'TeamLimits' } & TeamLimitsFragment;
+    personalPro: { __typename?: 'TeamLimits' } & TeamLimitsFragment;
+    teamFree: { __typename?: 'TeamLimits' } & TeamLimitsFragment;
+    teamPro: { __typename?: 'TeamLimits' } & TeamLimitsFragment;
+  };
 };
 
 export type RecentNotificationFragment = { __typename?: 'Notification' } & Pick<

--- a/packages/app/src/app/overmind/actions.ts
+++ b/packages/app/src/app/overmind/actions.ts
@@ -260,7 +260,8 @@ type ModalName =
   | 'addMemberToWorkspace'
   | 'legacyPayment'
   | 'selectWorkspaceToUpgrade'
-  | 'selectWorkspaceToStartTrial';
+  | 'selectWorkspaceToStartTrial'
+  | 'midTrial';
 
 export const modalOpened = (
   { state, effects }: Context,

--- a/packages/app/src/app/overmind/effects/gql/dashboard/fragments.ts
+++ b/packages/app/src/app/overmind/effects/gql/dashboard/fragments.ts
@@ -297,3 +297,13 @@ export const projectWithBranchesFragment = gql`
   }
   ${branchFragment}
 `;
+
+export const teamLimitsFragment = gql`
+  fragment teamLimits on TeamLimits {
+    maxEditors
+    maxPrivateProjects
+    maxPrivateSandboxes
+    maxPublicProjects
+    maxPublicSandboxes
+  }
+`;

--- a/packages/app/src/app/overmind/effects/gql/dashboard/queries.ts
+++ b/packages/app/src/app/overmind/effects/gql/dashboard/queries.ts
@@ -53,6 +53,8 @@ import {
   RepositoriesByTeamQueryVariables,
   RepositoryByDetailsQuery,
   RepositoryByDetailsQueryVariables,
+  LimitsQuery,
+  LimitsQueryVariables,
 } from 'app/graphql/types';
 import { gql, Query } from 'overmind-graphql';
 
@@ -67,6 +69,7 @@ import {
   branchFragment,
   projectFragment,
   projectWithBranchesFragment,
+  teamLimitsFragment,
 } from './fragments';
 
 export const deletedPersonalSandboxes: Query<
@@ -537,4 +540,24 @@ export const getRepositoryByDetails: Query<
   }
   ${projectWithBranchesFragment}
   ${branchFragment}
+`;
+
+export const getLimits: Query<LimitsQuery, LimitsQueryVariables> = gql`
+  query Limits {
+    limits {
+      personalFree {
+        ...teamLimits
+      }
+      personalPro {
+        ...teamLimits
+      }
+      teamFree {
+        ...teamLimits
+      }
+      teamPro {
+        ...teamLimits
+      }
+    }
+  }
+  ${teamLimitsFragment}
 `;

--- a/packages/app/src/app/overmind/namespaces/dashboard/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/dashboard/actions.ts
@@ -2366,3 +2366,13 @@ export const createDraftBranch = async (
     });
   }
 };
+
+export const getLimits = async ({ state, effects }: Context) => {
+  const { limits } = await effects.gql.queries.getLimits({});
+
+  if (!limits) {
+    return;
+  }
+
+  state.dashboard.limits = limits;
+};

--- a/packages/app/src/app/overmind/namespaces/dashboard/state.ts
+++ b/packages/app/src/app/overmind/namespaces/dashboard/state.ts
@@ -7,6 +7,7 @@ import {
   BranchFragment as Branch,
   ProjectFragment as Repository,
   ProjectWithBranchesFragment as RepositoryWithBranches,
+  Limits,
 } from 'app/graphql/types';
 import { DashboardAlbum } from 'app/pages/Dashboard/types';
 import isSameWeek from 'date-fns/isSameWeek';
@@ -96,6 +97,12 @@ export type State = {
   removingRepository: { owner: string; name: string } | null;
   removingBranch: { id: string } | null;
   creatingBranch: boolean;
+
+  /**
+   * General limits for different types of subscription. Not related to any
+   * current user or team.
+   */
+  limits?: Limits;
 };
 
 export const DEFAULT_DASHBOARD_SANDBOXES: DashboardSandboxStructure = {

--- a/packages/app/src/app/pages/Dashboard/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/index.tsx
@@ -39,7 +39,7 @@ const GlobalStyles = createGlobalStyle({
 
 // TODO: Move this page to v2 (also, this is a random commit to trigger the re-run of the build)
 export const Dashboard: FunctionComponent = () => {
-  const { hasLogIn, activeTeamInfo } = useAppState();
+  const { hasLogIn, activeTeamInfo, activeTeam } = useAppState();
   const { browser, notificationToast } = useEffects();
   const actions = useActions();
   const {
@@ -53,7 +53,7 @@ export const Dashboard: FunctionComponent = () => {
     dismissTrialWithoutPaymentInfoBanner,
   ] = useShowBanner();
   const [isMidTrialReminderDismissed] = useDismissible(
-    'DASHBOARD_MID_TRIAL_REMINDER'
+    `DASHBOARD_MID_TRIAL_REMINDER_${activeTeam}`
   );
   const { isTeamAdmin } = useWorkspaceAuthorization();
 

--- a/packages/app/src/app/pages/Dashboard/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/index.tsx
@@ -22,6 +22,7 @@ import {
 } from 'app/components/StripeMessages';
 import { useShowBanner } from 'app/components/StripeMessages/TrialWithoutPaymentInfo';
 import { useWorkspaceSubscription } from 'app/hooks/useWorkspaceSubscription';
+import { useWorkspaceAuthorization } from 'app/hooks/useWorkspaceAuthorization';
 import { useDashboardVisit } from 'app/hooks/useDashboardVisit';
 import { SubscriptionStatus } from 'app/graphql/types';
 import { useDismissible } from 'app/hooks';
@@ -54,6 +55,7 @@ export const Dashboard: FunctionComponent = () => {
   const [isMidTrialReminderDismissed] = useDismissible(
     'DASHBOARD_MID_TRIAL_REMINDER'
   );
+  const { isTeamAdmin } = useWorkspaceAuthorization();
 
   // only used for mobile
   const [sidebarVisible, setSidebarVisibility] = React.useState(false);
@@ -140,6 +142,7 @@ export const Dashboard: FunctionComponent = () => {
 
   useEffect(() => {
     if (
+      isTeamAdmin &&
       hasActiveTeamTrial &&
       hasPaymentMethod === false &&
       subscription.trialEnd &&
@@ -158,6 +161,7 @@ export const Dashboard: FunctionComponent = () => {
       }
     }
   }, [
+    isTeamAdmin,
     actions,
     hasActiveTeamTrial,
     hasPaymentMethod,

--- a/packages/app/src/app/pages/Dashboard/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/index.tsx
@@ -150,10 +150,6 @@ export const Dashboard: FunctionComponent = () => {
     ) {
       const today = startOfToday();
       const trialEndDate = new Date(subscription.trialEnd);
-
-      // const testValue = '2023-03-27T15:00:18.000000Z';
-      // const trialEndDate = new Date(testValue);
-
       const remainingTrialDays = differenceInDays(trialEndDate, today);
 
       if (remainingTrialDays <= 7) {

--- a/packages/app/src/app/pages/common/Modals/MidTrialModal/index.tsx
+++ b/packages/app/src/app/pages/common/Modals/MidTrialModal/index.tsx
@@ -83,7 +83,10 @@ export const MidTrialModal = () => {
           >
             {remainingTrialDays === 7
               ? 'One week'
-              : `${remainingTrialDays} days`}{' '}
+              : `${remainingTrialDays} ${pluralize({
+                  word: 'day',
+                  count: remainingTrialDays,
+                })}`}{' '}
             left on your trial.
           </Text>
           <Text as="p" size={19} color="#C2C2C2" align="center">

--- a/packages/app/src/app/pages/common/Modals/MidTrialModal/index.tsx
+++ b/packages/app/src/app/pages/common/Modals/MidTrialModal/index.tsx
@@ -20,6 +20,7 @@ import { useWorkspaceSubscription } from 'app/hooks/useWorkspaceSubscription';
 
 export const MidTrialModal = () => {
   const { modalClosed } = useActions();
+  const { activeTeam } = useAppState();
   const { pathname } = useLocation();
   const [
     experimentValue,
@@ -27,7 +28,7 @@ export const MidTrialModal = () => {
   ] = useState<ExperimentValues | null>(null);
   const experimentPromise = useExperimentResult('mid-trial-modal');
   const [, dismissMidTrialReminder] = useDismissible(
-    'DASHBOARD_MID_TRIAL_REMINDER'
+    `DASHBOARD_MID_TRIAL_REMINDER_${activeTeam}`
   );
   const { subscription } = useWorkspaceSubscription();
 

--- a/packages/app/src/app/pages/common/Modals/MidTrialModal/index.tsx
+++ b/packages/app/src/app/pages/common/Modals/MidTrialModal/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 
 import {
@@ -8,8 +8,10 @@ import {
   Badge,
   Button,
   IconButton,
+  SkeletonText,
 } from '@codesandbox/components';
 import track from '@codesandbox/common/lib/utils/analytics';
+import { ExperimentValues, useExperimentResult } from '@codesandbox/ab';
 
 import { useGetCheckoutURL } from 'app/hooks';
 import { useActions, useAppState } from 'app/overmind';
@@ -18,6 +20,17 @@ export const MidTrialModal = () => {
   const { dashboard: dashboardState } = useAppState();
   const { dashboard: dashboardActions, modalClosed } = useActions();
   const { pathname } = useLocation();
+  const [
+    experimentValue,
+    setExperimentValue,
+  ] = useState<ExperimentValues | null>(null);
+  const experimentPromise = useExperimentResult('mid-trial-modal');
+
+  useEffect(() => {
+    experimentPromise.then(experiment => {
+      setExperimentValue(experiment);
+    });
+  }, [experimentPromise]);
 
   const checkoutUrl = useGetCheckoutURL({
     success_path: pathname,
@@ -68,8 +81,20 @@ export const MidTrialModal = () => {
           </Text>
         </Stack>
 
-        {/* <LoseAfterTrial /> */}
-        <KeepWithTrial />
+        {!experimentValue ? (
+          <Stack direction="vertical" gap={4}>
+            <SkeletonText />
+            <SkeletonText />
+            <SkeletonText />
+            <SkeletonText />
+            <SkeletonText />
+            <SkeletonText />
+            <SkeletonText />
+          </Stack>
+        ) : null}
+
+        {experimentValue === ExperimentValues.A ? <LoseAfterTrial /> : null}
+        {experimentValue === ExperimentValues.B ? <KeepWithTrial /> : null}
       </Stack>
       <Stack gap={4} justify="space-between">
         <Element css={{ flexGrow: 1 }}>

--- a/packages/app/src/app/pages/common/Modals/MidTrialModal/index.tsx
+++ b/packages/app/src/app/pages/common/Modals/MidTrialModal/index.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
+import { differenceInDays, startOfToday } from 'date-fns';
 
 import {
   Text,
@@ -15,6 +16,7 @@ import { ExperimentValues, useExperimentResult } from '@codesandbox/ab';
 
 import { useDismissible, useGetCheckoutURL } from 'app/hooks';
 import { useActions, useAppState } from 'app/overmind';
+import { useWorkspaceSubscription } from 'app/hooks/useWorkspaceSubscription';
 
 export const MidTrialModal = () => {
   const { modalClosed } = useActions();
@@ -27,6 +29,11 @@ export const MidTrialModal = () => {
   const [, dismissMidTrialReminder] = useDismissible(
     'DASHBOARD_MID_TRIAL_REMINDER'
   );
+  const { subscription } = useWorkspaceSubscription();
+
+  const today = startOfToday();
+  const trialEndDate = new Date(subscription.trialEnd);
+  const remainingTrialDays = differenceInDays(trialEndDate, today);
 
   useEffect(() => {
     experimentPromise.then(experiment => {
@@ -73,7 +80,10 @@ export const MidTrialModal = () => {
             css={{ marginTop: 0 }}
             fontFamily="everett"
           >
-            One week left on your trial.
+            {remainingTrialDays === 7
+              ? 'One week'
+              : `${remainingTrialDays} days`}{' '}
+            left on your trial.
           </Text>
           <Text as="p" size={19} color="#C2C2C2" align="center">
             {!experimentValue ? <SkeletonText /> : null}

--- a/packages/app/src/app/pages/common/Modals/MidTrialModal/index.tsx
+++ b/packages/app/src/app/pages/common/Modals/MidTrialModal/index.tsx
@@ -17,8 +17,7 @@ import { useDismissible, useGetCheckoutURL } from 'app/hooks';
 import { useActions, useAppState } from 'app/overmind';
 
 export const MidTrialModal = () => {
-  const { dashboard: dashboardState } = useAppState();
-  const { dashboard: dashboardActions, modalClosed } = useActions();
+  const { modalClosed } = useActions();
   const { pathname } = useLocation();
   const [
     experimentValue,
@@ -39,11 +38,6 @@ export const MidTrialModal = () => {
     success_path: pathname,
     cancel_path: pathname,
   });
-
-  if (!dashboardState.limits) {
-    // TODO we do this statically in subscriptioncancellation
-    dashboardActions.getLimits();
-  }
 
   const handleClose = () => {
     track('Mid trial reminder: close modal', {

--- a/packages/app/src/app/pages/common/Modals/MidTrialModal/index.tsx
+++ b/packages/app/src/app/pages/common/Modals/MidTrialModal/index.tsx
@@ -1,0 +1,260 @@
+import React from 'react';
+import { useLocation } from 'react-router-dom';
+
+import {
+  Text,
+  Stack,
+  Element,
+  Badge,
+  Button,
+  IconButton,
+} from '@codesandbox/components';
+import track from '@codesandbox/common/lib/utils/analytics';
+
+import { useGetCheckoutURL } from 'app/hooks';
+import { useActions, useAppState } from 'app/overmind';
+
+export const MidTrialModal = () => {
+  const { dashboard: dashboardState } = useAppState();
+  const { dashboard: dashboardActions, modalClosed } = useActions();
+  const { pathname } = useLocation();
+
+  const checkoutUrl = useGetCheckoutURL({
+    success_path: pathname,
+    cancel_path: pathname,
+  });
+
+  if (!dashboardState.limits) {
+    // TODO we do this statically in subscriptioncancellation
+    dashboardActions.getLimits();
+  }
+
+  const handleClose = () => {
+    track('Mid trial reminder: close modal', {
+      codesandbox: 'V1',
+      event_source: 'UI',
+    });
+
+    modalClosed();
+  };
+
+  const trackUpgrade = () => {
+    track('Mid trial reminder: upgrade to pro', {
+      codesandbox: 'V1',
+      event_source: 'UI',
+    });
+  };
+
+  return (
+    <Stack css={{ padding: '24px' }} direction="vertical" gap={12}>
+      <Stack justify="flex-end">
+        <IconButton name="cross" title="Close" onClick={handleClose} />
+      </Stack>
+      <Stack direction="vertical" gap={6} css={{ textAlign: 'center' }}>
+        <Stack direction="vertical" gap={1}>
+          <Text
+            as="h2"
+            size={32}
+            color="#FFFFFF"
+            align="center"
+            css={{ marginTop: 0 }}
+            fontFamily="everett"
+          >
+            One week left on your trial.
+          </Text>
+          <Text as="p" size={19} color="#C2C2C2" align="center">
+            You will lose access to all Pro features when your trial expires.
+            {/* You will need a Team Pro subscription to continue using Pro features. */}
+          </Text>
+        </Stack>
+
+        {/* <LoseAfterTrial /> */}
+        <KeepWithTrial />
+      </Stack>
+      <Stack gap={4} justify="space-between">
+        <Element css={{ flexGrow: 1 }}>
+          <Button onClick={handleClose} variant="secondary">
+            Continue trial
+          </Button>
+        </Element>
+        <Element css={{ flexGrow: 1 }}>
+          <Button
+            as="a"
+            href={checkoutUrl}
+            onClick={trackUpgrade}
+            variant="primary"
+          >
+            Upgrade to pro
+          </Button>
+        </Element>
+      </Stack>
+    </Stack>
+  );
+};
+
+// Based on FEATURES in SubscriptionCancellation.tsx, they're just in a different
+// order.
+const LOSE_DEFAULT = [
+  {
+    key: 'editors',
+    pro: 'Up to 20 editors',
+    free: 'Limited to 5 editors',
+  },
+  {
+    key: 'sandboxes',
+    pro: 'Unlimited private sandboxes',
+    free: 'Limited to 20 public sandboxes',
+  },
+  {
+    key: 'repos',
+    pro: 'Unlimited private repositories',
+    free: 'Limited to 3 public repositories',
+  },
+  {
+    key: 'npm',
+    pro: 'Private NPM packages',
+    free: 'Limited to public NPM packages',
+  },
+  {
+    key: 'live',
+    pro: 'Live sessions',
+    free: 'No ability to go live',
+  },
+  {
+    key: 'ram',
+    pro: '6GB RAM',
+    free: '2GB RAM',
+    pill: '-66% capacity',
+  },
+  {
+    key: 'cpu',
+    pro: '4 vCPUs',
+    free: '2 vCPUs',
+    pill: '-2 vCPUs',
+  },
+  {
+    key: 'disk',
+    pro: '12GB Disk',
+    free: '6GB Disk',
+    pill: '-50% storage',
+  },
+];
+
+const LoseAfterTrial = () => {
+  const { activeTeamInfo } = useAppState();
+  const usage = activeTeamInfo?.usage;
+
+  return (
+    <Stack direction="vertical" gap={4}>
+      {LOSE_DEFAULT.map(feature => {
+        let lostFeature = feature.pro;
+        let pillValue = feature.pill;
+
+        if (feature.key === 'editors' && usage?.editorsQuantity > 5) {
+          const lostAmount = usage?.editorsQuantity - 5;
+
+          lostFeature = `${usage?.editorsQuantity} editors`;
+          pillValue = `-${lostAmount} editor seat${lostAmount > 1 ? 's' : ''}`;
+        }
+
+        if (
+          feature.key === 'sandboxes' &&
+          usage?.privateSandboxesQuantity > 0
+        ) {
+          pillValue = `${usage?.privateSandboxesQuantity} restricted`;
+        }
+
+        if (feature.key === 'repos' && usage?.privateProjectsQuantity > 3) {
+          pillValue = `${usage?.privateProjectsQuantity} restricted`;
+        }
+
+        return (
+          <div key={feature.key}>
+            <Text
+              size={16}
+              color="#999999"
+              lineHeight="24px"
+              css={{ textDecoration: 'line-through' }}
+            >
+              {lostFeature}
+            </Text>
+            <Stack align="center" gap={3} justify="center">
+              <Text size={16} color="#FFFFFF" lineHeight="24px">
+                {feature.free}
+              </Text>
+              {pillValue ? <Badge variant="error">{pillValue}</Badge> : null}
+            </Stack>
+          </div>
+        );
+      })}
+    </Stack>
+  );
+};
+
+const KEEP_DEFAULT = [
+  {
+    key: 'editors',
+    pro: 'Up to 20 editors',
+  },
+  {
+    key: 'sandboxes',
+    pro: 'Unlimited private sandboxes',
+  },
+  {
+    key: 'repos',
+    pro: 'Unlimited private repositories',
+  },
+  {
+    key: 'npm',
+    pro: 'Private NPM packages',
+  },
+  {
+    key: 'live',
+    pro: 'Live sessions',
+  },
+  {
+    key: 'ram',
+    pro: '6GB RAM',
+    pill: '3x capacity',
+  },
+  {
+    key: 'cpu',
+    pro: '4 vCPUs',
+    pill: '2x faster',
+  },
+  {
+    key: 'disk',
+    pro: '12GB Disk',
+    pill: '2x storage',
+  },
+];
+
+const KeepWithTrial = () => {
+  const { activeTeamInfo } = useAppState();
+  const usage = activeTeamInfo?.usage;
+
+  return (
+    <Stack direction="vertical" gap={4}>
+      {KEEP_DEFAULT.map(feature => {
+        let keepFeature = feature.pro;
+
+        if (feature.key === 'editors' && usage?.editorsQuantity > 5) {
+          keepFeature = `${usage?.editorsQuantity} editors`;
+        }
+
+        return (
+          <Stack key={feature.key} align="center" gap={3} justify="center">
+            <Text size={16} color="#FFFFFF" lineHeight="24px">
+              {keepFeature}
+            </Text>
+            {feature.pill ? (
+              <Text color="#0E0E0E">
+                <Badge variant="highlight">{feature.pill}</Badge>
+              </Text>
+            ) : null}
+          </Stack>
+        );
+      })}
+    </Stack>
+  );
+};

--- a/packages/app/src/app/pages/common/Modals/MidTrialModal/index.tsx
+++ b/packages/app/src/app/pages/common/Modals/MidTrialModal/index.tsx
@@ -17,6 +17,7 @@ import { ExperimentValues, useExperimentResult } from '@codesandbox/ab';
 import { useDismissible, useGetCheckoutURL } from 'app/hooks';
 import { useActions, useAppState } from 'app/overmind';
 import { useWorkspaceSubscription } from 'app/hooks/useWorkspaceSubscription';
+import { pluralize } from 'app/utils/pluralize';
 
 export const MidTrialModal = () => {
   const { modalClosed } = useActions();

--- a/packages/app/src/app/pages/common/Modals/MidTrialModal/index.tsx
+++ b/packages/app/src/app/pages/common/Modals/MidTrialModal/index.tsx
@@ -58,12 +58,12 @@ export const MidTrialModal = () => {
   };
 
   const handleUpgrade = () => {
-    dismissMidTrialReminder();
-
     track('Mid trial reminder: upgrade to pro', {
       codesandbox: 'V1',
       event_source: 'UI',
     });
+
+    dismissMidTrialReminder();
   };
 
   return (

--- a/packages/app/src/app/pages/common/Modals/index.tsx
+++ b/packages/app/src/app/pages/common/Modals/index.tsx
@@ -51,6 +51,7 @@ import { CropThumbnail } from './CropThumbnail';
 import { SubscriptionCancellationModal } from './SubscriptionCancellation';
 import { SelectWorkspaceToUpgrade } from './SelectWorkspaceToUpgrade';
 import { SelectWorkspaceToStartTrial } from './SelectWorkspaceToStartTrial';
+import { MidTrialModal } from './MidTrialModal';
 
 const modals = {
   preferences: {
@@ -217,6 +218,10 @@ const modals = {
   selectWorkspaceToStartTrial: {
     Component: SelectWorkspaceToStartTrial,
     width: 400,
+  },
+  midTrial: {
+    Component: MidTrialModal,
+    width: 600,
   },
 };
 

--- a/packages/components/src/components/Badge/index.tsx
+++ b/packages/components/src/components/Badge/index.tsx
@@ -4,9 +4,8 @@ import { Stack } from '../Stack';
 import { Text } from '../Text';
 
 export interface BadgeProps {
-  variant?: 'trial' | 'neutral' | 'warning' | 'highlight';
+  variant?: 'trial' | 'neutral' | 'warning' | 'highlight' | 'error';
   icon?: IconNames;
-  isPadded?: boolean;
 }
 
 const BG_MAP: Record<BadgeProps['variant'], string> = {
@@ -14,6 +13,7 @@ const BG_MAP: Record<BadgeProps['variant'], string> = {
   neutral: '#2e2e2e',
   warning: 'rgba(255, 255, 255, 0.06)',
   highlight: '#edffa5',
+  error: '#EF7A7A',
 };
 
 const COLOR_MAP: Record<BadgeProps['variant'], string> = {
@@ -21,6 +21,7 @@ const COLOR_MAP: Record<BadgeProps['variant'], string> = {
   neutral: 'inherit',
   warning: '#ef7a7a',
   highlight: 'inherit',
+  error: '#0E0E0E',
 };
 
 export const Badge: React.FC<BadgeProps> = ({


### PR DESCRIPTION
Added a modal with an AB test that shows up mid-trial. The modal shows up when:

- the active user is admin
- the workspace is in an active trial
- the workspace has no payment method specified
- the days left in the trial are equal to 7 or smaller
- the mid-trial modal hasn't been dismissed before

## Screenshots

### Keep with pro

Note: the title says 14 days left because I had to force the modal to show up.

<img width="1624" alt="image" src="https://user-images.githubusercontent.com/7533849/226406293-655298c6-6884-4d96-a90a-63fab61dac84.png">

### Lose after trial

Note: the title says 14 days left because I had to force the modal to show up.

<img width="1624" alt="image" src="https://user-images.githubusercontent.com/7533849/226406392-21788bb9-05fb-4f73-9811-014de55eb47e.png">
