### PR TITLE
feat: allow pro workspaces to use /upgrade to convert to ubb

### DIFF
--- a/packages/app/src/app/components/WorkspaceSetup/WorkspaceSetup.tsx
+++ b/packages/app/src/app/components/WorkspaceSetup/WorkspaceSetup.tsx
@@ -4,9 +4,9 @@ import { StepProps, WorkspaceSetupStep } from './types';
 import { Create } from './steps/Create';
 import { Plans } from './steps/Plans';
 import { PlanOptions } from './steps/PlanOptions';
-import { Payment } from './steps/Payment';
 import { SelectWorkspace } from './steps/SelectWorkspace';
 import { Addons } from './steps/Addons';
+import { Finalize } from './steps/Finalize';
 
 export type WorkspaceSetupProps = {
   steps: WorkspaceSetupStep[];
@@ -56,12 +56,12 @@ const STEP_COMPONENTS: Record<WorkspaceSetupStep, React.FC<StepProps>> = {
   'select-workspace': SelectWorkspace,
   plans: Plans,
   'plan-options': PlanOptions,
-  payment: Payment,
   addons: Addons,
+  finalize: Finalize,
 };
 
 const STEPS_WITH_CHECKOUT: WorkspaceSetupStep[] = [
   'plan-options',
-  'payment',
   'addons',
+  'finalize',
 ];

--- a/packages/app/src/app/components/WorkspaceSetup/steps/Addons.tsx
+++ b/packages/app/src/app/components/WorkspaceSetup/steps/Addons.tsx
@@ -11,6 +11,8 @@ import {
   SandboxAddon,
 } from 'app/overmind/namespaces/checkout/state';
 import styled from 'styled-components';
+import { useWorkspaceSubscription } from 'app/hooks/useWorkspaceSubscription';
+import { useURLSearchParams } from 'app/hooks/useURLSearchParams';
 import { StepProps } from '../types';
 import { StepHeader } from '../StepHeader';
 import { AnimatedStep } from '../elements';
@@ -22,7 +24,17 @@ export const Addons: React.FC<StepProps> = ({
   currentStep,
   numberOfSteps,
 }) => {
+  const { isPro } = useWorkspaceSubscription();
   const { checkout } = useActions();
+  const { getQueryParam } = useURLSearchParams();
+  const urlWorkspaceId = getQueryParam('workspace');
+
+  const handleSubmit = () => {
+    if (isPro) {
+      checkout.calculateConversionCharge({ workspaceId: urlWorkspaceId });
+    }
+    onNextStep();
+  };
 
   return (
     <AnimatedStep>
@@ -114,7 +126,7 @@ export const Addons: React.FC<StepProps> = ({
           </Element>
         </Stack>
 
-        <Button autoWidth size="large" onClick={onNextStep}>
+        <Button autoWidth size="large" onClick={handleSubmit}>
           Next
         </Button>
       </Stack>

--- a/packages/app/src/app/components/WorkspaceSetup/steps/ChangePlan.tsx
+++ b/packages/app/src/app/components/WorkspaceSetup/steps/ChangePlan.tsx
@@ -1,0 +1,111 @@
+import React from 'react';
+import { Stack, Button, Text, Icon } from '@codesandbox/components';
+import * as dashboardUrls from '@codesandbox/common/lib/utils/url-generator/dashboard';
+
+import { useURLSearchParams } from 'app/hooks/useURLSearchParams';
+import { useActions, useAppState } from 'app/overmind';
+import { StepProps } from '../types';
+import { StepHeader } from '../StepHeader';
+import { AnimatedStep } from '../elements';
+
+export const ChangePlan: React.FC<StepProps> = ({
+  onPrevStep,
+  onDismiss,
+  currentStep,
+  numberOfSteps,
+}) => {
+  const actions = useActions();
+  const { checkout } = useAppState();
+  const { getQueryParam } = useURLSearchParams();
+  const urlWorkspaceId = getQueryParam('workspace');
+
+  const handleSubmit = async e => {
+    e.preventDefault();
+    const result = await actions.checkout.convertToUsageBilling({
+      workspaceId: urlWorkspaceId,
+    });
+    if (result.success) {
+      window.location.href = dashboardUrls.portalOverview(urlWorkspaceId);
+    } else {
+      actions.addNotification({
+        message: result.error,
+        type: 'error',
+        timeAlive: 10,
+      });
+    }
+  };
+
+  return (
+    <AnimatedStep>
+      <Stack direction="vertical" gap={12} as="form" onSubmit={handleSubmit}>
+        <StepHeader
+          onPrevStep={onPrevStep}
+          onDismiss={onDismiss}
+          currentStep={currentStep}
+          numberOfSteps={numberOfSteps}
+          title="Review plan"
+        />
+
+        <Text color="#e5e5e5">You are switching to the following plan:</Text>
+
+        <Stack justify="space-between" gap={4}>
+          <Stack direction="vertical">
+            <Text size={6} color="#e5e5e5">
+              Pro plan
+            </Text>
+            <Text>{checkout.totalCredits} VM credits</Text>
+            <Text>{checkout.totalSandboxes} Sandboxes</Text>
+          </Stack>
+          <Text size={6} color="#e5e5e5">
+            ${checkout.totalPrice} / month
+          </Text>
+        </Stack>
+
+        <Text>
+          Additional VM credits are available on-demand for $0.018/credit.
+          <br />
+          Spending limit: ${checkout.spendingLimit} / month
+        </Text>
+
+        {checkout.convertProToUBBCharge && (
+          <Stack direction="vertical" gap={2}>
+            <Stack justify="space-between" gap={4}>
+              <Stack direction="vertical">
+                <Text size={6} color="#e5e5e5">
+                  Current charge
+                </Text>
+                {checkout.convertProToUBBCharge.total > 0 && (
+                  /** If amount charged is 0 show a single line */
+                  <Text>Charge (excl. taxes)</Text>
+                )}
+              </Stack>
+              <Stack direction="vertical" align="flex-end">
+                <Text size={6} color="#e5e5e5">
+                  ${checkout.convertProToUBBCharge.total}
+                </Text>
+                {checkout.convertProToUBBCharge.total > 0 && (
+                  /** If amount charged is 0 show a single line */
+                  <Text>
+                    ${checkout.convertProToUBBCharge.totalExcludingTax}
+                  </Text>
+                )}
+              </Stack>
+            </Stack>
+            <Stack css={{ color: '#A8BFFA' }} gap={1}>
+              <Icon name="circleBang" size={20} />
+              <Text>
+                The charge has been prorated based on your existing plan.
+                <br />
+                Your new billing cycle will start now.
+              </Text>
+            </Stack>
+          </Stack>
+        )}
+
+        <Button autoWidth size="large" type="submit">
+          Accept changes
+        </Button>
+      </Stack>
+    </AnimatedStep>
+  );
+};

--- a/packages/app/src/app/components/WorkspaceSetup/steps/Create.tsx
+++ b/packages/app/src/app/components/WorkspaceSetup/steps/Create.tsx
@@ -70,6 +70,7 @@ export const Create: React.FC<StepProps> = ({
 
         setQueryParam('workspace', team.id);
         setFreshWorkspaceId(team.id);
+        await actions.dashboard.getTeams();
         await actions.setActiveTeam({ id: team.id });
       }
     } catch {

--- a/packages/app/src/app/components/WorkspaceSetup/steps/Finalize.tsx
+++ b/packages/app/src/app/components/WorkspaceSetup/steps/Finalize.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { useWorkspaceSubscription } from 'app/hooks/useWorkspaceSubscription';
+import { StepProps } from '../types';
+import { Payment } from './Payment';
+import { ChangePlan } from './ChangePlan';
+
+export const Finalize: React.FC<StepProps> = props => {
+  const { isPro } = useWorkspaceSubscription();
+  if (isPro) {
+    return <ChangePlan {...props} />;
+  }
+  return <Payment {...props} />;
+};

--- a/packages/app/src/app/components/WorkspaceSetup/steps/Payment.tsx
+++ b/packages/app/src/app/components/WorkspaceSetup/steps/Payment.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { Stack, Button, Text, Icon } from '@codesandbox/components';
 import { useURLSearchParams } from 'app/hooks/useURLSearchParams';
-import { useAppState, useEffects } from 'app/overmind';
+import { useActions, useAppState, useEffects } from 'app/overmind';
 import { dashboard as dashboardURLs } from '@codesandbox/common/lib/utils/url-generator';
 import { StepProps } from '../types';
 import { StepHeader } from '../StepHeader';
@@ -20,8 +20,9 @@ export const Payment: React.FC<StepProps> = ({
 }) => {
   const { api } = useEffects();
   const {
-    checkout: { basePlan, creditAddons, sandboxAddons },
+    checkout: { basePlan },
   } = useAppState();
+  const actions = useActions();
   const { getQueryParam } = useURLSearchParams();
   const workspaceId = getQueryParam('workspace');
 
@@ -43,25 +44,13 @@ export const Payment: React.FC<StepProps> = ({
       return;
     }
 
-    const addons: string[] = [];
-    creditAddons.forEach(item => {
-      for (let i = 0; i < item.quantity; i++) {
-        addons.push(item.addon.id);
-      }
-    });
-    sandboxAddons.forEach(item => {
-      for (let i = 0; i < item.quantity; i++) {
-        addons.push(item.addon.id);
-      }
-    });
-
     try {
       const payload = await api.stripeCreateUBBCheckout({
         success_path: successPath,
         cancel_path: cancelPath,
         team_id: workspaceId,
         plan: basePlan.id,
-        addons,
+        addons: actions.checkout.getFlatAddonsList(),
       });
 
       if (payload.stripeCheckoutUrl) {

--- a/packages/app/src/app/components/WorkspaceSetup/steps/Plans.tsx
+++ b/packages/app/src/app/components/WorkspaceSetup/steps/Plans.tsx
@@ -8,7 +8,6 @@ import {
   Text,
   Tooltip,
 } from '@codesandbox/components';
-import * as dashboardUrls from '@codesandbox/common/lib/utils/url-generator/dashboard';
 import {
   CSB_FRIENDS_LINK,
   ORGANIZATION_CONTACT_LINK,
@@ -26,10 +25,8 @@ import styled from 'styled-components';
 import { useURLSearchParams } from 'app/hooks/useURLSearchParams';
 import { useActions, useAppState, useEffects } from 'app/overmind';
 import { VMTier } from 'app/overmind/effects/api/types';
-import { Redirect, useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 import { useWorkspaceFeatureFlags } from 'app/hooks/useWorkspaceFeatureFlags';
-import { useWorkspaceAuthorization } from 'app/hooks/useWorkspaceAuthorization';
-import { useWorkspaceSubscription } from 'app/hooks/useWorkspaceSubscription';
 import { StepProps } from '../types';
 import { StepHeader } from '../StepHeader';
 import { AnimatedStep } from '../elements';
@@ -44,15 +41,13 @@ export const Plans: React.FC<StepProps> = ({
 }) => {
   const { getQueryParam } = useURLSearchParams();
   const { activeTeam } = useAppState();
-  const { isAdmin } = useWorkspaceAuthorization();
-  const { isPro } = useWorkspaceSubscription();
+
   const actions = useActions();
   const effects = useEffects();
   const urlWorkspaceId = getQueryParam('workspace');
   const { pathname } = useLocation();
   const [tiers, setTiers] = useState<VMTier[]>([]);
   const { ubbBeta } = useWorkspaceFeatureFlags();
-
   const isUpgrading = pathname.includes('upgrade');
 
   useEffect(() => {
@@ -76,11 +71,6 @@ export const Plans: React.FC<StepProps> = ({
 
     onNextStep();
   };
-
-  if ((isUpgrading && isAdmin === false) || isPro === true) {
-    // Page was accessed by a non-admin or for pro workspaces
-    return <Redirect to={dashboardUrls.recent(urlWorkspaceId)} />;
-  }
 
   return (
     <AnimatedStep css={{ width: '100%' }}>

--- a/packages/app/src/app/components/WorkspaceSetup/types.ts
+++ b/packages/app/src/app/components/WorkspaceSetup/types.ts
@@ -4,7 +4,7 @@ export type WorkspaceSetupStep =
   | 'plans'
   | 'addons'
   | 'plan-options'
-  | 'payment';
+  | 'finalize';
 
 export interface StepProps {
   currentStep: number;

--- a/packages/app/src/app/graphql/types.ts
+++ b/packages/app/src/app/graphql/types.ts
@@ -5517,6 +5517,32 @@ export type JoinUsageBillingBetaMutation = {
   joinUsageBillingBeta: boolean;
 };
 
+export type PreviewConvertToUsageBillingMutationVariables = Exact<{
+  teamId: Scalars['UUID4'];
+  addons: Array<Scalars['String']> | Scalars['String'];
+  plan: Scalars['String'];
+}>;
+
+export type PreviewConvertToUsageBillingMutation = {
+  __typename?: 'RootMutationType';
+  previewConvertToUsageBilling: {
+    __typename?: 'InvoicePreview';
+    total: number;
+    totalExcludingTax: number | null;
+  };
+};
+
+export type ConvertToUsageBillingMutationVariables = Exact<{
+  teamId: Scalars['UUID4'];
+  addons: Array<Scalars['String']> | Scalars['String'];
+  plan: Scalars['String'];
+}>;
+
+export type ConvertToUsageBillingMutation = {
+  __typename?: 'RootMutationType';
+  convertToUsageBilling: boolean;
+};
+
 export type RecentlyDeletedPersonalSandboxesQueryVariables = Exact<{
   [key: string]: never;
 }>;

--- a/packages/app/src/app/hooks/useWorkspaceSubscription.ts
+++ b/packages/app/src/app/hooks/useWorkspaceSubscription.ts
@@ -7,6 +7,7 @@ import { useAppState } from 'app/overmind';
 import { isBefore, startOfToday } from 'date-fns';
 import { useControls } from 'leva';
 import { useWorkspaceAuthorization } from './useWorkspaceAuthorization';
+import { useWorkspaceFeatureFlags } from './useWorkspaceFeatureFlags';
 
 export enum SubscriptionDebugStatus {
   'DEFAULT' = 'Default (use API data)',
@@ -16,6 +17,7 @@ export enum SubscriptionDebugStatus {
 export const useWorkspaceSubscription = (): WorkspaceSubscriptionReturn => {
   const { activeTeamInfo, userCanStartTrial, environment } = useAppState();
   const { isBillingManager } = useWorkspaceAuthorization();
+  const { ubbBeta } = useWorkspaceFeatureFlags();
 
   const options: SubscriptionDebugStatus[] = [SubscriptionDebugStatus.DEFAULT];
 
@@ -73,6 +75,8 @@ export const useWorkspaceSubscription = (): WorkspaceSubscriptionReturn => {
   const isPaddle =
     subscription.paymentProvider === SubscriptionPaymentProvider.Paddle;
 
+  const isUbbPro = isPro && ubbBeta; // Will be replaced with a new subscription field
+
   return {
     subscription,
     isEligibleForTrial,
@@ -82,6 +86,7 @@ export const useWorkspaceSubscription = (): WorkspaceSubscriptionReturn => {
     hasExpiredTeamTrial,
     hasPaymentMethod,
     isPaddle,
+    isUbbPro,
   };
 };
 
@@ -94,6 +99,7 @@ const NO_WORKSPACE = {
   hasExpiredTeamTrial: undefined,
   hasPaymentMethod: undefined,
   isPaddle: undefined,
+  isUbbPro: undefined,
 };
 
 const NO_SUBSCRIPTION = {
@@ -104,6 +110,7 @@ const NO_SUBSCRIPTION = {
   hasExpiredTeamTrial: false,
   hasPaymentMethod: false,
   isPaddle: false,
+  isUbbPro: false,
 };
 
 export type WorkspaceSubscriptionReturn =
@@ -120,4 +127,5 @@ export type WorkspaceSubscriptionReturn =
       hasExpiredTeamTrial: boolean;
       hasPaymentMethod: boolean;
       isPaddle: boolean;
+      isUbbPro: boolean;
     };

--- a/packages/app/src/app/overmind/effects/gql/dashboard/mutations.ts
+++ b/packages/app/src/app/overmind/effects/gql/dashboard/mutations.ts
@@ -65,6 +65,10 @@ import {
   CreateBranchMutationVariables,
   SetTeamLimitsMutation,
   SetTeamLimitsMutationVariables,
+  PreviewConvertToUsageBillingMutation,
+  PreviewConvertToUsageBillingMutationVariables,
+  ConvertToUsageBillingMutation,
+  ConvertToUsageBillingMutationVariables,
 } from 'app/graphql/types';
 import { gql, Query } from 'overmind-graphql';
 
@@ -503,5 +507,38 @@ export const setTeamLimits: Query<
 export const joinUsageBillingBeta = gql`
   mutation JoinUsageBillingBeta($teamId: UUID4!) {
     joinUsageBillingBeta(teamId: $teamId)
+  }
+`;
+
+export const previewConvertToUsageBilling: Query<
+  PreviewConvertToUsageBillingMutation,
+  PreviewConvertToUsageBillingMutationVariables
+> = gql`
+  mutation PreviewConvertToUsageBilling(
+    $teamId: UUID4!
+    $addons: [String!]!
+    $plan: String!
+  ) {
+    previewConvertToUsageBilling(
+      plan: $plan
+      addons: $addons
+      teamId: $teamId
+    ) {
+      total
+      totalExcludingTax
+    }
+  }
+`;
+
+export const convertToUsageBilling: Query<
+  ConvertToUsageBillingMutation,
+  ConvertToUsageBillingMutationVariables
+> = gql`
+  mutation ConvertToUsageBilling(
+    $teamId: UUID4!
+    $addons: [String!]!
+    $plan: String!
+  ) {
+    convertToUsageBilling(plan: $plan, addons: $addons, teamId: $teamId)
   }
 `;

--- a/packages/app/src/app/overmind/namespaces/checkout/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/checkout/actions.ts
@@ -174,6 +174,10 @@ export const calculateConversionCharge = async (
       addons: actions.checkout.getFlatAddonsList(),
     });
 
+    if (!result.previewConvertToUsageBilling) {
+      return;
+    }
+
     // Cap the values to a min of 0
     state.checkout.convertProToUBBCharge = {
       total: Math.max(result.previewConvertToUsageBilling.total / 100, 0),

--- a/packages/app/src/app/overmind/namespaces/checkout/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/checkout/actions.ts
@@ -174,15 +174,14 @@ export const calculateConversionCharge = async (
       addons: actions.checkout.getFlatAddonsList(),
     });
 
-    if (!result.previewConvertToUsageBilling) {
-      return;
-    }
-
     // Cap the values to a min of 0
     state.checkout.convertProToUBBCharge = {
-      total: Math.max(result.previewConvertToUsageBilling.total / 100, 0),
+      total: Math.max(
+        (result.previewConvertToUsageBilling?.total ?? 0) / 100,
+        0
+      ),
       totalExcludingTax: Math.max(
-        result.previewConvertToUsageBilling.totalExcludingTax / 100,
+        (result.previewConvertToUsageBilling?.totalExcludingTax ?? 0) / 100,
         0
       ),
     };

--- a/packages/app/src/app/overmind/namespaces/checkout/state.ts
+++ b/packages/app/src/app/overmind/namespaces/checkout/state.ts
@@ -1,4 +1,5 @@
 import { PricingPlan } from 'app/constants';
+import { InvoicePreview } from 'app/graphql/types';
 
 export interface State {
   basePlan: PricingPlan | null;
@@ -8,6 +9,7 @@ export interface State {
   totalCredits: number;
   totalSandboxes: number;
   totalPrice: number;
+  convertProToUBBCharge: InvoicePreview | null;
 }
 
 export type Addon = CreditAddon | SandboxAddon;
@@ -45,4 +47,5 @@ export const state: State = {
   totalCredits: 0,
   totalSandboxes: 0,
   totalPrice: 0,
+  convertProToUBBCharge: null,
 };

--- a/packages/app/src/app/pages/WorkspaceFlows/CreateWorkspace.tsx
+++ b/packages/app/src/app/pages/WorkspaceFlows/CreateWorkspace.tsx
@@ -22,7 +22,7 @@ export const CreateWorkspace = () => {
 
   return (
     <WorkspaceSetup
-      steps={['create', 'plans', 'addons', 'plan-options', 'payment']}
+      steps={['create', 'plans', 'addons', 'plan-options', 'finalize']}
       onComplete={() => {
         clearFreshWorkspaceId();
         window.location.href = dashboardUrls.recent();

--- a/packages/app/src/app/pages/WorkspaceFlows/UpgradeWorkspace.tsx
+++ b/packages/app/src/app/pages/WorkspaceFlows/UpgradeWorkspace.tsx
@@ -6,9 +6,13 @@ import { useURLSearchParams } from 'app/hooks/useURLSearchParams';
 import { WorkspaceSetupStep } from 'app/components/WorkspaceSetup/types';
 import { useActions, useAppState } from 'app/overmind';
 import { signInPageUrl } from '@codesandbox/common/lib/utils/url-generator';
+import { useWorkspaceAuthorization } from 'app/hooks/useWorkspaceAuthorization';
+import { useWorkspaceSubscription } from 'app/hooks/useWorkspaceSubscription';
 
 export const UpgradeWorkspace = () => {
   const { hasLogIn } = useAppState();
+  const { isAdmin } = useWorkspaceAuthorization();
+  const { isUbbPro, isPaddle } = useWorkspaceSubscription();
   const { getQueryParam } = useURLSearchParams();
   const workspaceId = getQueryParam('workspace');
   const history = useHistory();
@@ -27,7 +31,7 @@ export const UpgradeWorkspace = () => {
       'plans',
       'addons',
       'plan-options',
-      'payment',
+      'finalize',
     ];
 
     if (!workspaceId) {
@@ -41,6 +45,11 @@ export const UpgradeWorkspace = () => {
     return (
       <Redirect to={signInPageUrl(`${location.pathname}${location.search}`)} />
     );
+  }
+
+  if (workspaceId && (isAdmin === false || isUbbPro || isPaddle)) {
+    // Page was accessed by a non-admin or for pro ubb workspaces or paddle
+    return <Redirect to={dashboardUrls.recent(workspaceId)} />;
   }
 
   return (


### PR DESCRIPTION
![image](https://github.com/codesandbox/codesandbox-client/assets/9945366/9f17322d-4fdc-419f-9610-1f7216b7382d)

To test:
* Ensure you have an old pro workspace (seat based, not flagged as ubb)
* Go to `/upgrade`, select the workspace
* Choose the pro plan, choose some addons, go over spending limit
* Last step is the accept changes now which should redirect to the portal instead of going to stripe