### PR TITLE
feat: rename frozen to protected

### DIFF
--- a/packages/app/src/app/overmind/namespaces/dashboard/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/dashboard/actions.ts
@@ -1256,7 +1256,8 @@ export const changeSandboxesFrozen = async (
     );
 
     actions.internal.handleError({
-      message: "We weren't able to update the frozen status of the sandboxes",
+      message:
+        "We weren't able to update the protected status of the sandboxes",
       error,
     });
   }

--- a/packages/app/src/app/pages/Dashboard/Components/Sandbox/SandboxCard.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Sandbox/SandboxCard.tsx
@@ -153,6 +153,8 @@ const SandboxStats: React.FC<SandboxStatsProps> = React.memo(
     prNumber,
     originalGit,
   }) => {
+    const boxType = showDevboxBadge ? 'devbox' : 'sandbox';
+
     const lastUpdatedText = (
       <Text key="last-updated" size={12} truncate>
         {shortDistance(lastUpdated)}
@@ -196,8 +198,8 @@ const SandboxStats: React.FC<SandboxStatsProps> = React.memo(
         <Stack gap={2} align="center">
           <PrivacyIcon />
           {isFrozen && (
-            <Tooltip label="Frozen Sandbox">
-              <Icon size={16} title="Frozen Sandbox" name="frozen" />
+            <Tooltip label={`Protected ${boxType}`}>
+              <Icon size={16} title={`Protected ${boxType}`} name="frozen" />
             </Tooltip>
           )}
           {prNumber ? (

--- a/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenus/MultiItemMenu.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenus/MultiItemMenu.tsx
@@ -150,7 +150,7 @@ export const MultiMenu = ({ selectedItems, page }: IMultiMenuProps) => {
 
   const FROZEN_ITEMS = [
     sandboxes.some(s => !s.sandbox.isFrozen) && {
-      label: 'Freeze items',
+      label: 'Protect items',
       fn: () => {
         actions.dashboard.changeSandboxesFrozen({
           sandboxIds: sandboxes.map(sandbox => sandbox.sandbox.id),
@@ -159,7 +159,7 @@ export const MultiMenu = ({ selectedItems, page }: IMultiMenuProps) => {
       },
     },
     sandboxes.some(s => s.sandbox.isFrozen) && {
-      label: 'Unfreeze items',
+      label: 'Remove items protection',
       fn: () => {
         actions.dashboard.changeSandboxesFrozen({
           sandboxIds: sandboxes.map(sandbox => sandbox.sandbox.id),

--- a/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenus/SandboxMenu.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenus/SandboxMenu.tsx
@@ -285,7 +285,7 @@ export const SandboxMenu: React.FC<SandboxMenuProps> = ({
             }}
             disabled={restricted}
           >
-            Unfreeze {label}
+            Remove {label} protection
           </MenuItem>
         ) : (
           <MenuItem
@@ -297,7 +297,7 @@ export const SandboxMenu: React.FC<SandboxMenuProps> = ({
             }}
             disabled={restricted}
           >
-            Freeze {label}
+            Protect {label}
           </MenuItem>
         ))}
 

--- a/packages/app/src/app/pages/Sandbox/Editor/ForkFrozenSandboxModal/ForkFrozenSandboxModal.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/ForkFrozenSandboxModal/ForkFrozenSandboxModal.tsx
@@ -27,20 +27,21 @@ const ModalContent: React.FC = () => {
   useKeyPressEvent('Enter', fork);
   return (
     <Alert
-      title={`Frozen ${customTemplate ? 'Template' : 'Sandbox'}`}
+      title={`Protected ${type}`}
       description={
         <>
           <p>
-            This {type} is frozen, which means you can’t make edits without
-            unfreezing it.
+            This {type} is protected, which means you can’t make edits unless
+            you fork it.
           </p>
           <p>
-            Do you want to unfreeze the {type} for this session or make a fork?
+            Do you want to remove the protection for the {type} for this session
+            or make a fork?
           </p>
         </>
       }
       onCancel={unlock}
-      cancelMessage="Unfreeze"
+      cancelMessage="Remove protection"
       onPrimaryAction={fork}
       confirmMessage={
         <Stack gap={2} align="center">

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/ProjectInfo/Summary/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/screens/ProjectInfo/Summary/index.tsx
@@ -21,6 +21,7 @@ import {
   Text,
   IconButton,
   Button,
+  Tooltip,
 } from '@codesandbox/components';
 import css from '@styled-system/css';
 import { Markdown } from 'app/components/Markdown';
@@ -196,14 +197,19 @@ export const Summary = () => {
 
       <List>
         {customTemplate && <TemplateConfig />}
-        <ListAction justify="space-between" onClick={updateFrozenState}>
-          <Label htmlFor="frozen">Frozen</Label>
-          <Switch
-            id="frozen"
-            onChange={updateFrozenState}
-            on={customTemplate ? sessionFrozen : isFrozen}
-          />
-        </ListAction>
+
+        <Tooltip label="Protected sandboxes cannot be edited unless they are forked.">
+          <ListAction justify="space-between" onClick={updateFrozenState}>
+            <Label htmlFor="frozen">Protected</Label>
+
+            <Switch
+              id="frozen"
+              onChange={updateFrozenState}
+              on={customTemplate ? sessionFrozen : isFrozen}
+            />
+          </ListAction>
+        </Tooltip>
+
         {isForked ? (
           <ListItem justify="space-between">
             <Text>{forkedTemplateSandbox ? 'Template' : 'Forked From'}</Text>


### PR DESCRIPTION
Pretty rough rename/replace for the concept. The frozen icon was kept on the cards as there's no clear icon to differentiate between privacy and protection. Will sync with design and product after the holidays to figure out some of the low hanging fruits for improving the dashboard.