### PR TITLE
refactor(sandbox): remove web-vitals from sandbox dependencies

### DIFF
--- a/packages/app/src/sandbox/compile.ts
+++ b/packages/app/src/sandbox/compile.ts
@@ -123,6 +123,7 @@ const BABEL_DEPENDENCIES = [
 // Dependencies that we actually don't need, we will replace this by a dynamic
 // system in the future
 const PREINSTALLED_DEPENDENCIES = [
+  'web-vitals', // Blocked by ad blockers :(
   'react-scripts',
   'react-scripts-ts',
   'parcel-bundler',


### PR DESCRIPTION
`web-vitals` is blocked by adblockers, many times. Also not really used in imports, so removing it from the installation step.