### PR TITLE
fix(BetaSandboxEditor): Clarify copy of the experimental sandbox editor messages

### DIFF
--- a/packages/app/src/app/components/CreateSandbox/ExperimentalBetaEditor.tsx
+++ b/packages/app/src/app/components/CreateSandbox/ExperimentalBetaEditor.tsx
@@ -22,7 +22,7 @@ export const ExperimentalBetaEditor = () => {
     return (
       <Stack justify="center" padding={2}>
         <Text size={3}>
-          Open{' '}
+          If you wish to disable the new sandbox editor, open{' '}
           <UnstyledButtonLink
             onClick={() => {
               actions.modals.newSandboxModal.close();
@@ -30,8 +30,8 @@ export const ExperimentalBetaEditor = () => {
             }}
           >
             Preferences
-          </UnstyledButtonLink>{' '}
-          to disable the new sandbox editor
+          </UnstyledButtonLink>
+          .
         </Text>
       </Stack>
     );
@@ -45,7 +45,7 @@ export const ExperimentalBetaEditor = () => {
             Beta
           </Badge>
           <Text weight="500">Try the new sandbox editor.</Text>
-          <Text>For a faster and more stable prototyping experience.</Text>
+          <Text>Get a faster and more stable prototyping experience.</Text>
         </Stack>
         <Switch
           onChange={() => {


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is a simple update to the copy of the new "experimental beta editor" banner. It should make it more clear to users how to opt out if they wish to.

## Checklist

- [ ] Documentation
- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->