### PR TITLE
feat: sign up for ubb self-serve flow

### DIFF
--- a/packages/app/src/app/components/WorkspaceSetup/steps/SelectWorkspace.tsx
+++ b/packages/app/src/app/components/WorkspaceSetup/steps/SelectWorkspace.tsx
@@ -1,10 +1,10 @@
 import React, { useState } from 'react';
 import { Button, Stack } from '@codesandbox/components';
 import { useActions, useAppState } from 'app/overmind';
-import { SubscriptionStatus } from 'app/graphql/types';
+import { SubscriptionStatus, TeamMemberAuthorization } from 'app/graphql/types';
 import { useURLSearchParams } from 'app/hooks/useURLSearchParams';
 import { InputSelect } from 'app/components/dashboard/InputSelect';
-import { useHistory } from 'react-router-dom';
+import { useHistory, useLocation } from 'react-router-dom';
 import { StepHeader } from '../StepHeader';
 import { AnimatedStep } from '../elements';
 import { StepProps } from '../types';
@@ -16,18 +16,35 @@ export const SelectWorkspace: React.FC<StepProps> = ({
   currentStep,
   numberOfSteps,
 }) => {
-  const { dashboard, activeTeam } = useAppState();
+  const { dashboard, activeTeam, user } = useAppState();
   const history = useHistory();
   const { setActiveTeam } = useActions();
   const { setQueryParam } = useURLSearchParams();
+  const { pathname } = useLocation();
+  const isSigningUpForBeta = pathname.includes('signup-beta');
 
-  const workspacesEligibleForUpgrade = dashboard.teams.filter(
-    t =>
-      !(
-        t.subscription?.status === SubscriptionStatus.Active ||
-        t.subscription?.status === SubscriptionStatus.Trialing
-      ) && t.featureFlags.ubbBeta
-  );
+  const workspacesEligibleForUpgrade = dashboard.teams
+    .filter(
+      t =>
+        // Only teams where you are admin
+        t.userAuthorizations.find(
+          ua =>
+            ua.userId === user?.id &&
+            ua.authorization === TeamMemberAuthorization.Admin
+        ) &&
+        // And teams that are not Pro
+        !(
+          t.subscription?.status === SubscriptionStatus.Active ||
+          t.subscription?.status === SubscriptionStatus.Trialing
+        )
+    )
+    .filter(t =>
+      isSigningUpForBeta
+        ? // If this is the signup for ubb beta, show only workspaces that are not in ubb
+          // Otherwise, show only workspaces that are ubb
+          !t.featureFlags.ubbBeta
+        : t.featureFlags.ubbBeta
+    );
 
   const [workspaceId, setWorkspaceId] = useState<string>(activeTeam);
 
@@ -38,12 +55,12 @@ export const SelectWorkspace: React.FC<StepProps> = ({
     onNextStep();
   };
 
-  if (workspacesEligibleForUpgrade.length === 0) {
+  if (user && workspacesEligibleForUpgrade.length === 0) {
     // No eligible workspace to upgrade
     history.replace('/create-workspace');
   }
 
-  if (workspacesEligibleForUpgrade.length === 1) {
+  if (user && workspacesEligibleForUpgrade.length === 1) {
     // Skip selection if a single workspace can be upgraded
     setActiveTeam({ id: workspaceId });
     setQueryParam('workspace', workspaceId);
@@ -71,7 +88,6 @@ export const SelectWorkspace: React.FC<StepProps> = ({
             id="workspace"
             name="workspace"
             label="Select the workspace you want to upgrade"
-            defaultValue={workspaceId}
             onChange={ev => setWorkspaceId(ev.target.value)}
             options={workspacesEligibleForUpgrade.map(w => ({
               label: w.name,

--- a/packages/app/src/app/graphql/types.ts
+++ b/packages/app/src/app/graphql/types.ts
@@ -1831,6 +1831,13 @@ export type RootMutationType = {
    * this mutation is a no-op. Returns an error if no live session exists.
    */
   joinLiveSession: LiveSession;
+  /**
+   * Join the usage-based billing beta on-demand
+   *
+   * This mutation requires the caller to be an admin of the team. Otherwise, an error will be
+   * returned `"Not an admin"`. The return value will always be `true`.
+   */
+  joinUsageBillingBeta: Scalars['Boolean'];
   /** Leave a team */
   leaveTeam: Scalars['String'];
   /** Make templates from sandboxes */
@@ -2256,6 +2263,10 @@ export type RootMutationTypeInviteToTeamViaEmailArgs = {
 
 export type RootMutationTypeJoinLiveSessionArgs = {
   id: Scalars['ID'];
+};
+
+export type RootMutationTypeJoinUsageBillingBetaArgs = {
+  teamId: Scalars['UUID4'];
 };
 
 export type RootMutationTypeLeaveTeamArgs = {

--- a/packages/app/src/app/overmind/effects/gql/dashboard/mutations.ts
+++ b/packages/app/src/app/overmind/effects/gql/dashboard/mutations.ts
@@ -780,3 +780,9 @@ export const setTeamLimits: Query<
     )
   }
 `;
+
+export const joinUsageBillingBeta = gql`
+  mutation JoinUsageBillingBeta($teamId: UUID4!) {
+    joinUsageBillingBeta(teamId: $teamId)
+  }
+`;

--- a/packages/app/src/app/pages/WorkspaceFlows/SignUpUBB.tsx
+++ b/packages/app/src/app/pages/WorkspaceFlows/SignUpUBB.tsx
@@ -1,0 +1,67 @@
+import React, { useEffect, useState } from 'react';
+import { WorkspaceSetup } from 'app/components/WorkspaceSetup';
+import * as dashboardUrls from '@codesandbox/common/lib/utils/url-generator/dashboard';
+import { Redirect, useHistory } from 'react-router-dom';
+import { useURLSearchParams } from 'app/hooks/useURLSearchParams';
+import { WorkspaceSetupStep } from 'app/components/WorkspaceSetup/types';
+import { useActions, useAppState } from 'app/overmind';
+import { signInPageUrl } from '@codesandbox/common/lib/utils/url-generator';
+import { useWorkspaceFeatureFlags } from 'app/hooks/useWorkspaceFeatureFlags';
+import { useWorkspaceAuthorization } from 'app/hooks/useWorkspaceAuthorization';
+
+export const SignUpUBB = () => {
+  const { hasLogIn } = useAppState();
+  const { getQueryParam } = useURLSearchParams();
+  const workspaceId = getQueryParam('workspace');
+  const { ubbBeta } = useWorkspaceFeatureFlags();
+  const { isAdmin } = useWorkspaceAuthorization();
+  const history = useHistory();
+
+  const {
+    dashboard: { dashboardMounted },
+  } = useActions();
+
+  useEffect(() => {
+    dashboardMounted();
+  }, [dashboardMounted]);
+
+  const [steps] = useState(() => {
+    // Ensure this is run only once
+    const initialSteps: WorkspaceSetupStep[] = [
+      'plans',
+      'plan-options',
+      'payment',
+    ];
+
+    if (!workspaceId) {
+      initialSteps.unshift('select-workspace');
+    }
+
+    return initialSteps;
+  });
+
+  if (!hasLogIn) {
+    return (
+      <Redirect to={signInPageUrl(`${location.pathname}${location.search}`)} />
+    );
+  }
+
+  if ((workspaceId && ubbBeta === true) || isAdmin === false) {
+    // Page was accessed with a non-ubb workspace id
+    return <Redirect to={dashboardUrls.recent(workspaceId)} />;
+  }
+
+  return (
+    <WorkspaceSetup
+      steps={steps}
+      onComplete={() => {
+        // Since the sign up for ubb can be completed with choosing the free plan,
+        // The app is reloaded to ensure feature flag is updated in the workspace
+        window.location.href = dashboardUrls.recent(workspaceId);
+      }}
+      onDismiss={() => {
+        history.push(dashboardUrls.recent(workspaceId));
+      }}
+    />
+  );
+};

--- a/packages/app/src/app/pages/WorkspaceFlows/index.ts
+++ b/packages/app/src/app/pages/WorkspaceFlows/index.ts
@@ -1,2 +1,3 @@
 export { CreateWorkspace } from './CreateWorkspace';
 export { UpgradeWorkspace } from './UpgradeWorkspace';
+export { SignUpUBB } from './SignUpUBB';

--- a/packages/app/src/app/pages/index.tsx
+++ b/packages/app/src/app/pages/index.tsx
@@ -12,7 +12,7 @@ import { ErrorBoundary } from './common/ErrorBoundary';
 import { Modals } from './common/Modals';
 import { DevAuthPage } from './DevAuth';
 import { StandalonePage } from './Standalone';
-import { CreateWorkspace, UpgradeWorkspace } from './WorkspaceFlows';
+import { CreateWorkspace, SignUpUBB, UpgradeWorkspace } from './WorkspaceFlows';
 import { Container, Content } from './elements';
 import { Dashboard } from './Dashboard';
 import { Sandbox } from './Sandbox';
@@ -221,6 +221,7 @@ const RoutesComponent: React.FC = () => {
             <Route path="/standalone/:componentId" component={StandalonePage} />
             <Route path="/create-workspace" component={CreateWorkspace} />
             <Route path="/upgrade" component={UpgradeWorkspace} />
+            <Route path="/signup-beta" component={SignUpUBB} />
             <Redirect from="/patron" to="/pro" />
             <Route component={NotFound} />
           </Switch>


### PR DESCRIPTION
`/signup-beta` works the same as `/upgrade`, it just runs the new mutation AJ implemented, so the workspaces are flipped to UBB during the flow