### PR TITLE
feat: check user trial eligible

### DIFF
--- a/packages/app/src/app/components/LoseFeatures/LoseFeatures.tsx
+++ b/packages/app/src/app/components/LoseFeatures/LoseFeatures.tsx
@@ -6,7 +6,7 @@ import { useAppState } from 'app/overmind';
 const LOSE_DEFAULT = [
   {
     key: 'editors',
-    pro: 'Up to 20 editors',
+    pro: 'Unlimited editors',
     free: 'Limited to 5 editors',
   },
   {

--- a/packages/app/src/app/constants.ts
+++ b/packages/app/src/app/constants.ts
@@ -18,9 +18,19 @@ export interface Feature {
 
 export const FREE_FEATURES: Feature[] = [
   {
-    key: 'public_limit',
-    label: 'Unlimited public repositories & sandboxes',
+    key: 'editor',
+    label: 'Single editor',
   },
+  {
+    key: 'public_limit',
+    label: 'Public repositories & sandboxes',
+  },
+  {
+    key: 'ai',
+    label: 'No access to AI tools',
+  },
+  { key: 'npm', label: 'Public npm packages' },
+  { key: 'permissions', label: 'Limited permissions' },
   { key: 'vm_mem', label: '2GiB RAM' },
   { key: 'vm_cpu', label: '2 vCPUs' },
   { key: 'vm_disk', label: '6GB Disk' },

--- a/packages/app/src/app/graphql/types.ts
+++ b/packages/app/src/app/graphql/types.ts
@@ -230,6 +230,11 @@ export type CurrentUser = {
   collection: Maybe<Collection>;
   collections: Array<Collection>;
   deletionRequested: Scalars['Boolean'];
+  /**
+   * Whether this user should be offered a trial.
+   *     Returns false if they have created any teams that have used a trial in the last 6 months.
+   */
+  eligibleForTrial: Scalars['Boolean'];
   email: Scalars['String'];
   /** Get all of the current user's GitHub organizations */
   githubOrganizations: Maybe<Array<GithubOrganization>>;
@@ -2154,7 +2159,7 @@ export type RootQueryType = {
   /** Get a sandbox */
   sandbox: Maybe<Sandbox>;
   /** A team from an invite token */
-  teamByToken: Maybe<Team>;
+  teamByToken: Maybe<TeamPreview>;
 };
 
 export type RootQueryTypeAlbumArgs = {
@@ -4231,7 +4236,7 @@ export type AllTeamsQuery = { __typename?: 'RootQueryType' } & {
   me: Maybe<
     { __typename?: 'CurrentUser' } & Pick<
       CurrentUser,
-      'personalWorkspaceId'
+      'personalWorkspaceId' | 'eligibleForTrial'
     > & {
         workspaces: Array<
           { __typename?: 'Team' } & TeamFragmentDashboardFragment
@@ -5101,7 +5106,9 @@ export type TeamByTokenQueryVariables = Exact<{
 }>;
 
 export type TeamByTokenQuery = { __typename?: 'RootQueryType' } & {
-  teamByToken: Maybe<{ __typename?: 'Team' } & Pick<Team, 'name'>>;
+  teamByToken: Maybe<
+    { __typename?: 'TeamPreview' } & Pick<TeamPreview, 'name'>
+  >;
 };
 
 export type JoinTeamByTokenMutationVariables = Exact<{

--- a/packages/app/src/app/hooks/useWorkspaceSubscription.ts
+++ b/packages/app/src/app/hooks/useWorkspaceSubscription.ts
@@ -155,7 +155,7 @@ export type WorkspaceSubscriptionReturn =
       isLegacyPersonalPro: boolean;
       isLegacyFreeTeam: boolean;
       isInactiveTeam: boolean;
-      isEligibleForTrial: false;
+      isEligibleForTrial: boolean;
       hasActiveTeamTrial: boolean;
       hasExpiredTeamTrial: boolean;
       hasPaymentMethod: boolean;

--- a/packages/app/src/app/hooks/useWorkspaceSubscription.ts
+++ b/packages/app/src/app/hooks/useWorkspaceSubscription.ts
@@ -15,8 +15,8 @@ export enum SubscriptionDebugStatus {
 }
 
 export const useWorkspaceSubscription = (): WorkspaceSubscriptionReturn => {
-  const { activeTeamInfo } = useAppState();
-  const { isTeamSpace } = useWorkspaceAuthorization();
+  const { activeTeamInfo, userCanStartTrial } = useAppState();
+  const { isTeamSpace, isBillingManager } = useWorkspaceAuthorization();
   const isPersonalSpace = !isTeamSpace;
 
   const options: SubscriptionDebugStatus[] = [SubscriptionDebugStatus.DEFAULT];
@@ -50,7 +50,7 @@ export const useWorkspaceSubscription = (): WorkspaceSubscriptionReturn => {
     return {
       ...NO_SUBSCRIPTION,
       isLegacyFreeTeam: isTeamSpace,
-      isEligibleForTrial: isTeamSpace,
+      isEligibleForTrial: userCanStartTrial,
       numberOfSeats: activeTeamInfo.limits.maxEditors ?? MAX_TEAM_FREE_EDITORS,
     };
   }
@@ -70,6 +70,8 @@ export const useWorkspaceSubscription = (): WorkspaceSubscriptionReturn => {
 
   const isLegacyPersonalPro = isPro && isPersonalSpace && isLegacySpace;
   const isLegacyFreeTeam = isFree && isTeamSpace && isLegacySpace;
+  const isEligibleForTrial =
+    userCanStartTrial && isLegacyFreeTeam && isBillingManager;
 
   const hasPaymentMethod = subscription.paymentMethodAttached;
 
@@ -95,12 +97,12 @@ export const useWorkspaceSubscription = (): WorkspaceSubscriptionReturn => {
   return {
     subscription,
     numberOfSeats,
+    isEligibleForTrial,
     isPro,
     isFree,
     isLegacyPersonalPro,
     isLegacyFreeTeam,
     isInactiveTeam,
-    isEligibleForTrial: false, // Teams with an active or past subscription are not eligible for trial.
     hasActiveTeamTrial,
     hasExpiredTeamTrial,
     hasPaymentMethod,

--- a/packages/app/src/app/overmind/effects/gql/dashboard/queries.ts
+++ b/packages/app/src/app/overmind/effects/gql/dashboard/queries.ts
@@ -228,6 +228,7 @@ export const getTeams: Query<AllTeamsQuery, AllTeamsQueryVariables> = gql`
   query AllTeams {
     me {
       personalWorkspaceId
+      eligibleForTrial
       workspaces {
         ...teamFragmentDashboard
       }

--- a/packages/app/src/app/overmind/internalActions.ts
+++ b/packages/app/src/app/overmind/internalActions.ts
@@ -672,6 +672,7 @@ export const getTeamIdFromUrlOrStore = async ({
       // Also set state while we're at it
       state.dashboard.teams = teams.me.workspaces;
       state.personalWorkspaceId = teams.me.personalWorkspaceId;
+      state.userCanStartTrial = teams.me.eligibleForTrial;
     }
   }
 

--- a/packages/app/src/app/overmind/namespaces/dashboard/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/dashboard/actions.ts
@@ -165,6 +165,7 @@ export const getTeams = async ({ state, effects }: Context) => {
 
   state.dashboard.teams = teams.me.workspaces;
   state.personalWorkspaceId = teams.me.personalWorkspaceId;
+  state.userCanStartTrial = teams.me.eligibleForTrial;
 };
 
 export const removeFromTeam = async (

--- a/packages/app/src/app/overmind/state.ts
+++ b/packages/app/src/app/overmind/state.ts
@@ -36,6 +36,7 @@ type State = {
   personalWorkspaceId: string | null;
   activeTeam: string | null;
   activeTeamInfo: CurrentTeam | null;
+  userCanStartTrial: boolean;
   connected: boolean;
   notifications: Notification[];
   isLoadingCLI: boolean;
@@ -124,6 +125,7 @@ export const state: State = {
   activeTeam: null,
   activeTeamInfo: null,
   personalWorkspaceId: null,
+  userCanStartTrial: false,
   connected: true,
   notifications: [],
   contributors: [],

--- a/packages/app/src/app/pages/Dashboard/Components/UpgradeBanner/UpgradeBanner.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/UpgradeBanner/UpgradeBanner.tsx
@@ -19,6 +19,7 @@ import { useWorkspaceAuthorization } from 'app/hooks/useWorkspaceAuthorization';
 import { useWorkspaceSubscription } from 'app/hooks/useWorkspaceSubscription';
 import { useDashboardVisit } from 'app/hooks/useDashboardVisit';
 import { useHistory } from 'react-router';
+import { useAppState } from 'app/overmind';
 
 // When flex wraps and the list of features
 // is shown below the call to action.
@@ -26,6 +27,7 @@ const WRAP_WIDTH = 1320;
 
 export const UpgradeBanner: React.FC = () => {
   const history = useHistory();
+  const { userCanStartTrial } = useAppState();
   const [isBannerDismissed, dismissBanner] = useDismissible(
     'DASHBOARD_RECENT_UPGRADE'
   );
@@ -37,7 +39,10 @@ export const UpgradeBanner: React.FC = () => {
     isPro,
   } = useWorkspaceSubscription();
 
-  const canStartTrial = isPersonalSpace || isEligibleForTrial;
+  // Either the workspace is eligible for trial or user is on
+  // a personal space and cand start a trial
+  const trialAvailable =
+    (isPersonalSpace && userCanStartTrial) || isEligibleForTrial;
   const { hasVisited } = useDashboardVisit();
 
   const [checkout, createCheckout, canCheckout] = useCreateCheckout();
@@ -81,7 +86,6 @@ export const UpgradeBanner: React.FC = () => {
 
     // Banner only shows for personal space, to upsell the pro workspaces
     // Takes the user to the /pro page
-    // TODO: When can you start a free trial?
     if (isPersonalSpace) {
       return (
         <Button
@@ -96,7 +100,7 @@ export const UpgradeBanner: React.FC = () => {
           }}
           autoWidth
         >
-          Start 14-day free trial
+          {userCanStartTrial ? 'Start 14-day free trial' : 'Upgrade'}
         </Button>
       );
     }
@@ -109,7 +113,7 @@ export const UpgradeBanner: React.FC = () => {
       return 'Reactivate Pro';
     }
 
-    if (canStartTrial) {
+    if (trialAvailable) {
       return 'Try Pro for free';
     }
 
@@ -153,7 +157,7 @@ export const UpgradeBanner: React.FC = () => {
                 {renderMainCTA()}
                 <Link
                   href={
-                    canStartTrial
+                    trialAvailable
                       ? SUBSCRIPTION_DOCS_URLS.teams.trial
                       : SUBSCRIPTION_DOCS_URLS.teams.non_trial
                   }
@@ -191,7 +195,7 @@ type Feature = {
 const FEATURES_LIST: Feature[] = [
   {
     icon: 'profile',
-    label: 'Up to 20 editors',
+    label: 'Unlimited editors',
   },
   {
     icon: 'lock',

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Settings/UserSettings/ManageSubscription/Upgrade.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Settings/UserSettings/ManageSubscription/Upgrade.tsx
@@ -16,7 +16,9 @@ const List = styled(Stack)`
   }
 `;
 
-export const Upgrade: React.FC = () => {
+export const Upgrade: React.FC<{ userCanStartTrial: boolean }> = ({
+  userCanStartTrial,
+}) => {
   return (
     <Card
       css={{
@@ -32,10 +34,10 @@ export const Upgrade: React.FC = () => {
 
         <List direction="vertical" gap={1} as="ul">
           <Text as="li" size={3}>
-            Private sandboxes & repositories
+            Unlimited editors
           </Text>
           <Text as="li" size={3}>
-            Up to 20 editors
+            Unlimited private sandboxes & repositories
           </Text>
           <Text as="li" size={3}>
             Advanced privacy settings
@@ -58,7 +60,7 @@ export const Upgrade: React.FC = () => {
           }}
           variant="trial"
         >
-          Upgrade to Pro
+          {userCanStartTrial ? 'Start trial' : 'Upgrade to Pro'}
         </Button>
       </Stack>
     </Card>

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Settings/UserSettings/ManageSubscription/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Settings/UserSettings/ManageSubscription/index.tsx
@@ -11,7 +11,7 @@ import { Card } from '../../components';
 import { ProcessingPayment } from '../../components/ProcessingPayment';
 
 export const ManageSubscription = () => {
-  const { user, isProcessingPayment } = useAppState();
+  const { user, isProcessingPayment, userCanStartTrial } = useAppState();
   const { isFree, isPaddle, isStripe } = useWorkspaceSubscription();
 
   if (isFree) {
@@ -19,7 +19,7 @@ export const ManageSubscription = () => {
       return <ProcessingPayment />;
     }
 
-    return <Upgrade />;
+    return <Upgrade userCanStartTrial={userCanStartTrial} />;
   }
 
   // Legacy Personal Pro

--- a/packages/app/src/app/pages/Dashboard/Sidebar/BottomMessages/CreateProWorkspace.tsx
+++ b/packages/app/src/app/pages/Dashboard/Sidebar/BottomMessages/CreateProWorkspace.tsx
@@ -4,7 +4,9 @@ import React from 'react';
 import track from '@codesandbox/common/lib/utils/analytics';
 import { proUrl } from '@codesandbox/common/lib/utils/url-generator/dashboard';
 
-export const CreateProWorkspace = () => (
+export const CreateProWorkspace: React.FC<{ userCanStartTrial: boolean }> = ({
+  userCanStartTrial,
+}) => (
   <Stack align="flex-start" direction="vertical" gap={2}>
     <Text css={{ color: '#999', fontWeight: 400, fontSize: 12 }}>
       Create a <Text css={{ color: '#c2c2c2', fontWeight: 500 }}>Pro</Text>{' '}
@@ -13,7 +15,7 @@ export const CreateProWorkspace = () => (
     <Link
       as={RouterLink}
       to={proUrl({ source: 'personal_side_banner' })}
-      title="Start 14-day free trial"
+      title={userCanStartTrial ? 'Start 14-day free trial' : 'Upgrade to Pro'}
       css={{
         fontSize: '12px',
         fontWeight: 500,
@@ -27,7 +29,7 @@ export const CreateProWorkspace = () => (
         });
       }}
     >
-      Start trial
+      {userCanStartTrial ? 'Start trial' : 'Upgrade to Pro'}
     </Link>
   </Stack>
 );

--- a/packages/app/src/app/pages/Dashboard/Sidebar/BottomMessages/StartTrial.tsx
+++ b/packages/app/src/app/pages/Dashboard/Sidebar/BottomMessages/StartTrial.tsx
@@ -1,20 +1,12 @@
 import React from 'react';
-import { Stack, Text, Button } from '@codesandbox/components';
+import { Link as RouterLink } from 'react-router-dom';
+import { Stack, Text, Link } from '@codesandbox/components';
 import track from '@codesandbox/common/lib/utils/analytics';
-import { useCreateCheckout } from 'app/hooks';
-import { useWorkspaceAuthorization } from 'app/hooks/useWorkspaceAuthorization';
-import { dashboard } from '@codesandbox/common/lib/utils/url-generator';
-
-const EVENT_NAME = 'Side banner - Start Trial';
+import { proUrl } from '@codesandbox/common/lib/utils/url-generator/dashboard';
 
 export const StartTrial: React.FC<{ activeTeam: string }> = ({
   activeTeam,
 }) => {
-  const { isBillingManager } = useWorkspaceAuthorization();
-
-  const [checkout, createCheckout] = useCreateCheckout();
-  const disabled = checkout.status === 'loading';
-
   return (
     <Stack align="flex-start" direction="vertical" gap={2}>
       <Text css={{ color: '#999', fontWeight: 400, fontSize: 12 }}>
@@ -22,34 +14,24 @@ export const StartTrial: React.FC<{ activeTeam: string }> = ({
         for the full CodeSandbox Experience.
       </Text>
 
-      <Button
-        disabled={disabled}
-        variant="link"
-        onClick={() => {
-          track(
-            isBillingManager ? EVENT_NAME : `${EVENT_NAME} - As non-admin`,
-            {
-              codesandbox: 'V1',
-              event_source: 'UI',
-            }
-          );
-
-          createCheckout({
-            success_path: dashboard.recent(activeTeam),
-            utm_source: 'dashboard_import_limits',
-          });
-        }}
+      <Link
+        as={RouterLink}
+        to={proUrl({ source: 'side_banner_team', workspaceId: activeTeam })}
         css={{
           fontSize: '12px',
           fontWeight: 500,
           color: '#EDFFA5',
           textDecoration: 'none',
-          padding: '4px 0',
         }}
-        autoWidth
+        onClick={() => {
+          track('Side banner - Start Trial for existing team', {
+            codesandbox: 'V1',
+            event_source: 'UI',
+          });
+        }}
       >
         Start trial
-      </Button>
+      </Link>
     </Stack>
   );
 };

--- a/packages/app/src/app/pages/Dashboard/Sidebar/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Sidebar/index.tsx
@@ -308,13 +308,17 @@ export const Sidebar: React.FC<SidebarProps> = ({
 
         {teamDataLoaded && isFree ? (
           <Element css={{ margin: 'auto 24px 0' }}>
-            {isEligibleForTrial ? <StartTrial activeTeam={activeTeam} /> : null}
+            {isTeamSpace && isBillingManager && isEligibleForTrial ? (
+              <StartTrial activeTeam={activeTeam} />
+            ) : null}
 
             {isTeamSpace && !isEligibleForTrial ? (
               <UpgradeFreeTeamToPro activeTeam={activeTeam} />
             ) : null}
 
-            {isPersonalSpace ? <CreateProWorkspace /> : null}
+            {isPersonalSpace ? (
+              <CreateProWorkspace userCanStartTrial={state.userCanStartTrial} />
+            ) : null}
           </Element>
         ) : null}
 

--- a/packages/app/src/app/pages/Pro/Create.tsx
+++ b/packages/app/src/app/pages/Pro/Create.tsx
@@ -23,7 +23,7 @@ import { StyledPricingDetailsText } from './components/elements';
 import { NewTeamModal } from '../Dashboard/Components/NewTeamModal';
 
 export const ProCreate = () => {
-  const { hasLoadedApp, isLoggedIn } = useAppState();
+  const { hasLoadedApp, isLoggedIn, userCanStartTrial } = useAppState();
 
   const { openCreateTeamModal } = useActions();
 
@@ -39,9 +39,8 @@ export const ProCreate = () => {
 
   if (!hasLoadedApp || !isLoggedIn) return null;
 
-  // TODO: Check if user is eligible for trial
   const newWorkspaceCTA: CTA = {
-    text: 'Start trial',
+    text: userCanStartTrial ? 'Start trial' : 'Upgrade to Pro',
     variant: 'dark',
     onClick: () => {
       openCreateTeamModal();

--- a/packages/app/src/app/pages/common/Modals/MidTrialModal/index.tsx
+++ b/packages/app/src/app/pages/common/Modals/MidTrialModal/index.tsx
@@ -160,7 +160,7 @@ export const MidTrialModal = () => {
 const KEEP_DEFAULT = [
   {
     key: 'editors',
-    pro: 'Up to 20 editors',
+    pro: 'Unlimited editors',
   },
   {
     key: 'sandboxes',


### PR DESCRIPTION
New field coming from BE, if the current user has the ability to start a trial.
Each user gets one trial after the release.
A team/workspace can be on a trial if it is legacy free and the user has the ability to start the trial and is an admin.