### PR TITLE
fix(trial): Create customer portal instead of checkout url and combine components

### DIFF
--- a/packages/app/src/app/components/LoseFeatures/LoseFeatures.tsx
+++ b/packages/app/src/app/components/LoseFeatures/LoseFeatures.tsx
@@ -1,0 +1,101 @@
+import React from 'react';
+
+import { Stack, Badge, Text } from '@codesandbox/components';
+import { useAppState } from 'app/overmind';
+
+const LOSE_DEFAULT = [
+  {
+    key: 'editors',
+    pro: 'Up to 20 editors',
+    free: 'Limited to 5 editors',
+  },
+  {
+    key: 'sandboxes',
+    pro: 'Unlimited private sandboxes',
+    free: 'Limited to 20 public sandboxes',
+  },
+  {
+    key: 'repos',
+    pro: 'Unlimited private repositories',
+    free: 'Limited to 3 public repositories',
+  },
+  {
+    key: 'npm',
+    pro: 'Private NPM packages',
+    free: 'Limited to public NPM packages',
+  },
+  {
+    key: 'live',
+    pro: 'Live sessions',
+    free: 'No ability to go live',
+  },
+  {
+    key: 'ram',
+    pro: '6GB RAM',
+    free: '2GB RAM',
+    pill: '-66% capacity',
+  },
+  {
+    key: 'cpu',
+    pro: '4 vCPUs',
+    free: '2 vCPUs',
+    pill: '-2 vCPUs',
+  },
+  {
+    key: 'disk',
+    pro: '12GB Disk',
+    free: '6GB Disk',
+    pill: '-50% storage',
+  },
+];
+
+export const LoseFeatures = () => {
+  const { activeTeamInfo } = useAppState();
+  const usage = activeTeamInfo?.usage;
+
+  return (
+    <Stack direction="vertical" gap={4}>
+      {LOSE_DEFAULT.map(feature => {
+        let lostFeature = feature.pro;
+        let pillValue = feature.pill;
+
+        if (feature.key === 'editors' && usage?.editorsQuantity > 5) {
+          const lostAmount = usage?.editorsQuantity - 5;
+
+          lostFeature = `${usage?.editorsQuantity} editors`;
+          pillValue = `-${lostAmount} editor seat${lostAmount > 1 ? 's' : ''}`;
+        }
+
+        if (
+          feature.key === 'sandboxes' &&
+          usage?.privateSandboxesQuantity > 0
+        ) {
+          pillValue = `${usage?.privateSandboxesQuantity} restricted`;
+        }
+
+        if (feature.key === 'repos' && usage?.privateProjectsQuantity > 3) {
+          pillValue = `${usage?.privateProjectsQuantity} restricted`;
+        }
+
+        return (
+          <div key={feature.key}>
+            <Text
+              size={16}
+              color="#999999"
+              lineHeight="24px"
+              css={{ textDecoration: 'line-through' }}
+            >
+              {lostFeature}
+            </Text>
+            <Stack align="center" gap={3} justify="center">
+              <Text size={16} color="#FFFFFF" lineHeight="24px">
+                {feature.free}
+              </Text>
+              {pillValue ? <Badge variant="warning">{pillValue}</Badge> : null}
+            </Stack>
+          </div>
+        );
+      })}
+    </Stack>
+  );
+};

