### PR TITLE
feat: ubb waitlist banner

### DIFF
--- a/packages/app/src/app/constants.ts
+++ b/packages/app/src/app/constants.ts
@@ -20,15 +20,15 @@ export interface Feature {
 export const FREE_FEATURES: Feature[] = [
   {
     key: 'editor',
-    label: 'Single editor',
+    label: 'Up to 5 editors',
   },
   {
     key: 'public_limit',
-    label: 'Public repositories & sandboxes',
+    label: 'Public repositories',
   },
   {
-    key: 'ai',
-    label: 'No access to AI tools',
+    key: 'public_boxes',
+    label: 'Public devboxes and sandboxes',
   },
   { key: 'npm', label: 'Public npm packages' },
   { key: 'permissions', label: 'Limited permissions' },

--- a/packages/app/src/app/constants.ts
+++ b/packages/app/src/app/constants.ts
@@ -17,7 +17,27 @@ export interface Feature {
   highlighted?: boolean;
 }
 
-export const TEAM_PRO_FEATURES: Feature[] = [
+export const FREE_FEATURES: Feature[] = [
+  {
+    key: 'editor',
+    label: 'Single editor',
+  },
+  {
+    key: 'public_limit',
+    label: 'Public repositories & sandboxes',
+  },
+  {
+    key: 'ai',
+    label: 'No access to AI tools',
+  },
+  { key: 'npm', label: 'Public npm packages' },
+  { key: 'permissions', label: 'Limited permissions' },
+  { key: 'vm_mem', label: '2GiB RAM' },
+  { key: 'vm_cpu', label: '2 vCPUs' },
+  { key: 'vm_disk', label: '6GB Disk' },
+];
+
+export const PRO_FEATURES: Feature[] = [
   {
     key: 'editors',
     label: 'Unlimited editors',
@@ -38,7 +58,7 @@ export const TEAM_PRO_FEATURES: Feature[] = [
   { key: 'vm_disk', label: '12GB Disk' },
 ];
 
-export const TEAM_PRO_FEATURES_WITH_PILLS: Feature[] = [
+export const PRO_FEATURES_WITH_PILLS: Feature[] = [
   {
     key: 'editors',
     label: 'Unlimited editors',

--- a/packages/app/src/app/pages/Pro/Upgrade.tsx
+++ b/packages/app/src/app/pages/Pro/Upgrade.tsx
@@ -39,7 +39,7 @@ export const ProUpgrade = () => {
     isLoggedIn,
   } = useAppState();
   const { isBillingManager } = useWorkspaceAuthorization();
-  const { isFree, isPro, isPaddle } = useWorkspaceSubscription();
+  const { isFree, isPro } = useWorkspaceSubscription();
 
   /**
    * There is currently no way to know if teams have a custom subscription. This means we will

--- a/packages/app/src/app/pages/Pro/Upgrade.tsx
+++ b/packages/app/src/app/pages/Pro/Upgrade.tsx
@@ -6,7 +6,6 @@ import {
   Stack,
   Element,
   Text,
-  Icon,
   Badge,
   SkeletonText,
 } from '@codesandbox/components';

--- a/packages/app/src/app/pages/Pro/Upgrade.tsx
+++ b/packages/app/src/app/pages/Pro/Upgrade.tsx
@@ -14,32 +14,33 @@ import { Navigation } from 'app/pages/common/Navigation';
 import { useCreateCustomerPortal } from 'app/hooks/useCreateCustomerPortal';
 import track from '@codesandbox/common/lib/utils/analytics';
 import {
+  FREE_FEATURES,
   ORGANIZATION_CONTACT_LINK,
   ORG_FEATURES,
-  TEAM_PRO_FEATURES,
-  TEAM_PRO_FEATURES_WITH_PILLS,
+  PRO_FEATURES,
+  PRO_FEATURES_WITH_PILLS,
 } from 'app/constants';
 
 import { useWorkspaceAuthorization } from 'app/hooks/useWorkspaceAuthorization';
 import { useWorkspaceSubscription } from 'app/hooks/useWorkspaceSubscription';
 import { usePriceCalculation } from 'app/hooks/usePriceCalculation';
-import { SubscriptionPaymentProvider } from '../../graphql/types';
 import { SubscriptionCard } from './components/SubscriptionCard';
 import type { CTA } from './components/SubscriptionCard';
 import { StyledPricingDetailsText } from './components/elements';
-import { NewTeamModal } from '../Dashboard/Components/NewTeamModal';
 import { TeamSubscriptionOptions } from '../Dashboard/Components/TeamSubscriptionOptions/TeamSubscriptionOptions';
+import { PricingTable } from './components/PricingTable';
+import { UBBWaitlist } from './components/UBBWaitlist';
 
 export const ProUpgrade = () => {
   const {
     activeTeam,
     activeTeamInfo,
-    dashboard,
+
     hasLoadedApp,
     isLoggedIn,
   } = useAppState();
   const { isBillingManager } = useWorkspaceAuthorization();
-  const { isFree, isPro } = useWorkspaceSubscription();
+  const { isFree, isPro, isPaddle } = useWorkspaceSubscription();
 
   /**
    * There is currently no way to know if teams have a custom subscription. This means we will
@@ -82,11 +83,6 @@ export const ProUpgrade = () => {
       : null;
 
   if (!hasLoadedApp || !isLoggedIn) return null;
-
-  const hasAnotherPaymentProvider = dashboard.teams.some(
-    team =>
-      team.subscription?.paymentProvider === SubscriptionPaymentProvider.Paddle
-  );
 
   return (
     <ThemeProvider>
@@ -148,11 +144,17 @@ export const ProUpgrade = () => {
               },
             }}
           >
+            <SubscriptionCard title="Free" features={FREE_FEATURES}>
+              <Stack gap={1} direction="vertical">
+                <Text size={32} weight="400">
+                  $0
+                </Text>
+                <StyledPricingDetailsText>forever</StyledPricingDetailsText>
+              </Stack>
+            </SubscriptionCard>
             <SubscriptionCard
               title="Pro"
-              features={
-                isPro ? TEAM_PRO_FEATURES : TEAM_PRO_FEATURES_WITH_PILLS
-              }
+              features={isPro ? PRO_FEATURES : PRO_FEATURES_WITH_PILLS}
               isHighlighted={!hasCustomSubscription}
               {...(isFree
                 ? {
@@ -238,24 +240,12 @@ export const ProUpgrade = () => {
               </Stack>
             </SubscriptionCard>
           </Stack>
+
+          <UBBWaitlist />
         </Stack>
 
-        {hasAnotherPaymentProvider ? (
-          <Stack
-            gap={2}
-            align="center"
-            justify="center"
-            css={{ color: '#999999', padding: '32px' }}
-          >
-            <Icon name="info" size={16} />
-            <Text size={3} variant="muted">
-              CodeSandbox is migrating to a new payment provider. Previous
-              active subscriptions will not be affected.
-            </Text>
-          </Stack>
-        ) : null}
+        {isFree && <PricingTable />}
       </Element>
-      <NewTeamModal />
     </ThemeProvider>
   );
 };

--- a/packages/app/src/app/pages/Pro/components/UBBWaitlist.tsx
+++ b/packages/app/src/app/pages/Pro/components/UBBWaitlist.tsx
@@ -15,9 +15,7 @@ export const UBBWaitlist = () => (
     gap={4}
   >
     <Stack direction="vertical" gap={2}>
-      <Text size={6} fontFamily="everett">
-        Pay only for what you use
-      </Text>
+      <Text size={6}>Pay only for what you use</Text>
       <Text>
         We&apos;re transitioning to a usage-based billing model, where you can
         have as many contributors as you want, and only pay for the resources

--- a/packages/app/src/app/pages/Pro/components/UBBWaitlist.tsx
+++ b/packages/app/src/app/pages/Pro/components/UBBWaitlist.tsx
@@ -40,6 +40,8 @@ export const UBBWaitlist = () => (
         },
       }}
       as="a"
+      target="_blank"
+      rel="noreferrer noopener"
       href="https://codesandbox.typeform.com/to/Y7gfpCiA"
     >
       Sign up for the beta

--- a/packages/app/src/app/pages/Pro/components/UBBWaitlist.tsx
+++ b/packages/app/src/app/pages/Pro/components/UBBWaitlist.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { Stack, Text } from '@codesandbox/components';
+
+export const UBBWaitlist = () => (
+  <Stack
+    direction="horizontal"
+    css={{
+      margin: 'auto',
+      padding: '24px 32px',
+      alignItems: 'center',
+      maxWidth: '976px',
+      background: '#DCF76E',
+      color: '#0E0E0E',
+    }}
+    gap={4}
+  >
+    <Stack direction="vertical" gap={2}>
+      <Text size={6} fontFamily="everett">
+        Pay only for what you use
+      </Text>
+      <Text>
+        We&apos;re transitioning to a usage-based billing model, where you can
+        have as many contributors as you want, and only pay for the resources
+        you use. Be among the first to help us fine-tune our model by becoming a
+        beta tester!
+      </Text>
+    </Stack>
+    <Text
+      css={{
+        display: 'block',
+        background: '#0E0E0E',
+        color: '#fff',
+        padding: '16px 20px',
+        textDecoration: 'none',
+        whiteSpace: 'nowrap',
+        borderRadius: '4px',
+        transition: 'background .3s',
+        '&:hover': {
+          background: '#252525',
+        },
+      }}
+      as="a"
+      href="https://codesandbox.typeform.com/to/Y7gfpCiA"
+    >
+      Sign up for the beta
+    </Text>
+  </Stack>
+);

--- a/packages/app/src/app/pages/Pro/legacy-pages/WorkspacePlanSelection.tsx
+++ b/packages/app/src/app/pages/Pro/legacy-pages/WorkspacePlanSelection.tsx
@@ -14,13 +14,15 @@ import { useWorkspaceSubscription } from 'app/hooks/useWorkspaceSubscription';
 import { useWorkspaceAuthorization } from 'app/hooks/useWorkspaceAuthorization';
 import { formatCurrency } from 'app/utils/currency';
 import {
-  TEAM_PRO_FEATURES,
+  PRO_FEATURES,
   ORG_FEATURES,
   ORGANIZATION_CONTACT_LINK,
+  FREE_FEATURES,
 } from 'app/constants';
 import { SubscriptionCard } from '../components/SubscriptionCard';
 import type { CTA } from '../components/SubscriptionCard';
 import { StyledPricingDetailsText } from '../components/elements';
+import { UBBWaitlist } from '../components/UBBWaitlist';
 
 // TODO: Rename
 export const WorkspacePlanSelection: React.FC = () => {
@@ -133,9 +135,17 @@ export const WorkspacePlanSelection: React.FC = () => {
             },
           }}
         >
+          <SubscriptionCard title="Free" features={FREE_FEATURES}>
+            <Stack gap={1} direction="vertical">
+              <Text size={32} weight="400">
+                $0
+              </Text>
+              <StyledPricingDetailsText>forever</StyledPricingDetailsText>
+            </Stack>
+          </SubscriptionCard>
           <SubscriptionCard
             title="Pro"
-            features={TEAM_PRO_FEATURES}
+            features={PRO_FEATURES}
             cta={teamProCta}
             isHighlighted
           >
@@ -196,6 +206,8 @@ export const WorkspacePlanSelection: React.FC = () => {
             </Stack>
           </SubscriptionCard>
         </Stack>
+
+        <UBBWaitlist />
       </Stack>
     </div>
   );


### PR DESCRIPTION
A few small UI differences compared to the figma design:
- `Pay only for what you use` in Everett, not in Inter
- no border radius to match the subscription cards

![image](https://github.com/codesandbox/codesandbox-client/assets/9945366/b4736536-bc6e-4091-a6a9-9a6cafbe9027)
