### PR TITLE
fix: redirect to v2 editor fallback

### DIFF
--- a/packages/app/src/app/components/Preview/DevTools/index.tsx
+++ b/packages/app/src/app/components/Preview/DevTools/index.tsx
@@ -542,7 +542,7 @@ export class DevTools extends React.PureComponent<Props, State> {
               disableLogging={disableLogging}
               isOnEmbedPage={this.props.isOnEmbedPage}
               // @ts-ignore
-              isOnPrem={window._env_.IS_ONPREM === 'true'}
+              isOnPrem={window._env_?.IS_ONPREM === 'true'}
             />
 
             {!primary && (

--- a/packages/app/src/app/overmind/namespaces/editor/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/editor/actions.ts
@@ -305,9 +305,13 @@ export const sandboxChanged = withLoadApp<{
   try {
     const params = state.activeTeam ? { teamId: state.activeTeam } : undefined;
     const sandbox = await effects.api.getSandbox(newId, params);
+    const experimentalV2Enabled = effects.browser.storage.get<boolean>(
+      'CSB/BETA_SANDBOX_EDITOR'
+    );
 
     // Failsafe, in case someone types in the URL to load a v2 sandbox in v1
-    if (sandbox.v2) {
+    // or if they have the experimental v2 editor enabled
+    if (sandbox.v2 || (!sandbox.isSse && experimentalV2Enabled)) {
       const sandboxV2Url = sandboxUrl({
         id: sandbox.id,
         alias: sandbox.alias,

--- a/packages/app/src/app/pages/common/Modals/PreferencesModal/Experiments/BetaSandboxEditor.tsx
+++ b/packages/app/src/app/pages/common/Modals/PreferencesModal/Experiments/BetaSandboxEditor.tsx
@@ -24,7 +24,7 @@ const ROWS_REQUEST_URL =
   'https://api.rows.com/v1beta1/spreadsheets/JFBFxxAPvXEYDY7cU9GCA/tables/15558697-182d-43f7-a1f2-6c293a557295/values/A:F:append';
 
 // @ts-ignore
-const ROWS_API_KEY = window._env_?.ROWS_API_KEY;
+const ROWS_API_KEY = '1WcvujvzSSQ1GtbnoYvrGb8liPJFWud915ELpjwnVfV5';
 
 export const BetaSandboxEditor = () => {
   const { user } = useAppState();


### PR DESCRIPTION
Fixed rows integration to ensure we get the data from the current experiment
Also added a hard redirect when the editor loads in v1 but the user activated the experiment
Unrelated, fixed a potential env error at runtime, which shouldn't happen outside of testing environments, but still