### PR TITLE
feat(pricing): remove personal refs and use legacy flag for determining badges

### DIFF
--- a/.codesandbox/tasks.json
+++ b/.codesandbox/tasks.json
@@ -24,7 +24,7 @@
     "app:fast": {
       "name": "Application (fast + production)",
       "command": "yarn start:fast",
-      "runAtStart": true,
+      "runAtStart": false,
       "preview": {
         "port": 3000
       },
@@ -35,6 +35,7 @@
     "app:fast:stream": {
       "name": "Application (fast + stream)",
       "command": "yarn start:fast:stream",
+      "runAtStart": true,
       "preview": {
         "port": 3000
       },

--- a/packages/app/src/app/hooks/useWorkspaceAuthorization.ts
+++ b/packages/app/src/app/hooks/useWorkspaceAuthorization.ts
@@ -1,4 +1,4 @@
-import { TeamMemberAuthorization } from 'app/graphql/types';
+import { TeamMemberAuthorization, TeamType } from 'app/graphql/types';
 import { useAppState } from 'app/overmind';
 
 type WorkspaceAuthorizationReturn = {
@@ -13,7 +13,7 @@ type WorkspaceAuthorizationReturn = {
 };
 
 export const useWorkspaceAuthorization = (): WorkspaceAuthorizationReturn => {
-  const { activeTeamInfo, personalWorkspaceId, user } = useAppState();
+  const { activeTeamInfo, user } = useAppState();
 
   const { authorization, teamManager } =
     activeTeamInfo?.userAuthorizations.find(auth => auth.userId === user?.id) ??
@@ -23,7 +23,7 @@ export const useWorkspaceAuthorization = (): WorkspaceAuthorizationReturn => {
    * Personal states
    */
 
-  const isPersonalSpace = activeTeamInfo?.id === personalWorkspaceId;
+  const isPersonalSpace = activeTeamInfo?.type === TeamType.Personal;
 
   /**
    * User states

--- a/packages/app/src/app/hooks/useWorkspaceSubscription.ts
+++ b/packages/app/src/app/hooks/useWorkspaceSubscription.ts
@@ -18,6 +18,7 @@ export enum SubscriptionDebugStatus {
 export const useWorkspaceSubscription = (): WorkspaceSubscriptionReturn => {
   const { activeTeamInfo } = useAppState();
   const { isTeamSpace } = useWorkspaceAuthorization();
+  const isPersonalSpace = !isTeamSpace;
 
   const options: SubscriptionDebugStatus[] = [SubscriptionDebugStatus.DEFAULT];
 
@@ -56,22 +57,21 @@ export const useWorkspaceSubscription = (): WorkspaceSubscriptionReturn => {
     };
   }
 
+  const isLegacySpace = activeTeamInfo.legacy;
+
   const isPro =
     subscription.status === SubscriptionStatus.Active ||
     subscription.status === SubscriptionStatus.Trialing;
+  const isFree = !isPro;
 
-  // TODO: Update this to ensure deactivated teams are
-  // only newer teams created after the pricing updates
-  const isDeactivatedTeam =
+  const isInactiveTeam =
     isTeamSpace &&
+    !isLegacySpace &&
     (subscription.status === SubscriptionStatus.Cancelled ||
       subscription.status === SubscriptionStatus.IncompleteExpired);
 
-  const isFree = !isPro;
-  const isLegacyPersonalPro = isPro && !isTeamSpace;
-
-  // TODO: Update to ensure only older team show as legacy
-  const isLegacyFreeTeam = isFree && isTeamSpace;
+  const isLegacyPersonalPro = isPro && isPersonalSpace && isLegacySpace;
+  const isLegacyFreeTeam = isFree && isTeamSpace && isLegacySpace;
 
   const hasPaymentMethod = subscription.paymentMethodAttached;
 
@@ -101,7 +101,7 @@ export const useWorkspaceSubscription = (): WorkspaceSubscriptionReturn => {
     isFree,
     isLegacyPersonalPro,
     isLegacyFreeTeam,
-    isDeactivatedTeam,
+    isInactiveTeam,
     isEligibleForTrial: false, // Teams with an active or past subscription are not eligible for trial.
     hasActiveTeamTrial,
     hasExpiredTeamTrial,
@@ -118,7 +118,7 @@ const NO_WORKSPACE = {
   isFree: undefined,
   isLegacyPersonalPro: undefined,
   isLegacyFreeTeam: undefined,
-  isDeactivatedTeam: undefined,
+  isInactiveTeam: undefined,
   isEligibleForTrial: undefined,
   hasActiveTeamTrial: undefined,
   hasExpiredTeamTrial: undefined,
@@ -133,7 +133,7 @@ const NO_SUBSCRIPTION = {
   isFree: true,
   isLegacyPersonalPro: false,
   isLegacyFreeTeam: false,
-  isDeactivatedTeam: false,
+  isInactiveTeam: false,
   hasActiveTeamTrial: false,
   hasExpiredTeamTrial: false,
   hasPaymentMethod: false,
@@ -161,7 +161,7 @@ export type WorkspaceSubscriptionReturn =
       isFree: boolean;
       isLegacyPersonalPro: boolean;
       isLegacyFreeTeam: boolean;
-      isDeactivatedTeam: boolean;
+      isInactiveTeam: boolean;
       isEligibleForTrial: false;
       hasActiveTeamTrial: boolean;
       hasExpiredTeamTrial: boolean;

--- a/packages/app/src/app/overmind/effects/gql/dashboard/fragments.ts
+++ b/packages/app/src/app/overmind/effects/gql/dashboard/fragments.ts
@@ -117,9 +117,11 @@ export const teamFragmentDashboard = gql`
   fragment teamFragmentDashboard on Team {
     id
     name
+    type
     description
     creatorId
     avatarUrl
+    legacy
     settings {
       minimumPrivacy
     }
@@ -160,8 +162,9 @@ export const currentTeamInfoFragment = gql`
     description
     inviteToken
     name
+    type
     avatarUrl
-
+    legacy
     users {
       id
       avatarUrl

--- a/packages/app/src/app/pages/Dashboard/Components/UpgradeBanner/UpgradeBanner.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/UpgradeBanner/UpgradeBanner.tsx
@@ -121,7 +121,6 @@ const Features: React.FC = () => {
 export const UpgradeBanner: React.FC = () => {
   const {
     dashboard: { teams },
-    personalWorkspaceId,
   } = useAppState();
   const { modalOpened, openCreateTeamModal } = useActions();
   const [isBannerDismissed, dismissBanner] = useDismissible(
@@ -137,10 +136,7 @@ export const UpgradeBanner: React.FC = () => {
     return null;
   }
 
-  const trialEligibleTeams = getTrialEligibleTeams({
-    teams,
-    personalWorkspaceId,
-  });
+  const trialEligibleTeams = getTrialEligibleTeams(teams);
 
   const renderMainCTA = () => {
     if (isPersonalSpace) {

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Settings/UserSettings/WorkspaceSettings.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Settings/UserSettings/WorkspaceSettings.tsx
@@ -7,7 +7,6 @@ import {
   Tooltip,
   IconButton,
   Element,
-  Badge,
 } from '@codesandbox/components';
 import {
   AppleIcon,
@@ -17,7 +16,6 @@ import {
 import css from '@styled-system/css';
 import { useAppState, useActions } from 'app/overmind';
 
-import { useWorkspaceSubscription } from 'app/hooks/useWorkspaceSubscription';
 import { Header } from '../../../../Components/Header';
 import { Card } from '../components';
 import { ManageSubscription } from './ManageSubscription';
@@ -25,7 +23,6 @@ import { ManageSubscription } from './ManageSubscription';
 export const WorkspaceSettings = () => {
   const { user, activeTeam } = useAppState();
   const actions = useActions();
-  const { isFree } = useWorkspaceSubscription();
 
   const [editing, setEditing] = useState(false);
   const [loading, setLoading] = useState(false);
@@ -200,11 +197,6 @@ export const WorkspaceSettings = () => {
                     onClick={() => setEditing(false)}
                   />
                 </Stack>
-                {isFree && (
-                  <Stack>
-                    <Badge variant="trial">Free</Badge>
-                  </Stack>
-                )}
               </Stack>
             </Stack>
           </Stack>
@@ -262,11 +254,6 @@ export const WorkspaceSettings = () => {
                   onClick={() => setEditing(true)}
                 />
               </Stack>
-              {isFree && (
-                <Stack>
-                  <Badge variant="trial">Free</Badge>
-                </Stack>
-              )}
             </Stack>
           </Stack>
         )}

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Settings/components/TeamInfo.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Settings/components/TeamInfo.tsx
@@ -29,7 +29,7 @@ export const TeamInfo: React.FC = () => {
   const actions = useActions();
 
   const { isTeamAdmin } = useWorkspaceAuthorization();
-  const { isLegacyFreeTeam } = useWorkspaceSubscription();
+  const { isLegacyFreeTeam, isInactiveTeam } = useWorkspaceSubscription();
 
   const getFile = async avatar => {
     const url = await new Promise((resolve, reject) => {
@@ -208,7 +208,8 @@ export const TeamInfo: React.FC = () => {
         </Stack>
 
         <Stack>
-          {isLegacyFreeTeam ? <Badge variant="trial">Free</Badge> : null}
+          {isLegacyFreeTeam && <Badge variant="trial">Free</Badge>}
+          {isInactiveTeam && <Badge variant="neutral">Inactive</Badge>}
         </Stack>
 
         <Text size={3} css={{ marginTop: '8px' }} variant="muted">

--- a/packages/app/src/app/pages/Pro/Upgrade.tsx
+++ b/packages/app/src/app/pages/Pro/Upgrade.tsx
@@ -226,7 +226,6 @@ export const ProUpgrade = () => {
                 });
                 return setActiveTeam(payload);
               }}
-              personalWorkspaceId={personalWorkspaceId}
               activeTeamInfo={activeTeamInfo}
             />
             <Element css={{ maxWidth: '976px', textAlign: 'center' }}>

--- a/packages/app/src/app/pages/Pro/components/UpsellTeamProCard.tsx
+++ b/packages/app/src/app/pages/Pro/components/UpsellTeamProCard.tsx
@@ -16,14 +16,13 @@ export const UpsellTeamProCard: React.FC<{ trackingLocation: string }> = ({
   trackingLocation,
 }) => {
   const experimentPromise = useExperimentResult('pro-page-sticker');
-  const { dashboard, pro, personalWorkspaceId, user } = useAppState();
+  const { dashboard, pro, user } = useAppState();
   const { modalOpened, openCreateTeamModal } = useActions();
   const [showSticker, setShowSticker] = React.useState(false);
   const currency = useCurrencyFromTimeZone();
 
   const upgradeableTeams = getUpgradeableTeams({
     teams: dashboard.teams,
-    personalWorkspaceId,
     userId: user?.id,
   });
 

--- a/packages/app/src/app/pages/Pro/legacy-pages/WorkspacePlanSelection.tsx
+++ b/packages/app/src/app/pages/Pro/legacy-pages/WorkspacePlanSelection.tsx
@@ -7,7 +7,11 @@ import { Element, Stack, Text, SkeletonText } from '@codesandbox/components';
 import track from '@codesandbox/common/lib/utils/analytics';
 import { useAppState, useActions } from 'app/overmind';
 import { Step } from 'app/overmind/namespaces/pro/types';
-import { SubscriptionType, SubscriptionInterval } from 'app/graphql/types';
+import {
+  SubscriptionType,
+  SubscriptionInterval,
+  TeamType,
+} from 'app/graphql/types';
 import { useWorkspaceSubscription } from 'app/hooks/useWorkspaceSubscription';
 import { useWorkspaceAuthorization } from 'app/hooks/useWorkspaceAuthorization';
 import { formatCurrency } from 'app/utils/currency';
@@ -68,13 +72,13 @@ export const WorkspacePlanSelection: React.FC = () => {
   if (!activeTeam || !dashboard.teams.length) return null;
 
   const personalWorkspace = dashboard.teams.find(
-    t => t.id === personalWorkspaceId
+    t => t.type === TeamType.Personal
   )!;
 
   const workspacesList = [
     personalWorkspace,
     ...sortBy(
-      dashboard.teams.filter(team => team.id !== personalWorkspaceId),
+      dashboard.teams.filter(team => team.type !== TeamType.Team),
       team => team.name.toLowerCase()
     ),
   ];
@@ -149,7 +153,6 @@ export const WorkspacePlanSelection: React.FC = () => {
           <Switcher
             workspaces={workspacesList}
             setActiveTeam={setActiveTeam}
-            personalWorkspaceId={personalWorkspaceId}
             activeTeamInfo={activeTeamInfo}
           />
 

--- a/packages/app/src/app/pages/Profile/AllSandboxes.tsx
+++ b/packages/app/src/app/pages/Profile/AllSandboxes.tsx
@@ -10,6 +10,7 @@ import {
   IconButton,
   Menu,
 } from '@codesandbox/components';
+import { TeamType } from 'app/graphql/types';
 import css from '@styled-system/css';
 import designLanguage from '@codesandbox/components/lib/design-language/theme';
 import { motion } from 'framer-motion';
@@ -219,7 +220,6 @@ const UpgradeBanner = () => {
     user,
     profile: { current },
     dashboard: { teams },
-    personalWorkspaceId,
     activeTeamInfo,
   } = useAppState();
   const { modalOpened } = useActions();
@@ -242,7 +242,7 @@ const UpgradeBanner = () => {
 
   if (!showUpgradeMessage) return null;
 
-  const personalWorkspace = teams.find(team => team.id === personalWorkspaceId);
+  const personalWorkspace = teams.find(team => team.type === TeamType.Personal);
 
   return (
     <Stack

--- a/packages/app/src/app/pages/Profile/MinimumPrivacy.tsx
+++ b/packages/app/src/app/pages/Profile/MinimumPrivacy.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { TeamType } from 'app/graphql/types';
 import { useActions, useAppState } from 'app/overmind';
 import {
   Stack,
@@ -36,7 +37,7 @@ export const MinimumPrivacy: React.FC<{ closeModal?: () => void }> = ({
     dashboard: { setTeamMinimumPrivacy },
     profile: { fetchSandboxes },
   } = useActions();
-  const personalWorkspace = teams.find(team => team.id === personalWorkspaceId);
+  const personalWorkspace = teams.find(team => team.type === TeamType.Personal);
   const [minimumPrivacy, setMinimumPrivacy] = React.useState(
     personalWorkspace.settings.minimumPrivacy
   );

--- a/packages/app/src/app/pages/Sandbox/Editor/Header/ForkButton/ForkButton.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Header/ForkButton/ForkButton.tsx
@@ -11,7 +11,7 @@ import {
 import { useAppState } from 'app/overmind';
 import { TeamAvatar } from 'app/components/TeamAvatar';
 import { CurrentUser } from '@codesandbox/common/lib/types';
-import { MemberAuthorization } from 'app/graphql/types';
+import { MemberAuthorization, TeamType } from 'app/graphql/types';
 import { ForkIcon } from '../icons';
 
 interface TeamItemProps {
@@ -69,7 +69,6 @@ interface TeamOrUserItemProps {
   item: ITeamItem;
   forkClicked: (teamId: string) => void;
   disabled: boolean;
-  isPersonal: boolean;
 }
 const TeamOrUserItem: React.FC<TeamOrUserItemProps> = props => {
   if (props.disabled) {
@@ -108,7 +107,7 @@ export const ForkButton: React.FC<ForkButtonProps> = props => {
   let otherWorkspaces: ITeamItem[] = [];
 
   const userSpace = state.dashboard.teams.find(
-    t => t.id === state.personalWorkspaceId
+    t => t.type === TeamType.Personal
   )!;
 
   const allTeams: {
@@ -118,7 +117,7 @@ export const ForkButton: React.FC<ForkButtonProps> = props => {
     userAuthorizations: MemberAuthorization[];
   }[] = [
     userSpace,
-    ...state.dashboard.teams.filter(t => t.id !== state.personalWorkspaceId),
+    ...state.dashboard.teams.filter(t => t.type === TeamType.Team),
   ].filter(Boolean);
 
   if (allTeams.length) {
@@ -216,16 +215,12 @@ export const ForkButton: React.FC<ForkButtonProps> = props => {
                     forkClicked={props.forkClicked}
                     item={currentSpace}
                     disabled={state.activeWorkspaceAuthorization === 'READ'}
-                    isPersonal={
-                      currentSpace.teamId === state.personalWorkspaceId
-                    }
                   />
                 )}
 
                 <Menu.Divider />
                 {otherWorkspaces.map((space, i) => (
                   <TeamOrUserItem
-                    isPersonal={space.teamId === state.personalWorkspaceId}
                     key={space.teamId}
                     forkClicked={props.forkClicked}
                     item={space}

--- a/packages/app/src/app/pages/Sandbox/Editor/Header/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Header/index.tsx
@@ -9,12 +9,7 @@ import { SandboxName } from './SandboxName';
 import { WorkspaceName } from './WorkspaceName';
 
 export const Header = () => {
-  const {
-    editor,
-    isAuthenticating,
-    activeTeamInfo,
-    personalWorkspaceId,
-  } = useAppState();
+  const { editor, isAuthenticating, activeTeamInfo } = useAppState();
 
   return (
     <Stack
@@ -34,13 +29,9 @@ export const Header = () => {
     >
       <Stack align="center">
         <AppMenu />
-        {activeTeamInfo && personalWorkspaceId && (
+        {activeTeamInfo && (
           <WorkspaceName
-            name={
-              activeTeamInfo.id === personalWorkspaceId
-                ? 'Personal'
-                : activeTeamInfo.name
-            }
+            name={activeTeamInfo.name}
             plan={activeTeamInfo.subscription?.type}
           />
         )}

--- a/packages/app/src/app/pages/common/Modals/SelectWorkspaceToStartTrial/index.tsx
+++ b/packages/app/src/app/pages/common/Modals/SelectWorkspaceToStartTrial/index.tsx
@@ -14,14 +14,11 @@ import { useActions, useAppState } from 'app/overmind';
 import { Alert } from '../Common/Alert';
 
 export const SelectWorkspaceToStartTrial: React.FC = () => {
-  const { dashboard, personalWorkspaceId } = useAppState();
+  const { dashboard } = useAppState();
   const { openCreateTeamModal, modalClosed } = useActions();
   const [checkout, createCheckout] = useCreateCheckout();
 
-  const trialEligibleTeams = getTrialEligibleTeams({
-    teams: dashboard.teams,
-    personalWorkspaceId,
-  });
+  const trialEligibleTeams = getTrialEligibleTeams(dashboard.teams);
 
   const [selectedTeam, setSelectedTeam] = React.useState(
     trialEligibleTeams[0]?.id

--- a/packages/app/src/app/pages/common/Modals/SelectWorkspaceToUpgrade/index.tsx
+++ b/packages/app/src/app/pages/common/Modals/SelectWorkspaceToUpgrade/index.tsx
@@ -15,13 +15,12 @@ import { getUpgradeableTeams } from 'app/utils/teams';
 import { Alert } from '../Common/Alert';
 
 export const SelectWorkspaceToUpgrade: React.FC = () => {
-  const { dashboard, personalWorkspaceId, user } = useAppState();
+  const { dashboard, user } = useAppState();
   const { openCreateTeamModal, modalClosed } = useActions();
   const [checkout, createCheckout] = useCreateCheckout();
 
   const upgradeableTeams = getUpgradeableTeams({
     teams: dashboard.teams,
-    personalWorkspaceId,
     userId: user?.id,
   });
 

--- a/packages/app/src/app/utils/teams.ts
+++ b/packages/app/src/app/utils/teams.ts
@@ -1,21 +1,21 @@
 import {
   SubscriptionType,
+  SubscriptionStatus,
   TeamFragmentDashboardFragment,
   TeamMemberAuthorization,
+  TeamType,
 } from 'app/graphql/types';
 
 export const getUpgradeableTeams = ({
   teams,
-  personalWorkspaceId,
   userId,
 }: {
   teams: TeamFragmentDashboardFragment[];
-  personalWorkspaceId: string | undefined;
   userId: string | undefined;
 }) =>
   teams.filter(team => {
     if (
-      team.id === personalWorkspaceId ||
+      team.type === TeamType.Team &&
       team.subscription?.type === SubscriptionType.TeamPro
     ) {
       return false;
@@ -31,17 +31,41 @@ export const getUpgradeableTeams = ({
     );
   });
 
-export const getTrialEligibleTeams = ({
-  teams,
-  personalWorkspaceId,
-}: {
-  teams: TeamFragmentDashboardFragment[];
-  personalWorkspaceId: string | undefined;
-}) =>
+export const getTrialEligibleTeams = (teams: TeamFragmentDashboardFragment[]) =>
   teams.filter(team => {
-    if (team.id === personalWorkspaceId || Boolean(team.subscription)) {
+    if (team.type === TeamType.Personal || Boolean(team.subscription)) {
       return false;
     }
 
     return true;
   });
+
+/**
+ * Use this function when displaying a list a teams
+ * For the current active workspace, use the `useWorkspaceSubscription` to get all relevant data
+ * @param team
+ */
+export const determineSpecialBadges = (team: TeamFragmentDashboardFragment) => {
+  const subscriptionStatus = team.subscription?.status;
+  const isPersonalSpace = team.type === TeamType.Personal;
+  const isLegacySpace = team.legacy;
+  const hasActiveSubscription =
+    subscriptionStatus === SubscriptionStatus.Active ||
+    subscriptionStatus === SubscriptionStatus.Trialing;
+  const hasCancelledSubscription =
+    subscriptionStatus === SubscriptionStatus.Cancelled ||
+    subscriptionStatus === SubscriptionStatus.IncompleteExpired;
+
+  const isPersonalProLegacy =
+    isPersonalSpace && hasActiveSubscription && isLegacySpace;
+  const isTeamFreeLegacy =
+    !isPersonalSpace && !hasActiveSubscription && isLegacySpace;
+  const isInactive =
+    !isLegacySpace && !isPersonalSpace && hasCancelledSubscription;
+
+  return {
+    isPersonalProLegacy,
+    isTeamFreeLegacy,
+    isInactive,
+  };
+};


### PR DESCRIPTION
Closes PC-1040

Remove `Personal` and use username everywhere
Use team.type instead of always verifying the `personalWorkspaceId`
Add the proper badges based on the state of the workspace:
* Pro for legacy personal pro (to be decided if this remains)
* Free for legacy free teams
* Inactive for new teams that have cancelled or have trials expired