### PR TITLE
chore: remove `ProtocolTransformer` that replaces `npmjs.org` with `npmjs.cf`

### DIFF
--- a/packages/sandpack-core/src/npm/dynamic/fetch-protocols/index.ts
+++ b/packages/sandpack-core/src/npm/dynamic/fetch-protocols/index.ts
@@ -6,7 +6,6 @@ import { isGithubDependency, JSDelivrGHFetcher } from './jsdelivr/jsdelivr-gh';
 import { isTarDependency, TarFetcher } from './tar';
 import { GistFetcher } from './gist';
 import { FetchProtocol } from '../fetch-npm-module';
-import { ProtocolTransformer } from './transformer';
 
 let contributedProtocols: ProtocolDefinition[] = [];
 
@@ -28,17 +27,23 @@ const protocols: ProtocolDefinition[] = [
     protocol: new JSDelivrGHFetcher(),
     condition: (name, version) => isGithubDependency(version),
   },
-  {
-    protocol: new ProtocolTransformer(new TarFetcher(), (name, version) => [
-      name,
-      version.replace(
-        'https://registry.npmjs.org/',
-        'https://registry.npmjs.cf/'
-      ),
-    ]),
-    condition: (name, version) =>
-      version.startsWith('https://registry.npmjs.org/'),
-  },
+  /**
+   * npmjs.cf has been deprecated, while registry.npmjs.org has CORS supports now:
+   *
+   * - npmjs.cf depreacation notice: https://github.com/npmjs-cf/meta/issues/8
+   * - npm registry CORS support: https://github.com/npm/feedback/discussions/117#discussioncomment-2691120
+   */
+  // {
+  //   protocol: new ProtocolTransformer(new TarFetcher(), (name, version) => [
+  //     name,
+  //     version.replace(
+  //       'https://registry.npmjs.org/',
+  //       'https://registry.npmjs.cf/'
+  //     ),
+  //   ]),
+  //   condition: (name, version) =>
+  //     version.startsWith('https://registry.npmjs.org/'),
+  // },
   {
     protocol: new TarFetcher(),
     condition: (name, version) => isTarDependency(version),


### PR DESCRIPTION
## What kind of change does this PR introduce?

The PR removes the `ProtocolTransformer` that replaces `npmjs.org` with `npmjs.cf` in `fetch-protocols`.

## What is the current behavior?

Fetch tarball from `registry.npmjs.cf`.

## What is the new behavior?

Fetch tarball from `registry.npmjs.org`.

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

The existing test cases should be enough to make sure there is no undesired behavior introduced by the PR.

## Checklist

- [ ] Documentation
- [x] Testing: N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

-----

`npmjs.cf` is being deprecated (https://github.com/npmjs-cf/meta/issues/8) while `registry.npmjs.org` has CORS enabled since 2022 (https://github.com/npm/feedback/discussions/117#discussioncomment-2691120).

