### PR TITLE
feat: add a "Go to Dashboard" button to /s

### DIFF
--- a/packages/app/src/app/components/Create/GenericCreate.tsx
+++ b/packages/app/src/app/components/Create/GenericCreate.tsx
@@ -1,9 +1,16 @@
 import React, { useEffect } from 'react';
 
-import { Stack, Text, IconButton, Element } from '@codesandbox/components';
+import {
+  Stack,
+  Text,
+  IconButton,
+  Element,
+  Button,
+} from '@codesandbox/components';
 import track from '@codesandbox/common/lib/utils/analytics';
 import { useActions } from 'app/overmind';
 import { useWorkspaceLimits } from 'app/hooks/useWorkspaceLimits';
+
 import { Container, HeaderInformation } from './elements';
 import { LargeCTAButton } from '../dashboard/LargeCTAButton';
 import {
@@ -29,7 +36,7 @@ export const GenericCreate: React.FC<{
   return (
     <Container
       css={{
-        height: '260px',
+        height: isModal ? '260px' : '290px',
         '@media screen and (max-width: 750px)': {
           height: 'auto',
         },
@@ -132,6 +139,20 @@ export const GenericCreate: React.FC<{
           alignment="vertical"
         />
       </Element>
+
+      {!isModal && (
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'center',
+            paddingBottom: '16px',
+          }}
+        >
+          <Button css={{ width: 'fit-content' }} variant="link" to="/dashboard">
+            Go to Dashboard
+          </Button>
+        </div>
+      )}
     </Container>
   );
 };

--- a/packages/app/src/app/pages/Sandbox/Editor/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/index.tsx
@@ -276,6 +276,7 @@ export const Editor = ({ showNewSandboxModal }: EditorTypes) => {
                           width: 950,
                           position: 'relative',
                           marginTop: '-200px',
+                          borderRadius: '8px',
 
                           '@media screen and (max-width: 950)': {
                             width: 'auto',


### PR DESCRIPTION
Noticed that people can get lost when they get redirected to the "Create Sandbox" modal, with this change we do give them a way to go to the dashboard:

<img width="1438" alt="image" src="https://github.com/codesandbox/codesandbox-client/assets/587016/2c8c1670-8206-462e-9bc1-4a9b71426639">
