### PR TITLE
fix: preview URL generation when domain is coming from env

### DIFF
--- a/packages/common/src/components/Preview/index.tsx
+++ b/packages/common/src/components/Preview/index.tsx
@@ -89,7 +89,7 @@ const getSSEUrl = (sandbox?: Sandbox, initialPath: string = '') => {
   const previewDomain = window._env_?.PREVIEW_DOMAIN;
 
   if (usesStaticPreviewURL && previewDomain) {
-    return previewDomain;
+    return `${location.protocol}//${previewDomain}/${initialPath}`;
   }
 
   return `https://${sandbox ? `${sandbox.id}.` : ''}sse.${

--- a/packages/common/src/utils/url-generator.ts
+++ b/packages/common/src/utils/url-generator.ts
@@ -166,12 +166,11 @@ export const frameUrl = (
   const usesStaticPreviewURL = window._env_?.USE_STATIC_PREVIEW === 'true';
   // @ts-ignore
   const previewDomain = window._env_?.PREVIEW_DOMAIN;
+  const path = append.indexOf('/') === 0 ? append.substr(1) : append;
 
   if (usesStaticPreviewURL && previewDomain) {
-    return previewDomain;
+    return `${location.protocol}//${previewDomain}/${path}`;
   }
-
-  const path = append.indexOf('/') === 0 ? append.substr(1) : append;
 
   const templateIsServer = isServer(sandbox.template);
 


### PR DESCRIPTION
Only domain is specified in ENV, so this PR adds the logic to prepend the protocol and also adds the initialPath to the preview URL