### PR TITLE
feat: add all checkout options on the pro page

### DIFF
--- a/packages/app/src/app/components/CreateSandbox/CreateSandbox.tsx
+++ b/packages/app/src/app/components/CreateSandbox/CreateSandbox.tsx
@@ -183,7 +183,7 @@ export const CreateSandbox: React.FC<CreateSandboxProps> = ({
 
   const onCreateCheckout = () => {
     createCheckout({
-      utm_source: 'dashboard_upgrade_banner',
+      trackingLocation: 'dashboard_upgrade_banner',
     });
   };
 

--- a/packages/app/src/app/components/CreateSandbox/Import/InactiveTeam.tsx
+++ b/packages/app/src/app/components/CreateSandbox/Import/InactiveTeam.tsx
@@ -23,7 +23,7 @@ export const InactiveTeam: React.FC = () => {
         <MessageStripe.Action
           onClick={() => {
             createCheckout({
-              utm_source: 'max_public_repos',
+              trackingLocation: 'max_public_repos',
             });
 
             track(getEventName(false, isBillingManager), EVENT_PROPS);

--- a/packages/app/src/app/components/CreateSandbox/Import/MaxPublicRepos.tsx
+++ b/packages/app/src/app/components/CreateSandbox/Import/MaxPublicRepos.tsx
@@ -26,7 +26,7 @@ export const MaxPublicRepos: React.FC = () => {
         <MessageStripe.Action
           onClick={() => {
             createCheckout({
-              utm_source: 'max_public_repos',
+              trackingLocation: 'max_public_repos',
             });
 
             track(

--- a/packages/app/src/app/components/CreateSandbox/Import/PrivateRepoFreeTeam.tsx
+++ b/packages/app/src/app/components/CreateSandbox/Import/PrivateRepoFreeTeam.tsx
@@ -49,7 +49,7 @@ export const PrivateRepoFreeTeam: React.FC = () => {
             modals.newSandboxModal.close();
           } else {
             createCheckout({
-              utm_source: 'dashboard_import_limits',
+              trackingLocation: 'dashboard_import_limits',
             });
           }
 

--- a/packages/app/src/app/components/CreateSandbox/Import/PrivateRepoFreeTeam.tsx
+++ b/packages/app/src/app/components/CreateSandbox/Import/PrivateRepoFreeTeam.tsx
@@ -1,5 +1,5 @@
 import track from '@codesandbox/common/lib/utils/analytics';
-import { Element, Link as StyledLink } from '@codesandbox/components';
+import { Link as StyledLink } from '@codesandbox/components';
 import { useCreateCheckout } from 'app/hooks';
 import { useWorkspaceSubscription } from 'app/hooks/useWorkspaceSubscription';
 import { useWorkspaceAuthorization } from 'app/hooks/useWorkspaceAuthorization';
@@ -20,14 +20,16 @@ export const PrivateRepoFreeTeam: React.FC = () => {
    * Can't checkout? '/docs/learn/introduction/workspace#managing-teams-and-subscriptions'
    */
 
-  const ctaURL = ((): string | false => {
-    if (!canCheckout) {
-      return isPersonalSpace
-        ? '/pro'
-        : '/docs/learn/plans/workspace#managing-teams-and-subscriptions';
+  const ctaURL = ((): string | null => {
+    if (isPersonalSpace) {
+      return '/pro';
     }
 
-    return false;
+    if (!canCheckout) {
+      return '/docs/learn/plans/workspace#managing-teams-and-subscriptions';
+    }
+
+    return null;
   })();
 
   return (
@@ -59,11 +61,7 @@ export const PrivateRepoFreeTeam: React.FC = () => {
           });
         }}
       >
-        upgrade to{' '}
-        <Element as="span" css={{ textTransform: 'uppercase' }}>
-          pro
-        </Element>
-        .
+        upgrade to Pro.
       </StyledLink>
     </>
   );

--- a/packages/app/src/app/hooks/useCreateCheckout.ts
+++ b/packages/app/src/app/hooks/useCreateCheckout.ts
@@ -95,7 +95,7 @@ export const useCreateCheckout = (): [
 
       if (!activeTeam || !user) {
         // Should not happen but it's done for typing reasons
-        setStatus({ status: 'error', error: 'Invalid activeTeam or user' });
+        throw new Error('Invalid activeTeam or user');
       }
 
       let teamId = activeTeam;

--- a/packages/app/src/app/hooks/useCreateCheckout.ts
+++ b/packages/app/src/app/hooks/useCreateCheckout.ts
@@ -93,6 +93,11 @@ export const useCreateCheckout = (): [
     try {
       setStatus({ status: 'loading' });
 
+      if (!activeTeam || !user) {
+        // Should not happen but it's done for typing reasons
+        setStatus({ status: 'error', error: 'Invalid activeTeam or user' });
+      }
+
       let teamId = activeTeam;
 
       if (createTeam) {

--- a/packages/app/src/app/pages/Dashboard/Components/Repository/stripes.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Repository/stripes.tsx
@@ -39,7 +39,7 @@ export const PrivateRepoFreeTeam: React.FC = () => {
               window.location.href = '/pro';
             } else {
               createCheckout({
-                utm_source: 'dashboard_private_repo_upgrade',
+                trackingLocation: 'dashboard_private_repo_upgrade',
               });
             }
           }}
@@ -66,7 +66,7 @@ export const MaxReposFreeTeam: React.FC = () => {
           disabled={checkout.status === 'loading'}
           onClick={() => {
             createCheckout({
-              utm_source: 'dashboard_private_repo_upgrade',
+              trackingLocation: 'dashboard_private_repo_upgrade',
             });
 
             track(getEventName(isEligibleForTrial, isBillingManager), {

--- a/packages/app/src/app/pages/Dashboard/Components/TeamSubscriptionOptions/TeamSubscriptionOptions.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/TeamSubscriptionOptions/TeamSubscriptionOptions.tsx
@@ -1,40 +1,55 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { ComboButton, Stack, Text } from '@codesandbox/components';
 import track from '@codesandbox/common/lib/utils/analytics';
 import { useCreateCheckout } from 'app/hooks';
 import { useWorkspaceSubscription } from 'app/hooks/useWorkspaceSubscription';
+import { useEffects } from 'app/overmind';
 
 type TeamSubscriptionOptionsProps = {
   buttonVariant?: React.ComponentProps<typeof ComboButton>['variant'];
   buttonStyles?: React.ComponentProps<typeof ComboButton>['customStyles'];
   ctaCopy?: string;
-  trackingLocation: string;
+  trackingLocation: 'settings_upgrade' | 'pro_page';
+  createTeam?: boolean;
 };
 export const TeamSubscriptionOptions: React.FC<TeamSubscriptionOptionsProps> = ({
   buttonVariant,
   buttonStyles,
   ctaCopy,
   trackingLocation,
+  createTeam,
 }) => {
   const { isEligibleForTrial } = useWorkspaceSubscription();
+  const effects = useEffects();
 
   const [checkout, createCheckout, canCheckout] = useCreateCheckout();
   const disabled = checkout.status === 'loading';
 
+  useEffect(() => {
+    if (checkout.status === 'error') {
+      effects.notificationToast.error(
+        `Could not create stripe checkout link. ${checkout.error}`
+      );
+    }
+  }, [checkout]);
+
   const createMonthlyCheckout = () => {
     createCheckout({
-      utm_source: 'settings_upgrade',
+      trackingLocation,
+      createTeam,
     });
   };
 
   const createYearlyCheckout = () => {
     createCheckout({
-      recurring_interval: 'year',
-      utm_source: 'settings_upgrade',
+      interval: 'year',
+      trackingLocation,
+      createTeam,
     });
   };
 
-  if (!canCheckout) {
+  // Only show this for existing teams, not for the create team flow
+  if (!createTeam && !canCheckout) {
     return (
       <Text as="p" variant="body" css={{ marginTop: 0 }}>
         Contact your team admin to upgrade.

--- a/packages/app/src/app/pages/Dashboard/Components/UpgradeBanner/UpgradeBanner.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/UpgradeBanner/UpgradeBanner.tsx
@@ -74,7 +74,7 @@ export const UpgradeBanner: React.FC = () => {
             }
 
             createCheckout({
-              utm_source: 'restrictions_banner',
+              trackingLocation: 'restrictions_banner',
             });
           }}
           autoWidth

--- a/packages/app/src/app/pages/Dashboard/Components/shared/InactiveTeamStripe.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/shared/InactiveTeamStripe.tsx
@@ -20,7 +20,7 @@ export const InactiveTeamStripe: React.FC = ({ children }) => {
             });
 
             createCheckout({
-              utm_source: 'restrictions_banner',
+              trackingLocation: 'restrictions_banner',
             });
           }}
         >

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Sandboxes/MaxSandboxesRestrictionsBanner.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Sandboxes/MaxSandboxesRestrictionsBanner.tsx
@@ -33,7 +33,7 @@ export const MaxSandboxesRestrictionsBanner: React.FC = () => {
             }
 
             createCheckout({
-              utm_source: 'restrictions_banner',
+              trackingLocation: 'restrictions_banner',
             });
           }}
         >

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/ManageSubscription/upgrade.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/ManageSubscription/upgrade.tsx
@@ -51,7 +51,7 @@ export const Upgrade = () => {
 
         <TeamSubscriptionOptions
           buttonVariant="trial"
-          trackingLocation="Team Settings"
+          trackingLocation="settings_upgrade"
         />
       </Stack>
     </Card>

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/WorkspaceSettings.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/WorkspaceSettings.tsx
@@ -251,7 +251,7 @@ export const WorkspaceSettings: React.FC = () => {
               }
 
               createCheckout({
-                utm_source: 'dashboard_workspace_settings',
+                trackingLocation: 'dashboard_workspace_settings',
               });
             }}
           >

--- a/packages/app/src/app/pages/Pro/Upgrade.tsx
+++ b/packages/app/src/app/pages/Pro/Upgrade.tsx
@@ -224,7 +224,7 @@ export const ProUpgrade = () => {
                             fontWeight: 500,
                             height: 'auto',
                           }}
-                          trackingLocation="subscription page"
+                          trackingLocation="pro_page"
                         />
                       ),
                     }

--- a/packages/app/src/app/pages/common/Modals/EditorSeatsUpgrade/index.tsx
+++ b/packages/app/src/app/pages/common/Modals/EditorSeatsUpgrade/index.tsx
@@ -66,7 +66,7 @@ export const EditorSeatsUpgrade: React.FC = () => {
                 }
 
                 createCheckout({
-                  utm_source: 'editor_seats_upgrade',
+                  trackingLocation: 'editor_seats_upgrade',
                 });
               }}
               autoWidth

--- a/packages/app/src/app/pages/common/Modals/LiveSessionRestricted/index.tsx
+++ b/packages/app/src/app/pages/common/Modals/LiveSessionRestricted/index.tsx
@@ -72,8 +72,8 @@ export const LiveSessionRestricted: React.FC = () => {
                 }
 
                 createCheckout({
-                  cancel_path: sandboxUrl({ id }),
-                  utm_source: 'v1_live_session_upgrade',
+                  cancelPath: sandboxUrl({ id }),
+                  trackingLocation: 'v1_live_session_upgrade',
                 });
               }}
               autoWidth


### PR DESCRIPTION
Deploying it on stream for testing the full flow (+stripe)

The main change is on the /pro page where the dropdown appears instead of the single CTA button. All other changes are just params passing and renames / cleanup