### PR TITLE
fix: debounce error in dependencies

### DIFF
--- a/packages/app/src/app/pages/Sandbox/SearchDependencies/SearchBox.tsx
+++ b/packages/app/src/app/pages/Sandbox/SearchDependencies/SearchBox.tsx
@@ -1,9 +1,9 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useCallback, useEffect, useRef } from 'react';
 import { Input, Element } from '@codesandbox/components';
 import { useAppState, useActions } from 'app/overmind';
 import css from '@styled-system/css';
 import useKeys from 'react-use/lib/useKeyboardJs';
-import { debounce } from 'lodash-es';
+import { debounce } from 'lodash';
 import { AlgoliaIcon } from './icons';
 
 const getBackgroundColor = ({ focus, theme }) =>
@@ -72,6 +72,15 @@ export const SearchBox = ({ handleManualSelect, onChange, listRef }) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [workspace.dependencySearch]);
 
+  const handleChange = (value: string) => {
+    changeDependencySearch(value);
+    if (workspace.showingSelectedDependencies) {
+      toggleShowingSelectedDependencies();
+    }
+  };
+
+  const debouncedChange = useCallback(debounce(handleChange, 500), []);
+
   return (
     <form
       ref={form}
@@ -128,13 +137,8 @@ export const SearchBox = ({ handleManualSelect, onChange, listRef }) => {
               fontSize: 4,
             },
           })}
-          onChange={debounce(e => {
-            changeDependencySearch(e.target.value);
-            if (workspace.showingSelectedDependencies) {
-              toggleShowingSelectedDependencies();
-            }
-          }, 500)}
-          value={workspace.dependencySearch}
+          onChange={e => debouncedChange(e.target.value)}
+          defaultValue={workspace.dependencySearch}
         />
         <AlgoliaIcon
           css={css({


### PR DESCRIPTION
Using the debounce inline was not passing the event argument properly. I also moved it into a useCallback to avoid calling debounce again on each re-render.

Closes PC-981