### PR TITLE
fix: ensure beta is switched off first when the disable form is submitted

### DIFF
--- a/packages/app/src/app/pages/common/Modals/PreferencesModal/Experiments/BetaSandboxEditor.tsx
+++ b/packages/app/src/app/pages/common/Modals/PreferencesModal/Experiments/BetaSandboxEditor.tsx
@@ -75,6 +75,17 @@ export const BetaSandboxEditor = () => {
           as="form"
           onSubmit={ev => {
             ev.preventDefault();
+            setBetaSandboxEditor(false);
+            setFeedbackMode(false);
+            setFeedbackOptions({
+              buggyExperience: false,
+              missingLiveRoom: false,
+              slowness: false,
+              navigability: false,
+              other: false,
+              feedback: null,
+            });
+
             if (isInProd && ROWS_API_KEY) {
               effects.http.post(
                 ROWS_REQUEST_URL,
@@ -90,17 +101,7 @@ export const BetaSandboxEditor = () => {
               );
             }
 
-            setFeedbackMode(false);
-            setBetaSandboxEditor(false);
             track('Disable new sandbox editor - User preferences');
-            setFeedbackOptions({
-              buggyExperience: false,
-              missingLiveRoom: false,
-              slowness: false,
-              navigability: false,
-              other: false,
-              feedback: null,
-            });
           }}
           paddingTop={4}
         >


### PR DESCRIPTION
There were reports of the switch not being reset after the form submitted. Could not reproduce but the only cause might be an exception thrown by the rows form submit, so I flipped the order to ensure the flag is always set to false.