### PR TITLE
fix: pass on query params when redirecting to v2

### DIFF
--- a/packages/app/src/app/overmind/namespaces/editor/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/editor/actions.ts
@@ -331,6 +331,7 @@ export const sandboxChanged = withLoadApp<{
             git: githubInfoForURL,
             isV2: sandbox.v2,
             isSse: sandbox.isSse,
+            query: url.searchParams,
           },
           hasBetaEditorExperiment
         );

--- a/packages/common/src/types/index.ts
+++ b/packages/common/src/types/index.ts
@@ -780,7 +780,7 @@ export type SandboxUrlSourceData = {
   git?: GitInfo | null;
   isV2?: boolean;
   isSse?: boolean;
-  query?: Record<string, string>;
+  query?: Record<string, string> | URLSearchParams;
 };
 
 export type DevToolsTabPosition = {


### PR DESCRIPTION
Fixes https://github.com/codesandbox/codesandbox-client/issues/8299

When redirecting to v2, we were not passing on the query params. Because of this, e.g. the `file` parameter would get lost.

Tested this on the dev server inside CodeSandbox, now it's passed along.