### PR TITLE
fix(compile): create one TestRunner between sandbox compiles

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1691,6 +1691,15 @@
         "bug",
         "code"
       ]
+    },
+    {
+      "login": "SSHari",
+      "name": "Sai Hari",
+      "avatar_url": "https://avatars.githubusercontent.com/u/11434879?v=4",
+      "profile": "https://thesshguy.com/",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "contributorsPerLine": 7,

--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ Thanks goes to these wonderful people
     <td align="center"><a href="http://baobangdong.cn"><img src="https://avatars.githubusercontent.com/u/36991862?v=4" width="100px;" alt="B2D1"/><br /><sub><b>B2D1</b></sub></a><br /><a href="https://github.com/codesandbox/codesandbox-client/commits?author=B2D1" title="Documentation">📖</a></td>
     <td align="center"><a href="https://github.com/kettanaito"><img src="https://github.com/kettanaito.png" width="100px;" alt="Artem"/><br /><sub><b>Artem</b></sub></a><br /><a href="https://github.com/codesandbox/codesandbox-client/commits?author=kettanaito" title="Code">💻</a></td>
     <td align="center"><a href="http://hugos.computer"><img src="https://avatars.githubusercontent.com/u/1035169?v=4" width="100px;" alt="Hugo Wiledal"/><br /><sub><b>Hugo Wiledal</b></sub></a><br /><a href="https://github.com/codesandbox/codesandbox-client/issues?q=author%3Awiledal" title="Bug reports">🐛</a> <a href="https://github.com/codesandbox/codesandbox-client/commits?author=wiledal" title="Code">💻</a></td>
+    <td align="center"><a href="https://thesshguy.com/"><img src="https://avatars.githubusercontent.com/u/11434879?v=4" width="100px;" alt="Sai Hari"/><br /><sub><b>Sai Hari</b></sub></a><br /><a href="https://github.com/codesandbox/codesandbox-client/commits?author=SSHari" title="Code">💻</a></td>
   </tr>
 </table>
 

--- a/packages/app/src/sandbox/compile.ts
+++ b/packages/app/src/sandbox/compile.ts
@@ -890,11 +890,9 @@ async function compile(opts: CompileOptions) {
 
     setTimeout(async () => {
       try {
-        testRunner =
-          testRunner ||
-          (await import('./eval/tests/jest-lite')
-            .then(s => s.default)
-            .then(TestRunner => new TestRunner(manager)));
+        const jestLiteModule = await import('./eval/tests/jest-lite');
+        const TestRunner = jestLiteModule.default;
+        testRunner = testRunner || new TestRunner(manager);
 
         sendTestCount(modules);
       } catch (e) {


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?

<!-- Is it a Bug fix, feature, docs update, ... -->

Bug fix

## What is the current behavior?

<!-- You can also link to an open issue here -->

This is a proposed upstream fix for a [related Sandpack issue](https://github.com/codesandbox/sandpack/issues/927).

If you call the `compile` logic multiple times in a short amount of time, then the create `TestRunner` logic won't work as expected. Since the `testRunner` is shared between compiles, this is what ends up happening:

1. Call compile (**Compile A**)
2. Call compile again immediately (**Compile B**)
3. **Compile A**: `setTimeout` is called (wait `600ms`)
4. **Compile B**: `setTimeout` is called (wait `600ms`)
5. **Compile A**: `setTimeout` runs
6. **Compile A**: Because `testRunner` is `undefined`, await `jest-lite` module import
7. **Compile B**: `setTimeout` runs (step 6 is suspended because of the `await`)
8. **Compile B**: Because step 6 was suspended because of the `await`, `testRunner` is still `undefined`, so await `jest-lite` module import
9. **Compile A**: Set `testRunner` to `new TestRunner(manager)`
10. **Compile B**: Set `testRunner` to `new TestRunner(manager)`

The last two steps are the key to this issue. Because we call `new TestRunner(manager)` _twice_, we end up with _two_ [Code Sandbox message listeners](https://github.com/codesandbox/codesandbox-client/blob/master/packages/app/src/sandbox/eval/tests/jest-lite.ts#L112). When the `TestRunner` responds to a message (e.g. `run-all-tests`), it handles the message twice which means the tests are run twice. Since there's a shared global state used for tests and reporting results, the two test runs end up conflicting with each other and we get the error that's seen in that linked Sandpack issue.

Verifying this is easier to do in Sandpack because the issue currently exists there. In Sandpack, we call `compile` multiple times when a client is initialized which is reproducing this problem. While I think we may be able to make some improvements on the Sandpack side so that we don't compile more than once initially, I don't think we should rely on that to prevent this bug. I think the better fix for this issue is to address it in this package instead.

I couldn't figure out how to reproduce this error directly in this package. I _was_ able to simulate this behavior/issue by adding the following to the [app package's sandbox index file](https://github.com/codesandbox/codesandbox-client/blob/master/packages/app/src/sandbox/index.ts#L58):

```ts
setTimeout(() => compile(data), 1);
```

When I added the above line and opened a Jest Code Sandbox locally, I got the same error after running the test:

<img width="702" alt="Screenshot 2023-05-10 at 1 06 03 AM" src="https://github.com/codesandbox/codesandbox-client/assets/11434879/44c4d321-bad7-448e-bf98-98c74cd978e8">

## What is the new behavior?

Calling `compile` multiple times doesn't throw this error anymore because we only create the `TestRunner` once. The key part of the change is the line:

```ts
testRunner = testRunner || new TestRunner(manager);
```

This line happens _after_ the `await`, which means that when it runs for the second compile (i.e. **Compile B**), `testRunner` _will_ be set.

<!-- if this is a feature change -->

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

**codesandbox-client**

I simulated the error in this package using the method above. After I made the fix, I no longer saw the error in this package.

**sandpack**

1. I made the change locally
2. I started the app package's Sandpack script (i.e. `start:sandpack-sandbox`)
3. I started Sandpack locally and pointed the `bundlerURL` to my local sandbox (running on `localhost:3000`)
4. I no longer saw the error on the Sandpack side

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
