### PR TITLE
feat: improve templates management

### DIFF
--- a/packages/app/src/app/components/Create/hooks/useTeamTemplates.ts
+++ b/packages/app/src/app/components/Create/hooks/useTeamTemplates.ts
@@ -39,8 +39,9 @@ export const useTeamTemplates = ({
 }: UseTeamTemplatesParams): State => {
   const skip = !hasLogIn;
 
-  const noDevboxesWhenListingSandboxes = (t: TemplateFragment) =>
-    type === 'sandbox' ? !t.sandbox.isV2 : true;
+  const respectBoxType = (t: TemplateFragment) =>
+    (type === 'sandbox' && !t.sandbox.isV2) ||
+    (type === 'devbox' && t.sandbox.isV2);
 
   const { data, error } = useQuery<
     RecentAndWorkspaceTemplatesQuery,
@@ -81,13 +82,7 @@ export const useTeamTemplates = ({
 
   return {
     state: 'ready',
-    recentTemplates: data.me.recentlyUsedTemplates.filter(
-      t =>
-        (type === 'sandbox' && !t.sandbox.isV2) ||
-        (type === 'devbox' && t.sandbox.isV2)
-    ),
-    teamTemplates: data.me.team.templates.filter(
-      noDevboxesWhenListingSandboxes
-    ),
+    recentTemplates: data.me.recentlyUsedTemplates.filter(respectBoxType),
+    teamTemplates: data.me.team.templates.filter(respectBoxType),
   };
 };

--- a/packages/app/src/app/overmind/namespaces/dashboard/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/dashboard/actions.ts
@@ -848,6 +848,16 @@ export const makeTemplates = async (
     await effects.gql.mutations.makeSandboxesTemplate({
       sandboxIds: ids,
     });
+    const hadTemplatesBeforeFetching = state.sidebar.hasTemplates;
+    await actions.sidebar.getSidebarData(state.activeTeam);
+
+    if (!hadTemplatesBeforeFetching) {
+      notificationState.addNotification({
+        title: 'Template successfully created',
+        message: 'Check out your new "Templates" collection in the sidebar.',
+        status: NotificationStatus.SUCCESS,
+      });
+    }
   } catch (error) {
     state.dashboard.sandboxes = { ...oldSandboxes };
     effects.notificationToast.error('There was a problem making your template');

--- a/packages/app/src/app/overmind/namespaces/dashboard/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/dashboard/actions.ts
@@ -670,17 +670,22 @@ export const deleteSandbox = async (
 
 export const unmakeTemplates = async (
   { effects, actions, state }: Context,
-  { templateIds }: { templateIds: string[] }
+  { templateIds, isOnRecentPage = false }: { templateIds: string[], isOnRecentPage?: boolean }
 ) => {
   const oldTemplates = {
     TEMPLATE_HOME: state.dashboard.sandboxes.TEMPLATE_HOME,
     TEMPLATES: state.dashboard.sandboxes.TEMPLATES,
   };
-  actions.dashboard.deleteTemplateFromState(templateIds);
+
   try {
     await effects.gql.mutations.unmakeSandboxesTemplate({
       sandboxIds: templateIds,
     });
+    if (isOnRecentPage) {
+      actions.dashboard.getStartPageSandboxes();
+    } else {
+      actions.dashboard.deleteTemplateFromState(templateIds);
+    }
   } catch (error) {
     state.dashboard.sandboxes.TEMPLATES = oldTemplates.TEMPLATES
       ? [...oldTemplates.TEMPLATES]
@@ -833,8 +838,10 @@ export const makeTemplates = async (
   { effects, state, actions }: Context,
   {
     sandboxIds: ids,
+    isOnRecentPage = false,
   }: {
     sandboxIds: string[];
+    isOnRecentPage?: boolean;
   }
 ) => {
   effects.analytics.track('Dashboard - Make Template', {
@@ -842,12 +849,18 @@ export const makeTemplates = async (
   });
 
   const oldSandboxes = state.dashboard.sandboxes;
-  actions.dashboard.internal.deleteSandboxesFromState({ ids });
 
   try {
     await effects.gql.mutations.makeSandboxesTemplate({
       sandboxIds: ids,
     });
+
+    if (isOnRecentPage) {
+      actions.dashboard.getStartPageSandboxes();
+    } else {
+      actions.dashboard.internal.deleteSandboxesFromState({ ids });
+    }
+
     const hadTemplatesBeforeFetching = state.sidebar.hasTemplates;
     await actions.sidebar.getSidebarData(state.activeTeam);
 

--- a/packages/app/src/app/overmind/namespaces/dashboard/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/dashboard/actions.ts
@@ -670,7 +670,10 @@ export const deleteSandbox = async (
 
 export const unmakeTemplates = async (
   { effects, actions, state }: Context,
-  { templateIds, isOnRecentPage = false }: { templateIds: string[], isOnRecentPage?: boolean }
+  {
+    templateIds,
+    isOnRecentPage = false,
+  }: { templateIds: string[]; isOnRecentPage?: boolean }
 ) => {
   const oldTemplates = {
     TEMPLATE_HOME: state.dashboard.sandboxes.TEMPLATE_HOME,
@@ -862,7 +865,7 @@ export const makeTemplates = async (
     }
 
     const hadTemplatesBeforeFetching = state.sidebar.hasTemplates;
-    await actions.sidebar.getSidebarData(state.activeTeam);
+    await actions.sidebar.getSidebarData(state.activeTeam || undefined);
 
     if (!hadTemplatesBeforeFetching) {
       notificationState.addNotification({

--- a/packages/app/src/app/pages/Dashboard/Components/Sandbox/SandboxBadge.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Sandbox/SandboxBadge.tsx
@@ -22,7 +22,7 @@ export const SandboxBadge: React.FC<SandboxBadgeProps> = ({
   }
 
   if (isTemplate) {
-    boxTypeLabel = 'Template';
+    boxTypeLabel += ' template';
   }
 
   return (

--- a/packages/app/src/app/pages/Dashboard/Components/Sandbox/SandboxBadge.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Sandbox/SandboxBadge.tsx
@@ -1,0 +1,36 @@
+import { Icon, Stack, Text } from '@codesandbox/components';
+import React from 'react';
+
+export interface SandboxBadgeProps {
+  isDevbox: boolean;
+  isTemplate: boolean;
+  restricted: boolean;
+}
+
+export const SandboxBadge: React.FC<SandboxBadgeProps> = ({
+  isDevbox,
+  isTemplate,
+  restricted,
+}) => {
+  const boxIcon = isDevbox ? 'boxDevbox' : 'boxSandbox';
+  let boxTypeColor = isDevbox ? '#FFFFFF' : '#A6A6A6';
+  let boxTypeLabel = isDevbox ? 'Devbox' : 'Sandbox';
+
+  if (restricted) {
+    boxTypeColor = '#F7CC66';
+    boxTypeLabel = 'Restricted';
+  }
+
+  if (isTemplate) {
+    boxTypeLabel = 'Template';
+  }
+
+  return (
+    <Stack align="center" gap={1}>
+      <Icon name={boxIcon} color={boxTypeColor} />
+      <Text size={2} color={boxTypeColor}>
+        {boxTypeLabel}
+      </Text>
+    </Stack>
+  );
+};

--- a/packages/app/src/app/pages/Dashboard/Components/Sandbox/SandboxCard.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Sandbox/SandboxCard.tsx
@@ -1,14 +1,12 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 import { RepoFragmentDashboardFragment } from 'app/graphql/types';
 import {
-  Badge,
   Stack,
   Text,
   Input,
   Icon,
   IconButton,
   Link,
-  Tooltip,
   InteractiveOverlay,
   Element,
 } from '@codesandbox/components';
@@ -18,6 +16,7 @@ import { SandboxItemComponentProps } from './types';
 import { StyledCard } from '../shared/StyledCard';
 import { useSandboxThumbnail } from './useSandboxThumbnail';
 import { Brightness } from './useImageBrightness';
+import { SandboxBadge } from './SandboxBadge';
 
 type SandboxTitleProps = {
   brightness?: Brightness;
@@ -137,53 +136,31 @@ const SandboxTitle: React.FC<SandboxTitleProps> = React.memo(
 
 type SandboxStatsProps = {
   isFrozen?: boolean;
+  isTemplate?: boolean;
   prNumber?: number;
   restricted: boolean;
-  showDevboxBadge: boolean;
+  isDevbox: boolean;
   originalGit?: RepoFragmentDashboardFragment['originalGit'];
 } & Pick<SandboxItemComponentProps, 'noDrag' | 'lastUpdated' | 'PrivacyIcon'>;
 const SandboxStats: React.FC<SandboxStatsProps> = React.memo(
   ({
     isFrozen,
+    isTemplate,
     restricted,
-    showDevboxBadge,
+    isDevbox,
     noDrag,
     lastUpdated,
     PrivacyIcon,
     prNumber,
     originalGit,
   }) => {
-    const boxType = showDevboxBadge ? 'devbox' : 'sandbox';
+    const boxType = isDevbox ? 'devbox' : 'sandbox';
 
     const lastUpdatedText = (
       <Text key="last-updated" size={12} truncate>
         {shortDistance(lastUpdated)}
       </Text>
     );
-
-    const badge = useMemo<JSX.Element>(() => {
-      if (restricted) {
-        return <Badge variant="trial">Restricted</Badge>;
-      }
-
-      if (showDevboxBadge) {
-        return (
-          <Stack align="center" gap={1}>
-            <Icon color="#FFFFFF" name="boxDevbox" />
-            <Text color="#FFFFFF" size={2}>
-              Devbox
-            </Text>
-          </Stack>
-        );
-      }
-
-      return (
-        <Stack align="center" gap={1}>
-          <Icon name="boxSandbox" />
-          <Text size={2}>Sandbox</Text>
-        </Stack>
-      );
-    }, [restricted, showDevboxBadge]);
 
     return (
       <Stack
@@ -198,9 +175,7 @@ const SandboxStats: React.FC<SandboxStatsProps> = React.memo(
         <Stack gap={2} align="center">
           <PrivacyIcon />
           {isFrozen && (
-            <Tooltip label={`Protected ${boxType}`}>
-              <Icon size={16} title={`Protected ${boxType}`} name="frozen" />
-            </Tooltip>
+            <Icon size={16} title={`Protected ${boxType}`} name="frozen" />
           )}
           {prNumber ? (
             <Link
@@ -214,7 +189,11 @@ const SandboxStats: React.FC<SandboxStatsProps> = React.memo(
           ) : null}
           {noDrag ? null : lastUpdatedText}
         </Stack>
-        {badge}
+        <SandboxBadge
+          restricted={restricted}
+          isTemplate={isTemplate}
+          isDevbox={isDevbox}
+        />
       </Stack>
     );
   }
@@ -333,10 +312,11 @@ export const SandboxCard = ({
             originalGit={sandbox.originalGit}
             prNumber={sandbox.prNumber}
             lastUpdated={lastUpdated}
+            isTemplate={!!sandbox.customTemplate}
             isFrozen={sandbox.isFrozen && !sandbox.customTemplate}
             PrivacyIcon={PrivacyIcon}
             restricted={restricted}
-            showDevboxBadge={sandbox.isV2}
+            isDevbox={sandbox.isV2}
           />
         </CardContent>
       </StyledCard>

--- a/packages/app/src/app/pages/Dashboard/Components/Sandbox/SandboxListItem.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Sandbox/SandboxListItem.tsx
@@ -5,7 +5,6 @@ import {
   Column,
   Stack,
   Element,
-  Badge,
   Text,
   Input,
   ListAction,

--- a/packages/app/src/app/pages/Dashboard/Components/Sandbox/SandboxListItem.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Sandbox/SandboxListItem.tsx
@@ -14,6 +14,7 @@ import {
 } from '@codesandbox/components';
 import css from '@styled-system/css';
 import { SandboxItemComponentProps } from './types';
+import { SandboxBadge } from './SandboxBadge';
 
 export const SandboxListItem = ({
   sandbox,
@@ -147,11 +148,13 @@ export const SandboxListItem = ({
         </Column>
         {/* Column span 0 on mobile because the Grid is bugged */}
         <Column span={[0, 2, 2]}>
-          {restricted ? (
-            <Stack align="center">
-              <Badge variant="trial">Restricted</Badge>
-            </Stack>
-          ) : null}
+          <Stack align="center">
+            <SandboxBadge
+              isDevbox={sandbox.isV2}
+              isTemplate={!!sandbox.customTemplate}
+              restricted={restricted}
+            />
+          </Stack>
         </Column>
         <Column span={[0, 3, 3]} as={Stack} align="center">
           {sandbox.removedAt ? (

--- a/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenus/SandboxMenu.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenus/SandboxMenu.tsx
@@ -30,8 +30,8 @@ export const SandboxMenu: React.FC<SandboxMenuProps> = ({
   const {
     browser: { copyToClipboard },
   } = useEffects();
-  const { sandbox, type } = item;
-  const isTemplate = type === 'template';
+  const { sandbox } = item;
+  const isTemplate = !!sandbox.customTemplate;
 
   const { visible, setVisibility, position } = React.useContext(Context);
   const history = useHistory();
@@ -215,23 +215,23 @@ export const SandboxMenu: React.FC<SandboxMenuProps> = ({
         </Tooltip>
       )}
 
-      {hasAccess && userRole !== 'READ' ? (
-        <>
-          <Menu.Divider />
-          {sandbox.privacy !== 0 && (
-            <MenuItem
-              onSelect={() =>
-                actions.dashboard.changeSandboxesPrivacy({
-                  sandboxIds: [sandbox.id],
-                  privacy: 0,
-                })
-              }
-            >
-              Make {label} public
-            </MenuItem>
-          )}
-        </>
-      ) : null}
+      {hasAccess && userRole !== 'READ'
+        ? sandbox.privacy !== 0 && (
+            <>
+              <Menu.Divider />
+              <MenuItem
+                onSelect={() =>
+                  actions.dashboard.changeSandboxesPrivacy({
+                    sandboxIds: [sandbox.id],
+                    privacy: 0,
+                  })
+                }
+              >
+                Make {label} public
+              </MenuItem>
+            </>
+          )
+        : null}
 
       {hasAccess && userRole !== 'READ' && isPro ? (
         <>
@@ -311,7 +311,7 @@ export const SandboxMenu: React.FC<SandboxMenuProps> = ({
             }}
             disabled={restricted}
           >
-            Convert to {boxType}
+            Convert back to {boxType}
           </MenuItem>
         ) : (
           <MenuItem
@@ -322,7 +322,7 @@ export const SandboxMenu: React.FC<SandboxMenuProps> = ({
             }}
             disabled={restricted}
           >
-            Make {boxType} a template
+            Convert into a template
           </MenuItem>
         ))}
       {hasAccess &&

--- a/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenus/SandboxMenu.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenus/SandboxMenu.tsx
@@ -307,6 +307,7 @@ export const SandboxMenu: React.FC<SandboxMenuProps> = ({
             onSelect={() => {
               actions.dashboard.unmakeTemplates({
                 templateIds: [sandbox.id],
+                isOnRecentPage: location.pathname.includes('recent'),
               });
             }}
             disabled={restricted}
@@ -318,6 +319,7 @@ export const SandboxMenu: React.FC<SandboxMenuProps> = ({
             onSelect={() => {
               actions.dashboard.makeTemplates({
                 sandboxIds: [sandbox.id],
+                isOnRecentPage: location.pathname.includes('recent'),
               });
             }}
             disabled={restricted}


### PR DESCRIPTION
### Added some consistency for the badges we use in the dashboard
* Default badge is `Devbox/Sandbox`
* Icon is always reflecting the type of box
* If turned into a template, the label `Template` replaces the `Devbox/Sandbox`
* If restricted (will be deprecated soon) the label turns into `Restricted` with a warning color instead of the bright purple one
* Same logic applies for the list view now as well

![Screenshot 2023-12-22 at 14 14 31](https://github.com/codesandbox/codesandbox-client/assets/9945366/5399edc6-fc87-4487-a71a-1ac1feebb77b)
![image](https://github.com/codesandbox/codesandbox-client/assets/9945366/66d169a5-3080-4bcf-ad45-de1b1d411a69)

### Fix context menu for templates
![image](https://github.com/codesandbox/codesandbox-client/assets/9945366/15a82ddc-8b5c-4e7b-b49d-e2a33400c0d8)

### Notification when the first template is created. Also the templates collection appears now in the dashboard immediately after creating the first template.
![Screenshot 2023-12-22 at 14 15 01](https://github.com/codesandbox/codesandbox-client/assets/9945366/19c406f1-e945-4d08-bf76-4a81b31aad19)