### PR TITLE
fix(env.sh): Include empty environment variables in env.sh

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -12,12 +12,10 @@ echo "window._env_ = {" >> $envConfigFilePath
 
 while IFS='=' read -r varname varvalue || [ -n "$varname" ]; do
   value=""
-  if [ -n "$varname" ]; then
+  if [ ! -z $(printenv | grep "$varname=") ]; then
     eval "value=\"\${$varname}\""
-  fi
-
+  else
   # Otherwise use value from .env file
-  if [ -z "$value" ]; then
     value="$varvalue"
   fi
   


### PR DESCRIPTION
Include env vars even if they are empty.