### PR TITLE
fix(UI): avoid flashing the GH permissions banners

### DIFF
--- a/packages/app/src/app/hooks/useGitHubPermissions.ts
+++ b/packages/app/src/app/hooks/useGitHubPermissions.ts
@@ -17,7 +17,7 @@ export const useGitHubPermissions = (): {
     return NO_PERMISSIONS;
   }
 
-  if (hasLogIn && !user) {
+  if (!user) {
     // Data not loaded yet
     return {
       restrictsPublicRepos: undefined,

--- a/packages/app/src/app/hooks/useGitHubPermissions.ts
+++ b/packages/app/src/app/hooks/useGitHubPermissions.ts
@@ -13,7 +13,7 @@ export const useGitHubPermissions = (): {
 } => {
   const { hasLogIn, user } = useAppState();
 
-  if (!hasLogIn || !user) {
+  if (!hasLogIn) {
     return NO_PERMISSIONS;
   }
 

--- a/packages/app/src/app/hooks/useGitHubPermissions.ts
+++ b/packages/app/src/app/hooks/useGitHubPermissions.ts
@@ -7,14 +7,23 @@ const NO_PERMISSIONS = {
 };
 
 export const useGitHubPermissions = (): {
-  restrictsPublicRepos: boolean;
-  restrictsPrivateRepos: boolean;
+  restrictsPublicRepos: boolean | undefined;
+  restrictsPrivateRepos: boolean | undefined;
   profile: { email: string; scopes: string[] } | null;
 } => {
   const { hasLogIn, user } = useAppState();
 
   if (!hasLogIn || !user) {
     return NO_PERMISSIONS;
+  }
+
+  if (hasLogIn && !user) {
+    // Data not loaded yet
+    return {
+      restrictsPublicRepos: undefined,
+      restrictsPrivateRepos: undefined,
+      profile: null,
+    };
   }
 
   const {

--- a/packages/app/src/app/pages/Dashboard/Components/shared/RestrictedImportDisclaimer.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/shared/RestrictedImportDisclaimer.tsx
@@ -23,7 +23,8 @@ export const RestrictedImportDisclaimer: React.FC<{ insideGrid?: boolean }> = ({
 
   const dismissedBannerButRestrictsPublicRepos =
     dismissedPermissionsBanner && restrictsPublicRepos;
-  const onlyAllowsPublicRepos = !restrictsPublicRepos && restrictsPrivateRepos;
+  const onlyAllowsPublicRepos =
+    restrictsPublicRepos === false && restrictsPrivateRepos === true;
 
   if (dismissedBannerButRestrictsPublicRepos || onlyAllowsPublicRepos) {
     return (

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Recent/RecentContent.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Recent/RecentContent.tsx
@@ -119,7 +119,7 @@ export const RecentContent: React.FC<RecentContentProps> = ({
       </Stack>
       <DocumentationRow />
       <TemplatesRow />
-      {!restrictsPublicRepos && <SuggestionsRow page="recent" />}
+      {restrictsPublicRepos === false && <SuggestionsRow page="recent" />}
     </StyledWrapper>
   );
 };

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Repositories/EmptyRepositories.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Repositories/EmptyRepositories.tsx
@@ -63,7 +63,9 @@ export const EmptyRepositories: React.FC = () => {
       </EmptyPage.StyledGrid>
       <RestrictedImportDisclaimer />
       <Element css={{ minHeight: 32 }} />
-      {!restrictsPublicRepos && <SuggestionsRow page="empty repositories" />}
+      {restrictsPublicRepos === false && (
+        <SuggestionsRow page="empty repositories" />
+      )}
     </EmptyPage.StyledWrapper>
   );
 };


### PR DESCRIPTION
For all the flags that dictate different messages and banners we need 3 states:
* undefined - value is not yet computed / loaded
* false / true

Otherwise, some of these flags flash between false/true while the page loads.

Before

https://github.com/codesandbox/codesandbox-client/assets/9945366/4daa2f8f-b9e7-4804-b19e-616342631ce3

After

https://github.com/codesandbox/codesandbox-client/assets/9945366/1069cb5f-4bcd-4233-9884-3f3302755439

