### PR TITLE
feat(SuggestedRepositories): allow multi/parallel import

### DIFF
--- a/packages/app/src/app/pages/Dashboard/Components/NewTeamModal/TeamImport.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/NewTeamModal/TeamImport.tsx
@@ -9,15 +9,6 @@ import { useGitHubPermissions } from 'app/hooks/useGitHubPermissions';
 export const TeamImport = ({ onComplete }: { onComplete: () => void }) => {
   const { restrictsPublicRepos } = useGitHubPermissions();
 
-  const handleImportClicked = () => {
-    track('New Team - Imported repository', {
-      codesandbox: 'V1',
-      event_source: 'UI',
-    });
-
-    onComplete();
-  };
-
   return (
     <Element css={{ width: '100%', height: '546px' }} padding={8}>
       <Stack
@@ -52,17 +43,14 @@ export const TeamImport = ({ onComplete }: { onComplete: () => void }) => {
             <RestrictedPublicReposImport />
           ) : (
             <Element css={{ width: '100%' }}>
-              <SuggestedRepositories
-                isImportOnly
-                onImportClicked={handleImportClicked}
-              />
+              <SuggestedRepositories isImportOnly />
             </Element>
           )}
         </Stack>
         <Button
           css={{ width: 'auto' }}
           onClick={() => {
-            track('New Team - Skip import', {
+            track('New Team - Done import', {
               codesandbox: 'V1',
               event_source: 'UI',
             });
@@ -71,7 +59,7 @@ export const TeamImport = ({ onComplete }: { onComplete: () => void }) => {
           }}
           variant="link"
         >
-          Skip
+          Done
         </Button>
       </Stack>
     </Element>

--- a/packages/components/src/components/Button/index.tsx
+++ b/packages/components/src/components/Button/index.tsx
@@ -180,7 +180,7 @@ const Dot = styled.span`
   animation: ${transition} 1.5s ease-out infinite;
 `;
 
-const AnimatingDots = () => (
+export const AnimatingDots = () => (
   <>
     <VisuallyHidden>Loading</VisuallyHidden>
     <span role="presentation">

--- a/packages/components/src/components/InteractiveOverlay/InteractiveOverlay.tsx
+++ b/packages/components/src/components/InteractiveOverlay/InteractiveOverlay.tsx
@@ -67,6 +67,10 @@ const StyledButton = styled.button<
   font-family: inherit;
   cursor: pointer;
 
+  &:disabled {
+    cursor: not-allowed;
+  }
+
   ${overlayStyles}
 `;
 


### PR DESCRIPTION
There was a bug on the `new_workspace` triggered screen, the modal no longer closes now after the import. 

Fixes PC-1152

While there, I tweaked the import experience and allowed multiple repos to be imported in parallel.

https://github.com/codesandbox/codesandbox-client/assets/9945366/6f4e93ab-1d93-4008-b4d9-59377beb2d0a

The experience can be further improved, but let's talk on Monday about the onboarding flow.

