### PR TITLE
feat(api): add new endpoint for retrieving features

### DIFF
--- a/packages/app/src/app/overmind/actions.ts
+++ b/packages/app/src/app/overmind/actions.ts
@@ -167,6 +167,12 @@ export const onInitializeOvermind = async (
   effects.browserExtension.hasExtension().then(hasExtension => {
     actions.preview.setExtension(hasExtension);
   });
+
+  try {
+    state.features = await effects.api.getFeatures();
+  } catch {
+    // Just for safety so it doesn't crash the overmind initialize flow
+  }
 };
 
 export const appUnmounted = async ({ effects, actions }: Context) => {

--- a/packages/app/src/app/overmind/effects/api/apiFactory.ts
+++ b/packages/app/src/app/overmind/effects/api/apiFactory.ts
@@ -10,13 +10,13 @@ const API_ROOT = '/api';
  * use the root path.
  */
 const getBaseApi = (path: string, useRoot: boolean = false) => {
-  if (useRoot) {
-    return API_ROOT;
-  }
-
   // Special case for /auth/workos requests which are not on /api/v1
   if (path.startsWith('/auth/workos')) {
     return '';
+  }
+
+  if (useRoot) {
+    return API_ROOT;
   }
 
   return path.startsWith('/beta') ? API_ROOT : `${API_ROOT}/v1`;

--- a/packages/app/src/app/overmind/effects/api/index.ts
+++ b/packages/app/src/app/overmind/effects/api/index.ts
@@ -41,6 +41,7 @@ import {
   SandboxAPIResponse,
   AvatarAPIResponse,
   FinalizeSignUpOptions,
+  MetaFeatures,
 } from './types';
 
 let api: Api;
@@ -704,5 +705,10 @@ export default {
     return api.get<{ redirectUrl: string }>('/auth/workos/initialize', {
       email,
     });
+  },
+  getFeatures(): Promise<MetaFeatures> {
+    // useRoot = true since this is on /api/meta/features
+    // TODO: Refactor api factory to start from /api and apply /v1 as a legacy feature
+    return api.get('/meta/features', undefined, undefined, true);
   },
 };

--- a/packages/app/src/app/overmind/effects/api/types.ts
+++ b/packages/app/src/app/overmind/effects/api/types.ts
@@ -41,3 +41,10 @@ export type FinalizeSignUpOptions = {
   role: string;
   usage: string;
 };
+
+export type MetaFeatures = {
+  loginWithApple?: boolean;
+  loginWithGithub?: boolean;
+  loginWithGoogle?: boolean;
+  loginWithWorkos?: boolean;
+};

--- a/packages/app/src/app/overmind/state.ts
+++ b/packages/app/src/app/overmind/state.ts
@@ -10,6 +10,7 @@ import {
 } from 'app/graphql/types';
 import { derived } from 'overmind';
 import { hasLogIn } from '@codesandbox/common/lib/utils/user';
+import { MetaFeatures } from './effects/api/types';
 
 export type PendingUserType = {
   avatarUrl: string | null;
@@ -80,6 +81,13 @@ type State = {
    * but our data does not year have the workspace subscription information
    */
   isProcessingPayment: boolean;
+
+  /**
+   * Different features might be available based on the backend response
+   * eg: different login providers
+   * Each field is undefined until the endpoint returns.
+   */
+  features: MetaFeatures;
 };
 
 export const state: State = {
@@ -144,4 +152,10 @@ export const state: State = {
     github: false,
   },
   isProcessingPayment: false,
+  features: {
+    // Fallback values for when the features endpoint is not available
+    loginWithApple: true,
+    loginWithGoogle: true,
+    loginWithGithub: true,
+  },
 };

--- a/packages/app/src/app/pages/SignIn/ChooseProvider.tsx
+++ b/packages/app/src/app/pages/SignIn/ChooseProvider.tsx
@@ -205,11 +205,18 @@ export const ChooseProvider: React.FC<ChooseProviderProps> = ({
     setLoadingAuth,
     toggleSignInModal,
   } = useActions();
-  const { loadingAuth, cancelOnLogin } = useAppState();
+  const { loadingAuth, cancelOnLogin, features } = useAppState();
 
   const [signInMode, setSignInMode] = React.useState<SignInMode>(
     defaultSignInMode
   );
+
+  const showSwitchToSSO = signInMode === 'DEFAULT' && features.loginWithWorkos;
+  const showSwitchToDefault =
+    signInMode === 'SSO' &&
+    (features.loginWithApple ||
+      features.loginWithGoogle ||
+      features.loginWithGithub);
 
   const handleSignIn = async (
     provider: 'github' | 'google' | 'apple' | 'sso',
@@ -281,26 +288,29 @@ export const ChooseProvider: React.FC<ChooseProviderProps> = ({
               </Text>
             </Stack>
             <Stack direction="vertical" gap={3}>
-              <Button
-                css={{
-                  width: '100%',
-                  height: '48px',
-                }}
-                loading={loadingAuth.github}
-                onClick={() => handleSignIn('github')}
-              >
-                <GitHubIcon />
-                <Text
-                  as="span"
+              {features.loginWithGithub && (
+                <Button
                   css={{
-                    lineHeight: 1,
+                    width: '100%',
+                    height: '48px',
                   }}
-                  size={4}
-                  weight="medium"
+                  loading={loadingAuth.github}
+                  onClick={() => handleSignIn('github')}
                 >
-                  Sign in with GitHub
-                </Text>
-              </Button>
+                  <GitHubIcon />
+                  <Text
+                    as="span"
+                    css={{
+                      lineHeight: 1,
+                    }}
+                    size={4}
+                    weight="medium"
+                  >
+                    Sign in with GitHub
+                  </Text>
+                </Button>
+              )}
+
               <Stack
                 css={{
                   '@media screen and (max-width: 440px)': {
@@ -309,46 +319,50 @@ export const ChooseProvider: React.FC<ChooseProviderProps> = ({
                 }}
                 gap={3}
               >
-                <Button
-                  css={{
-                    width: '100%',
-                    height: '40px',
-                    flex: 1,
-                  }}
-                  loading={loadingAuth.google}
-                  onClick={() => handleSignIn('google')}
-                  secondary
-                >
-                  <GoogleIcon />
-                  <Text
-                    as="span"
-                    css={{ lineHeight: 1 }}
-                    size={3}
-                    weight="medium"
+                {features.loginWithGoogle && (
+                  <Button
+                    css={{
+                      width: '100%',
+                      height: '40px',
+                      flex: 1,
+                    }}
+                    loading={loadingAuth.google}
+                    onClick={() => handleSignIn('google')}
+                    secondary
                   >
-                    Sign in with Google
-                  </Text>
-                </Button>
-                <Button
-                  css={{
-                    width: '100%',
-                    height: '40px',
-                    flex: 1,
-                  }}
-                  loading={loadingAuth.apple}
-                  onClick={() => handleSignIn('apple')}
-                  secondary
-                >
-                  <AppleIcon />
-                  <Text
-                    as="span"
-                    css={{ lineHeight: 1 }}
-                    size={3}
-                    weight="medium"
+                    <GoogleIcon />
+                    <Text
+                      as="span"
+                      css={{ lineHeight: 1 }}
+                      size={3}
+                      weight="medium"
+                    >
+                      Sign in with Google
+                    </Text>
+                  </Button>
+                )}
+                {features.loginWithApple && (
+                  <Button
+                    css={{
+                      width: '100%',
+                      height: '40px',
+                      flex: 1,
+                    }}
+                    loading={loadingAuth.apple}
+                    onClick={() => handleSignIn('apple')}
+                    secondary
                   >
-                    Sign in with Apple
-                  </Text>
-                </Button>
+                    <AppleIcon />
+                    <Text
+                      as="span"
+                      css={{ lineHeight: 1 }}
+                      size={3}
+                      weight="medium"
+                    >
+                      Sign in with Apple
+                    </Text>
+                  </Button>
+                )}
               </Stack>
             </Stack>
             {cancelOnLogin && (
@@ -373,7 +387,7 @@ export const ChooseProvider: React.FC<ChooseProviderProps> = ({
         )}
 
         <Stack as="footer" align="center" direction="vertical">
-          {signInMode === 'DEFAULT' && (
+          {showSwitchToSSO && (
             <StyledGhostButton
               onClick={() => setSignInMode('SSO')}
               variant="ghost"
@@ -381,7 +395,7 @@ export const ChooseProvider: React.FC<ChooseProviderProps> = ({
               Sign in with SSO
             </StyledGhostButton>
           )}
-          {signInMode === 'SSO' && (
+          {showSwitchToDefault && (
             <Text lineHeight="16px" size={13} variant="muted">
               Not SSO?{''}
               <StyledGhostButton

--- a/packages/app/src/app/pages/SignIn/SignIn.tsx
+++ b/packages/app/src/app/pages/SignIn/SignIn.tsx
@@ -13,7 +13,12 @@ interface SignInProps {
 }
 
 export const SignIn: React.FC<SignInProps> = ({ redirectTo, onSignIn }) => {
-  const { duplicateAccountStatus, pendingUser, pendingUserId } = useAppState();
+  const {
+    duplicateAccountStatus,
+    pendingUser,
+    pendingUserId,
+    features,
+  } = useAppState();
   const { getPendingUser } = useActions();
 
   useEffect(() => {
@@ -22,8 +27,12 @@ export const SignIn: React.FC<SignInProps> = ({ redirectTo, onSignIn }) => {
     }
   }, [getPendingUser, pendingUserId]);
 
+  const isAnyRegularAuthProviderAvailable =
+    features.loginWithApple ||
+    features.loginWithGithub ||
+    features.loginWithGoogle;
   const defaultSignInMode: SignInMode =
-    new URLSearchParams(location.search).get('sso_mode') === 'true'
+    features.loginWithWorkos && !isAnyRegularAuthProviderAvailable
       ? 'SSO'
       : 'DEFAULT';
 


### PR DESCRIPTION
Integrates the new `/meta/features` endpoint that tells the client (for now) which login options are available. SSO and OAuth login options are now conditioned by these flags.

The new api routes that are no longer on /v1 will need some better support with the current implementation of apiFactory, but I'll change that in a subsequent PR to avoid dragging this for too long or blowing the scope here.

Closes PC-1113