### PR TITLE
feat(sso): UI

### DIFF
--- a/packages/app/src/app/components/SignInModal.tsx
+++ b/packages/app/src/app/components/SignInModal.tsx
@@ -73,9 +73,7 @@ export const SignInModal = () => {
                   boxShadow: '2',
                 })}
               >
-                <Stack direction="vertical" gap={64}>
-                  <SignIn redirectTo={redirectOnLogin} />
-                </Stack>
+                <SignIn redirectTo={redirectOnLogin} />
               </Element>
             </OutsideClickHandler>
           </Stack>

--- a/packages/app/src/app/components/SignInModal.tsx
+++ b/packages/app/src/app/components/SignInModal.tsx
@@ -74,7 +74,6 @@ export const SignInModal = () => {
                 })}
               >
                 <Stack direction="vertical" gap={64}>
-                  {/* <Element paddingBottom={6}>Welcome</Element> */}
                   <SignIn redirectTo={redirectOnLogin} />
                 </Stack>
               </Element>

--- a/packages/app/src/app/pages/SignIn/ChooseProvider.tsx
+++ b/packages/app/src/app/pages/SignIn/ChooseProvider.tsx
@@ -50,7 +50,7 @@ type SSOSignInProps = {
 };
 const SSOSignIn: React.FC<SSOSignInProps> = ({ changeSignInMode }) => {
   const inputRef = React.useRef<HTMLInputElement>(null);
-  const [validationState] = React.useState<ValidationState>({
+  const [validation] = React.useState<ValidationState>({
     state: 'IDLE',
   });
 
@@ -65,7 +65,7 @@ const SSOSignIn: React.FC<SSOSignInProps> = ({ changeSignInMode }) => {
     async (e: FormEvent<HTMLFormElement>) => {
       e.preventDefault();
     },
-    [validationState]
+    [validation]
   );
 
   return (
@@ -79,7 +79,7 @@ const SSOSignIn: React.FC<SSOSignInProps> = ({ changeSignInMode }) => {
       gap={8}
     >
       <StyledHeading as="h1" id="heading">
-        Sign in with SSO login
+        Sign in with SSO
       </StyledHeading>
       <Stack
         as="form"
@@ -91,7 +91,8 @@ const SSOSignIn: React.FC<SSOSignInProps> = ({ changeSignInMode }) => {
         <Stack direction="vertical" gap={1}>
           <Element css={{ position: 'relative', height: '48px' }}>
             <Input
-              aria-describedby="heading error"
+              aria-labelledby="heading"
+              aria-describedby="error"
               css={{
                 height: '100%',
                 padding: '16px',
@@ -99,7 +100,7 @@ const SSOSignIn: React.FC<SSOSignInProps> = ({ changeSignInMode }) => {
                 // Want the affordances but not the styling.
                 ':disabled': { opacity: 1 },
               }}
-              disabled={validationState.state !== 'IDLE'}
+              disabled={validation.state !== 'IDLE'}
               placeholder="Enter your email"
               ref={inputRef}
               type="email"
@@ -125,12 +126,12 @@ const SSOSignIn: React.FC<SSOSignInProps> = ({ changeSignInMode }) => {
                   INVALID: (
                     <Icon css={{ color: '#ED6C6C' }} name="infoOutline" />
                   ),
-                }[validationState.state]
+                }[validation.state]
               }
             </Element>
           </Element>
           <Element aria-live="polite" id="error">
-            {validationState.state === 'INVALID' ? (
+            {validation.state === 'INVALID' ? (
               <Text
                 css={{
                   fontSize: '12px',
@@ -139,7 +140,7 @@ const SSOSignIn: React.FC<SSOSignInProps> = ({ changeSignInMode }) => {
                   color: '#EF7A7A',
                 }}
               >
-                {validationState.error}. Please contact your team admin or{' '}
+                {validation.error}. Please contact your team admin or{' '}
                 <MainButton
                   css={{
                     all: 'unset',
@@ -161,7 +162,7 @@ const SSOSignIn: React.FC<SSOSignInProps> = ({ changeSignInMode }) => {
             width: '100%',
             height: '48px',
           }}
-          disabled={validationState.state !== 'IDLE'}
+          disabled={validation.state !== 'IDLE'}
           type="submit"
         >
           <Text
@@ -172,7 +173,7 @@ const SSOSignIn: React.FC<SSOSignInProps> = ({ changeSignInMode }) => {
             size={4}
             weight="medium"
           >
-            {['VALIDATING', 'VALID'].includes(validationState.state)
+            {['VALIDATING', 'VALID'].includes(validation.state)
               ? 'Signin in...'
               : 'Continue with SSO'}
           </Text>
@@ -373,16 +374,19 @@ export const ChooseProvider: React.FC<ChooseProviderProps> = ({
               onClick={() => setSignInMode(SignInMode.SSO)}
               variant="ghost"
             >
-              Sign in with SSO login
+              Sign in with SSO
             </StyledGhostButton>
           )}
           {signInMode === SignInMode.SSO && (
-            <StyledGhostButton
-              onClick={() => setSignInMode(SignInMode.Default)}
-              variant="ghost"
-            >
-              Not SSO? Sign in
-            </StyledGhostButton>
+            <Text lineHeight="16px" size={13} variant="muted">
+              Not SSO?{''}
+              <StyledGhostButton
+                onClick={() => setSignInMode(SignInMode.Default)}
+                variant="ghost"
+              >
+                Sign in
+              </StyledGhostButton>
+            </Text>
           )}
 
           <Text

--- a/packages/app/src/app/pages/SignIn/ChooseProvider.tsx
+++ b/packages/app/src/app/pages/SignIn/ChooseProvider.tsx
@@ -45,9 +45,15 @@ type ValidationState =
   | { state: 'VALID' }
   | { state: 'INVALID'; error: string };
 
-const SSOSignIn: React.FC = () => {
+type SSOSignInProps = {
+  changeSignInMode: () => void;
+};
+const SSOSignIn: React.FC<SSOSignInProps> = ({ changeSignInMode }) => {
   const inputRef = React.useRef<HTMLInputElement>(null);
-  const [validationState] = React.useState<ValidationState>({ state: 'IDLE' });
+  const [validationState] = React.useState<ValidationState>({
+    state: 'INVALID',
+    error: 'This email is not configured for SSO login',
+  });
 
   React.useEffect(() => {
     const inputElement = inputRef.current;
@@ -120,14 +126,28 @@ const SSOSignIn: React.FC = () => {
           <Element aria-live="polite">
             {validationState.state === 'INVALID' ? (
               <Text
+                as={motion.p}
                 css={{
                   fontSize: '12px',
                   lineHeight: '16px',
                   letterSpacing: '0.005em',
                   color: '#EF7A7A',
                 }}
+                layout
               >
-                {validationState.error}
+                {validationState.error}. Please contact your team admin or{' '}
+                <MainButton
+                  css={{
+                    all: 'unset',
+                    textDecoration: 'underline',
+                    transition: 'color .3s',
+                  }}
+                  onClick={changeSignInMode}
+                  variant="link"
+                >
+                  sign in through a different method
+                </MainButton>
+                .
               </Text>
             ) : null}
           </Element>
@@ -335,7 +355,11 @@ export const ChooseProvider: React.FC<ChooseProviderProps> = ({
             )}
           </Stack>
         )}
-        {signInMode === SignInMode.SSO && <SSOSignIn />}
+        {signInMode === SignInMode.SSO && (
+          <SSOSignIn
+            changeSignInMode={() => setSignInMode(SignInMode.Default)}
+          />
+        )}
 
         <Stack as="footer" align="center" direction="vertical">
           {signInMode === SignInMode.Default && (

--- a/packages/app/src/app/pages/SignIn/ChooseProvider.tsx
+++ b/packages/app/src/app/pages/SignIn/ChooseProvider.tsx
@@ -204,8 +204,6 @@ export const ChooseProvider: React.FC<ChooseProviderProps> = ({
     toggleSignInModal,
   } = useActions();
   const { loadingAuth, cancelOnLogin } = useAppState();
-  // const location = useLocation();
-  // const history = useHistory();
 
   const [signInMode, setSignInMode] = React.useState<SignInMode>(
     ssoMode ? SignInMode.SSO : SignInMode.Default

--- a/packages/app/src/app/pages/SignIn/ChooseProvider.tsx
+++ b/packages/app/src/app/pages/SignIn/ChooseProvider.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import {
   Button as MainButton,
   Element,
+  Icon,
   Input,
   Stack,
   Text,
@@ -37,8 +38,15 @@ const StyledGhostButton = styled(MainButton)`
   }
 `;
 
+type ValidationState =
+  | { state: 'IDLE' }
+  | { state: 'LOADING' }
+  | { state: 'VALID' }
+  | { state: 'INVALID'; error: string };
+
 const SSOSignIn: React.FC = () => {
   const inputRef = React.useRef<HTMLInputElement>(null);
+  const [validationState] = React.useState<ValidationState>({ state: 'IDLE' });
 
   React.useEffect(() => {
     const inputElement = inputRef.current;
@@ -58,16 +66,56 @@ const SSOSignIn: React.FC = () => {
         direction="vertical"
         gap={2}
       >
-        <Element css={{ position: 'relative', height: '48px' }}>
-          <Input
-            aria-labelledby="heading"
-            css={{ height: '100%' }}
-            placeholder="Enter your email"
-            ref={inputRef}
-            type="email"
-            required
-          />
-        </Element>
+        <Stack direction="vertical" gap={1}>
+          <Element css={{ position: 'relative', height: '48px' }}>
+            <Input
+              aria-labelledby="heading"
+              css={{ height: '100%', padding: '16px' }}
+              placeholder="Enter your email"
+              ref={inputRef}
+              type="email"
+              required
+            />
+            <Element
+              css={{
+                position: 'absolute',
+                display: 'flexflexflex',
+                height: 'fit-content',
+                background: '#252525',
+                padding: '2px',
+                right: '16px',
+                left: 'auto',
+                top: 0,
+                bottom: 0,
+                margin: 'auto 0',
+              }}
+            >
+              {
+                {
+                  VALID: <Icon css={{ color: '#B3FBB4' }} name="simpleCheck" />,
+                  INVALID: (
+                    <Icon css={{ color: '#ED6C6C' }} name="infoOutline" />
+                  ),
+                }[validationState.state]
+              }
+            </Element>
+          </Element>
+          <Element aria-live="polite">
+            {validationState.state === 'INVALID' ? (
+              <Text
+                css={{
+                  fontSize: '12px',
+                  lineHeight: '16px',
+                  letterSpacing: '0.005em',
+                  color: '#EF7A7A',
+                }}
+              >
+                {validationState.error}
+              </Text>
+            ) : null}
+          </Element>
+        </Stack>
+
         <Button
           css={{
             width: '100%',

--- a/packages/app/src/app/pages/SignIn/ChooseProvider.tsx
+++ b/packages/app/src/app/pages/SignIn/ChooseProvider.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { FormEvent } from 'react';
 import styled from 'styled-components';
+import { AnimatePresence, motion } from 'framer-motion';
 import {
   Button as MainButton,
   Element,
@@ -55,8 +56,23 @@ const SSOSignIn: React.FC = () => {
     }
   }, []);
 
+  const handleFormSubmit = React.useCallback(
+    async (e: FormEvent<HTMLFormElement>) => {
+      e.preventDefault();
+    },
+    []
+  );
+
   return (
-    <Stack align="center" direction="vertical" gap={8}>
+    <Stack
+      as={motion.div}
+      align="center"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      direction="vertical"
+      gap={8}
+    >
       <StyledHeading as="h1" id="heading">
         Sign in with SSO login
       </StyledHeading>
@@ -64,6 +80,7 @@ const SSOSignIn: React.FC = () => {
         as="form"
         css={{ width: '100%', maxWidth: '420px' }}
         direction="vertical"
+        onSubmit={handleFormSubmit}
         gap={2}
       >
         <Stack direction="vertical" gap={1}>
@@ -121,6 +138,7 @@ const SSOSignIn: React.FC = () => {
             width: '100%',
             height: '48px',
           }}
+          disabled={validationState.state !== 'IDLE'}
           type="submit"
         >
           <Text
@@ -131,7 +149,9 @@ const SSOSignIn: React.FC = () => {
             size={4}
             weight="medium"
           >
-            Continue with SSO
+            {validationState.state === 'LOADING'
+              ? 'Signin in...'
+              : 'Continue with SSO'}
           </Text>
         </Button>
       </Stack>
@@ -146,10 +166,12 @@ enum SignInMode {
 
 type ChooseProviderProps = {
   redirectTo?: string;
+  ssoMode?: SignInMode;
   onSignIn?: () => void;
 };
 export const ChooseProvider: React.FC<ChooseProviderProps> = ({
   redirectTo,
+  ssoMode,
   onSignIn,
 }) => {
   const {
@@ -160,7 +182,7 @@ export const ChooseProvider: React.FC<ChooseProviderProps> = ({
   const { loadingAuth, cancelOnLogin } = useAppState();
 
   const [signInMode, setSignInMode] = React.useState<SignInMode>(
-    SignInMode.SSO
+    ssoMode ? SignInMode.SSO : SignInMode.Default
   );
 
   const handleSignIn = async (provider: 'github' | 'google' | 'apple') => {
@@ -185,179 +207,188 @@ export const ChooseProvider: React.FC<ChooseProviderProps> = ({
     setLoadingAuth(provider);
   };
   return (
-    <Stack
-      as="section"
-      align="center"
-      css={{
-        width: '100%',
-        height: '100%',
-        padding: '48px 0',
-        color: '#fff',
-      }}
-      direction="vertical"
-      justify="space-between"
-    >
-      <CodeSandboxIcon width={48} height={48} />
-      {signInMode === SignInMode.Default && (
-        <Stack direction="vertical" gap={8}>
-          <Stack direction="vertical" gap={3}>
-            <StyledHeading
-              as="h1"
-              css={{
-                maxWidth: '396px',
-              }}
-            >
-              Sign in to CodeSandbox
-            </StyledHeading>
-            <Text
-              css={{
-                textAlign: 'center',
-                lineHeight: 1.5,
-                opacity: 0.6,
-              }}
-              size={4}
-            >
-              Login or register to start building your projects today.
-            </Text>
-          </Stack>
-          <Stack direction="vertical" gap={3}>
-            <Button
-              css={{
-                width: '100%',
-                height: '48px',
-              }}
-              loading={loadingAuth.github}
-              onClick={() => handleSignIn('github')}
-            >
-              <GitHubIcon />
-              <Text
-                as="span"
+    <AnimatePresence>
+      <Stack
+        as="section"
+        align="center"
+        css={{
+          width: '100%',
+          height: '100%',
+          padding: '48px 0',
+          color: '#fff',
+        }}
+        direction="vertical"
+        justify="space-between"
+      >
+        <CodeSandboxIcon width={48} height={48} />
+        {signInMode === SignInMode.Default && (
+          <Stack
+            as={motion.div}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            direction="vertical"
+            gap={8}
+          >
+            <Stack direction="vertical" gap={3}>
+              <StyledHeading
+                as="h1"
                 css={{
-                  lineHeight: 1,
+                  maxWidth: '396px',
+                }}
+              >
+                Sign in to CodeSandbox
+              </StyledHeading>
+              <Text
+                css={{
+                  textAlign: 'center',
+                  lineHeight: 1.5,
+                  opacity: 0.6,
                 }}
                 size={4}
-                weight="medium"
               >
-                Sign in with GitHub
+                Login or register to start building your projects today.
               </Text>
-            </Button>
-            <Stack
-              css={{
-                '@media screen and (max-width: 440px)': {
-                  flexDirection: 'column',
-                },
-              }}
-              gap={3}
-            >
-              <Button
-                css={{
-                  width: '100%',
-                  height: '40px',
-                  flex: 1,
-                }}
-                loading={loadingAuth.google}
-                onClick={() => handleSignIn('google')}
-                secondary
-              >
-                <GoogleIcon />
-                <Text
-                  as="span"
-                  css={{ lineHeight: 1 }}
-                  size={3}
-                  weight="medium"
-                >
-                  Sign in with Google
-                </Text>
-              </Button>
-              <Button
-                css={{
-                  width: '100%',
-                  height: '40px',
-                  flex: 1,
-                }}
-                loading={loadingAuth.apple}
-                onClick={() => handleSignIn('apple')}
-                secondary
-              >
-                <AppleIcon />
-                <Text
-                  as="span"
-                  css={{ lineHeight: 1 }}
-                  size={3}
-                  weight="medium"
-                >
-                  Sign in with Apple
-                </Text>
-              </Button>
             </Stack>
+            <Stack direction="vertical" gap={3}>
+              <Button
+                css={{
+                  width: '100%',
+                  height: '48px',
+                }}
+                loading={loadingAuth.github}
+                onClick={() => handleSignIn('github')}
+              >
+                <GitHubIcon />
+                <Text
+                  as="span"
+                  css={{
+                    lineHeight: 1,
+                  }}
+                  size={4}
+                  weight="medium"
+                >
+                  Sign in with GitHub
+                </Text>
+              </Button>
+              <Stack
+                css={{
+                  '@media screen and (max-width: 440px)': {
+                    flexDirection: 'column',
+                  },
+                }}
+                gap={3}
+              >
+                <Button
+                  css={{
+                    width: '100%',
+                    height: '40px',
+                    flex: 1,
+                  }}
+                  loading={loadingAuth.google}
+                  onClick={() => handleSignIn('google')}
+                  secondary
+                >
+                  <GoogleIcon />
+                  <Text
+                    as="span"
+                    css={{ lineHeight: 1 }}
+                    size={3}
+                    weight="medium"
+                  >
+                    Sign in with Google
+                  </Text>
+                </Button>
+                <Button
+                  css={{
+                    width: '100%',
+                    height: '40px',
+                    flex: 1,
+                  }}
+                  loading={loadingAuth.apple}
+                  onClick={() => handleSignIn('apple')}
+                  secondary
+                >
+                  <AppleIcon />
+                  <Text
+                    as="span"
+                    css={{ lineHeight: 1 }}
+                    size={3}
+                    weight="medium"
+                  >
+                    Sign in with Apple
+                  </Text>
+                </Button>
+              </Stack>
+            </Stack>
+            {cancelOnLogin && (
+              <MainButton
+                variant="link"
+                type="button"
+                onClick={() => {
+                  cancelOnLogin();
+                  toggleSignInModal();
+                }}
+              >
+                <Text>Continue without an account</Text>
+              </MainButton>
+            )}
           </Stack>
-          {cancelOnLogin && (
-            <MainButton
-              variant="link"
-              type="button"
-              onClick={() => {
-                cancelOnLogin();
-                toggleSignInModal();
-              }}
+        )}
+        {signInMode === SignInMode.SSO && <SSOSignIn />}
+
+        <Stack as="footer" align="center" direction="vertical">
+          {signInMode === SignInMode.Default && (
+            <StyledGhostButton
+              onClick={() => setSignInMode(SignInMode.SSO)}
+              variant="ghost"
             >
-              <Text>Continue without an account</Text>
-            </MainButton>
+              Sign in with SSO login
+            </StyledGhostButton>
           )}
+          {signInMode === SignInMode.SSO && (
+            <StyledGhostButton
+              onClick={() => setSignInMode(SignInMode.Default)}
+              variant="ghost"
+            >
+              Not SSO? Sign in
+            </StyledGhostButton>
+          )}
+
+          <Text
+            css={{
+              lineHeight: '13px',
+              maxWidth: '240px',
+              margin: '24px 0 0 0',
+
+              a: {
+                color: 'inherit',
+              },
+            }}
+            variant="muted"
+            align="center"
+            size={12}
+            block
+          >
+            By continuing, you agree to CodeSandbox{' '}
+            <a
+              href="https://codesandbox.io/legal/terms"
+              target="_blank"
+              rel="noreferrer"
+            >
+              Terms of Service
+            </a>
+            ,{' '}
+            <a
+              href="https://codesandbox.io/legal/privacy"
+              target="_blank"
+              rel="noreferrer"
+            >
+              Privacy Policy
+            </a>
+          </Text>
         </Stack>
-      )}
-      {signInMode === SignInMode.SSO && <SSOSignIn />}
-
-      <Stack as="footer" align="center" direction="vertical">
-        {signInMode === SignInMode.Default && (
-          <StyledGhostButton
-            onClick={() => setSignInMode(SignInMode.SSO)}
-            variant="ghost"
-          >
-            Sign in with SSO login
-          </StyledGhostButton>
-        )}
-        {signInMode === SignInMode.SSO && (
-          <StyledGhostButton
-            onClick={() => setSignInMode(SignInMode.Default)}
-            variant="ghost"
-          >
-            Not SSO? Sign in
-          </StyledGhostButton>
-        )}
-
-        <Text
-          css={{
-            lineHeight: '13px',
-            maxWidth: '240px',
-            margin: '24px 0 0 0',
-
-            a: {
-              color: 'inherit',
-            },
-          }}
-          variant="muted"
-          align="center"
-          size={12}
-          block
-        >
-          By continuing, you agree to CodeSandbox{' '}
-          <a
-            href="https://codesandbox.io/legal/terms"
-            target="_blank"
-            rel="noreferrer"
-          >
-            Terms of Service
-          </a>
-          ,{' '}
-          <a
-            href="https://codesandbox.io/legal/privacy"
-            target="_blank"
-            rel="noreferrer"
-          >
-            Privacy Policy
-          </a>
-        </Text>
       </Stack>
-    </Stack>
+    </AnimatePresence>
   );
 };

--- a/packages/app/src/app/pages/SignIn/ChooseProvider.tsx
+++ b/packages/app/src/app/pages/SignIn/ChooseProvider.tsx
@@ -1,5 +1,12 @@
 import React from 'react';
-import { Button as MainButton, Stack, Text } from '@codesandbox/components';
+import styled from 'styled-components';
+import {
+  Button as MainButton,
+  Element,
+  Input,
+  Stack,
+  Text,
+} from '@codesandbox/components';
 import {
   AppleIcon,
   github as GitHubIcon,
@@ -8,8 +15,86 @@ import {
 } from '@codesandbox/components/lib/components/Icon/icons';
 import { useActions, useAppState } from 'app/overmind';
 import history from 'app/utils/history';
-
 import { Button } from './components/Button';
+
+const StyledHeading = styled(Text)`
+  margin: 0;
+  text-align: center;
+  font-family: Everett, sans-serif;
+  font-size: 48px;
+  font-weight: 500;
+  line-height: 1.17;
+  letters-pacing: -0.018em;
+`;
+
+const StyledGhostButton = styled(MainButton)`
+  padding: 4px;
+  width: fit-content;
+
+  :hover:not([disabled]),
+  :focus:not([disabled]) {
+    background: transparent;
+  }
+`;
+
+const SSOSignIn: React.FC = () => {
+  const inputRef = React.useRef<HTMLInputElement>(null);
+
+  React.useEffect(() => {
+    const inputElement = inputRef.current;
+    if (inputElement) {
+      inputElement.focus();
+    }
+  }, []);
+
+  return (
+    <Stack align="center" direction="vertical" gap={8}>
+      <StyledHeading as="h1" id="heading">
+        Sign in with SSO login
+      </StyledHeading>
+      <Stack
+        as="form"
+        css={{ width: '100%', maxWidth: '420px' }}
+        direction="vertical"
+        gap={2}
+      >
+        <Element css={{ position: 'relative', height: '48px' }}>
+          <Input
+            aria-labelledby="heading"
+            css={{ height: '100%' }}
+            placeholder="Enter your email"
+            ref={inputRef}
+            type="email"
+            required
+          />
+        </Element>
+        <Button
+          css={{
+            width: '100%',
+            height: '48px',
+          }}
+          type="submit"
+        >
+          <Text
+            as="span"
+            css={{
+              lineHeight: 1,
+            }}
+            size={4}
+            weight="medium"
+          >
+            Continue with SSO
+          </Text>
+        </Button>
+      </Stack>
+    </Stack>
+  );
+};
+
+enum SignInMode {
+  SSO = 'SSO',
+  Default = 'Default',
+}
 
 type ChooseProviderProps = {
   redirectTo?: string;
@@ -19,12 +104,16 @@ export const ChooseProvider: React.FC<ChooseProviderProps> = ({
   redirectTo,
   onSignIn,
 }) => {
-  const { loadingAuth, cancelOnLogin } = useAppState();
   const {
     signInButtonClicked,
     setLoadingAuth,
     toggleSignInModal,
   } = useActions();
+  const { loadingAuth, cancelOnLogin } = useAppState();
+
+  const [signInMode, setSignInMode] = React.useState<SignInMode>(
+    SignInMode.SSO
+  );
 
   const handleSignIn = async (provider: 'github' | 'google' | 'apple') => {
     setLoadingAuth(provider);
@@ -49,6 +138,7 @@ export const ChooseProvider: React.FC<ChooseProviderProps> = ({
   };
   return (
     <Stack
+      as="section"
       align="center"
       css={{
         width: '100%',
@@ -60,141 +150,166 @@ export const ChooseProvider: React.FC<ChooseProviderProps> = ({
       justify="space-between"
     >
       <CodeSandboxIcon width={48} height={48} />
-      <Stack direction="vertical" gap={8}>
-        <Stack direction="vertical" gap={3}>
-          <Text
-            as="h1"
-            css={{
-              maxWidth: '396px',
-              margin: 0,
-              textAlign: 'center',
-              fontFamily: 'Everett, sans-serif',
-              lineHeight: 1.17,
-              letterSpacing: '-0.018em',
-            }}
-            size={48}
-            weight="medium"
-          >
-            Sign in to CodeSandbox
-          </Text>
-          <Text
-            css={{
-              textAlign: 'center',
-              lineHeight: 1.5,
-              opacity: 0.6,
-            }}
-            size={4}
-          >
-            Login or register to start building your projects today.
-          </Text>
-        </Stack>
-        <Stack direction="vertical" gap={3}>
-          <Button
-            css={{
-              width: '100%',
-              height: '48px',
-            }}
-            loading={loadingAuth.github}
-            onClick={() => handleSignIn('github')}
-          >
-            <GitHubIcon />
-            <Text
-              as="span"
+      {signInMode === SignInMode.Default && (
+        <Stack direction="vertical" gap={8}>
+          <Stack direction="vertical" gap={3}>
+            <StyledHeading
+              as="h1"
               css={{
-                lineHeight: 1,
+                maxWidth: '396px',
+              }}
+            >
+              Sign in to CodeSandbox
+            </StyledHeading>
+            <Text
+              css={{
+                textAlign: 'center',
+                lineHeight: 1.5,
+                opacity: 0.6,
               }}
               size={4}
-              weight="medium"
             >
-              Sign in with GitHub
+              Login or register to start building your projects today.
             </Text>
-          </Button>
-          <Stack
-            css={{
-              '@media screen and (max-width: 440px)': {
-                flexDirection: 'column',
-              },
-            }}
-            gap={3}
-          >
-            <Button
-              css={{
-                width: '100%',
-                height: '40px',
-                flex: 1,
-              }}
-              loading={loadingAuth.google}
-              onClick={() => handleSignIn('google')}
-              secondary
-            >
-              <GoogleIcon />
-              <Text as="span" css={{ lineHeight: 1 }} size={3} weight="medium">
-                Sign in with Google
-              </Text>
-            </Button>
-            <Button
-              css={{
-                width: '100%',
-                height: '40px',
-                flex: 1,
-              }}
-              loading={loadingAuth.apple}
-              onClick={() => handleSignIn('apple')}
-              secondary
-            >
-              <AppleIcon />
-              <Text as="span" css={{ lineHeight: 1 }} size={3} weight="medium">
-                Sign in with Apple
-              </Text>
-            </Button>
           </Stack>
+          <Stack direction="vertical" gap={3}>
+            <Button
+              css={{
+                width: '100%',
+                height: '48px',
+              }}
+              loading={loadingAuth.github}
+              onClick={() => handleSignIn('github')}
+            >
+              <GitHubIcon />
+              <Text
+                as="span"
+                css={{
+                  lineHeight: 1,
+                }}
+                size={4}
+                weight="medium"
+              >
+                Sign in with GitHub
+              </Text>
+            </Button>
+            <Stack
+              css={{
+                '@media screen and (max-width: 440px)': {
+                  flexDirection: 'column',
+                },
+              }}
+              gap={3}
+            >
+              <Button
+                css={{
+                  width: '100%',
+                  height: '40px',
+                  flex: 1,
+                }}
+                loading={loadingAuth.google}
+                onClick={() => handleSignIn('google')}
+                secondary
+              >
+                <GoogleIcon />
+                <Text
+                  as="span"
+                  css={{ lineHeight: 1 }}
+                  size={3}
+                  weight="medium"
+                >
+                  Sign in with Google
+                </Text>
+              </Button>
+              <Button
+                css={{
+                  width: '100%',
+                  height: '40px',
+                  flex: 1,
+                }}
+                loading={loadingAuth.apple}
+                onClick={() => handleSignIn('apple')}
+                secondary
+              >
+                <AppleIcon />
+                <Text
+                  as="span"
+                  css={{ lineHeight: 1 }}
+                  size={3}
+                  weight="medium"
+                >
+                  Sign in with Apple
+                </Text>
+              </Button>
+            </Stack>
+          </Stack>
+          {cancelOnLogin && (
+            <MainButton
+              variant="link"
+              type="button"
+              onClick={() => {
+                cancelOnLogin();
+                toggleSignInModal();
+              }}
+            >
+              <Text>Continue without an account</Text>
+            </MainButton>
+          )}
         </Stack>
-        {cancelOnLogin && (
-          <MainButton
-            variant="link"
-            type="button"
-            onClick={() => {
-              cancelOnLogin();
-              toggleSignInModal();
-            }}
+      )}
+      {signInMode === SignInMode.SSO && <SSOSignIn />}
+
+      <Stack as="footer" align="center" direction="vertical">
+        {signInMode === SignInMode.Default && (
+          <StyledGhostButton
+            onClick={() => setSignInMode(SignInMode.SSO)}
+            variant="ghost"
           >
-            <Text>Continue without an account</Text>
-          </MainButton>
+            Sign in with SSO login
+          </StyledGhostButton>
         )}
+        {signInMode === SignInMode.SSO && (
+          <StyledGhostButton
+            onClick={() => setSignInMode(SignInMode.Default)}
+            variant="ghost"
+          >
+            Not SSO? Sign in
+          </StyledGhostButton>
+        )}
+
+        <Text
+          css={{
+            lineHeight: '13px',
+            maxWidth: '240px',
+            margin: '24px 0 0 0',
+
+            a: {
+              color: 'inherit',
+            },
+          }}
+          variant="muted"
+          align="center"
+          size={12}
+          block
+        >
+          By continuing, you agree to CodeSandbox{' '}
+          <a
+            href="https://codesandbox.io/legal/terms"
+            target="_blank"
+            rel="noreferrer"
+          >
+            Terms of Service
+          </a>
+          ,{' '}
+          <a
+            href="https://codesandbox.io/legal/privacy"
+            target="_blank"
+            rel="noreferrer"
+          >
+            Privacy Policy
+          </a>
+        </Text>
       </Stack>
-
-      <Text
-        variant="muted"
-        align="center"
-        size={10}
-        block
-        css={{
-          lineHeight: '13px',
-          maxWidth: '200px',
-          margin: '24px 0 0 0',
-
-          a: {
-            color: 'inherit',
-          },
-        }}
-      >
-        By continuing, you agree to CodeSandbox{' '}
-        <a
-          href="https://codesandbox.io/legal/terms"
-          target="_blank"
-          rel="noreferrer"
-        >
-          Terms of Service
-        </a>
-        ,{' '}
-        <a
-          href="https://codesandbox.io/legal/privacy"
-          target="_blank"
-          rel="noreferrer"
-        >
-          Privacy Policy
-        </a>
-      </Text>
     </Stack>
   );
 };

--- a/packages/app/src/app/pages/SignIn/SignIn.tsx
+++ b/packages/app/src/app/pages/SignIn/SignIn.tsx
@@ -10,7 +10,7 @@ interface SignInProps {
   onSignIn?: () => void;
 }
 
-export const SignIn = ({ redirectTo, onSignIn }: SignInProps) => {
+export const SignIn: React.FC<SignInProps> = ({ redirectTo, onSignIn }) => {
   const { duplicateAccountStatus, pendingUser, pendingUserId } = useAppState();
   const { getPendingUser } = useActions();
 

--- a/packages/app/src/app/pages/SignIn/SignIn.tsx
+++ b/packages/app/src/app/pages/SignIn/SignIn.tsx
@@ -20,6 +20,10 @@ export const SignIn: React.FC<SignInProps> = ({ redirectTo, onSignIn }) => {
     }
   }, [getPendingUser, pendingUserId]);
 
+  const ssoMode = JSON.parse(
+    new URL(location.href).searchParams.get('sso_mode')
+  );
+
   /**
    * 🚧 Utility to debug Duplicate Account
    */
@@ -49,5 +53,11 @@ export const SignIn: React.FC<SignInProps> = ({ redirectTo, onSignIn }) => {
   /**
    * ⬇️ Sign in provider
    */
-  return <ChooseProvider redirectTo={redirectTo} onSignIn={onSignIn} />;
+  return (
+    <ChooseProvider
+      redirectTo={redirectTo}
+      onSignIn={onSignIn}
+      ssoMode={ssoMode}
+    />
+  );
 };

--- a/packages/app/src/app/pages/SignIn/components/Button.tsx
+++ b/packages/app/src/app/pages/SignIn/components/Button.tsx
@@ -11,8 +11,7 @@ type Props = {
    */
   onClick?: () => void;
   secondary?: boolean;
-  type?: React.ButtonHTMLAttributes<HTMLButtonElement>['type'];
-};
+} & React.ButtonHTMLAttributes<HTMLButtonElement>;
 
 export const Button = ({ children, secondary, loading, ...props }: Props) => (
   <BaseButton

--- a/packages/app/src/app/pages/SignIn/components/Button.tsx
+++ b/packages/app/src/app/pages/SignIn/components/Button.tsx
@@ -7,7 +7,7 @@ type Props = {
   children: React.ReactNode;
   loading?: boolean;
   secondary?: boolean;
-} & React.ButtonHTMLAttributes<HTMLButtonElement>;
+} & React.ComponentProps<typeof BaseButton>;
 
 export const Button = ({ children, secondary, loading, ...props }: Props) => (
   <BaseButton

--- a/packages/app/src/app/pages/SignIn/components/Button.tsx
+++ b/packages/app/src/app/pages/SignIn/components/Button.tsx
@@ -6,10 +6,6 @@ import { css } from '@styled-system/css';
 type Props = {
   children: React.ReactNode;
   loading?: boolean;
-  /**
-   * If the button type is "submit", the onClick isn't needed.
-   */
-  onClick?: () => void;
   secondary?: boolean;
 } & React.ButtonHTMLAttributes<HTMLButtonElement>;
 

--- a/packages/app/src/app/pages/SignIn/components/Button.tsx
+++ b/packages/app/src/app/pages/SignIn/components/Button.tsx
@@ -11,7 +11,8 @@ type Props = {
    */
   onClick?: () => void;
   secondary?: boolean;
-} & React.ComponentProps<typeof BaseButton>;
+  type?: React.ButtonHTMLAttributes<HTMLButtonElement>['type'];
+};
 
 export const Button = ({ children, secondary, loading, ...props }: Props) => (
   <BaseButton

--- a/packages/app/src/app/pages/SignIn/components/Button.tsx
+++ b/packages/app/src/app/pages/SignIn/components/Button.tsx
@@ -6,9 +6,12 @@ import { css } from '@styled-system/css';
 type Props = {
   children: React.ReactNode;
   loading?: boolean;
-  onClick: () => void;
+  /**
+   * If the button type is "submit", the onClick isn't needed.
+   */
+  onClick?: () => void;
   secondary?: boolean;
-};
+} & React.ComponentProps<typeof BaseButton>;
 
 export const Button = ({ children, secondary, loading, ...props }: Props) => (
   <BaseButton

--- a/packages/components/src/components/Icon/icons.tsx
+++ b/packages/components/src/components/Icon/icons.tsx
@@ -1314,3 +1314,20 @@ export const team = props => (
     />
   </Element>
 );
+
+export const infoOutline = props => (
+  <Element
+    as="svg"
+    fill="none"
+    viewBox="0 0 16 16"
+    xmlns="http://www.w3.org/2000/svg"
+    {...props}
+  >
+    <path
+      fill="currentColor"
+      fillRule="evenodd"
+      d="M15.667 8A7.167 7.167 0 1 1 1.333 8a7.167 7.167 0 0 1 14.334 0ZM8.5 14.167a6.167 6.167 0 1 0 0-12.334 6.167 6.167 0 0 0 0 12.334Zm0-2.333a.5.5 0 0 1-.5-.5v-.084a.5.5 0 0 1 1 0v.084a.5.5 0 0 1-.5.5Zm0-3.317a.5.5 0 0 1-.5-.5V4.683a.5.5 0 0 1 1 0v3.334a.5.5 0 0 1-.5.5Z"
+      clipRule="evenodd"
+    />
+  </Element>
+);


### PR DESCRIPTION
I might need to change the API a bit when hooking things with the API but wanted to get most of the UI out of the way.

You can directly access this by opening `/signin?sso_mode=true`

|IDLE|
|:-:|
|![xkrisk-3000 csb app_signin_sso_mode=true (2)](https://user-images.githubusercontent.com/24959348/228023128-a9c17a14-dbbc-4f7e-9c26-7dfc2499007f.png)|

|VALIDATING|
|:-:|
|![xkrisk-3000 csb app_signin_sso_mode=true (1)](https://user-images.githubusercontent.com/24959348/228023160-633c9e81-cdfa-4d58-a28c-35d51dc82392.png)|

|INVALID|
|:-:|
|![xkrisk-3000 csb app_signin_sso_mode=true](https://user-images.githubusercontent.com/24959348/228023260-454a9c30-adcf-48b4-b506-d1a8cab16f36.png)|

