### PR TITLE
fix: check for sandboxId before giving like

### DIFF
--- a/.codesandbox/Dockerfile
+++ b/.codesandbox/Dockerfile
@@ -1,1 +1,3 @@
 FROM node:16-bullseye
+
+RUN apt update -y && apt install -y zstd

--- a/packages/app/src/embed/components/App/index.js
+++ b/packages/app/src/embed/components/App/index.js
@@ -252,6 +252,12 @@ export default class App extends React.PureComponent<
     const jwt = this.jwt();
     track('Embed - Toggle Like');
 
+    const sandboxId = this.state.sandbox.id;
+    if (sandboxId.includes('/')) {
+      // The sandbox id comes from a message that's sent to the window,
+      // so we can't trust it. We'll check if there's a / in there.
+      return;
+    }
     if (this.state.sandbox.userLiked && jwt) {
       this.setState(s => ({
         sandbox: {


### PR DESCRIPTION
Really small change, but perhaps someone could forge a sandbox with `postMessage` and then change the sandbox id. Even then, we would do a request with a weird body that the server will reject, but it's better safe than sorry.