### PR TITLE
fix(npm-private): dont throw error on sandboxes

### DIFF
--- a/packages/sandpack-core/src/npm/dynamic/fetch-protocols/npm-registry.ts
+++ b/packages/sandpack-core/src/npm/dynamic/fetch-protocols/npm-registry.ts
@@ -139,14 +139,9 @@ export class NpmRegistryFetcher implements FetchProtocol {
     if (this.authToken) {
       // Custom registry url
       headers.append('Authorization', `${this.authType} ${this.authToken}`);
-    } else {
-      const sandpackToken = getSandpackSecret();
-      if (!sandpackToken) {
-        throw new Error('NPM_REGISTRY_UNAUTHENTICATED_REQUEST');
-      }
-
+    } else if (getSandpackSecret()) {
       // CSB proxy
-      headers.append('Authorization', `Bearer ${sandpackToken}`);
+      headers.append('Authorization', `Bearer ${getSandpackSecret()}`);
     }
 
     return {


### PR DESCRIPTION
It avoids throwing an error on regular sandboxes that contain private packages. Initially, I thought this would only affect Sandpack, but it seems it has also been used on csb.io sandboxes. 