### PR TITLE
feat: add tracking

### DIFF
--- a/packages/app/src/app/components/WorkspaceSetup/steps/Addons.tsx
+++ b/packages/app/src/app/components/WorkspaceSetup/steps/Addons.tsx
@@ -155,6 +155,7 @@ const CreditAddonButton = ({ addon }: { addon: CreditAddon }) => {
         track('Checkout - Click on addon', {
           from: isUpgrading ? 'upgrade' : 'create-workspace',
           currentPlan: isPro ? 'pro' : 'free',
+          addonId: addon.id,
         });
         actions.checkout.addCreditsPackage(addon);
       }}

--- a/packages/app/src/app/components/WorkspaceSetup/steps/PlanOptions.tsx
+++ b/packages/app/src/app/components/WorkspaceSetup/steps/PlanOptions.tsx
@@ -1,8 +1,11 @@
 import React from 'react';
 import { Stack, Button, Text } from '@codesandbox/components';
+import track from '@codesandbox/common/lib/utils/analytics';
 import { InputText } from 'app/components/dashboard/InputText';
 import { useURLSearchParams } from 'app/hooks/useURLSearchParams';
 import { useActions, useAppState } from 'app/overmind';
+import { useWorkspaceSubscription } from 'app/hooks/useWorkspaceSubscription';
+import { useLocation } from 'react-router-dom';
 import { StepProps } from '../types';
 import { StepHeader } from '../StepHeader';
 import { AnimatedStep } from '../elements';
@@ -19,6 +22,9 @@ export const PlanOptions: React.FC<StepProps> = ({
   const { getQueryParam } = useURLSearchParams();
   const urlWorkspaceId = getQueryParam('workspace');
   const [error, setError] = React.useState<React.ReactNode>('');
+  const { isPro } = useWorkspaceSubscription();
+  const { pathname } = useLocation();
+  const isUpgrading = pathname.includes('upgrade');
 
   const handleChange = e => {
     setError('');
@@ -61,6 +67,10 @@ export const PlanOptions: React.FC<StepProps> = ({
         css={{ maxWidth: '400px' }}
         as="form"
         onSubmit={() => {
+          track('Checkout - Proceed to checkout', {
+            from: isUpgrading ? 'upgrade' : 'create-workspace',
+            currentPlan: isPro ? 'pro' : 'free',
+          });
           onNextStep();
         }}
       >

--- a/packages/app/src/app/components/WorkspaceSetup/steps/Plans.tsx
+++ b/packages/app/src/app/components/WorkspaceSetup/steps/Plans.tsx
@@ -8,6 +8,7 @@ import {
   Text,
   Tooltip,
 } from '@codesandbox/components';
+import track from '@codesandbox/common/lib/utils/analytics';
 import {
   CSB_FRIENDS_LINK,
   ORGANIZATION_CONTACT_LINK,
@@ -72,6 +73,10 @@ export const Plans: React.FC<StepProps> = ({
 
   const handleProPlanSelection = async () => {
     actions.checkout.selectPlan(UBB_PRO_PLAN);
+    track('Checkout - Select Pro Plan', {
+      from: isUpgrading ? 'upgrade' : 'create-workspace',
+      currentPlan: isFree ? 'free' : 'pro',
+    });
     onNextStep();
   };
 
@@ -117,7 +122,13 @@ export const Plans: React.FC<StepProps> = ({
                       '&:hover': { backgroundColor: '#fff' },
                     }}
                     size="large"
-                    onClick={() => onEarlyExit()}
+                    onClick={() => {
+                      track('Checkout - Select Free Plan', {
+                        from: isUpgrading ? 'upgrade' : 'create-workspace',
+                        currentPlan: isFree ? 'free' : 'pro',
+                      });
+                      onEarlyExit();
+                    }}
                   >
                     {freeButtonCTA}
                   </Button>
@@ -195,6 +206,12 @@ export const Plans: React.FC<StepProps> = ({
                 <Button
                   as="a"
                   href={ORGANIZATION_CONTACT_LINK}
+                  onClick={() => {
+                    track('Checkout - Select Enterprise Plan', {
+                      from: isUpgrading ? 'upgrade' : 'create-workspace',
+                      currentPlan: isFree ? 'free' : 'pro',
+                    });
+                  }}
                   variant="primary"
                   size="large"
                   target="_blank"


### PR DESCRIPTION
@tromika can you review this as well?

Closes PC-1670

3 events on the Plans page -> for the 3 buttons you can click

![image](https://github.com/codesandbox/codesandbox-client/assets/9945366/93b0939c-db37-44f1-8aca-69d89869f312)

2 events on the Addons page
* Click on addon
* Click on proceed

![image](https://github.com/codesandbox/codesandbox-client/assets/9945366/d7e46826-de18-4f7c-b4d8-9a48a7b2c9ae)

1 event for Proceed to checkout

![image](https://github.com/codesandbox/codesandbox-client/assets/9945366/2e26ad70-096c-4e7e-9cd5-9a9f4a247ec5)
