### PR TITLE
Feat: Hide .eslintrc.cjs file

### DIFF
--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Explorer/Files/DirectoryEntry/DirectoryChildren/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/Explorer/Files/DirectoryEntry/DirectoryChildren/index.tsx
@@ -1,4 +1,7 @@
-import { HIDDEN_DIRECTORIES } from '@codesandbox/common/lib/templates/constants/files';
+import {
+  HIDDEN_DIRECTORIES,
+  HIDDEN_FILES,
+} from '@codesandbox/common/lib/templates/constants/files';
 import { Directory, Module } from '@codesandbox/common/lib/types';
 import { useActions, useAppState } from 'app/overmind';
 import { sortBy } from 'lodash-es';
@@ -79,7 +82,11 @@ export const DirectoryChildren: React.FC<IDirectoryChildrenProps> = ({
           />
         ))}
       {sortBy(
-        modules.filter(x => x.directoryShortid === parentShortid),
+        modules
+          .filter(x => x.directoryShortid === parentShortid)
+          .filter(
+            x => !(x.directoryShortid == null && HIDDEN_FILES.includes(x.title))
+          ),
         'title'
       ).map(m => (
         <ModuleEntry

--- a/packages/common/src/templates/constants/files.ts
+++ b/packages/common/src/templates/constants/files.ts
@@ -1,2 +1,2 @@
 export const HIDDEN_DIRECTORIES = ['.codesandbox', '.devcontainer'];
-export const HIDDEN_FILES = ['.eslintrc.mjs'];
+export const HIDDEN_FILES = ['.eslintrc.cjs'];

--- a/packages/common/src/templates/constants/files.ts
+++ b/packages/common/src/templates/constants/files.ts
@@ -1,1 +1,2 @@
 export const HIDDEN_DIRECTORIES = ['.codesandbox', '.devcontainer'];
+export const HIDDEN_FILES = ['.eslintrc.mjs'];


### PR DESCRIPTION
To enable smoother transition to Devboxes we are adding the ESLint configuration, but hiding it for Sandboxes.