### PR TITLE
style(dashboard): remove fake button to upload team image at the create team flow

### DIFF
--- a/packages/app/src/app/pages/Dashboard/Components/NewTeamModal/TeamInfo.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/NewTeamModal/TeamInfo.tsx
@@ -70,16 +70,6 @@ export const TeamInfo: React.FC<{ onComplete: () => void }> = ({
         width: '100%',
       }}
     >
-      <Element
-        css={{ backgroundColor: '#252525', borderRadius: '4px' }}
-        padding={6}
-      >
-        <Icon
-          name="camera"
-          size={16}
-          css={{ color: '#C2C2C2', display: 'block' }}
-        />
-      </Element>
       <Stack align="center" direction="vertical" gap={2}>
         <Text
           as="h2"


### PR DESCRIPTION
This image makes the user to think that there is functionality to upload an image. While the feature is not implemented, it makes no sense to keep this "fake button".

Old:
<img width="826" alt="image" src="https://user-images.githubusercontent.com/2926010/226449160-fc6f3e16-a396-4528-8b1d-09b44dfc2b28.png">



New:
<img width="852" alt="image" src="https://user-images.githubusercontent.com/2926010/226449252-e6b56d3f-a7b9-480d-b88c-3b69bdb7e8e1.png">
