### PR TITLE
feat(pricing): Determine user location and show appropriate price

### DIFF
--- a/packages/app/src/app/hooks/useCurrencyFromTimeZone.ts
+++ b/packages/app/src/app/hooks/useCurrencyFromTimeZone.ts
@@ -1,0 +1,9 @@
+export const useCurrencyFromTimeZone = () => {
+  const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+  if (timeZone === 'Asia/Kolkata' || timeZone === 'Asia/Calcutta') {
+    return 'INR';
+  }
+
+  return 'USD';
+};

--- a/packages/app/src/app/overmind/namespaces/pro/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/pro/actions.ts
@@ -6,7 +6,11 @@ import { Step, PaymentSummary, PaymentPreview } from './types';
 export const pageMounted = withLoadApp(async ({ effects, state, actions }) => {
   // We have to call the api effect directly rather than using an action because
   // for some reason an action doesn't work.
-  state.pro.prices = await effects.api.getPrices();
+  const prices = await effects.api.getPrices();
+
+  if (prices) {
+    state.pro.prices = prices;
+  }
 
   // This action does work.
   actions.getActiveTeamInfo();

--- a/packages/app/src/app/pages/Pro/Upgrade.tsx
+++ b/packages/app/src/app/pages/Pro/Upgrade.tsx
@@ -42,9 +42,9 @@ const useCurrencyFromTimeZone = () => {
 
   if (timeZone === 'Asia/Kolkata' || timeZone === 'Asia/Calcutta') {
     return 'INR';
-  } else {
-    return 'USD';
   }
+
+  return 'USD';
 };
 
 export const ProUpgrade = () => {

--- a/packages/app/src/app/pages/Pro/Upgrade.tsx
+++ b/packages/app/src/app/pages/Pro/Upgrade.tsx
@@ -28,6 +28,7 @@ import { formatCurrency } from 'app/utils/currency';
 import { useGetCheckoutURL } from 'app/hooks';
 import { useWorkspaceAuthorization } from 'app/hooks/useWorkspaceAuthorization';
 import { useWorkspaceSubscription } from 'app/hooks/useWorkspaceSubscription';
+import { useCurrencyFromTimeZone } from 'app/hooks/useCurrencyFromTimeZone';
 import { Switcher } from './components/Switcher';
 import { SubscriptionPaymentProvider } from '../../graphql/types';
 import { SubscriptionCard } from './components/SubscriptionCard';
@@ -36,16 +37,6 @@ import type { CTA } from './components/SubscriptionCard';
 import { StyledPricingDetailsText } from './components/elements';
 import { TeamSubscriptionOptions } from '../Dashboard/Components/TeamSubscriptionOptions/TeamSubscriptionOptions';
 import { NewTeamModal } from '../Dashboard/Components/NewTeamModal';
-
-const useCurrencyFromTimeZone = () => {
-  const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-
-  if (timeZone === 'Asia/Kolkata' || timeZone === 'Asia/Calcutta') {
-    return 'INR';
-  }
-
-  return 'USD';
-};
 
 export const ProUpgrade = () => {
   const {
@@ -185,6 +176,7 @@ export const ProUpgrade = () => {
     // subscriptions
     const price = period === 'year' ? priceInCurrency / 12 : priceInCurrency;
 
+    // The formatCurrency function will divide the amount by 100
     return formatCurrency({
       currency: priceInCurrency ? currency : 'USD',
       amount: price,

--- a/packages/app/src/app/pages/Pro/Upgrade.tsx
+++ b/packages/app/src/app/pages/Pro/Upgrade.tsx
@@ -293,13 +293,28 @@ export const ProUpgrade = () => {
                 >
                   <Stack gap={1} direction="vertical">
                     <Text size={32} weight="500">
-                      {getPricePerMonth('individual', 'year')}
+                      {pro?.prices ? (
+                        getPricePerMonth('individual', 'year')
+                      ) : (
+                        <SkeletonText css={{ width: '60px', height: '40px' }} />
+                      )}
                     </Text>
                     <StyledPricingDetailsText>
                       <div>per month,</div>
                       <div>
                         billed annually, or{' '}
-                        {getPricePerMonth('individual', 'month')} per month.
+                        {pro?.prices ? (
+                          getPricePerMonth('individual', 'month')
+                        ) : (
+                          <SkeletonText
+                            css={{
+                              display: 'inline-block',
+                              marginBottom: '-4px',
+                              width: '20px',
+                            }}
+                          />
+                        )}{' '}
+                        per month.
                       </div>
                     </StyledPricingDetailsText>
                   </Stack>

--- a/packages/app/src/app/pages/Pro/Upgrade.tsx
+++ b/packages/app/src/app/pages/Pro/Upgrade.tsx
@@ -40,7 +40,7 @@ import { NewTeamModal } from '../Dashboard/Components/NewTeamModal';
 const useCurrencyFromTimeZone = () => {
   const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
 
-  if (timeZone === 'Asia/Kolkata') {
+  if (timeZone === 'Asia/Kolkata' || timeZone === 'Asia/Calcutta') {
     return 'INR';
   } else {
     return 'USD';

--- a/packages/app/src/app/pages/Pro/Upgrade.tsx
+++ b/packages/app/src/app/pages/Pro/Upgrade.tsx
@@ -9,6 +9,7 @@ import {
   Element,
   Text,
   Icon,
+  SkeletonText,
 } from '@codesandbox/components';
 import { Navigation } from 'app/pages/common/Navigation';
 import { useCreateCustomerPortal } from 'app/hooks/useCreateCustomerPortal';
@@ -168,9 +169,19 @@ export const ProUpgrade = () => {
     type: 'individual' | 'team',
     period: 'year' | 'month'
   ) => {
-    const priceInCurrency =
-      pro?.prices?.[type]?.[period]?.[currency.toLowerCase()] ||
-      pro?.prices?.[type]?.[period]?.usd; // fallback to usd
+    if (!pro?.prices) {
+      return null; // still loading
+    }
+
+    let priceInCurrency =
+      pro.prices?.[type]?.[period]?.[currency.toLowerCase()];
+
+    const hasPriceInCurrency = priceInCurrency !== null && priceInCurrency >= 0;
+
+    if (!hasPriceInCurrency) {
+      // Fallback to USD
+      priceInCurrency = pro?.prices?.[type]?.[period]?.usd;
+    }
 
     // Divide by 12 if the period is year to get monthly price for yearly
     // subscriptions
@@ -326,12 +337,27 @@ export const ProUpgrade = () => {
                 >
                   <Stack gap={1} direction="vertical">
                     <Text size={32} weight="500">
-                      {getPricePerMonth('team', 'year')}
+                      {pro?.prices ? (
+                        getPricePerMonth('team', 'year')
+                      ) : (
+                        <SkeletonText css={{ width: '60px', height: '40px' }} />
+                      )}
                     </Text>
                     <StyledPricingDetailsText>
                       per editor per month,
                       <br /> billed annually, or{' '}
-                      {getPricePerMonth('team', 'month')} per month.
+                      {pro?.prices ? (
+                        getPricePerMonth('team', 'month')
+                      ) : (
+                        <SkeletonText
+                          css={{
+                            display: 'inline-block',
+                            marginBottom: '-4px',
+                            width: '20px',
+                          }}
+                        />
+                      )}{' '}
+                      per month.
                     </StyledPricingDetailsText>
                   </Stack>
                 </SubscriptionCard>

--- a/packages/app/src/app/pages/Pro/components/UpsellTeamProCard.tsx
+++ b/packages/app/src/app/pages/Pro/components/UpsellTeamProCard.tsx
@@ -72,7 +72,7 @@ export const UpsellTeamProCard: React.FC<{ trackingLocation: string }> = ({
     type: 'individual' | 'team',
     period: 'year' | 'month'
   ) => {
-    if (!pro?.prices?.[type]?.[period]) {
+    if (!pro?.prices) {
       return null; // still loading
     }
 

--- a/packages/app/src/app/pages/Pro/components/UpsellTeamProCard.tsx
+++ b/packages/app/src/app/pages/Pro/components/UpsellTeamProCard.tsx
@@ -72,12 +72,18 @@ export const UpsellTeamProCard: React.FC<{ trackingLocation: string }> = ({
     type: 'individual' | 'team',
     period: 'year' | 'month'
   ) => {
-    const priceInCurrency =
-      pro?.prices?.[type]?.[period]?.[currency.toLowerCase()] ||
-      pro?.prices?.[type]?.[period]?.usd; // fallback to usd
+    if (!pro?.prices?.[type]?.[period]) {
+      return null; // still loading
+    }
 
-    if (!priceInCurrency) {
-      return null;
+    let priceInCurrency =
+      pro.prices?.[type]?.[period]?.[currency.toLowerCase()];
+
+    const hasPriceInCurrency = priceInCurrency !== null && priceInCurrency >= 0;
+
+    if (!hasPriceInCurrency) {
+      // Fallback to USD
+      priceInCurrency = pro?.prices?.[type]?.[period]?.usd;
     }
 
     // Divide by 12 if the period is year to get monthly price for yearly
@@ -86,7 +92,7 @@ export const UpsellTeamProCard: React.FC<{ trackingLocation: string }> = ({
 
     // The formatCurrency function will divide the amount by 100
     return formatCurrency({
-      currency: priceInCurrency ? currency : 'USD',
+      currency: hasPriceInCurrency ? currency : 'USD',
       amount: price,
     });
   };

--- a/packages/app/src/app/pages/Pro/legacy-pages/WorkspacePlanSelection.tsx
+++ b/packages/app/src/app/pages/Pro/legacy-pages/WorkspacePlanSelection.tsx
@@ -219,7 +219,7 @@ export const WorkspacePlanSelection: React.FC = () => {
                     {subscription ? (
                       getPrice()
                     ) : (
-                      <SkeletonText css={{ width: '60px', height: '38px' }} />
+                      <SkeletonText css={{ width: '60px', height: '40px' }} />
                     )}
                   </Text>
                   {isYearlyInterval ? (

--- a/packages/app/src/app/utils/currency.ts
+++ b/packages/app/src/app/utils/currency.ts
@@ -1,13 +1,32 @@
 type Price = { currency: string; amount?: number };
 
+/**
+ * This function isn't fool proof. We're using it mainly for the INR currency. The
+ * EUR currency is only used for Paddle subscriptions.
+ */
+const getLocaleFromCurrency = (currency: string) => {
+  if (currency === 'INR') {
+    return 'hi-IN';
+  }
+
+  if (currency === 'EUR') {
+    // The nl-NL locale isn't right for every country, but it's the simplest solution
+    // for now. For example, en-DE adds the euro symbol to the end of the amount.
+    return 'nl-NL';
+  }
+
+  return 'en-US';
+};
+
 export const formatCurrency = ({ currency, amount }: Price) => {
   if (typeof amount === 'undefined') {
     return null;
   }
 
-  const formatter = new Intl.NumberFormat('en-US', {
+  const locale = getLocaleFromCurrency(currency);
+
+  const formatter = new Intl.NumberFormat(locale, {
     style: 'currency',
-    minimumFractionDigits: 0,
     maximumFractionDigits: 0,
     currency,
   });


### PR DESCRIPTION
In this PR we're fixing the price calculation. There were some bugs and we also needed to calculate and format the pricing based on the users locale and currency.

### Determining location

We're determining the user location based on their timezone. This isn't fool proof but we expect Stripe to take care of that. The timezone will tell us what the country of origin is.

#### Testing

1. On an Apple device, turn off automatic time and location in the date & time settings. Change your "closest city" to an Indian one (e.g. Kolkata). This will update your timezone.
2.  Visit the pro page and select a personal workspace without subscription.
3. You should now see the price in Rupees.

### Formatting price based on locale

#### Rupees
We base the formatting locale on the currency. When the timezone is set to the Indian one, the currency will be Rupees and the locale will be set to `hi-IN`.

#### Euros
When the currency is in `EUR`, this is the case with Paddle subscriptions, we will default to the `nl-NL` locale. This formats the price with the euro sign in front of the price. In e.g. the `de-DE` locale the euro sign is placed behind the price, and we don't want that in this case.

#### Dollars
When the currency is in `USD`, which is the case for most other subscriptions we default the locale to `en-US`. This will format the price accordingly.

### Currency not available in stripe

When a certain currency is not available in Stripe (like right now, we haven't activated INR on production yet) we fall back to USD prices and currency.

### Loading states

When the workspace has an active subscription, we're loading the `subscription`. This might take some time, and we show a skeleton rather than nothing. We previously rendered `NaN`, this has now been resolved.

When the workspace does not have a subscription, we're loading the `prices`. This might take some time, and we show a skeleton rather than nothing. We previously rendered `NaN`, this has now been resolved.

### Active subscriptions

For active subscriptions we didn't format the price in the right way. It always showed dollars, and the `unitPrice` in cents wasn't divided to full dollars (or other full currencies). This has been resolved.

### Screenshots

#### Personal free

| Loading  | Ready |
| ------------- | ------------- |
| <img width="1624" alt="personal-free-loading" src="https://user-images.githubusercontent.com/7533849/228539343-d44eb17a-53ef-4134-a53d-a14ced685567.png"> | <img width="1624" alt="personal-free" src="https://user-images.githubusercontent.com/7533849/228539531-96e22019-c253-415c-a9ea-94325f7700fa.png"> |

#### Personal Patron subscription

| Loading  | Ready |
| ------------- | ------------- |
| <img width="1624" alt="patron-personal-active-loading" src="https://user-images.githubusercontent.com/7533849/228541482-fa4a827d-0218-43b7-864f-6328d97cdc02.png"> | <img width="1624" alt="patron-personal-active" src="https://user-images.githubusercontent.com/7533849/228541516-ad37d6de-8825-4f66-b491-838f537a1610.png"> |

#### Personal upsell card

The upsell to team subscription card (on the right).

| Loading  | Ready |
| ------------- | ------------- |
| <img width="1624" alt="personal-upsell-loading" src="https://user-images.githubusercontent.com/7533849/228541007-28546cbf-038d-436d-a3a7-019225fec831.png"> | <img width="1624" alt="personal-upsell-active" src="https://user-images.githubusercontent.com/7533849/228541048-e08d562f-d2c2-47ad-b482-3eca484cb23b.png"> |

#### Team free

| Loading  | Ready |
| ------------- | ------------- |
| <img width="1624" alt="team-free-loading" src="https://user-images.githubusercontent.com/7533849/228541169-8b353cab-e8c6-4561-b1b3-3b9a3d2fedca.png"> | <img width="1624" alt="team-free" src="https://user-images.githubusercontent.com/7533849/228541201-2c925095-69b9-46ee-b670-2aa910085742.png"> |

#### Team Stripe subscription

| Loading  | Ready |
| ------------- | ------------- |
| <img width="1624" alt="stripe-team-active-loading" src="https://user-images.githubusercontent.com/7533849/228541723-4f6fe6bf-66e3-49d9-8b9d-396bb4856971.png"> | <img width="1624" alt="stripe-team-active" src="https://user-images.githubusercontent.com/7533849/228541747-19310f66-27fd-49ca-a023-23066f366a3b.png"> |

#### Team Paddle subscription

| Loading  | Ready |
| ------------- | ------------- |
| <img width="1624" alt="paddle-team-active-loading" src="https://user-images.githubusercontent.com/7533849/228541893-3c93a921-4f4c-4223-bb13-6044888ed8e0.png"> | <img width="1624" alt="paddle-team-active" src="https://user-images.githubusercontent.com/7533849/228541931-70bf2291-9f40-40c8-9566-8da6e3001f92.png"> |

#### Personal free with Rupees

| Ready |
| ------------- |
| <img width="1624" alt="personal-free-rupee" src="https://user-images.githubusercontent.com/7533849/228542050-c3ea3969-f4f5-4250-88ee-fc5aef484b01.png"> |