### PR TITLE
fix: vanilla template html entry handling

### DIFF
--- a/packages/common/src/templates/parcel.ts
+++ b/packages/common/src/templates/parcel.ts
@@ -27,6 +27,11 @@ export class ParcelTemplate extends Template {
     return entries.filter(Boolean);
   }
 
+  getHTMLEntries(configurationFiles: ParsedConfigurationFiles): string[] {
+    const entries = this.getEntries(configurationFiles);
+    return entries.filter(e => e.endsWith('.html'));
+  }
+
   /**
    * The file to open by the editor
    */


### PR DESCRIPTION
Currently vanilla templates do not handle correctly the case of `/src/index.html`, this PR fixes it