### PR TITLE
fix: prevent empty tab list from rendering

### DIFF
--- a/packages/app/src/app/components/Preview/DevTools/index.tsx
+++ b/packages/app/src/app/components/Preview/DevTools/index.tsx
@@ -524,7 +524,7 @@ export class DevTools extends React.PureComponent<Props, State> {
           minHeight: 0,
         }}
       >
-        {!hideTabs && (
+        {!hideTabs && panes.length > 0 && (
           <Header
             onTouchStart={!primary ? this.handleTouchStart : undefined}
             onMouseDown={!primary ? this.handleMouseDown : undefined}


### PR DESCRIPTION
Patching a previous fix to ensure a tab list which is filtered (because of the removal of some tabs) does not render anymore

Closes #8099 