### PR TITLE
fix: plans options

### DIFF
--- a/packages/app/src/app/components/WorkspaceSetup/WorkspaceSetup.tsx
+++ b/packages/app/src/app/components/WorkspaceSetup/WorkspaceSetup.tsx
@@ -11,7 +11,7 @@ import { Finalize } from './steps/Finalize';
 export type WorkspaceSetupProps = {
   steps: WorkspaceSetupStep[];
   startFrom?: WorkspaceSetupStep; // when this isn't passed, first one from the array is used
-  onComplete: () => void;
+  onComplete: (fullReload?: boolean) => void;
   onDismiss: () => void;
 };
 

--- a/packages/app/src/app/components/WorkspaceSetup/types.ts
+++ b/packages/app/src/app/components/WorkspaceSetup/types.ts
@@ -11,6 +11,6 @@ export interface StepProps {
   numberOfSteps: number;
   onNextStep: () => void;
   onPrevStep: () => void;
-  onEarlyExit: () => void;
+  onEarlyExit: (fullReload?: boolean) => void;
   onDismiss: () => void;
 }

--- a/packages/app/src/app/pages/WorkspaceFlows/UpgradeWorkspace.tsx
+++ b/packages/app/src/app/pages/WorkspaceFlows/UpgradeWorkspace.tsx
@@ -55,10 +55,12 @@ export const UpgradeWorkspace = () => {
   return (
     <WorkspaceSetup
       steps={steps}
-      onComplete={() => {
-        // If the flow is actually completed with a stripe checkout
-        // the redirect is handled by stripe so this is just for early exit
-        history.push(dashboardUrls.recent(workspaceId));
+      onComplete={fullReload => {
+        if (fullReload) {
+          window.location.href = dashboardUrls.recent(workspaceId);
+        } else {
+          history.push(dashboardUrls.recent(workspaceId));
+        }
       }}
       onDismiss={() => {
         history.push(dashboardUrls.recent(workspaceId));


### PR DESCRIPTION
There were a few issues with the plans upgrade because of the complications with opting into ubb. So I cleared the paths.

Closes PC-1645

Option 1. Existing old free workspace, converting to UBB

![image](https://github.com/codesandbox/codesandbox-client/assets/9945366/847abcd7-af4e-4a82-a53a-acaba92c4ab0)

Option 2. Existing old pro workspace, converting to UBB

![Screenshot 2024-01-26 at 12 03 17](https://github.com/codesandbox/codesandbox-client/assets/9945366/90db396d-aa84-49b6-a455-5d9d86f84888)

Option 3. Existing UBB free, wanting to upgrade

![Screenshot 2024-01-26 at 12 03 41](https://github.com/codesandbox/codesandbox-client/assets/9945366/2a0e3d88-80e9-49ba-a29d-6f5f8eea0797)

Option 4. New workspace

![image](https://github.com/codesandbox/codesandbox-client/assets/9945366/a3a997c1-9785-45b2-8900-63bf4fd0dcff)
