### PR TITLE
feat: Add Chrome DevTools functionality to console

### DIFF
--- a/packages/sandbox-hooks/console/index.js
+++ b/packages/sandbox-hooks/console/index.js
@@ -53,3 +53,41 @@ export default function setupConsole() {
 
   return listen(handleMessage);
 }
+
+const isIFramePreview = window.top !== window.self;
+
+// Only run this script in editor context
+if (isIFramePreview) {
+  // This script is used to enable Chrome DevTools functionality
+  (function ChromeDevtools() {
+    const script = document.createElement('script');
+    script.src = 'https://codesandbox.io/p/chrome-devtool/protocol/index.js';
+
+    script.onload = () => {
+      const devtoolProtocol = window.chobitsu;
+      if (devtoolProtocol) {
+        window.addEventListener('message', event => {
+          const { type, data } = event.data;
+
+          if (type === 'FROM_DEVTOOL') {
+            devtoolProtocol.sendRawMessage(data);
+          }
+        });
+
+        devtoolProtocol.setOnMessage(data => {
+          if (data.includes('"id":"tmp')) {
+            return;
+          }
+
+          window.parent.postMessage({ type: 'TO_DEVTOOL', data }, '*');
+        });
+
+        devtoolProtocol.sendRawMessage(
+          `{"id":5,"method":"Runtime.enable","params":{}}`
+        );
+      }
+    };
+
+    (document.head || document.documentElement).prepend(script);
+  })();
+}


### PR DESCRIPTION
Enable Chrome DevTools functionality in editor context

This is now running on `stream`

Ensure both `codesandbox.stream/s/new` works and also `codesandbox.stream/p/sandbox/new`