### PR TITLE
feat: Added configurable property

### DIFF
--- a/packages/sandbox-hooks/url-listeners.js
+++ b/packages/sandbox-hooks/url-listeners.js
@@ -83,12 +83,14 @@ export default function setupHistoryListeners() {
       get() {
         return historyList.length;
       },
+      configurable: true,
     },
 
     state: {
       get() {
         return historyList[historyPosition].state;
       },
+      configurable: true,
     },
   });
 


### PR DESCRIPTION
We need this to be configurable or the V2 protocol loaded on Sandboxes will not be able to override the history API in the browser.