### PR TITLE
fix(registry): prevent non-admins from performing actions

### DIFF
--- a/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/RegistryForm.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/RegistryForm.tsx
@@ -277,7 +277,8 @@ export const RegistryForm = ({
                       <Stack
                         align="center"
                         direction="horizontal"
-                        css={css({ width: '100%' })}
+                        key={scope}
+                        css={{ width: '100%' }}
                       >
                         <Input
                           required

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/RegistrySettings.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/RegistrySettings.tsx
@@ -11,7 +11,7 @@ import { Alert } from '../components/Alert';
 export const RegistrySettings = () => {
   const actions = useActions();
   const { activeTeam, dashboard } = useAppState();
-  const [loading, setLoading] = React.useState(true);
+  const [loading, setLoading] = React.useState(false);
   const [submitting, setSubmitting] = React.useState(false);
   const [resetting, setResetting] = React.useState(false);
   const { isFree, isPro } = useWorkspaceSubscription();
@@ -37,13 +37,21 @@ export const RegistrySettings = () => {
     }
     // We need to add "activeTeam"
     // eslint-disable-next-line
-  }, [setLoading, actions.dashboard, activeTeam]);
+  }, [setLoading, actions.dashboard, activeTeam, isTeamAdmin]);
 
   useEffect(() => {
+    if (!isTeamAdmin) {
+      return;
+    }
+
     loadCurrentNpmRegistry();
-  }, [loadCurrentNpmRegistry]);
+  }, [isTeamAdmin, loadCurrentNpmRegistry]);
 
   const onSubmit = async (params: CreateRegistryParams) => {
+    if (!isTeamAdmin) {
+      return;
+    }
+
     setSubmitting(true);
     try {
       await actions.dashboard.createOrUpdateCurrentNpmRegistry(params);
@@ -51,8 +59,6 @@ export const RegistrySettings = () => {
       setSubmitting(false);
     }
   };
-
-  if (loading) return null;
 
   return (
     <Stack direction="vertical" gap={6}>
@@ -83,51 +89,53 @@ export const RegistrySettings = () => {
         <Alert message="Please contact your admin to set a custom npm registry." />
       ) : null}
 
-      <Stack
-        css={css({
-          padding: 6,
-          border: '1px solid',
-          backgroundColor: 'card.background',
-          borderColor: 'transparent',
-          borderRadius: 'medium',
-          position: 'relative',
-          opacity: isFree || !isTeamAdmin ? 0.4 : 1,
-          pointerEvents: isFree || !isTeamAdmin ? 'none' : 'all',
-        })}
-      >
-        {!resetting && (
-          <RegistryForm
-            onCancel={() => {
-              resetForm();
-            }}
-            onSubmit={onSubmit}
-            isSubmitting={submitting}
-            registry={dashboard.workspaceSettings.npmRegistry}
-            disabled={isFree || !isTeamAdmin}
-          />
-        )}
-      </Stack>
-
-      {isPro && isTeamAdmin ? (
-        <Stack justify="center" align="center">
-          <Button
-            variant="link"
-            onClick={() =>
-              actions.dashboard.deleteCurrentNpmRegistry({}).then(() => {
-                resetForm();
-              })
-            }
+      {!loading && (
+        <>
+          <Stack
             css={css({
-              maxWidth: 150,
-              ':hover:not(:disabled)': {
-                color: 'reds.200',
-              },
+              padding: 6,
+              border: '1px solid',
+              backgroundColor: 'card.background',
+              borderColor: 'transparent',
+              borderRadius: 'medium',
+              position: 'relative',
+              opacity: isFree || !isTeamAdmin ? 0.4 : 1,
+              pointerEvents: isFree || !isTeamAdmin ? 'none' : 'all',
             })}
           >
-            Reset Registry
-          </Button>
-        </Stack>
-      ) : null}
+            {!resetting && (
+              <RegistryForm
+                onCancel={resetForm}
+                onSubmit={onSubmit}
+                isSubmitting={submitting}
+                registry={dashboard.workspaceSettings.npmRegistry}
+                disabled={isFree || !isTeamAdmin}
+              />
+            )}
+          </Stack>
+
+          {isPro && isTeamAdmin ? (
+            <Stack justify="center" align="center">
+              <Button
+                variant="link"
+                onClick={() =>
+                  actions.dashboard.deleteCurrentNpmRegistry({}).then(() => {
+                    resetForm();
+                  })
+                }
+                css={css({
+                  maxWidth: 150,
+                  ':hover:not(:disabled)': {
+                    color: 'reds.200',
+                  },
+                })}
+              >
+                Reset Registry
+              </Button>
+            </Stack>
+          ) : null}
+        </>
+      )}
     </Stack>
   );
 };


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?

<!-- Is it a Bug fix, feature, docs update, ... -->

## What is the current behavior?

<!-- You can also link to an open issue here -->

Closes XTD-841.

- When visiting `dashboard/settings/npm-registry` as a non-admin, an error was shown:

![image](https://user-images.githubusercontent.com/24959348/228111679-28385cd4-d85e-4620-a684-5a0c0f17acf0.png)

## What is the new behavior?

<!-- if this is a feature change -->

- When visiting `dashboard/settings/npm-registry` as a non-admin, we don't try to fetch the registry so no error is shown.

