### PR TITLE
PTB-451 -- Revamp Notification Preferences

### DIFF
--- a/packages/app/src/app/overmind/effects/gql/notifications/mutations.ts
+++ b/packages/app/src/app/overmind/effects/gql/notifications/mutations.ts
@@ -21,16 +21,28 @@ export const updateNotificationPreferences: Query<
   mutation UpdateNotificationPreferences(
     $emailCommentMention: Boolean
     $emailCommentReply: Boolean
+    $emailMarketing: Boolean
     $emailNewComment: Boolean
+    $emailSandboxInvite: Boolean
+    $emailTeamInvite: Boolean
+    $inAppPrReviewRequest: Boolean
   ) {
     updateNotificationPreferences(
       emailCommentMention: $emailCommentMention
       emailCommentReply: $emailCommentReply
+      emailMarketing: $emailMarketing
       emailNewComment: $emailNewComment
+      emailSandboxInvite: $emailSandboxInvite
+      emailTeamInvite: $emailTeamInvite
+      inAppPrReviewRequest: $inAppPrReviewRequest
     ) {
       emailCommentMention
       emailCommentReply
+      emailMarketing
       emailNewComment
+      emailSandboxInvite
+      emailTeamInvite
+      inAppPrReviewRequest
     }
   }
 `;

--- a/packages/app/src/app/overmind/effects/gql/notifications/queries.ts
+++ b/packages/app/src/app/overmind/effects/gql/notifications/queries.ts
@@ -17,7 +17,11 @@ export const getEmailPreferences: Query<
       notificationPreferences {
         emailCommentMention
         emailCommentReply
+        emailMarketing
         emailNewComment
+        emailSandboxInvite
+        emailTeamInvite
+        inAppPrReviewRequest
       }
     }
   }

--- a/packages/app/src/app/overmind/namespaces/userNotifications/state.ts
+++ b/packages/app/src/app/overmind/namespaces/userNotifications/state.ts
@@ -3,7 +3,11 @@ import { RecentNotificationFragment } from 'app/graphql/types';
 export type preferenceTypes = {
   emailCommentMention: boolean;
   emailCommentReply: boolean;
+  emailMarketing: boolean;
   emailNewComment: boolean;
+  emailSandboxInvite: boolean;
+  emailTeamInvite: boolean;
+  inAppPrReviewRequest: boolean;
 };
 
 type State = {

--- a/packages/app/src/app/pages/common/Modals/PreferencesModal/MailPreferences/index.tsx
+++ b/packages/app/src/app/pages/common/Modals/PreferencesModal/MailPreferences/index.tsx
@@ -2,7 +2,7 @@ import { Text, Element } from '@codesandbox/components';
 import React, { FunctionComponent, useEffect } from 'react';
 import { useAppState, useActions } from 'app/overmind';
 
-import { SubContainer, PaddedPreference } from '../elements';
+import { Rule, SubContainer, PaddedPreference } from '../elements';
 
 export const MailPreferences: FunctionComponent = () => {
   const {
@@ -18,77 +18,92 @@ export const MailPreferences: FunctionComponent = () => {
   return (
     <>
       <Text block marginBottom={6} size={4} weight="regular">
-        Email me when...
+        Notfication Preferences
       </Text>
 
       {preferences ? (
         <SubContainer>
-          <Element paddingTop={4}>
-            <PaddedPreference
-              setValue={(value: boolean) =>
-                updateNotificationPreferences({
-                  emailNewComment: value,
-                })
-              }
-              title="New comment"
-              tooltip="Email on new comment"
-              type="boolean"
-              value={preferences.emailNewComment}
-            />
-            <Text
-              block
-              marginTop={2}
-              size={3}
-              style={{ maxWidth: '60%' }}
-              variant="muted"
-            >
-              A user left a comment on one of my sandboxes
-            </Text>
-          </Element>
-          <Element paddingTop={4}>
-            <PaddedPreference
-              setValue={(value: boolean) =>
-                updateNotificationPreferences({
-                  emailCommentReply: value,
-                })
-              }
-              title="Replies"
-              tooltip="Email on new reply"
-              type="boolean"
-              value={preferences.emailCommentReply}
-            />
-            <Text
-              block
-              marginTop={2}
-              size={3}
-              style={{ maxWidth: '60%' }}
-              variant="muted"
-            >
-              A reply has been left on one of my comments
-            </Text>
-          </Element>
-          <Element paddingTop={4}>
-            <PaddedPreference
-              setValue={(value: boolean) =>
-                updateNotificationPreferences({
-                  emailCommentMention: value,
-                })
-              }
-              title="@Mentions"
-              tooltip="Email on new mention"
-              type="boolean"
-              value={preferences.emailCommentMention}
-            />
-          </Element>
+          <Text block marginBottom={2} size={3} weight="regular">
+            Review Notifications
+          </Text>
           <Text
             block
-            marginTop={2}
+            marginBottom={2}
             size={3}
             style={{ maxWidth: '60%' }}
             variant="muted"
           >
-            Someone mentioned me in a comment
+            In-browser notifications related to pull requests and reviews. These
+            will only be sent for repositories that have the GitHub App
+            installed and have been imported into any of your teams.
           </Text>
+          <Element paddingTop={4}>
+            <PaddedPreference
+              setValue={(value: boolean) =>
+                updateNotificationPreferences({
+                  inAppPrReviewRequest: value,
+                })
+              }
+              title="Notify me when someone requests my review on a pull request"
+              tooltip="Notify on review request"
+              type="boolean"
+              value={preferences.inAppPrReviewRequest}
+            />
+          </Element>
+          <Rule />
+          <Text block marginTop={4} marginBottom={4} size={3} weight="regular">
+            Email Notifications
+          </Text>
+          <Text
+            block
+            marginBottom={2}
+            size={3}
+            style={{ maxWidth: '60%' }}
+            variant="muted"
+          >
+            These notifications will always show in the browser, but receiving
+            an email is optional.
+          </Text>
+          <Element paddingTop={4}>
+            <PaddedPreference
+              setValue={(value: boolean) =>
+                updateNotificationPreferences({
+                  emailTeamInvite: value,
+                })
+              }
+              title="Email when someone invites me to a team"
+              tooltip="Email on team invite"
+              type="boolean"
+              value={preferences.emailTeamInvite}
+            />
+          </Element>
+          <Element paddingTop={4}>
+            <PaddedPreference
+              setValue={(value: boolean) =>
+                updateNotificationPreferences({
+                  emailSandboxInvite: value,
+                })
+              }
+              title="Email when someone invites me to collaborate on a sandbox"
+              tooltip="Email on team invite"
+              type="boolean"
+              value={preferences.emailSandboxInvite}
+            />
+          </Element>
+          <Rule />
+          <Element paddingTop={4}>
+            <PaddedPreference
+              setValue={(value: boolean) =>
+                updateNotificationPreferences({
+                  emailMarketing: value,
+                })
+              }
+              title="Send me occasional news and product updates via email"
+              tooltip="Product emails"
+              type="boolean"
+              value={preferences.emailMarketing}
+            />
+          </Element>
         </SubContainer>
       ) : (
         <Text align="center" marginTop={6} size={3}>

--- a/packages/app/src/app/pages/common/Modals/PreferencesModal/MailPreferences/index.tsx
+++ b/packages/app/src/app/pages/common/Modals/PreferencesModal/MailPreferences/index.tsx
@@ -26,17 +26,19 @@ export const MailPreferences: FunctionComponent = () => {
           <Text block marginBottom={2} size={3} weight="regular">
             Review Notifications
           </Text>
+
           <Text
             block
-            marginBottom={2}
-            size={3}
-            style={{ maxWidth: '60%' }}
+            marginTop={2}
+            size={2}
             variant="muted"
+            style={{ maxWidth: '90%' }}
           >
             In-browser notifications related to pull requests and reviews. These
             will only be sent for repositories that have the GitHub App
             installed and have been imported into any of your teams.
           </Text>
+
           <Element paddingTop={4}>
             <PaddedPreference
               setValue={(value: boolean) =>
@@ -54,16 +56,12 @@ export const MailPreferences: FunctionComponent = () => {
           <Text block marginTop={4} marginBottom={4} size={3} weight="regular">
             Email Notifications
           </Text>
-          <Text
-            block
-            marginBottom={2}
-            size={3}
-            style={{ maxWidth: '60%' }}
-            variant="muted"
-          >
+
+          <Text block marginTop={2} size={2} variant="muted">
             These notifications will always show in the browser, but receiving
             an email is optional.
           </Text>
+
           <Element paddingTop={4}>
             <PaddedPreference
               setValue={(value: boolean) =>
@@ -90,8 +88,9 @@ export const MailPreferences: FunctionComponent = () => {
               value={preferences.emailSandboxInvite}
             />
           </Element>
+
           <Rule />
-          <Element paddingTop={4}>
+          <Element paddingTop={2}>
             <PaddedPreference
               setValue={(value: boolean) =>
                 updateNotificationPreferences({

--- a/packages/app/src/app/pages/common/Modals/PreferencesModal/index.tsx
+++ b/packages/app/src/app/pages/common/Modals/PreferencesModal/index.tsx
@@ -71,13 +71,12 @@ const getItems = (isLoggedIn: boolean, user: CurrentUser): MenuItem[] =>
       id: 'integrations',
       title: 'Integrations',
     },
-    user &&
-      user.experiments.inPilot && {
-        Content: MailPreferences,
-        Icon: MailIcon,
-        id: 'emailSettings',
-        title: 'Email Settings',
-      },
+    user && {
+      Content: MailPreferences,
+      Icon: MailIcon,
+      id: 'emailSettings',
+      title: 'Notification Preferences',
+    },
     {
       Content: Experiments,
       Icon: FlaskIcon,


### PR DESCRIPTION
As preparation for more possible future notification types, I updated the notification preferences part of the Preferences Modal.

I want to create a follow-up PR that allows users to open this from the notifications icon in the top right too, but turns out that is not as simple as I had hoped. (But hey, I'm learning some stuff as I go I suppose)

To look at it: sign in, and click the menu in the top right > preferences > notification preferences

<img width="1046" alt="image" src="https://github.com/codesandbox/codesandbox-client/assets/17491062/1759bbcf-5665-4b55-a666-c7c79e38c823">


<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?

<!-- Is it a Bug fix, feature, docs update, ... -->

## What is the current behavior?

<!-- You can also link to an open issue here -->

## What is the new behavior?

<!-- if this is a feature change -->

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Step A
2. Step B
3. Step C

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Testing <!-- We can only merge the PR if this is checked -->
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
