### PR TITLE
Update to a version of `console-feed` that can log `bigint` values

### DIFF
--- a/packages/app/integration-tests/tests/sandboxes.test.js
+++ b/packages/app/integration-tests/tests/sandboxes.test.js
@@ -50,7 +50,6 @@ const SANDBOXES = [
   //  'gpgpu-curl-noise-yq6y8', // leva (based on stitches)
   'vx55c', // react stitches
   'fo3c0n', // vue3 with <script setup>
-  'tender-cookies-iwrwek', // console.log a `bigint`
 ];
 
 // Logic for parallelizing the tests

--- a/packages/app/integration-tests/tests/sandboxes.test.js
+++ b/packages/app/integration-tests/tests/sandboxes.test.js
@@ -50,6 +50,7 @@ const SANDBOXES = [
   //  'gpgpu-curl-noise-yq6y8', // leva (based on stitches)
   'vx55c', // react stitches
   'fo3c0n', // vue3 with <script setup>
+  'tender-cookies-iwrwek', // console.log a `bigint`
 ];
 
 // Logic for parallelizing the tests

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -115,7 +115,7 @@
     "comlink-loader": "^2.0.0",
     "compare-versions": "^3.1.0",
     "console": "^0.7.2",
-    "console-feed": "^3.1.9",
+    "console-feed": "^3.5.0",
     "cropperjs": "^1.5.11",
     "css-modules-loader-core": "^1.1.0",
     "date-fns": "^2.4.1",

--- a/packages/sandbox-hooks/package.json
+++ b/packages/sandbox-hooks/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@codesandbox/common": "^1.0.8",
     "codesandbox-api": "0.0.32",
-    "console-feed": "^3.1.9",
+    "console-feed": "^3.5.0",
     "css-line-break": "^1.1.1",
     "react-dev-utils": "3.1.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -10474,10 +10474,10 @@ console-control-strings@^1.0.0, console-control-strings@^1.1.0, console-control-
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
   integrity sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==
 
-console-feed@^3.1.9:
-  version "3.1.9"
-  resolved "https://registry.yarnpkg.com/console-feed/-/console-feed-3.1.9.tgz#946191e5bf7a10fcabb478703129bc8b9eef5a9e"
-  integrity sha512-GAJCSTEvU3uZl4xVmYm7FONqzKelOj/+/+HZREb2w9CiOCjXRJtRP3nKiBYK8GszIDExiODEyz1WxWl2hHFkow==
+console-feed@^3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/console-feed/-/console-feed-3.5.0.tgz#0edf7dd1ebd82a24f5727315d0392fbb9a3c2f35"
+  integrity sha512-2N5b37yH0HeaqbBDsHBx0jEy3qvhTGA1dVdGyEM6C1NQhVmIX+ToU6Rt/uo86K0lLs4Lg1orC940YSn+Z3kk5g==
   dependencies:
     "@emotion/core" "^10.0.10"
     "@emotion/styled" "^10.0.12"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes: #5981.

## What is the current behavior?

Codesandbox's console fatals when you try to log `bigints`.

## What is the new behavior?

It works.

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

Added an integration test. Can you please update the snapshots for me?

## Checklist

- [ ] ~Documentation~ (No need)
- [ ] Testing (Added an integration test, but need the snapshots updated please!)
- [X] Ready to be merged
- [ ] ~Added myself to contributors table~