### PR TITLE
docs(editor): update links to CodeSandbox tutorial in AI, Docker, and VS Code

### DIFF
--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/AI/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/AI/index.tsx
@@ -40,7 +40,7 @@ export const AITools = () => {
             Yes, fork
           </Button>
           <Link
-            href="https://codesandbox.io/docs/learn/sandboxes/overview?tab=cloud"
+            href="https://codesandbox.io/docs/tutorial/convert-browser-sandbox-cloud"
             target="_blank"
             rel="noreferrer noopener"
           >

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Docker/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Docker/index.tsx
@@ -36,7 +36,7 @@ export const Docker = () => {
             Yes, {canConvert ? 'convert' : 'fork and convert'}
           </Button>
           <Link
-            href="https://codesandbox.io/docs/learn/sandboxes/overview?tab=cloud"
+            href="https://codesandbox.io/docs/tutorial/convert-browser-sandbox-cloud"
             target="_blank"
             rel="noreferrer noopener"
           >

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/VSCode/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/VSCode/index.tsx
@@ -24,8 +24,8 @@ export const VSCode = () => {
           servers, databases, and much more.
         </Text>
         <Text as="p" variant="muted" margin={0}>
-          Don&apos;t worry&mdash;this sandbox will not be deleted. After converting,
-          you will have both versions.
+          Don&apos;t worry&mdash;this sandbox will not be deleted. After
+          converting, you will have both versions.
         </Text>
         <Text as="p" variant="muted" margin={0}>
           Do you want to fork this sandbox?
@@ -40,7 +40,7 @@ export const VSCode = () => {
             Yes, fork
           </Button>
           <Link
-            href="https://codesandbox.io/docs/learn/sandboxes/overview?tab=cloud"
+            href="https://codesandbox.io/docs/tutorial/convert-browser-sandbox-cloud"
             target="_blank"
             rel="noreferrer noopener"
           >


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR simply updates 3 links to the Docs in the left sidebar (Docker, VS Code, and AI).

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

Open a sandbox and check the Docker, VS Code, and AI tabs on the left. The "Learn More" link now points to the "Convert a browser sandbox into a cloud sandbox" tutorial.