### PR TITLE
FIx: remove pilot check when rendering email settings

### DIFF
--- a/packages/app/src/app/pages/common/Modals/PreferencesModal/index.tsx
+++ b/packages/app/src/app/pages/common/Modals/PreferencesModal/index.tsx
@@ -71,13 +71,12 @@ const getItems = (isLoggedIn: boolean, user: CurrentUser): MenuItem[] =>
       id: 'integrations',
       title: 'Integrations',
     },
-    user &&
-      user.experiments.inPilot && {
-        Content: MailPreferences,
-        Icon: MailIcon,
-        id: 'emailSettings',
-        title: 'Email Settings',
-      },
+    user && {
+      Content: MailPreferences,
+      Icon: MailIcon,
+      id: 'emailSettings',
+      title: 'Email Settings',
+    },
     {
       Content: Experiments,
       Icon: FlaskIcon,


### PR DESCRIPTION
I _knew_ these used to exist...

This removes the `pilot` check from the email preferences (since that concept no longer exists)

Now it's back, we can refactor / improve / add other preferences here too.

<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?

<!-- Is it a Bug fix, feature, docs update, ... -->

## What is the current behavior?

<!-- You can also link to an open issue here -->

## What is the new behavior?

<!-- if this is a feature change -->

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Step A
2. Step B
3. Step C

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Testing <!-- We can only merge the PR if this is checked -->
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
