### PR TITLE
fix(import): Check if selectOptions exist before rendering options

### DIFF
--- a/packages/app/src/app/pages/Dashboard/Content/routes/Repositories/EmptyRepositories.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Repositories/EmptyRepositories.tsx
@@ -173,9 +173,9 @@ const Suggested = () => {
     <>
       <Stack gap={2}>
         <Text size={16}>Start by importing from </Text>
-        {githubAccounts.state === 'loading' ? (
-          <SkeletonText />
-        ) : (
+        {githubAccounts.state === 'loading' ? <SkeletonText /> : null}
+
+        {githubAccounts.state === 'ready' && selectedAccount ? (
           <AccountSelect
             options={selectOptions}
             value={selectedAccount}
@@ -188,7 +188,7 @@ const Suggested = () => {
               setSelectedAccount(account);
             }}
           />
-        )}
+        ) : null}
       </Stack>
 
       {githubRepos.state === 'loading' ? (


### PR DESCRIPTION
Fixes #7530
Fixes #7524

And probably fixes #7517 too.
And probably fixes #7516 too.

Just checking for the `githubAccounts.state` wasn't enough as we need to make sure there's actually accounts that can be selected. We do this by checking if `selectedAccount` exists. To check if this actually fixes the issues I've rendered the `AccountSelect` without checks and it crashes and throws exactly the same error.