### PR TITLE
fix(create): set title to name instead of alias

### DIFF
--- a/packages/app/src/app/components/Create/CreateBox.tsx
+++ b/packages/app/src/app/components/Create/CreateBox.tsx
@@ -143,7 +143,7 @@ export const CreateBox: React.FC<CreateBoxProps> = ({
       openInVSCode,
       hasBetaEditorExperiment,
       body: {
-        alias: name,
+        title: name,
         collectionId,
         privacy: permission,
         v2: createAs === 'devbox',

--- a/packages/app/src/app/overmind/namespaces/editor/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/editor/actions.ts
@@ -760,6 +760,7 @@ export const forkExternalSandbox = async (
       collectionId: string;
       alias?: string;
       v2?: boolean;
+      title?: string;
       privacy?: 0 | 1 | 2;
     };
   }


### PR DESCRIPTION
We were setting the `alias` to the input field, but the `alias` should almost always be auto-generated (with some exceptions). The fact that the server didn't reject this was probably a bug. Newly created sandboxes with custom titles result in a 404 in the editor.

With this change, we're setting the title instead of the alias to the field. That should make it work now! I'll fast-track this change and merge it immediately.

This is something confusing, and a bit legacy. We _should_ allow people to set custom aliases, but it looks like our infra does not handle that right now.