### PR TITLE
fix: Add condition to check active team info

### DIFF
--- a/packages/app/src/app/components/Create/ImportRepository/ForkRepoForm.tsx
+++ b/packages/app/src/app/components/Create/ImportRepository/ForkRepoForm.tsx
@@ -99,6 +99,10 @@ export const ForkRepoForm: React.FC<ForkRepoFormProps> = ({
     : [];
 
   useEffect(() => {
+    if (!activeTeamInfo) {
+      return;
+    }
+
     setSelectedOrg(
       'data' in githubAccounts
         ? fuzzyMatchGithubToCsb(activeTeamInfo.name, accountOptions).login


### PR DESCRIPTION
Not sure how activeTeamInfo can be null at this stage, but saw a sentry error coming in and I added an extra check to be safe