### PR TITLE
feat: move workspace name in post-pro flow

### DIFF
--- a/packages/app/src/app/components/dashboard/InputText.tsx
+++ b/packages/app/src/app/components/dashboard/InputText.tsx
@@ -1,4 +1,4 @@
-import React, { InputHTMLAttributes } from 'react';
+import React, { InputHTMLAttributes, forwardRef } from 'react';
 import styled from 'styled-components';
 import { Stack } from '@codesandbox/components';
 import { Label } from './Label';
@@ -32,23 +32,19 @@ interface InputTextProps extends InputHTMLAttributes<HTMLInputElement> {
   hideLabel?: boolean;
 }
 
-export const InputText = ({
-  id,
-  label,
-  name,
-  isInvalid,
-  hideLabel,
-  ...restProps
-}: InputTextProps) => (
-  <Stack gap={2} direction="vertical">
-    {!hideLabel && <Label htmlFor={id}>{label}</Label>}
-    <StyledInput
-      id={id}
-      name={name}
-      type="text"
-      aria-label={label}
-      isInvalid={isInvalid}
-      {...restProps}
-    />
-  </Stack>
+export const InputText = forwardRef<HTMLInputElement, InputTextProps>(
+  ({ id, label, name, isInvalid, hideLabel, ...restProps }, ref) => (
+    <Stack gap={2} direction="vertical">
+      {!hideLabel && <Label htmlFor={id}>{label}</Label>}
+      <StyledInput
+        id={id}
+        name={name}
+        type="text"
+        aria-label={label}
+        isInvalid={isInvalid}
+        ref={ref}
+        {...restProps}
+      />
+    </Stack>
+  )
 );

--- a/packages/app/src/app/components/dashboard/Textarea.tsx
+++ b/packages/app/src/app/components/dashboard/Textarea.tsx
@@ -25,7 +25,7 @@ const StyledTextarea = styled.textarea<{ resize: boolean }>`
 
 interface TextareaProps extends TextareaHTMLAttributes<HTMLTextAreaElement> {
   id: string;
-  label: string;
+  label?: string;
   name: string;
   resize?: boolean;
 }
@@ -39,7 +39,7 @@ export const Textarea = ({
 }: TextareaProps) => {
   return (
     <Stack gap={2} direction="vertical">
-      <Label htmlFor={id}>{label}</Label>
+      {label && <Label htmlFor={id}>{label}</Label>}
       <StyledTextarea id={id} name={name} resize={resize} {...restProps} />
     </Stack>
   );

--- a/packages/app/src/app/overmind/actions.ts
+++ b/packages/app/src/app/overmind/actions.ts
@@ -619,7 +619,7 @@ export const openCreateTeamModal = (
   props?: OpenCreateTeamModalParams
 ) => {
   actions.modals.newTeamModal.open({
-    step: props?.step ?? 'create',
+    step: props?.step ?? 'name',
     hasNextStep: props?.hasNextStep ?? true,
   });
 };

--- a/packages/app/src/app/pages/Dashboard/Components/NewTeamModal/TeamImport.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/NewTeamModal/TeamImport.tsx
@@ -10,7 +10,7 @@ export const TeamImport = ({ onComplete }: { onComplete: () => void }) => {
   const { restrictsPublicRepos } = useGitHubPermissions();
 
   return (
-    <Element css={{ width: '100%', height: '546px' }} padding={8}>
+    <Element css={{ width: '100%' }} padding={12}>
       <Stack
         align="center"
         direction="vertical"
@@ -47,20 +47,22 @@ export const TeamImport = ({ onComplete }: { onComplete: () => void }) => {
             </Element>
           )}
         </Stack>
-        <Button
-          css={{ width: 'auto' }}
-          onClick={() => {
-            track('New Team - Done import', {
-              codesandbox: 'V1',
-              event_source: 'UI',
-            });
+        <Stack css={{ width: '100%', justifyContent: 'flex-end' }}>
+          <Button
+            css={{ width: 'auto' }}
+            onClick={() => {
+              track('New Team - Done import', {
+                codesandbox: 'V1',
+                event_source: 'UI',
+              });
 
-            onComplete();
-          }}
-          variant="link"
-        >
-          Done
-        </Button>
+              onComplete();
+            }}
+            variant="link"
+          >
+            Done
+          </Button>
+        </Stack>
       </Stack>
     </Element>
   );

--- a/packages/app/src/app/pages/Dashboard/Components/NewTeamModal/TeamMembers.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/NewTeamModal/TeamMembers.tsx
@@ -170,9 +170,7 @@ export const TeamMembers: React.FC<{
           >
             Invite team members
           </Text>
-          <Text id="invitees-role" htmlFor="member" color="#999">
-            Insert email addresses separated by a comma
-          </Text>
+          <Text color="#999">Insert email addresses separated by a comma</Text>
         </Stack>
         <Stack
           as="form"
@@ -183,7 +181,6 @@ export const TeamMembers: React.FC<{
         >
           <Stack gap={4} direction="vertical">
             <Textarea
-              aria-describedby="invitees-role"
               id="member"
               name="members"
               value={addressesString}

--- a/packages/app/src/app/pages/Dashboard/Components/NewTeamModal/TeamMembers.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/NewTeamModal/TeamMembers.tsx
@@ -154,21 +154,26 @@ export const TeamMembers: React.FC<{
           width: '100%',
         }}
       >
-        <Text
-          as="h2"
-          size={32}
-          weight="500"
-          align="center"
-          css={{
-            margin: 0,
-            color: '#ffffff',
-            fontFamily: 'Everett, sans-serif',
-            lineHeight: '42px',
-            letterSpacing: '-0.01em',
-          }}
-        >
-          {activeTeamInfo.name}
-        </Text>
+        <Stack gap={2} direction="vertical">
+          <Text
+            as="h2"
+            size={32}
+            weight="500"
+            align="center"
+            css={{
+              margin: 0,
+              color: '#ffffff',
+              fontFamily: 'Everett, sans-serif',
+              lineHeight: '42px',
+              letterSpacing: '-0.01em',
+            }}
+          >
+            Invite team members
+          </Text>
+          <Text id="invitees-role" htmlFor="member" color="#999">
+            Insert email addresses separated by a comma
+          </Text>
+        </Stack>
         <Stack
           as="form"
           onSubmit={handleSubmit}
@@ -180,7 +185,6 @@ export const TeamMembers: React.FC<{
             <Textarea
               aria-describedby="invitees-role"
               id="member"
-              label="Invite additional team members (Insert email addresses separated by a comma)"
               name="members"
               value={addressesString}
               onChange={e => {
@@ -208,7 +212,7 @@ export const TeamMembers: React.FC<{
             ) : null}
 
             <StyledButton loading={inviteLoading} type="submit">
-              Invite members
+              Send invites
             </StyledButton>
           </Stack>
           <Text
@@ -238,7 +242,7 @@ export const TeamMembers: React.FC<{
       <Stack
         css={{
           width: '100%',
-          padding: '48px 56px',
+          padding: '48px',
         }}
         justify={hideSkip ? 'center' : 'space-between'}
       >
@@ -266,7 +270,7 @@ export const TeamMembers: React.FC<{
             }}
             variant="link"
           >
-            Skip
+            Next
           </Button>
         )}
       </Stack>

--- a/packages/app/src/app/pages/Dashboard/Components/NewTeamModal/TeamName.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/NewTeamModal/TeamName.tsx
@@ -1,32 +1,35 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { useActions, useAppState } from 'app/overmind';
 import { Stack, Text, Link, Element, Icon } from '@codesandbox/components';
 import { InputText } from 'app/components/dashboard/InputText';
 import { StyledButton } from 'app/components/dashboard/Button';
 import track from '@codesandbox/common/lib/utils/analytics';
-import { dashboard as dashboardURLs } from '@codesandbox/common/lib/utils/url-generator';
-import { useCreateCheckout } from 'app/hooks';
 
-export const TeamCreate: React.FC<{ onComplete: () => void }> = () => {
-  const { dashboard } = useAppState();
+export const TeamName: React.FC<{ onComplete: () => void }> = ({
+  onComplete,
+}) => {
+  const { dashboard, activeTeamInfo } = useAppState();
   const actions = useActions();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [existingTeamError, setExistingTeamError] = useState(false);
-  const [checkout, createCheckout] = useCreateCheckout();
+  const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
-    if (checkout.status === 'error') {
-      setError(`Could not create stripe checkout link. ${checkout.error}`);
+    if (!activeTeamInfo || !inputRef.current) {
+      return;
     }
-  }, [checkout]);
+
+    inputRef.current.focus();
+    inputRef.current.select();
+  }, [activeTeamInfo]);
 
   const onSubmit = async event => {
     event.preventDefault();
     const teamName = event.target.name.value?.trim();
 
-    if (teamName) {
-      track('New Team - Create Team', {
+    if (teamName && teamName !== activeTeamInfo?.name) {
+      track('New Team - Set Name', {
         codesandbox: 'V1',
         event_source: 'UI',
       });
@@ -34,23 +37,19 @@ export const TeamCreate: React.FC<{ onComplete: () => void }> = () => {
       setError(null);
       setLoading(true);
       try {
-        const newTeam = await actions.dashboard.createTeam({
-          teamName,
-        });
-
-        await createCheckout({
-          team_id: newTeam.id,
-          success_path: dashboardURLs.recent(newTeam.id, {
-            new_workspace: 'true',
-          }),
-          utm_source: 'pro_page',
+        await actions.dashboard.setTeamInfo({
+          name: teamName,
+          description: null,
+          file: null,
         });
       } catch {
-        setError('There was a problem creating your team');
+        setError('There was a problem updating your workspace');
       } finally {
         setLoading(false);
       }
     }
+
+    onComplete();
   };
 
   const handleInput = e => {
@@ -97,8 +96,9 @@ export const TeamCreate: React.FC<{ onComplete: () => void }> = () => {
             letterSpacing: '-0.01em',
           }}
         >
-          Name your workspace
+          Welcome to Pro
         </Text>
+        <Text color="#999">Let&apos;s give your workspace a name</Text>
       </Stack>
       <Stack
         as="form"
@@ -115,7 +115,9 @@ export const TeamCreate: React.FC<{ onComplete: () => void }> = () => {
           required
           autoFocus
           hideLabel
+          defaultValue={activeTeamInfo?.name}
           onChange={handleInput}
+          ref={inputRef}
         />
 
         {existingTeamError && (

--- a/packages/app/src/app/pages/Dashboard/Components/NewTeamModal/TeamName.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/NewTeamModal/TeamName.tsx
@@ -67,7 +67,11 @@ export const TeamName: React.FC<{ onComplete: () => void }> = ({
 
     // Check if there's any team with the same name.
     setExistingTeamError(
-      Boolean(dashboard.teams.find(team => team.name === trimmedName))
+      Boolean(
+        dashboard.teams.find(
+          team => team.name === trimmedName && team.id !== activeTeamInfo?.id
+        )
+      )
     );
   };
 

--- a/packages/app/src/app/pages/Dashboard/Components/NewTeamModal/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/NewTeamModal/index.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import css from '@styled-system/css';
 import {
   IconButton,
   Stack,
@@ -11,14 +10,14 @@ import Modal from 'app/components/Modal';
 import { useActions, useAppState } from 'app/overmind';
 
 import track from '@codesandbox/common/lib/utils/analytics';
-import { TeamCreate } from './TeamCreate';
+import { TeamName } from './TeamName';
 import { TeamMembers } from './TeamMembers';
 import { TeamImport } from './TeamImport';
 
-export type TeamStep = 'create' | 'members' | 'import';
+export type TeamStep = 'name' | 'members' | 'import';
 
 const NEXT_STEP: Record<TeamStep, TeamStep | null> = {
-  create: null,
+  name: 'members',
   members: 'import',
   import: null,
 };
@@ -31,7 +30,7 @@ type NewTeamProps = {
 const NewTeam: React.FC<NewTeamProps> = ({ step, hasNextStep, onClose }) => {
   const { activeTeamInfo } = useAppState();
   const [currentStep, setCurrentStep] = React.useState<TeamStep>(
-    step ?? 'create'
+    step ?? 'name'
   );
 
   const nextStep =
@@ -51,16 +50,12 @@ const NewTeam: React.FC<NewTeamProps> = ({ step, hasNextStep, onClose }) => {
     <>
       <Element padding={6}>
         <Stack align="center" justify="space-between">
-          <Text
-            css={css({
-              color: '#808080',
-            })}
-            size={3}
-          >
-            {activeTeamInfo && currentStep !== 'create'
+          <Text color="#999" size={3}>
+            {activeTeamInfo && currentStep !== 'name'
               ? activeTeamInfo.name
-              : 'New workspace'}
+              : ''}
           </Text>
+
           <IconButton
             name="cross"
             variant="square"
@@ -71,16 +66,14 @@ const NewTeam: React.FC<NewTeamProps> = ({ step, hasNextStep, onClose }) => {
         </Stack>
       </Element>
       <Stack
-        css={css({
-          flex: 1,
-        })}
+        css={{ flex: 1 }}
         align="center"
         direction="vertical"
         justify="center"
       >
         {
           {
-            create: <TeamCreate onComplete={handleStepCompletion} />,
+            name: <TeamName onComplete={handleStepCompletion} />,
             members: (
               <TeamMembers
                 hideSkip={!nextStep}

--- a/packages/app/src/app/pages/Dashboard/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/index.tsx
@@ -108,7 +108,7 @@ export const Dashboard: FunctionComponent = () => {
     const searchParams = new URLSearchParams(location.search);
 
     if (JSON.parse(searchParams.get('new_workspace'))) {
-      actions.openCreateTeamModal({ step: 'members' });
+      actions.openCreateTeamModal({ step: 'name' });
       searchParams.delete('new_workspace');
     } else if (JSON.parse(searchParams.get('import_repo'))) {
       actions.openCreateSandboxModal({ initialTab: 'import' });

--- a/packages/app/src/app/pages/Pro/Create.tsx
+++ b/packages/app/src/app/pages/Pro/Create.tsx
@@ -61,7 +61,7 @@ export const ProCreate = () => {
     onClick: async () => {
       setIsLoading(true);
       const newTeam = await actions.dashboard.createTeam({
-        teamName: `${user.username}'s pro team`,
+        teamName: `${user.username}'s pro`,
       });
 
       await createCheckout({


### PR DESCRIPTION
Closes PC-1222

Removes the step to name the workspace / create team before going to stripe.

On the pro page, when you start trial / upgrade to pro you go directly to stripe
When stripe redirects to the dashboard, you end up with `new_workspace=true` in the query string.
The modal window now has 3 steps:
<img width="790" alt="image" src="https://github.com/codesandbox/codesandbox-client/assets/9945366/657a57d5-4426-43c5-a320-4582a4709d21">
<img width="756" alt="image" src="https://github.com/codesandbox/codesandbox-client/assets/9945366/71896003-7da5-4d6d-ae19-a8453d995d57">
<img width="760" alt="image" src="https://github.com/codesandbox/codesandbox-client/assets/9945366/ef0d12cc-7190-401b-9b4b-796957a918d3">

A few style adjustments to match on all 3 screens
