### PR TITLE
fix(dashboard): dragging & selecting sandboxes

### DIFF
--- a/packages/app/src/app/pages/Dashboard/Components/Folder/FolderCard.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Folder/FolderCard.tsx
@@ -32,10 +32,16 @@ export const FolderCard: React.FC<FolderItemComponentProps> = ({
   showDropStyles,
   // drag preview
   thumbnailRef,
+
+  'data-selection-id': dataSelectionId,
   ...props
 }) => (
   <InteractiveOverlay>
-    <StyledCard dimmed={isDragging} selected={selected || showDropStyles}>
+    <StyledCard
+      data-selection-id={dataSelectionId}
+      dimmed={isDragging}
+      selected={selected || showDropStyles}
+    >
       <Stack justify="space-between">
         <Icon size={20} name="folder" color="#E3FF73" />
         {!isNewFolder ? (

--- a/packages/app/src/app/pages/Dashboard/Components/Folder/types.ts
+++ b/packages/app/src/app/pages/Dashboard/Components/Folder/types.ts
@@ -22,4 +22,6 @@ export interface FolderItemComponentProps {
   showDropStyles?: boolean;
   // drag preview
   thumbnailRef?: React.Ref<HTMLDivElement>;
+
+  'data-selection-id'?: string;
 }

--- a/packages/app/src/app/pages/Dashboard/Components/Sandbox/SandboxCard.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Sandbox/SandboxCard.tsx
@@ -217,6 +217,8 @@ export const SandboxCard = ({
   // drag preview
   thumbnailRef,
   isDragging,
+
+  'data-selection-id': dataSelectionId,
   ...props
 }: SandboxItemComponentProps) => {
   const thumbnail = useSandboxThumbnail({
@@ -235,6 +237,7 @@ export const SandboxCard = ({
     <InteractiveOverlay>
       <StyledCard
         dimmed={isDragging}
+        data-selection-id={dataSelectionId}
         css={{
           overflow: 'hidden',
 

--- a/packages/app/src/app/pages/Dashboard/Components/Sandbox/types.ts
+++ b/packages/app/src/app/pages/Dashboard/Components/Sandbox/types.ts
@@ -33,4 +33,6 @@ export interface SandboxItemComponentProps {
 
   thumbnailRef: React.Ref<HTMLDivElement>;
   isDragging: boolean;
+
+  'data-selection-id'?: string;
 }

--- a/packages/app/src/app/pages/Dashboard/Components/Selection/DragPreview.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Selection/DragPreview.tsx
@@ -106,7 +106,7 @@ export const DragPreview: React.FC<DragPreviewProps> = React.memo(
     const thumbnailElement = thumbnailRef.current;
     const thumbnailSize = React.useMemo(() => {
       if (!thumbnailElement) {
-        return { width: 0, height: 0 };
+        return { width: 318, height: 154 };
       }
 
       const thumbnailRect = thumbnailElement.getBoundingClientRect();

--- a/packages/app/src/app/pages/Dashboard/Sidebar/RowItem.tsx
+++ b/packages/app/src/app/pages/Dashboard/Sidebar/RowItem.tsx
@@ -131,6 +131,8 @@ export const RowItem: React.FC<RowItemProps> = ({
         minHeight: nestingLevel ? '32px' : '36px',
         paddingX: 0,
         opacity: isDragging && !canDrop ? 0.25 : 1,
+        display: 'flex',
+        flexDirection: 'column',
         color:
           isCurrentLink || (isDragging && canDrop)
             ? 'sideBar.foreground'

--- a/packages/app/src/app/pages/Dashboard/Sidebar/utils.tsx
+++ b/packages/app/src/app/pages/Dashboard/Sidebar/utils.tsx
@@ -27,5 +27,6 @@ export const linkStyles = {
   alignItems: 'center',
   paddingLeft: 8,
   paddingRight: 8,
-  flexShrink: 0,
+  flex: 1,
+  color: 'inherit',
 };


### PR DESCRIPTION
There were a couple regressions in the editor that I noticed recently:

1. When dragging to select sandboxes and folders, they only get selected when you hover over the title of the card.
2. Clicking on a folder / link in the sidebar only works if you click the actual `a` element, not the surrounding `li` with all styles
3. Dragging sandbox cards looks _ugly_ if there is not thumbnail
4. We stopped highlighting the active folder in the sidebar

This PR fixes those regressions!