### PR TITLE
fix(pro): Ensure /pro link does not upgrade personal accounts

### DIFF
--- a/packages/app/src/app/components/StripeMessages/FreeViewOnlyStripe.tsx
+++ b/packages/app/src/app/components/StripeMessages/FreeViewOnlyStripe.tsx
@@ -31,8 +31,8 @@ export const FreeViewOnlyStripe = () => {
   return (
     <MessageStripe>
       <span>
-        You no longer have a <Text weight="bold">Pro</Text> subscription. This
-        sandbox is in view mode only.{' '}
+        Private or unlisted sandboxes need a <Text weight="bold">Pro</Text>{' '}
+        subscription. This sandbox is in view mode only.{' '}
         <LinkButton onClick={changeToPublic}>Make it public</LinkButton> or
         upgrade to <Text weight="bold">Pro</Text>.
       </span>
@@ -41,7 +41,7 @@ export const FreeViewOnlyStripe = () => {
           as="a"
           href={proUrl({
             source: 'v1_sandbox_view_only_upgrade',
-            workspaceId: activeTeam,
+            ...(isPersonalSpace ? {} : { workspaceId: activeTeam }),
           })}
           onClick={() => {
             track('Limit banner: editor - Upgrade', {

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Settings/components/PermissionSettings.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Settings/components/PermissionSettings.tsx
@@ -46,7 +46,7 @@ export const PermissionSettings = () => {
             <MessageStripe.Action
               as="a"
               href={proUrl({
-                workspaceId: activeTeam,
+                ...(isPersonalSpace ? {} : { workspaceId: activeTeam }),
                 source: 'dashboard_permission_settings',
               })}
               onClick={proTracking}


### PR DESCRIPTION
Last two places where it was possible to go to the pro page with the personal workspaceId in the URL