### PR TITLE
Debounce Algolia Search

### DIFF
--- a/packages/app/src/app/pages/Sandbox/SearchDependencies/SearchBox.tsx
+++ b/packages/app/src/app/pages/Sandbox/SearchDependencies/SearchBox.tsx
@@ -4,6 +4,7 @@ import { useAppState, useActions } from 'app/overmind';
 import css from '@styled-system/css';
 import useKeys from 'react-use/lib/useKeyboardJs';
 import { AlgoliaIcon } from './icons';
+import { debounce } from 'lodash-es';
 
 const getBackgroundColor = ({ focus, theme }) =>
   `url('data:image/svg+xml,%3Csvg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg"%3E%3Cpath fill-rule="evenodd" clip-rule="evenodd" d="M7.75208 8.73995C6.9345 9.40212 5.89308 9.79879 4.75902 9.79879C2.13068 9.79879 0 7.66811 0 5.03978C0 2.41145 2.13068 0.280762 4.75902 0.280762C7.38735 0.280762 9.51803 2.41145 9.51803 5.03978C9.51803 6.17384 9.12136 7.21526 8.45919 8.03285L13.3536 12.9272L12.6464 13.6343L7.75208 8.73995ZM8.51803 5.03978C8.51803 7.11583 6.83506 8.79879 4.75902 8.79879C2.68297 8.79879 1 7.11583 1 5.03978C1 2.96373 2.68297 1.28076 4.75902 1.28076C6.83506 1.28076 8.51803 2.96373 8.51803 5.03978Z" fill="%23${
@@ -127,12 +128,12 @@ export const SearchBox = ({ handleManualSelect, onChange, listRef }) => {
               fontSize: 4,
             },
           })}
-          onChange={e => {
+          onChange={debounce(e => {
             changeDependencySearch(e.target.value);
             if (workspace.showingSelectedDependencies) {
               toggleShowingSelectedDependencies();
             }
-          }}
+          }, 500)}
           value={workspace.dependencySearch}
         />
         <AlgoliaIcon

--- a/packages/app/src/app/pages/Sandbox/SearchDependencies/SearchBox.tsx
+++ b/packages/app/src/app/pages/Sandbox/SearchDependencies/SearchBox.tsx
@@ -3,8 +3,8 @@ import { Input, Element } from '@codesandbox/components';
 import { useAppState, useActions } from 'app/overmind';
 import css from '@styled-system/css';
 import useKeys from 'react-use/lib/useKeyboardJs';
-import { AlgoliaIcon } from './icons';
 import { debounce } from 'lodash-es';
+import { AlgoliaIcon } from './icons';
 
 const getBackgroundColor = ({ focus, theme }) =>
   `url('data:image/svg+xml,%3Csvg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg"%3E%3Cpath fill-rule="evenodd" clip-rule="evenodd" d="M7.75208 8.73995C6.9345 9.40212 5.89308 9.79879 4.75902 9.79879C2.13068 9.79879 0 7.66811 0 5.03978C0 2.41145 2.13068 0.280762 4.75902 0.280762C7.38735 0.280762 9.51803 2.41145 9.51803 5.03978C9.51803 6.17384 9.12136 7.21526 8.45919 8.03285L13.3536 12.9272L12.6464 13.6343L7.75208 8.73995ZM8.51803 5.03978C8.51803 7.11583 6.83506 8.79879 4.75902 8.79879C2.68297 8.79879 1 7.11583 1 5.03978C1 2.96373 2.68297 1.28076 4.75902 1.28076C6.83506 1.28076 8.51803 2.96373 8.51803 5.03978Z" fill="%23${


### PR DESCRIPTION
Adds a debounce to the algolia search, so we don't fire off too many requests while someone is still typing.

Let me know if there's a better way to do this? But I noticed we use this `debounce` function in lots of places, so it seemed like the right thing to do?

<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?

<!-- Is it a Bug fix, feature, docs update, ... -->

## What is the current behavior?

<!-- You can also link to an open issue here -->

## What is the new behavior?

<!-- if this is a feature change -->

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Step A
2. Step B
3. Step C

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Testing <!-- We can only merge the PR if this is checked -->
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
