### PR TITLE
fix: redirect back to recent when upgrade flow is not going to stripe

### DIFF
--- a/packages/app/src/app/pages/WorkspaceFlows/UpgradeWorkspace.tsx
+++ b/packages/app/src/app/pages/WorkspaceFlows/UpgradeWorkspace.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { WorkspaceSetup } from 'app/components/WorkspaceSetup';
 import * as dashboardUrls from '@codesandbox/common/lib/utils/url-generator/dashboard';
-import { Redirect } from 'react-router-dom';
+import { Redirect, useHistory } from 'react-router-dom';
 import { useURLSearchParams } from 'app/hooks/useURLSearchParams';
 import { WorkspaceSetupStep } from 'app/components/WorkspaceSetup/types';
 import { useActions, useAppState } from 'app/overmind';
@@ -15,6 +15,7 @@ export const UpgradeWorkspace = () => {
   const workspaceId = getQueryParam('workspace');
   const { ubbBeta } = useWorkspaceFeatureFlags();
   const { isAdmin } = useWorkspaceAuthorization();
+  const history = useHistory();
 
   const {
     dashboard: { dashboardMounted },
@@ -54,11 +55,12 @@ export const UpgradeWorkspace = () => {
     <WorkspaceSetup
       steps={steps}
       onComplete={() => {
-        // When setup is finished do a full reload
-        window.location.href = dashboardUrls.portalOverview(workspaceId);
+        // If the flow is actually completed with a stripe checkout
+        // the redirect is handled by stripe so this is just for early exit
+        history.push(dashboardUrls.recent(workspaceId));
       }}
       onDismiss={() => {
-        window.location.href = dashboardUrls.portalOverview(workspaceId);
+        history.push(dashboardUrls.recent(workspaceId));
       }}
     />
   );


### PR DESCRIPTION
Right now when you hit cancel when doing the upgrade you get to the portal, which doesn't make too much sense.