--- a/packages/app/src/app/pages/common/Modals/MidTrialModal/index.tsx
+++ b/packages/app/src/app/pages/common/Modals/MidTrialModal/index.tsx
@@ -90,7 +90,14 @@ export const MidTrialModal = () => {
                 })}`}{' '}
             left on your trial.
           </Text>
-          <Text as="p" size={19} color="#C2C2C2" align="center">
+          <Text
+            as="p"
+            size={19}
+            color="#C2C2C2"
+            align="center"
+            lineHeight="28px"
+            css={{ margin: 0 }}
+          >
             {!experimentValue ? <SkeletonText /> : null}
 
             {experimentValue === ExperimentValues.A
@@ -228,7 +235,7 @@ const LoseAfterTrial = () => {
               <Text size={16} color="#FFFFFF" lineHeight="24px">
                 {feature.free}
               </Text>
-              {pillValue ? <Badge variant="error">{pillValue}</Badge> : null}
+              {pillValue ? <Badge variant="warning">{pillValue}</Badge> : null}
             </Stack>
           </div>
         );

--- a/packages/app/src/app/pages/common/Modals/MidTrialModal/index.tsx
+++ b/packages/app/src/app/pages/common/Modals/MidTrialModal/index.tsx
@@ -62,7 +62,7 @@ export const MidTrialModal = () => {
       event_source: 'UI',
     });
 
-    // Custom implementation based on useGetCheckoutURL hook because the modal
+    // Custom implementation based on useCreateCustomerPortal hook because the modal
     // needs to be dismissed before redirecting.
     try {
       setLoadingPortal(true);

--- a/packages/app/src/app/pages/common/Modals/MidTrialModal/index.tsx
+++ b/packages/app/src/app/pages/common/Modals/MidTrialModal/index.tsx
@@ -18,6 +18,7 @@ import { useDismissible, useGetCheckoutURL } from 'app/hooks';
 import { useActions, useAppState } from 'app/overmind';
 import { useWorkspaceSubscription } from 'app/hooks/useWorkspaceSubscription';
 import { pluralize } from 'app/utils/pluralize';
+import { LoseFeatures } from 'app/components/LoseFeatures/LoseFeatures';
 
 export const MidTrialModal = () => {
   const { modalClosed } = useActions();
@@ -34,7 +35,7 @@ export const MidTrialModal = () => {
   const { subscription } = useWorkspaceSubscription();
 
   const today = startOfToday();
-  const trialEndDate = new Date(subscription.trialEnd);
+  const trialEndDate = new Date(subscription?.trialEnd);
   const remainingTrialDays = differenceInDays(trialEndDate, today);
 
   useEffect(() => {
@@ -69,44 +70,46 @@ export const MidTrialModal = () => {
 
   return (
     <Stack css={{ padding: '24px' }} direction="vertical" gap={12}>
-      <Stack justify="flex-end">
-        <IconButton name="cross" title="Close" onClick={handleClose} />
-      </Stack>
       <Stack direction="vertical" gap={6} css={{ textAlign: 'center' }}>
-        <Stack direction="vertical" gap={1}>
-          <Text
-            as="h2"
-            size={32}
-            color="#FFFFFF"
-            align="center"
-            css={{ marginTop: 0 }}
-            fontFamily="everett"
-          >
-            {remainingTrialDays === 7
-              ? 'One week'
-              : `${remainingTrialDays} ${pluralize({
-                  word: 'day',
-                  count: remainingTrialDays,
-                })}`}{' '}
-            left on your trial.
-          </Text>
-          <Text
-            as="p"
-            size={19}
-            color="#C2C2C2"
-            align="center"
-            lineHeight="28px"
-            css={{ margin: 0 }}
-          >
-            {!experimentValue ? <SkeletonText /> : null}
+        <Stack direction="vertical" gap={4}>
+          <Stack justify="flex-end">
+            <IconButton name="cross" title="Close" onClick={handleClose} />
+          </Stack>
+          <Stack direction="vertical" gap={1}>
+            <Text
+              as="h2"
+              size={32}
+              color="#FFFFFF"
+              align="center"
+              css={{ marginTop: 0 }}
+              fontFamily="everett"
+            >
+              {remainingTrialDays === 7
+                ? 'One week'
+                : `${remainingTrialDays} ${pluralize({
+                    word: 'day',
+                    count: remainingTrialDays,
+                  })}`}{' '}
+              left on your trial.
+            </Text>
+            <Text
+              as="p"
+              size={19}
+              color="#C2C2C2"
+              align="center"
+              lineHeight="28px"
+              css={{ margin: 0 }}
+            >
+              {!experimentValue ? <SkeletonText /> : null}
 
-            {experimentValue === ExperimentValues.A
-              ? 'You will lose access to all Pro features when your trial expires.'
-              : null}
-            {experimentValue === ExperimentValues.B
-              ? 'You will need a Team Pro subscription to continue using Pro features.'
-              : null}
-          </Text>
+              {experimentValue === ExperimentValues.A
+                ? 'You will lose access to all Pro features when your trial expires.'
+                : null}
+              {experimentValue === ExperimentValues.B
+                ? 'You will need a Team Pro subscription to continue using Pro features.'
+                : null}
+            </Text>
+          </Stack>
         </Stack>
 
         {!experimentValue ? (
@@ -121,7 +124,7 @@ export const MidTrialModal = () => {
           </Stack>
         ) : null}
 
-        {experimentValue === ExperimentValues.A ? <LoseAfterTrial /> : null}
+        {experimentValue === ExperimentValues.A ? <LoseFeatures /> : null}
         {experimentValue === ExperimentValues.B ? <KeepWithTrial /> : null}
       </Stack>
       <Stack gap={4} justify="space-between">
@@ -141,105 +144,6 @@ export const MidTrialModal = () => {
           </Button>
         </Element>
       </Stack>
-    </Stack>
-  );
-};
-
-// Based on FEATURES in SubscriptionCancellation.tsx, they're just in a different
-// order.
-const LOSE_DEFAULT = [
-  {
-    key: 'editors',
-    pro: 'Up to 20 editors',
-    free: 'Limited to 5 editors',
-  },
-  {
-    key: 'sandboxes',
-    pro: 'Unlimited private sandboxes',
-    free: 'Limited to 20 public sandboxes',
-  },
-  {
-    key: 'repos',
-    pro: 'Unlimited private repositories',
-    free: 'Limited to 3 public repositories',
-  },
-  {
-    key: 'npm',
-    pro: 'Private NPM packages',
-    free: 'Limited to public NPM packages',
-  },
-  {
-    key: 'live',
-    pro: 'Live sessions',
-    free: 'No ability to go live',
-  },
-  {
-    key: 'ram',
-    pro: '6GB RAM',
-    free: '2GB RAM',
-    pill: '-66% capacity',
-  },
-  {
-    key: 'cpu',
-    pro: '4 vCPUs',
-    free: '2 vCPUs',
-    pill: '-2 vCPUs',
-  },
-  {
-    key: 'disk',
-    pro: '12GB Disk',
-    free: '6GB Disk',
-    pill: '-50% storage',
-  },
-];
-
-const LoseAfterTrial = () => {
-  const { activeTeamInfo } = useAppState();
-  const usage = activeTeamInfo?.usage;
-
-  return (
-    <Stack direction="vertical" gap={4}>
-      {LOSE_DEFAULT.map(feature => {
-        let lostFeature = feature.pro;
-        let pillValue = feature.pill;
-
-        if (feature.key === 'editors' && usage?.editorsQuantity > 5) {
-          const lostAmount = usage?.editorsQuantity - 5;
-
-          lostFeature = `${usage?.editorsQuantity} editors`;
-          pillValue = `-${lostAmount} editor seat${lostAmount > 1 ? 's' : ''}`;
-        }
-
-        if (
-          feature.key === 'sandboxes' &&
-          usage?.privateSandboxesQuantity > 0
-        ) {
-          pillValue = `${usage?.privateSandboxesQuantity} restricted`;
-        }
-
-        if (feature.key === 'repos' && usage?.privateProjectsQuantity > 3) {
-          pillValue = `${usage?.privateProjectsQuantity} restricted`;
-        }
-
-        return (
-          <div key={feature.key}>
-            <Text
-              size={16}
-              color="#999999"
-              lineHeight="24px"
-              css={{ textDecoration: 'line-through' }}
-            >
-              {lostFeature}
-            </Text>
-            <Stack align="center" gap={3} justify="center">
-              <Text size={16} color="#FFFFFF" lineHeight="24px">
-                {feature.free}
-              </Text>
-              {pillValue ? <Badge variant="warning">{pillValue}</Badge> : null}
-            </Stack>
-          </div>
-        );
-      })}
     </Stack>
   );
 };

--- a/packages/app/src/app/pages/common/Modals/SubscriptionCancellation/SubscriptionCancellation.tsx
+++ b/packages/app/src/app/pages/common/Modals/SubscriptionCancellation/SubscriptionCancellation.tsx
@@ -1,71 +1,16 @@
 import track from '@codesandbox/common/lib/utils/analytics';
 import {
-  Badge,
+  Element,
   Button,
   IconButton,
   Stack,
   Text,
 } from '@codesandbox/components';
-import { TEAM_FREE_LIMITS } from 'app/constants';
+import { LoseFeatures } from 'app/components/LoseFeatures/LoseFeatures';
 import { useCreateCustomerPortal } from 'app/hooks/useCreateCustomerPortal';
 import { useWorkspaceSubscription } from 'app/hooks/useWorkspaceSubscription';
 import { useActions, useAppState } from 'app/overmind';
-import { pluralize } from 'app/utils/pluralize';
 import React from 'react';
-
-type FeatureComp = {
-  key: string;
-  free: string;
-  pro: string;
-  pill?: string;
-};
-const FEATURES: FeatureComp[] = [
-  {
-    key: 'sandboxes',
-    pro: 'Unlimited private sandboxes',
-    free: 'Limited to 20 public sandboxes',
-  },
-  {
-    key: 'repos',
-    pro: 'Unlimited private repositories',
-    free: 'Limited to 3 public repositories',
-  },
-  {
-    key: 'editors',
-    pro: 'Up to 20 editors',
-    free: 'Limited to 5 editors',
-  },
-  {
-    key: 'npm',
-    pro: 'Private NPM packages',
-    free: 'Limited to public NPM packages',
-  },
-  {
-    key: 'live',
-    pro: 'Live sessions',
-    free: 'No ability to go live',
-  },
-  {
-    key: 'ram',
-    pro: '6GB RAM',
-    free: '2GB RAM',
-    pill: '-66% capacity',
-  },
-  {
-    key: 'cpu',
-    pro: '4 vCPUs',
-    free: '2 vCPUs',
-    pill: '-2 vCPUs',
-  },
-  {
-    key: 'disk',
-    pro: '12GB Disk',
-    free: '6GB Disk',
-    pill: '-50% storage',
-  },
-];
-
-const FEATURES_WITH_DYNAMIC_PILLS = ['editors', 'sandboxes', 'repos'];
 
 export const SubscriptionCancellationModal: React.FC = () => {
   const { activeTeamInfo } = useAppState();
@@ -87,154 +32,67 @@ export const SubscriptionCancellationModal: React.FC = () => {
     modalClosed();
   };
 
-  // TO DO: if we need this info more often, extract
-  // to a custom useWorkspaceUsage similar to
-  // useWorkspaceLimits.
-  const teamUsage = activeTeamInfo?.usage;
-
-  const getEditorsLabel = () => {
-    if (teamUsage && teamUsage.editorsQuantity > TEAM_FREE_LIMITS.editors) {
-      const lostSeats = teamUsage.editorsQuantity - TEAM_FREE_LIMITS.editors;
-      return `-${lostSeats} editor ${pluralize({
-        word: 'seat',
-        count: lostSeats,
-      })}`;
-    }
-
-    return undefined;
-  };
-
-  const getSandboxesLabel = () => {
-    const restrictedSandboxesCount =
-      (teamUsage?.privateProjectsQuantity ?? 0) -
-      TEAM_FREE_LIMITS.private_repos;
-    if (restrictedSandboxesCount > 0) {
-      return `${restrictedSandboxesCount} restricted`;
-    }
-
-    return undefined;
-  };
-
-  const getReposLabel = () => {
-    const restrictedRepositoriesCount =
-      (teamUsage?.privateProjectsQuantity ?? 0) -
-      TEAM_FREE_LIMITS.private_repos;
-    if (restrictedRepositoriesCount > 0) {
-      return `${restrictedRepositoriesCount} restricted`;
-    }
-
-    return undefined;
-  };
-
   return (
-    <Stack
-      css={{
-        position: 'relative',
-        overflow: 'hidden',
-        padding: '24px 32px 32px',
-      }}
-      direction="vertical"
-    >
-      <Stack justify="space-between">
-        <Text
-          as="h1"
-          css={{
-            margin: 0,
-            lineHeight: '28px',
-            letterSpacing: '-0.019em',
-          }}
-          size={19}
-          weight="normal"
-        >
-          You&apos;ll lose access to all Pro features
-        </Text>
-        <IconButton name="cross" title="Close" onClick={handleCloseModal} />
-      </Stack>
-      <Stack
-        as="ul"
-        css={{
-          listStyle: 'none',
-          margin: '24px 0 0',
-          padding: 0,
-        }}
-        direction="vertical"
-        gap={6}
-      >
-        {FEATURES.map(f => {
-          let badge = f.pill;
-          if (FEATURES_WITH_DYNAMIC_PILLS.includes(f.key)) {
-            badge = {
-              editors: getEditorsLabel(),
-              sandboxes: getSandboxesLabel(),
-              repos: getReposLabel(),
-            }[f.key];
-          }
-
-          return (
-            <Stack direction="vertical" key={f.key} gap={1}>
-              <Text
-                css={{
-                  textDecoration: 'line-through',
-                  color: '#999999',
-                }}
-                size={13}
-              >
-                {f.pro}
-              </Text>
-              <Stack align="baseline" gap={3}>
-                <Text size={13}>{f.free}</Text>
-                {badge ? <Badge variant="warning">{badge}</Badge> : null}
-              </Stack>
-            </Stack>
-          );
-        })}
-      </Stack>
-      <Stack
-        css={{
-          flexWrap: 'wrap',
-          marginLeft: 'auto',
-          marginRight: 0,
-          marginTop: '32px',
-        }}
-        gap={6}
-      >
-        <Button onClick={handleCloseModal} variant="link" autoWidth>
-          {hasActiveTeamTrial ? 'Continue trial' : 'Continue subscription'}
-        </Button>
-        {isPaddle ? (
-          <Button
-            css={{ padding: '0 32px' }}
-            loading={paddleLoading}
-            onClick={() => {
-              setPaddeLoading(true);
-              track('Team Settings - confirm paddle cancel subscription', {
-                codesandbox: 'V1',
-                event_source: 'UI',
-              });
-
-              pro.cancelWorkspaceSubscription();
-            }}
-            autoWidth
+    <Stack css={{ padding: '24px' }} direction="vertical" gap={12}>
+      <Stack direction="vertical" gap={6} css={{ textAlign: 'center' }}>
+        <Stack direction="vertical" gap={4}>
+          <Stack justify="flex-end">
+            <IconButton name="cross" title="Close" onClick={handleCloseModal} />
+          </Stack>
+          <Text
+            as="h2"
+            size={32}
+            color="#FFFFFF"
+            align="center"
+            css={{ marginTop: 0 }}
+            fontFamily="everett"
           >
-            I understand
-          </Button>
-        ) : (
-          <Button
-            css={{ padding: '0 32px' }}
-            loading={loadingCustomerPortal}
-            onClick={() => {
-              track('Team Settings: confirm cancellation from modal', {
-                codesandbox: 'V1',
-                event_source: 'UI',
-              });
+            You&apos;ll lose access to all Pro features
+          </Text>
+        </Stack>
+        <LoseFeatures />
+      </Stack>
 
-              createCustomerPortal();
-            }}
-            autoWidth
-          >
-            OK
+      <Stack gap={4} justify="space-between">
+        <Element css={{ flexGrow: 1 }}>
+          <Button onClick={handleCloseModal} variant="secondary">
+            Continue {hasActiveTeamTrial ? 'trial' : 'subscription'}
           </Button>
-        )}
+        </Element>
+        <Element css={{ flexGrow: 1 }}>
+          {isPaddle ? (
+            <Button
+              loading={paddleLoading}
+              onClick={() => {
+                setPaddeLoading(true);
+                track('Team Settings - confirm paddle cancel subscription', {
+                  codesandbox: 'V1',
+                  event_source: 'UI',
+                });
+
+                pro.cancelWorkspaceSubscription();
+              }}
+              variant="primary"
+            >
+              I understand
+            </Button>
+          ) : (
+            <Button
+              loading={loadingCustomerPortal}
+              onClick={() => {
+                track('Team Settings: confirm cancellation from modal', {
+                  codesandbox: 'V1',
+                  event_source: 'UI',
+                });
+
+                createCustomerPortal();
+              }}
+              variant="primary"
+            >
+              Cancel {hasActiveTeamTrial ? 'trial' : 'subscription'}
+            </Button>
+          )}
+        </Element>
       </Stack>
     </Stack>
   );

--- a/packages/app/src/app/pages/common/Modals/index.tsx
+++ b/packages/app/src/app/pages/common/Modals/index.tsx
@@ -209,7 +209,7 @@ const modals = {
   },
   subscriptionCancellation: {
     Component: SubscriptionCancellationModal,
-    width: 444,
+    width: 600,
   },
   selectWorkspaceToUpgrade: {
     Component: SelectWorkspaceToUpgrade,

--- a/packages/components/src/components/Badge/index.tsx
+++ b/packages/components/src/components/Badge/index.tsx
@@ -4,7 +4,7 @@ import { Stack } from '../Stack';
 import { Text } from '../Text';
 
 export interface BadgeProps {
-  variant?: 'trial' | 'neutral' | 'warning' | 'highlight' | 'error';
+  variant?: 'trial' | 'neutral' | 'warning' | 'highlight';
   icon?: IconNames;
 }
 
@@ -13,7 +13,6 @@ const BG_MAP: Record<BadgeProps['variant'], string> = {
   neutral: '#2e2e2e',
   warning: 'rgba(255, 255, 255, 0.06)',
   highlight: '#edffa5',
-  error: '#EF7A7A',
 };
 
 const COLOR_MAP: Record<BadgeProps['variant'], string> = {
@@ -21,7 +20,6 @@ const COLOR_MAP: Record<BadgeProps['variant'], string> = {
   neutral: 'inherit',
   warning: '#ef7a7a',
   highlight: 'inherit',
-  error: '#0E0E0E',
 };
 
 export const Badge: React.FC<BadgeProps> = ({


### PR DESCRIPTION
Combined the mid trial reminder with the cancel subscription modal so they share one style and one component to view the lost benefits.

Note: I've also fixed an **important** bug where we would try and load the checkout url for a team that's currently on trial - which doesn't work. Instead we're now creating a customer portal.

### Mid trial reminder updates
<img width="1624" alt="image" src="https://user-images.githubusercontent.com/7533849/227155624-b4468a53-a15b-460b-812b-553c53911063.png">

### Cancel trial or subscription updates
<img width="1624" alt="image" src="https://user-images.githubusercontent.com/7533849/227155772-7f0da1b0-bf8f-4a9a-b59d-0c8f1c3520f7.png">
