### PR TITLE
feat(permission): back to project button

### DIFF
--- a/packages/app/src/app/pages/Dashboard/Content/routes/Settings/components/PermissionSettings.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Settings/components/PermissionSettings.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useAppState, useActions } from 'app/overmind';
 import {
   Button,
@@ -294,6 +294,7 @@ const SandboxSecurity = ({ disabled }: { disabled: boolean }) => {
 
 const AIPermission = ({ disabled }: { disabled: boolean }) => {
   const { activeTeamInfo } = useAppState();
+  const [showContinueUrl, setShowContinueUrl] = useState(false);
 
   const options = [
     {
@@ -316,6 +317,9 @@ const AIPermission = ({ disabled }: { disabled: boolean }) => {
 
   const [state, setState] = React.useState(activeTeamInfo.settings.aiConsent);
   const { setTeamAiConsent } = useActions().dashboard;
+
+  const urlParams = new URLSearchParams(window.location.search);
+  const continueUrl = urlParams.get('continueUrl');
 
   return (
     <Stack
@@ -379,13 +383,20 @@ const AIPermission = ({ disabled }: { disabled: boolean }) => {
         </Text>
       </Stack>
 
-      <Stack justify="flex-end">
+      <Stack justify="flex-end" gap={2}>
+        {showContinueUrl && continueUrl && (
+          <Button autoWidth variant="secondary" as="a" href={continueUrl}>
+            Go back to the project
+          </Button>
+        )}
+
         <Button
-          disabled={disabled}
           autoWidth
+          disabled={disabled}
           onClick={async () => {
             track('Dashboard - Permissions panel - Changed AI consent');
             await setTeamAiConsent(state);
+            setShowContinueUrl(true);
           }}
         >
           Change Settings


### PR DESCRIPTION
It shows a back-to-project button after saving permission if it contains `continueUrl` query params.

Closes PC-969
Depends on https://github.com/codesandbox/codesandbox-applications/pull/2917