### PR TITLE
feat(Dashboard): prefill invite_email into the input on team settings

### DIFF
--- a/packages/app/src/app/components/UserSearchInput/UserSearchInput.tsx
+++ b/packages/app/src/app/components/UserSearchInput/UserSearchInput.tsx
@@ -107,6 +107,7 @@ export const UserSearchInput = ({
               placeholder: 'Enter username or email',
             })}
             autoFocus
+            autoComplete="off"
             spellcheck="false"
           />
         </div>

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Settings/components/InviteMember.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Settings/components/InviteMember.tsx
@@ -41,7 +41,12 @@ export const InviteMember: React.FC<InviteMemberProps> = ({
   const actions = useActions();
   const { userRole } = useWorkspaceAuthorization();
 
-  const [inviteValue, setInviteValue] = React.useState('');
+  const inviteEmailInUrl = new URLSearchParams(location.search).get(
+    'invite_email'
+  );
+  const defaultInviteValue = inviteEmailInUrl || '';
+
+  const [inviteValue, setInviteValue] = React.useState(defaultInviteValue);
   const [inviteLoading, setInviteLoading] = React.useState(false);
   const inviteLink = React.useMemo(() => teamInviteLink(team.inviteToken), [
     team.inviteToken,


### PR DESCRIPTION
Pre-populate the input with the invite_email from the query string
Also removes autoComplete on the input