### PR TITLE
fix(ts): reload TS projects once we have loadad the typings

### DIFF
--- a/packages/app/src/app/overmind/effects/vscode/index.ts
+++ b/packages/app/src/app/overmind/effects/vscode/index.ts
@@ -510,7 +510,10 @@ export class VSCodeEffect {
     setFs(this.sandboxFsSync.create(sandbox));
 
     if (isFirstLoad) {
-      this.sandboxFsSync.sync(() => {});
+      this.sandboxFsSync.sync(() => {
+        // Once we have synced the fs, reload the TS project, as some new dependencies might have been added
+        this.runCommand('typescript.reloadProjects');
+      });
     } else {
       this.editorApi.extensionService.stopExtensionHost();
       this.sandboxFsSync.sync(() => {


### PR DESCRIPTION
With the new version of TypeScript, sandboxes start with an error state because the typings are not available on boot (we dynamically download the typings, to improve editor load time). TS doesn't like this and gives a big error for all React code, from the start.

With this change, we tell the extension to explicitly check again for types after we've downloaded the types. That way, TS gets updated with the latest version and the errors are removed.

Fixes #8078

Used this sandbox to verify: https://vjl7jl-3000.csb.app/s/cocky-liskov-px6sj7?file=/src/App.tsx