### PR TITLE
feat: replace workspace settings with workspace portal

### DIFF
--- a/packages/app/scripts/start.js
+++ b/packages/app/scripts/start.js
@@ -250,10 +250,6 @@ function addMiddleware(devServer, index) {
       })
     );
     devServer.use(
-      '/t',
-      createProxyMiddleware({ target: PROXY_DOMAIN, changeOrigin: true })
-    );
-    devServer.use(
       '/auth/workos',
       createProxyMiddleware({
         target: PROXY_DOMAIN,

--- a/packages/app/scripts/start.js
+++ b/packages/app/scripts/start.js
@@ -250,6 +250,10 @@ function addMiddleware(devServer, index) {
       })
     );
     devServer.use(
+      '/t',
+      createProxyMiddleware({ target: PROXY_DOMAIN, changeOrigin: true })
+    );
+    devServer.use(
       '/auth/workos',
       createProxyMiddleware({
         target: PROXY_DOMAIN,

--- a/packages/app/src/app/hooks/useCreateCheckout.ts
+++ b/packages/app/src/app/hooks/useCreateCheckout.ts
@@ -97,7 +97,7 @@ export const useCreateCheckout = (): [
       }
 
       const teamId = activeTeam;
-      const successPath = dashboardURLs.settings(teamId);
+      const successPath = dashboardURLs.portalOverview(teamId);
 
       const payload = await api.stripeCreateCheckout({
         success_path: addStripeSuccessParam(successPath, trackingLocation),

--- a/packages/app/src/app/hooks/useCreateCheckout.ts
+++ b/packages/app/src/app/hooks/useCreateCheckout.ts
@@ -97,7 +97,7 @@ export const useCreateCheckout = (): [
       }
 
       const teamId = activeTeam;
-      const successPath = dashboardURLs.portalOverview(teamId);
+      const successPath = dashboardURLs.portalRelativePath(teamId);
 
       const payload = await api.stripeCreateCheckout({
         success_path: addStripeSuccessParam(successPath, trackingLocation),

--- a/packages/app/src/app/hooks/useCreateCustomerPortal.ts
+++ b/packages/app/src/app/hooks/useCreateCustomerPortal.ts
@@ -23,7 +23,7 @@ export const useCreateCustomerPortal = ({
       setLoading(true);
       const payload = await api.stripeCustomerPortal(
         team_id,
-        return_path ?? dashboard.settings(team_id)
+        return_path ?? dashboard.portalOverview(team_id)
       );
 
       if (payload.stripeCustomerPortalUrl) {

--- a/packages/app/src/app/hooks/useCreateCustomerPortal.ts
+++ b/packages/app/src/app/hooks/useCreateCustomerPortal.ts
@@ -23,7 +23,7 @@ export const useCreateCustomerPortal = ({
       setLoading(true);
       const payload = await api.stripeCustomerPortal(
         team_id,
-        return_path ?? dashboard.portalOverview(team_id)
+        return_path ?? dashboard.portalRelativePath(team_id)
       );
 
       if (payload.stripeCustomerPortalUrl) {

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/TeamSettings.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Settings/TeamSettings/TeamSettings.tsx
@@ -14,7 +14,6 @@ import {
   Switch as RouterSwitch,
   useLocation,
 } from 'react-router-dom';
-import * as dashboardUrls from '@codesandbox/common/lib/utils/url-generator/dashboard';
 
 import { SettingsNavigation } from '../components/Navigation';
 import { PermissionSettings } from '../components/PermissionSettings';
@@ -54,15 +53,15 @@ export const TeamSettings = () => {
               <RouterSwitch location={location}>
                 <Route
                   component={RegistrySettings}
-                  path={dashboardUrls.registrySettings()}
+                  path="/dashboard/settings/npm-registry"
                 />
                 <Route
                   component={PermissionSettings}
-                  path={dashboardUrls.permissionSettings()}
+                  path="/dashboard/settings/permissions"
                 />
                 <Route
                   component={WorkspaceSettings}
-                  path={dashboardUrls.settings()}
+                  path="/dashboard/settings"
                 />
               </RouterSwitch>
             </BrowserRouter>

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Settings/UserSettings/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Settings/UserSettings/index.tsx
@@ -4,7 +4,6 @@ import { useAppState } from 'app/overmind';
 import React from 'react';
 import { Helmet } from 'react-helmet';
 import { Route, BrowserRouter, Switch, useLocation } from 'react-router-dom';
-import * as dashboardUrls from '@codesandbox/common/lib/utils/url-generator/dashboard';
 
 import { useWorkspaceSubscription } from 'app/hooks/useWorkspaceSubscription';
 import { Header } from '../../../../Components/Header';
@@ -51,11 +50,11 @@ export const UserSettings = () => {
               <Switch location={location}>
                 <Route
                   component={PermissionSettings}
-                  path={dashboardUrls.permissionSettings()}
+                  path="/dashboard/settings/permissions"
                 />
                 <Route
                   component={WorkspaceSettings}
-                  path={dashboardUrls.settings()}
+                  path="/dashboard/settings"
                 />
               </Switch>
             </BrowserRouter>

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Settings/components/Navigation.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Settings/components/Navigation.tsx
@@ -2,7 +2,6 @@ import { Link, Stack } from '@codesandbox/components';
 import css from '@styled-system/css';
 import React from 'react';
 import { NavLink as RouterLink } from 'react-router-dom';
-import * as dashboardUrls from '@codesandbox/common/lib/utils/url-generator/dashboard';
 
 type NavigationLinkProps = {
   url?: string;
@@ -68,17 +67,15 @@ export const SettingsNavigation = ({
         })}
         gap={6}
       >
-        <NavigationLink url={dashboardUrls.settings(teamId)}>
-          Overview
-        </NavigationLink>
+        <NavigationLink url="/dashboard/settings">Overview</NavigationLink>
 
         {!isPersonal && (
-          <NavigationLink url={dashboardUrls.registrySettings(teamId)}>
+          <NavigationLink url="/dashboard/settings/npm-registry">
             NPM Registry
           </NavigationLink>
         )}
 
-        <NavigationLink url={dashboardUrls.permissionSettings(teamId)}>
+        <NavigationLink url="/dashboard/settings/permissions">
           Permissions
         </NavigationLink>
       </Stack>

--- a/packages/app/src/app/pages/Dashboard/Sidebar/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Sidebar/index.tsx
@@ -1,17 +1,10 @@
 import React from 'react';
-import { Link as RouterLink, useHistory } from 'react-router-dom';
+import { useHistory } from 'react-router-dom';
 import { useAppState, useActions } from 'app/overmind';
 import { motion, AnimatePresence } from 'framer-motion';
 import { dashboard as dashboardUrls } from '@codesandbox/common/lib/utils/url-generator';
 import { SkeletonTextBlock } from 'app/pages/Sandbox/Editor/Skeleton/elements';
-import {
-  Element,
-  List,
-  Link,
-  Text,
-  Stack,
-  Icon,
-} from '@codesandbox/components';
+import { Element, List, Text, Stack, Icon } from '@codesandbox/components';
 import css from '@styled-system/css';
 import { WorkspaceSelect } from 'app/components/WorkspaceSelect';
 import { getDaysUntil } from 'app/utils/dateTime';
@@ -154,7 +147,8 @@ export const Sidebar: React.FC<SidebarProps> = ({
               />
             </Stack>
           )}
-          <Link
+          <Element
+            as="a"
             css={{
               height: '36px',
               width: '36px',
@@ -169,12 +163,11 @@ export const Sidebar: React.FC<SidebarProps> = ({
                 color: '#fff',
               },
             }}
-            as={RouterLink}
-            to={dashboardUrls.settings(state.activeTeam)}
+            href={dashboardUrls.portalOverview(state.activeTeam)}
             title="Settings"
           >
             <Icon name="gear" size={16} />
-          </Link>
+          </Element>
         </Stack>
 
         <List

--- a/packages/app/src/app/pages/common/UserMenu/index.tsx
+++ b/packages/app/src/app/pages/common/UserMenu/index.tsx
@@ -3,6 +3,7 @@ import {
   profileUrl,
   docsUrl,
   csbSite,
+  dashboard as dashboardUrls,
 } from '@codesandbox/common/lib/utils/url-generator';
 import { Menu, Stack, Element, Icon, Text } from '@codesandbox/components';
 import { useAppState, useActions } from 'app/overmind';
@@ -113,7 +114,7 @@ export const UserMenu: FunctionComponent & {
           <Menu.Divider />
 
           {showManageSubscription && (
-            <Menu.Link to={`/dashboard/settings?workspace=${activeTeam}`}>
+            <Menu.Link href={dashboardUrls.portalOverview(activeTeam)}>
               <Stack align="center" gap={2}>
                 <Icon name="proBadge" size={16} />
                 <Text>Subscription</Text>

--- a/packages/common/src/utils/url-generator/dashboard.ts
+++ b/packages/common/src/utils/url-generator/dashboard.ts
@@ -98,6 +98,10 @@ export const portalRegistry = (teamId?: string | null) =>
 export const portalPermissions = (teamId?: string | null) =>
   appendTeamIdQueryParam(`${portalBaseUrl()}/permissions`, teamId);
 
+// This is used separately for checkout endpoints where the success/cancel paths need to be relative
+export const portalRelativePath = (teamId?: string | null) =>
+  appendTeamIdQueryParam(`${portalBaseUrl()}/overview`, teamId);
+
 export const search = (query: string, teamId?: string | null) => {
   let searchUrl = appendTeamIdQueryParam(
     `${DASHBOARD_URL_PREFIX}/search`,

--- a/packages/common/src/utils/url-generator/dashboard.ts
+++ b/packages/common/src/utils/url-generator/dashboard.ts
@@ -84,20 +84,19 @@ export const shared = (teamId?: string | null) =>
 export const liked = (teamId?: string | null) =>
   appendTeamIdQueryParam(`${DASHBOARD_URL_PREFIX}/liked`, teamId);
 
-export const settings = (teamId?: string | null) =>
-  appendTeamIdQueryParam(`${DASHBOARD_URL_PREFIX}/settings`, teamId);
+const portalBaseUrl = () => {
+  const origin = process.env.ENDPOINT || window.location.origin;
+  return `${origin}/t`;
+};
 
-export const registrySettings = (teamId?: string | null) =>
-  appendTeamIdQueryParam(
-    `${DASHBOARD_URL_PREFIX}/settings/npm-registry`,
-    teamId
-  );
+export const portalOverview = (teamId?: string | null) =>
+  appendTeamIdQueryParam(`${portalBaseUrl()}/overview`, teamId);
 
-export const permissionSettings = (teamId?: string | null) =>
-  appendTeamIdQueryParam(
-    `${DASHBOARD_URL_PREFIX}/settings/permissions`,
-    teamId
-  );
+export const portalRegistry = (teamId?: string | null) =>
+  appendTeamIdQueryParam(`${portalBaseUrl()}/registry`, teamId);
+
+export const portalPermissions = (teamId?: string | null) =>
+  appendTeamIdQueryParam(`${portalBaseUrl()}/permissions`, teamId);
 
 export const search = (query: string, teamId?: string | null) => {
   let searchUrl = appendTeamIdQueryParam(


### PR DESCRIPTION
All URLs pointing to the dashboard settings page are absolute paths to the workspace portal
Dashboard settings remains for now until we get this tested

Closes PC-1578