### PR TITLE
feat: improve create modal second screen

### DIFF
--- a/packages/app/src/app/components/Create/CreateBox.tsx
+++ b/packages/app/src/app/components/Create/CreateBox.tsx
@@ -39,6 +39,7 @@ import { CreateBoxForm } from './CreateBox/CreateBoxForm';
 import { TemplateInfo } from './CreateBox/TemplateInfo';
 import { useFeaturedTemplates } from './hooks/useFeaturedTemplates';
 import { useAllTemplates } from './hooks/useAllTemplates';
+import { useGlobalPersistedState } from 'app/hooks/usePersistedState';
 
 export const COLUMN_MEDIA_THRESHOLD = 1600;
 
@@ -74,6 +75,7 @@ export const CreateBox: React.FC<CreateBoxProps> = ({
   );
   const [selectedTemplate, setSelectedTemplate] = useState<TemplateFragment>();
   const [searchQuery, setSearchQuery] = useState<string>('');
+  const [autoLaunchVSCode] = useGlobalPersistedState("AUTO_LAUNCH_VSCODE", false);
 
   const { collections } = useTemplateCollections({ type });
   const { templates: officialTemplates } = useOfficialTemplates({ type });
@@ -142,6 +144,7 @@ export const CreateBox: React.FC<CreateBoxProps> = ({
       sandboxId: sandbox.id,
       openInNewWindow: false,
       openInVSCode,
+      autoLaunchVSCode,
       hasBetaEditorExperiment,
       body: {
         title: name,

--- a/packages/app/src/app/components/Create/CreateBox.tsx
+++ b/packages/app/src/app/components/Create/CreateBox.tsx
@@ -135,6 +135,7 @@ export const CreateBox: React.FC<CreateBoxProps> = ({
       type: 'fork',
       template_name:
         template.sandbox.title || template.sandbox.alias || template.sandbox.id,
+      open_in_editor: editor,
     });
 
     actions.editor.forkExternalSandbox({

--- a/packages/app/src/app/components/Create/CreateBox.tsx
+++ b/packages/app/src/app/components/Create/CreateBox.tsx
@@ -16,6 +16,7 @@ import { sandboxUrl } from '@codesandbox/common/lib/utils/url-generator';
 import { useBetaSandboxEditor } from 'app/hooks/useBetaSandboxEditor';
 import { pluralize } from 'app/utils/pluralize';
 import { ModalContentProps } from 'app/pages/common/Modals';
+import { useGlobalPersistedState } from 'app/hooks/usePersistedState';
 import {
   Container,
   Tab,
@@ -39,7 +40,6 @@ import { CreateBoxForm } from './CreateBox/CreateBoxForm';
 import { TemplateInfo } from './CreateBox/TemplateInfo';
 import { useFeaturedTemplates } from './hooks/useFeaturedTemplates';
 import { useAllTemplates } from './hooks/useAllTemplates';
-import { useGlobalPersistedState } from 'app/hooks/usePersistedState';
 
 export const COLUMN_MEDIA_THRESHOLD = 1600;
 
@@ -75,7 +75,10 @@ export const CreateBox: React.FC<CreateBoxProps> = ({
   );
   const [selectedTemplate, setSelectedTemplate] = useState<TemplateFragment>();
   const [searchQuery, setSearchQuery] = useState<string>('');
-  const [autoLaunchVSCode] = useGlobalPersistedState("AUTO_LAUNCH_VSCODE", false);
+  const [autoLaunchVSCode] = useGlobalPersistedState(
+    'AUTO_LAUNCH_VSCODE',
+    false
+  );
 
   const { collections } = useTemplateCollections({ type });
   const { templates: officialTemplates } = useOfficialTemplates({ type });

--- a/packages/app/src/app/components/Create/CreateBox/TemplateInfo.tsx
+++ b/packages/app/src/app/components/Create/CreateBox/TemplateInfo.tsx
@@ -37,7 +37,7 @@ export const TemplateInfo = ({ template }: TemplateInfoProps) => {
       <Text size={3} css={{ color: '#999', lineHeight: '1.4' }}>
         {template.sandbox.description}
       </Text>
-      <Stack gap={3} horizontal css={{ color: '#999' }}>
+      <Stack gap={3} css={{ color: '#999' }}>
         <Stack gap={1}>
           <Icon name="eye" size={14} />
           <Text size={2}>{formatNumber(template.sandbox.viewCount)}</Text>

--- a/packages/app/src/app/components/Create/CreateBox/TemplateInfo.tsx
+++ b/packages/app/src/app/components/Create/CreateBox/TemplateInfo.tsx
@@ -1,5 +1,6 @@
 import { getTemplateIcon } from '@codesandbox/common/lib/utils/getTemplateIcon';
-import { Stack, Text } from '@codesandbox/components';
+import { Stack, Text, Icon } from '@codesandbox/components';
+import { formatNumber } from '@codesandbox/components/lib/components/Stats';
 import { TemplateFragment } from 'app/graphql/types';
 import React from 'react';
 
@@ -28,14 +29,24 @@ export const TemplateInfo = ({ template }: TemplateInfoProps) => {
           {title}
         </Text>
         {author && (
-          <Text size={2} css={{ color: '#999' }}>
+          <Text size={3} css={{ color: '#999' }}>
             {author}
           </Text>
         )}
       </Stack>
-      <Text size={2} css={{ color: '#999', lineHeight: '1.4' }}>
+      <Text size={3} css={{ color: '#999', lineHeight: '1.4' }}>
         {template.sandbox.description}
       </Text>
+      <Stack gap={3} horizontal css={{ color: '#999' }}>
+        <Stack gap={1}>
+          <Icon name="eye" size={14} />
+          <Text size={2}>{formatNumber(template.sandbox.viewCount)}</Text>
+        </Stack>
+        <Stack gap={1}>
+          <Icon name="fork" size={14} />
+          <Text size={2}>{formatNumber(template.sandbox.forkCount)}</Text>
+        </Stack>
+      </Stack>
     </Stack>
   );
 };

--- a/packages/app/src/app/components/Create/utils/api.ts
+++ b/packages/app/src/app/components/Create/utils/api.ts
@@ -14,6 +14,8 @@ interface ExploreTemplateAPIResponse {
     author: { username: string } | null;
     environment: TemplateType;
     v2?: boolean;
+    fork_count: number;
+    view_count: number;
     custom_template: {
       id: string;
       icon_url: string;
@@ -63,6 +65,8 @@ const mapAPIResponseToTemplateInfo = (
       },
       isV2: sandbox.v2 || false,
       isSse: isServer(sandbox.environment),
+      forkCount: sandbox.fork_count,
+      viewCount: sandbox.view_count,
       git: sandbox.git && {
         id: sandbox.git.id,
         username: sandbox.git.username,

--- a/packages/app/src/app/components/Create/utils/queries.ts
+++ b/packages/app/src/app/components/Create/utils/queries.ts
@@ -15,6 +15,8 @@ const TEMPLATE_FRAGMENT = gql`
       updatedAt
       isV2
       isSse
+      forkCount
+      viewCount
 
       team {
         name

--- a/packages/app/src/app/graphql/types.ts
+++ b/packages/app/src/app/graphql/types.ts
@@ -1907,6 +1907,8 @@ export type RootMutationType = {
   setLiveSessionGuestPermission: LiveSession;
   setPreventSandboxesExport: Array<Sandbox>;
   setPreventSandboxesLeavingWorkspace: Array<Sandbox>;
+  /** Change the primary workspace for the current user */
+  setPrimaryWorkspace: Scalars['String'];
   /** set sandbox always on status */
   setSandboxAlwaysOn: Sandbox;
   setSandboxesFrozen: Array<Sandbox>;
@@ -2371,6 +2373,10 @@ export type RootMutationTypeSetPreventSandboxesExportArgs = {
 export type RootMutationTypeSetPreventSandboxesLeavingWorkspaceArgs = {
   preventSandboxLeaving: Scalars['Boolean'];
   sandboxIds: Array<Scalars['ID']>;
+};
+
+export type RootMutationTypeSetPrimaryWorkspaceArgs = {
+  primaryWorkspaceId: Scalars['UUID4'];
 };
 
 export type RootMutationTypeSetSandboxAlwaysOnArgs = {
@@ -2908,6 +2914,8 @@ export type TemplateFragment = {
     updatedAt: string;
     isV2: boolean;
     isSse: boolean | null;
+    forkCount: number;
+    viewCount: number;
     team: { __typename?: 'TeamPreview'; name: string } | null;
     author: { __typename?: 'User'; username: string } | null;
     source: { __typename?: 'Source'; template: string | null };
@@ -2938,6 +2946,8 @@ export type RecentAndWorkspaceTemplatesQuery = {
         updatedAt: string;
         isV2: boolean;
         isSse: boolean | null;
+        forkCount: number;
+        viewCount: number;
         team: { __typename?: 'TeamPreview'; name: string } | null;
         author: { __typename?: 'User'; username: string } | null;
         source: { __typename?: 'Source'; template: string | null };
@@ -2961,6 +2971,8 @@ export type RecentAndWorkspaceTemplatesQuery = {
           updatedAt: string;
           isV2: boolean;
           isSse: boolean | null;
+          forkCount: number;
+          viewCount: number;
           team: { __typename?: 'TeamPreview'; name: string } | null;
           author: { __typename?: 'User'; username: string } | null;
           source: { __typename?: 'Source'; template: string | null };

--- a/packages/app/src/app/overmind/namespaces/editor/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/editor/actions.ts
@@ -23,6 +23,7 @@ import {
   signInPageUrl,
   docsUrl,
   vsCodeUrl,
+  vsCodeLauncherUrl,
 } from '@codesandbox/common/lib/utils/url-generator';
 import { NotificationStatus } from '@codesandbox/notifications';
 import {
@@ -750,12 +751,14 @@ export const forkExternalSandbox = async (
     sandboxId,
     openInNewWindow,
     openInVSCode,
+    autoLaunchVSCode,
     hasBetaEditorExperiment,
     body,
   }: {
     sandboxId: string;
     openInNewWindow?: boolean;
     openInVSCode?: boolean;
+    autoLaunchVSCode?: boolean;
     hasBetaEditorExperiment?: boolean;
     body?: {
       collectionId: string;
@@ -777,7 +780,11 @@ export const forkExternalSandbox = async (
   try {
     const forkedSandbox = await effects.api.forkSandbox(sandboxId, usedBody);
     if (openInVSCode) {
-      window.open(vsCodeUrl(forkedSandbox.id));
+      if (autoLaunchVSCode) {
+        window.open(vsCodeUrl(forkedSandbox.id));
+      } else {
+        window.open(vsCodeLauncherUrl(forkedSandbox.id));
+      }
     } else {
       state.editor.sandboxes[forkedSandbox.id] = forkedSandbox;
 

--- a/packages/app/src/app/overmind/namespaces/editor/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/editor/actions.ts
@@ -22,6 +22,7 @@ import {
   sandboxUrl,
   signInPageUrl,
   docsUrl,
+  vsCodeUrl,
 } from '@codesandbox/common/lib/utils/url-generator';
 import { NotificationStatus } from '@codesandbox/notifications';
 import {
@@ -776,9 +777,7 @@ export const forkExternalSandbox = async (
   try {
     const forkedSandbox = await effects.api.forkSandbox(sandboxId, usedBody);
     if (openInVSCode) {
-      // TODO: Move to a reusable spot if the functionality is extended.
-      const VSCodeURL = `vscode://CodeSandbox-io.codesandbox-projects/sandbox/${forkedSandbox.id}`;
-      window.open(VSCodeURL);
+      window.open(vsCodeUrl(forkedSandbox.id));
     } else {
       state.editor.sandboxes[forkedSandbox.id] = forkedSandbox;
 

--- a/packages/common/src/utils/url-generator.ts
+++ b/packages/common/src/utils/url-generator.ts
@@ -122,8 +122,9 @@ export const sandboxUrl = (
     baseUrl = `${newEditorUrlPrefix()}sandbox/`;
   }
 
-  const queryParams = sandboxDetails.query ? `?${new URLSearchParams(sandboxDetails.query).toString()}` : '';
-
+  const queryParams = sandboxDetails.query
+    ? `?${new URLSearchParams(sandboxDetails.query).toString()}`
+    : '';
 
   if (sandboxDetails.git) {
     const { git } = sandboxDetails;
@@ -148,6 +149,10 @@ export const embedUrl = (sandbox: Sandbox) => {
   }
 
   return `/embed/${sandbox.id}`;
+};
+
+export const vsCodeUrl = (devboxId: string) => {
+  return `${protocolAndHost()}${newEditorUrlPrefix()}vscode?sandboxId=${devboxId}`;
 };
 
 const stagingFrameUrl = (shortid: string, path: string) => {

--- a/packages/common/src/utils/url-generator.ts
+++ b/packages/common/src/utils/url-generator.ts
@@ -151,8 +151,12 @@ export const embedUrl = (sandbox: Sandbox) => {
   return `/embed/${sandbox.id}`;
 };
 
-export const vsCodeUrl = (devboxId: string) => {
+export const vsCodeLauncherUrl = (devboxId: string) => {
   return `${protocolAndHost()}${newEditorUrlPrefix()}vscode?sandboxId=${devboxId}`;
+};
+
+export const vsCodeUrl = (devboxId: string) => {
+  return `vscode://CodeSandbox-io.codesandbox-projects/sandbox/${devboxId}`;
 };
 
 const stagingFrameUrl = (shortid: string, path: string) => {


### PR DESCRIPTION
A few different changes/improvements:

1. Add open_in_editor data to the tracking object when forking a template
2. Open `/p/vscode` or directly the vscode link based on the `CSB/AUTO_LAUNCH_VSCODE` flag
3. Add view and fork count on the template info component

![image](https://github.com/codesandbox/codesandbox-client/assets/9945366/8b2bf186-c022-4e50-b4ae-ff59891e6797)
