### PR TITLE
refactor(actions): remove privacy policy function and its dependencies

### DIFF
--- a/packages/app/src/app/overmind/actions.ts
+++ b/packages/app/src/app/overmind/actions.ts
@@ -155,7 +155,6 @@ export const onInitializeOvermind = async (
 
   effects.preview.initialize();
 
-  actions.internal.showPrivacyPolicyNotification();
   actions.internal.setViewModeForDashboard();
 
   effects.browser.onWindowMessage(event => {

--- a/packages/app/src/app/overmind/internalActions.ts
+++ b/packages/app/src/app/overmind/internalActions.ts
@@ -570,43 +570,6 @@ export const identifyCurrentUser = async ({ state, effects }: Context) => {
   }
 };
 
-export const showPrivacyPolicyNotification = ({ effects, state }: Context) => {
-  const seenTermsKey = 'ACCEPTED_TERMS_CODESANDBOX_v1.1';
-  if (effects.browser.storage.get(seenTermsKey)) {
-    return;
-  }
-
-  if (!state.isFirstVisit) {
-    effects.analytics.track('Saw Terms of Use Notification');
-    effects.notificationToast.add({
-      message:
-        'Hello, we are changing our Terms of Use effective Mar 31, 2021 12:00 UTC. Please read them, or see commit message for a brief sum up.',
-      title: 'Updated Terms of Use',
-      status: NotificationStatus.NOTICE,
-      sticky: true,
-      actions: {
-        secondary: {
-          label: 'Open Commit Message',
-          run: () => {
-            window.open(
-              'https://github.com/codesandbox/codesandbox-client/commit/36b0f928cb863868bbfd93bb455a74ff46951edc',
-              '_blank'
-            );
-          },
-        },
-        primary: {
-          label: 'Open Privacy Policy',
-          run: () => {
-            window.open('https://codesandbox.io/legal/privacy', '_blank');
-          },
-        },
-      },
-    });
-  }
-
-  effects.browser.storage.set(seenTermsKey, true);
-};
-
 const VIEW_MODE_DASHBOARD = 'VIEW_MODE_DASHBOARD';
 export const setViewModeForDashboard = ({ effects, state }: Context) => {
   const localStorageViewMode = effects.browser.storage.get(VIEW_MODE_DASHBOARD);


### PR DESCRIPTION
The terms of service update is from 2021, so it's not up-to-date anymore.