### PR TITLE
fix: always show USD symbol if no local currency is present

### DIFF
--- a/packages/app/src/app/pages/Pro/Upgrade.tsx
+++ b/packages/app/src/app/pages/Pro/Upgrade.tsx
@@ -189,7 +189,7 @@ export const ProUpgrade = () => {
 
     // The formatCurrency function will divide the amount by 100
     return formatCurrency({
-      currency: priceInCurrency ? currency : 'USD',
+      currency: hasPriceInCurrency ? currency : 'USD',
       amount: price,
     });
   };


### PR DESCRIPTION
A small bug got reported:

We showed the local currency symbol with the USD price if no local currency price is available.

EDIT: hard to test, unless we get someone in India to open /pro


