### PR TITLE
fix(settings): editor seats

### DIFF
--- a/packages/app/src/app/hooks/useWorkspaceSubscription.ts
+++ b/packages/app/src/app/hooks/useWorkspaceSubscription.ts
@@ -50,6 +50,7 @@ export const useWorkspaceSubscription = (): WorkspaceSubscriptionReturn => {
     return {
       ...NO_SUBSCRIPTION,
       isEligibleForTrial: isTeamSpace, // Currently, only teams are eligible for trial.
+      numberOfSeats: activeTeamInfo.limits.maxEditors,
     };
   }
 

--- a/packages/app/src/app/hooks/useWorkspaceSubscription.ts
+++ b/packages/app/src/app/hooks/useWorkspaceSubscription.ts
@@ -1,3 +1,4 @@
+import { TEAM_FREE_LIMITS } from 'app/constants';
 import {
   SubscriptionInterval,
   SubscriptionOrigin,
@@ -50,7 +51,8 @@ export const useWorkspaceSubscription = (): WorkspaceSubscriptionReturn => {
     return {
       ...NO_SUBSCRIPTION,
       isEligibleForTrial: isTeamSpace, // Currently, only teams are eligible for trial.
-      numberOfSeats: activeTeamInfo.limits.maxEditors,
+      numberOfSeats:
+        activeTeamInfo.limits.maxEditors ?? TEAM_FREE_LIMITS.editors,
     };
   }
 
@@ -115,7 +117,6 @@ const NO_WORKSPACE = {
 
 const NO_SUBSCRIPTION = {
   subscription: null,
-  numberOfSeats: 0,
   isPro: false,
   isFree: true,
   hasActiveTeamTrial: false,
@@ -128,7 +129,10 @@ const NO_SUBSCRIPTION = {
 
 export type WorkspaceSubscriptionReturn =
   | typeof NO_WORKSPACE
-  | (typeof NO_SUBSCRIPTION & { isEligibleForTrial: boolean })
+  | (typeof NO_SUBSCRIPTION & {
+      isEligibleForTrial: boolean;
+      numberOfSeats: number;
+    })
   | {
       subscription: {
         cancelAt?: string;

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Settings/components/InviteMember.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Settings/components/InviteMember.tsx
@@ -34,6 +34,7 @@ type InviteMemberProps = {
 export const InviteMember: React.FC<InviteMemberProps> = ({
   isPro,
   numberOfUnusedSeats,
+  restrictNewEditors,
   team,
 }) => {
   const effects = useEffects();
@@ -70,7 +71,7 @@ export const InviteMember: React.FC<InviteMemberProps> = ({
   const onInviteSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
 
-    if (newMemberRole === TeamMemberAuthorization.Write) {
+    if (newMemberRole === TeamMemberAuthorization.Write && restrictNewEditors) {
       actions.modalOpened({ modal: 'editorSeatsUpgrade' });
       return;
     }


### PR DESCRIPTION
Closes XTD-854.

- Checks if it should restrict new editors before showing the upgrade alert.
- Fix the number of seats for teams that never had a subscription.
