### PR TITLE
Sanne/pc 702 open preferences by url

### DIFF
--- a/packages/app/src/app/components/Notifications/Filters.tsx
+++ b/packages/app/src/app/components/Notifications/Filters.tsx
@@ -6,10 +6,13 @@ import css from '@styled-system/css';
 export const Filters = () => {
   const { userNotifications } = useAppState();
   const {
-    filterNotifications,
-    markAllNotificationsAsRead,
-    archiveAllNotifications,
-  } = useActions().userNotifications;
+    userNotifications: {
+      filterNotifications,
+      markAllNotificationsAsRead,
+      archiveAllNotifications,
+    },
+    preferences: { openPreferencesModal },
+  } = useActions();
 
   const options = {
     team_invite: 'Team Invite',
@@ -62,6 +65,9 @@ export const Filters = () => {
           size={12}
         />
         <Menu.List>
+          <Menu.Item onSelect={() => openPreferencesModal('notifications')}>
+            Manage notification preferences
+          </Menu.Item>
           <Menu.Item onSelect={() => archiveAllNotifications()}>
             Clear all notifications
           </Menu.Item>

--- a/packages/app/src/app/overmind/namespaces/preferences/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/preferences/actions.ts
@@ -23,6 +23,14 @@ export const devtoolsToggled = ({ state }: Context) => {
   state.preferences.showDevtools = !state.preferences.showDevtools;
 };
 
+export const openPreferencesModal = (
+  { state }: Context,
+  itemId: string = 'appearance'
+) => {
+  state.preferences.itemId = itemId;
+  state.currentModal = 'preferences';
+};
+
 export const setDevtoolsOpen = ({ state }: Context, isOpen: boolean) => {
   state.preferences.showDevtools = isOpen;
 };

--- a/packages/app/src/app/pages/Dashboard/Content/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/index.tsx
@@ -66,7 +66,6 @@ export const Content = withRouter(({ history }) => {
     >
       <Switch>
         <Route path="/dashboard/recent" component={Recent} />
-        <Route path="/dashboard/preferences" component={Recent} />
         <Route path="/dashboard/drafts" component={Drafts} />
         <Route path="/dashboard/sandboxes/:path*" component={Sandboxes} />
         <Route path="/dashboard/templates" component={Templates} />

--- a/packages/app/src/app/pages/Dashboard/Content/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/index.tsx
@@ -66,6 +66,7 @@ export const Content = withRouter(({ history }) => {
     >
       <Switch>
         <Route path="/dashboard/recent" component={Recent} />
+        <Route path="/dashboard/preferences" component={Recent} />
         <Route path="/dashboard/drafts" component={Drafts} />
         <Route path="/dashboard/sandboxes/:path*" component={Sandboxes} />
         <Route path="/dashboard/templates" component={Templates} />

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Recent/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Recent/index.tsx
@@ -7,19 +7,25 @@ import { Loading, Stack } from '@codesandbox/components';
 import { EmptyRecent } from './EmptyRecent';
 import { RecentContent } from './RecentContent';
 
-export const Recent = () => {
+export const Recent = props => {
+  const state = useAppState();
   const {
     activeTeam,
     dashboard: { sandboxes },
-  } = useAppState();
+  } = state;
   const {
     dashboard: { getPage },
+    preferences: { openPreferencesModal },
   } = useActions();
 
   useEffect(() => {
     getPage(sandboxesTypes.RECENT);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeTeam]);
+
+  if (props.location.pathname === '/dashboard/preferences') {
+    openPreferencesModal();
+  }
 
   const items: (DashboardSandbox | DashboardBranch)[] =
     sandboxes.RECENT_BRANCHES === null || sandboxes.RECENT_SANDBOXES === null

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Recent/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Recent/index.tsx
@@ -8,11 +8,10 @@ import { EmptyRecent } from './EmptyRecent';
 import { RecentContent } from './RecentContent';
 
 export const Recent = props => {
-  const state = useAppState();
   const {
     activeTeam,
     dashboard: { sandboxes },
-  } = state;
+  } = useAppState();
   const {
     dashboard: { getPage },
     preferences: { openPreferencesModal },
@@ -23,7 +22,7 @@ export const Recent = props => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeTeam]);
 
-  if (props.location.pathname === '/dashboard/preferences') {
+  if (props.location?.pathname === '/dashboard/preferences') {
     openPreferencesModal();
   }
 

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Recent/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Recent/index.tsx
@@ -14,17 +14,12 @@ export const Recent = props => {
   } = useAppState();
   const {
     dashboard: { getPage },
-    preferences: { openPreferencesModal },
   } = useActions();
 
   useEffect(() => {
     getPage(sandboxesTypes.RECENT);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeTeam]);
-
-  if (props.location?.pathname === '/dashboard/preferences') {
-    openPreferencesModal();
-  }
 
   const items: (DashboardSandbox | DashboardBranch)[] =
     sandboxes.RECENT_BRANCHES === null || sandboxes.RECENT_SANDBOXES === null

--- a/packages/app/src/app/pages/Dashboard/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/index.tsx
@@ -136,6 +136,8 @@ export const Dashboard: FunctionComponent = () => {
       actions.openCreateSandboxModal({ initialTab: 'import' });
     } else if (JSON.parse(searchParams.get('create_sandbox'))) {
       actions.openCreateSandboxModal();
+    } else if (JSON.parse(searchParams.get('preferences'))) {
+      actions.preferences.openPreferencesModal();
     }
   }, [actions, hasLogIn, location.search]);
 

--- a/packages/app/src/app/pages/common/Modals/PreferencesModal/index.tsx
+++ b/packages/app/src/app/pages/common/Modals/PreferencesModal/index.tsx
@@ -74,7 +74,7 @@ const getItems = (isLoggedIn: boolean, user: CurrentUser): MenuItem[] =>
     user && {
       Content: MailPreferences,
       Icon: MailIcon,
-      id: 'emailSettings',
+      id: 'notifications',
       title: 'Notification Preferences',
     },
     {
@@ -98,6 +98,7 @@ export const PreferencesModal: FunctionComponent = () => {
     preferences: { itemId = 'appearance' },
   } = useAppState();
   const items = getItems(isLoggedIn, user);
+
   const { Content } = items.find(({ id }) => id === itemId);
 
   return (


### PR DESCRIPTION
Replaces #7673 

- I moved the `openUserPreferences` function to `actions > preferences` so we can use the same function wherever we want to open this modal
(Being able to open this modal via URL is one of the number 1 requests from support, since otherwise it's so tricky to find)

Changed to a query parameter `?preferences=true` that will work anywhere within `/dashboard`


<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?

<!-- Is it a Bug fix, feature, docs update, ... -->

## What is the current behavior?

<!-- You can also link to an open issue here -->

## What is the new behavior?

<!-- if this is a feature change -->

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Step A
2. Step B
3. Step C

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Testing <!-- We can only merge the PR if this is checked -->
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
