### PR TITLE
fix: don't show GH suggested cards if no permission is given

### DIFF
--- a/packages/app/src/app/components/CreateSandbox/Import/Import.tsx
+++ b/packages/app/src/app/components/CreateSandbox/Import/Import.tsx
@@ -22,7 +22,7 @@ import {
 import { useActions, useAppState } from 'app/overmind';
 import { useWorkspaceLimits } from 'app/hooks/useWorkspaceLimits';
 import { useWorkspaceSubscription } from 'app/hooks/useWorkspaceSubscription';
-import { useGitHuPermissions } from 'app/hooks/useGitHubPermissions';
+import { useGitHubPermissions } from 'app/hooks/useGitHubPermissions';
 import { RestrictedPublicReposImport } from 'app/pages/Dashboard/Components/shared/RestrictedPublicReposImport';
 
 import { InactiveTeam } from './InactiveTeam';
@@ -78,7 +78,10 @@ type ImportProps = {
 };
 export const Import: React.FC<ImportProps> = ({ onRepoSelect }) => {
   const { activeTeam, hasLogIn } = useAppState();
-  const { restrictsPublicRepos, restrictsPrivateRepos } = useGitHuPermissions();
+  const {
+    restrictsPublicRepos,
+    restrictsPrivateRepos,
+  } = useGitHubPermissions();
   const {
     dashboard: { importGitHubRepository },
   } = useActions();
@@ -166,6 +169,7 @@ export const Import: React.FC<ImportProps> = ({ onRepoSelect }) => {
     privateRepoFreeAccountError === url.raw;
   const hasExistingImports =
     existingRepositoryTeams && existingRepositoryTeams.length >= 1;
+
   const disableImport =
     hasMaxPublicRepositories || restrictsPublicRepos || isInactiveTeam;
 

--- a/packages/app/src/app/components/CreateSandbox/Import/SuggestedRepositories.tsx
+++ b/packages/app/src/app/components/CreateSandbox/Import/SuggestedRepositories.tsx
@@ -17,7 +17,7 @@ import {
 import track from '@codesandbox/common/lib/utils/analytics';
 
 import { useActions, useAppState } from 'app/overmind';
-import { useGitHuPermissions } from 'app/hooks/useGitHubPermissions';
+import { useGitHubPermissions } from 'app/hooks/useGitHubPermissions';
 import { useWorkspaceAuthorization } from 'app/hooks/useWorkspaceAuthorization';
 import { useWorkspaceSubscription } from 'app/hooks/useWorkspaceSubscription';
 import { useGithubAccounts } from 'app/hooks/useGithubOrganizations';
@@ -40,7 +40,7 @@ export const SuggestedRepositories = ({
     dashboard: { repositoriesByTeamId },
   } = useAppState();
   const { modals, dashboard: dashboardActions } = useActions();
-  const { restrictsPrivateRepos } = useGitHuPermissions();
+  const { restrictsPrivateRepos } = useGitHubPermissions();
   const { isTeamSpace } = useWorkspaceAuthorization();
   const { isFree, isEligibleForTrial } = useWorkspaceSubscription();
   const [isImporting, setIsImporting] = useState<

--- a/packages/app/src/app/hooks/useGitHubPermissions.ts
+++ b/packages/app/src/app/hooks/useGitHubPermissions.ts
@@ -6,7 +6,7 @@ const NO_PERMISSIONS = {
   profile: null,
 };
 
-export const useGitHuPermissions = (): {
+export const useGitHubPermissions = (): {
   restrictsPublicRepos: boolean;
   restrictsPrivateRepos: boolean;
   profile: { email: string; scopes: string[] } | null;

--- a/packages/app/src/app/pages/Dashboard/Components/NewTeamModal/TeamImport.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/NewTeamModal/TeamImport.tsx
@@ -4,10 +4,10 @@ import { Element, Stack, Text, Button } from '@codesandbox/components';
 import track from '@codesandbox/common/lib/utils/analytics';
 import { RestrictedPublicReposImport } from 'app/pages/Dashboard/Components/shared/RestrictedPublicReposImport';
 import { SuggestedRepositories } from 'app/components/CreateSandbox/Import/SuggestedRepositories';
-import { useGitHuPermissions } from 'app/hooks/useGitHubPermissions';
+import { useGitHubPermissions } from 'app/hooks/useGitHubPermissions';
 
 export const TeamImport = ({ onComplete }: { onComplete: () => void }) => {
-  const { restrictsPublicRepos } = useGitHuPermissions();
+  const { restrictsPublicRepos } = useGitHubPermissions();
 
   const handleImportClicked = () => {
     track('New Team - Imported repository', {

--- a/packages/app/src/app/pages/Dashboard/Components/SuggestionsRow/SuggestionsRow.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/SuggestionsRow/SuggestionsRow.tsx
@@ -23,7 +23,7 @@ import { StyledCard } from 'app/pages/Dashboard/Components/shared/StyledCard';
 import { SolidSkeleton } from 'app/pages/Dashboard/Components/Skeleton';
 import { ProjectFragment as Repository } from 'app/graphql/types';
 import { AuthorizeForSuggested } from 'app/components/CreateSandbox/Import/AuthorizeForSuggested';
-import { useGitHuPermissions } from 'app/hooks/useGitHubPermissions';
+import { useGitHubPermissions } from 'app/hooks/useGitHubPermissions';
 import { useWorkspaceAuthorization } from 'app/hooks/useWorkspaceAuthorization';
 import { useWorkspaceSubscription } from 'app/hooks/useWorkspaceSubscription';
 
@@ -35,7 +35,7 @@ export const SuggestionsRow = ({ page }: { page: string }) => {
   const [selectedAccount, setSelectedAccount] = useState<string | undefined>();
   const [isImporting, setIsImporting] = useState<boolean>(false);
   const githubAccounts = useGithubAccounts();
-  const { restrictsPrivateRepos } = useGitHuPermissions();
+  const { restrictsPrivateRepos } = useGitHubPermissions();
   const { isTeamSpace } = useWorkspaceAuthorization();
   const { isFree } = useWorkspaceSubscription();
 

--- a/packages/app/src/app/pages/Dashboard/Components/shared/ReadOnlyRepoDisclaimer.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/shared/ReadOnlyRepoDisclaimer.tsx
@@ -1,5 +1,5 @@
 import { Icon } from '@codesandbox/components';
-import { useGitHuPermissions } from 'app/hooks/useGitHubPermissions';
+import { useGitHubPermissions } from 'app/hooks/useGitHubPermissions';
 import { useActions } from 'app/overmind';
 import React from 'react';
 import {
@@ -12,7 +12,7 @@ export const ReadOnlyRepoDisclaimer: React.FC<{ insideGrid?: boolean }> = ({
   insideGrid = false,
 }) => {
   const actions = useActions();
-  const { restrictsPublicRepos } = useGitHuPermissions();
+  const { restrictsPublicRepos } = useGitHubPermissions();
 
   if (!restrictsPublicRepos) {
     return null;

--- a/packages/app/src/app/pages/Dashboard/Components/shared/RestrictedImportDisclaimer.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/shared/RestrictedImportDisclaimer.tsx
@@ -1,6 +1,6 @@
 import { Icon } from '@codesandbox/components';
 import { useDismissible } from 'app/hooks';
-import { useGitHuPermissions } from 'app/hooks/useGitHubPermissions';
+import { useGitHubPermissions } from 'app/hooks/useGitHubPermissions';
 import { useActions } from 'app/overmind';
 import React from 'react';
 import {
@@ -13,7 +13,10 @@ export const RestrictedImportDisclaimer: React.FC<{ insideGrid?: boolean }> = ({
   insideGrid = false,
 }) => {
   const actions = useActions();
-  const { restrictsPublicRepos, restrictsPrivateRepos } = useGitHuPermissions();
+  const {
+    restrictsPublicRepos,
+    restrictsPrivateRepos,
+  } = useGitHubPermissions();
   const [dismissedPermissionsBanner] = useDismissible(
     'DASHBOARD_REPOSITORIES_PERMISSIONS_BANNER'
   );

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Recent/RecentContent.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Recent/RecentContent.tsx
@@ -22,6 +22,7 @@ import {
   PageTypes,
 } from 'app/pages/Dashboard/types';
 
+import { useGitHubPermissions } from 'app/hooks/useGitHubPermissions';
 import { DocumentationRow } from './DocumentationRow';
 import { RecentHeader } from './RecentHeader';
 
@@ -70,6 +71,7 @@ export const RecentContent: React.FC<RecentContentProps> = ({
     activeTeam,
     dashboard: { viewMode },
   } = useAppState();
+  const { restrictsPublicRepos } = useGitHubPermissions();
   const page: PageTypes = 'recent';
 
   return (
@@ -117,7 +119,7 @@ export const RecentContent: React.FC<RecentContentProps> = ({
       </Stack>
       <DocumentationRow />
       <TemplatesRow />
-      <SuggestionsRow page="recent" />
+      {!restrictsPublicRepos && <SuggestionsRow page="recent" />}
     </StyledWrapper>
   );
 };

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Repositories/EmptyRepositories.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Repositories/EmptyRepositories.tsx
@@ -8,12 +8,14 @@ import { appendOnboardingTracking } from 'app/pages/Dashboard/Content/utils';
 import { RestrictedImportDisclaimer } from 'app/pages/Dashboard/Components/shared/RestrictedImportDisclaimer';
 import { EmptyPage } from 'app/pages/Dashboard/Components/EmptyPage';
 import { SuggestionsRow } from 'app/pages/Dashboard/Components/SuggestionsRow/SuggestionsRow';
+import { useGitHubPermissions } from 'app/hooks/useGitHubPermissions';
 
 const DESCRIPTION =
   'Save hours every week by shortening the review cycle and empowering everyone to contribute.<br />Every branch in Repositories is connected to git and has its own sandbox running in a fast microVM.';
 
 export const EmptyRepositories: React.FC = () => {
   const actions = useActions();
+  const { restrictsPublicRepos } = useGitHubPermissions();
 
   return (
     <EmptyPage.StyledWrapper
@@ -61,7 +63,7 @@ export const EmptyRepositories: React.FC = () => {
       </EmptyPage.StyledGrid>
       <RestrictedImportDisclaimer />
       <Element css={{ minHeight: 32 }} />
-      <SuggestionsRow page="empty repositories" />
+      {!restrictsPublicRepos && <SuggestionsRow page="empty repositories" />}
     </EmptyPage.StyledWrapper>
   );
 };

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Repositories/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Repositories/index.tsx
@@ -8,7 +8,7 @@ import { SelectionProvider } from 'app/pages/Dashboard/Components/Selection';
 import { Element } from '@codesandbox/components';
 import { useWorkspaceLimits } from 'app/hooks/useWorkspaceLimits';
 import { useWorkspaceSubscription } from 'app/hooks/useWorkspaceSubscription';
-import { useGitHuPermissions } from 'app/hooks/useGitHubPermissions';
+import { useGitHubPermissions } from 'app/hooks/useGitHubPermissions';
 import { MaxReposFreeTeam } from 'app/pages/Dashboard/Components/Repository/stripes';
 import { RestrictedPublicReposImport } from 'app/pages/Dashboard/Components/shared/RestrictedPublicReposImport';
 import { InactiveTeamStripe } from 'app/pages/Dashboard/Components/shared/InactiveTeamStripe';
@@ -44,7 +44,7 @@ export const RepositoriesPage = () => {
     hasMaxPrivateRepositories,
   } = useWorkspaceLimits();
 
-  const { restrictsPublicRepos } = useGitHuPermissions();
+  const { restrictsPublicRepos } = useGitHubPermissions();
 
   const pageType: PageTypes = 'repositories';
 

--- a/packages/app/src/app/pages/Dashboard/Sidebar/BottomMessages/TrialExpiring.tsx
+++ b/packages/app/src/app/pages/Dashboard/Sidebar/BottomMessages/TrialExpiring.tsx
@@ -30,7 +30,7 @@ export const TrialExpiring: React.FC<{
 
       {cancelAtPeriodEnd ? (
         <Text css={{ color: '#999', fontWeight: 400, fontSize: 12 }}>
-          After this period, your Team will be migrated to the Free plan.
+          After this period, your Workspace will be inactive.
         </Text>
       ) : (
         <Text css={{ color: '#999', fontWeight: 400, fontSize: 12 }}>

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Deployment/GithubPages/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Deployment/GithubPages/index.tsx
@@ -14,7 +14,7 @@ import getTemplate from '@codesandbox/common/lib/templates';
 import React, { FunctionComponent, useEffect } from 'react';
 
 import { useAppState, useActions } from 'app/overmind';
-import { useGitHuPermissions } from 'app/hooks/useGitHubPermissions';
+import { useGitHubPermissions } from 'app/hooks/useGitHubPermissions';
 import { Info } from './Info';
 import { GitHubIcon, FileIcon, VisitIcon } from '../icons';
 
@@ -29,7 +29,10 @@ export const GithubPages: FunctionComponent = () => {
     signInGithubClicked,
     deployment: { deployWithGitHubPages, fetchGithubSite },
   } = useActions();
-  const { restrictsPublicRepos, restrictsPrivateRepos } = useGitHuPermissions();
+  const {
+    restrictsPublicRepos,
+    restrictsPrivateRepos,
+  } = useGitHubPermissions();
 
   useEffect(() => {
     fetchGithubSite();

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/GitHub/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/GitHub/index.tsx
@@ -9,7 +9,7 @@ import {
   Stack,
   Text,
 } from '@codesandbox/components';
-import { useGitHuPermissions } from 'app/hooks/useGitHubPermissions';
+import { useGitHubPermissions } from 'app/hooks/useGitHubPermissions';
 import { useAppState } from 'app/overmind';
 import React from 'react';
 
@@ -70,7 +70,10 @@ export const GitHub = () => {
     },
     isLoggedIn,
   } = useAppState();
-  const { restrictsPublicRepos, restrictsPrivateRepos } = useGitHuPermissions();
+  const {
+    restrictsPublicRepos,
+    restrictsPrivateRepos,
+  } = useGitHubPermissions();
 
   const changeCount = gitChanges
     ? gitChanges.added.length +

--- a/packages/app/src/app/pages/common/Modals/PreferencesModal/Integrations/GitHubPermissions.tsx
+++ b/packages/app/src/app/pages/common/Modals/PreferencesModal/Integrations/GitHubPermissions.tsx
@@ -7,7 +7,7 @@ import {
   Icon,
   Text,
 } from '@codesandbox/components';
-import { useGitHuPermissions } from 'app/hooks/useGitHubPermissions';
+import { useGitHubPermissions } from 'app/hooks/useGitHubPermissions';
 import { useActions } from 'app/overmind';
 
 const MAP_SCOPE_DESCRIPTION = {
@@ -47,7 +47,7 @@ const Details: React.FC = () => {
     restrictsPublicRepos,
     restrictsPrivateRepos,
     profile,
-  } = useGitHuPermissions();
+  } = useGitHubPermissions();
   const { signInGithubClicked, signOutGithubIntegration } = useActions();
 
   if (restrictsPublicRepos) {


### PR DESCRIPTION
This solves a few issues like unnecessary requests being made by the SuggestionRow (which throw errors to the users) when no permissions are given. Also renamed a typo in hook and changed the text on the sidebar trial expiration message