### PR TITLE
feat: allow anonymous user to open devbox templates from /s

### DIFF
--- a/packages/app/src/app/components/Create/CreateBox.tsx
+++ b/packages/app/src/app/components/Create/CreateBox.tsx
@@ -169,6 +169,13 @@ export const CreateBox: React.FC<CreateBoxProps> = ({
     template: TemplateFragment,
     trackingSource: string
   ) => {
+    const { sandbox } = template;
+    if (!hasLogIn) {
+      // Open template in editor for anonymous users
+      window.location.href = sandboxUrl(sandbox, hasBetaEditorExperiment);
+      return;
+    }
+
     if (hasSecondStep) {
       setSelectedTemplate(template);
       setViewState('fromTemplate');

--- a/packages/app/src/app/components/Create/TemplateCard.tsx
+++ b/packages/app/src/app/components/Create/TemplateCard.tsx
@@ -3,7 +3,6 @@ import { formatNumber, Icon, Stack, Text } from '@codesandbox/components';
 import { getTemplateIcon } from '@codesandbox/common/lib/utils/getTemplateIcon';
 import { TemplateFragment } from 'app/graphql/types';
 import { VisuallyHidden } from 'reakit/VisuallyHidden';
-import { useAppState } from 'app/overmind';
 import { TemplateButton } from './elements';
 
 interface TemplateCardProps {
@@ -23,7 +22,6 @@ export const TemplateCard = ({
   padding,
   forks,
 }: TemplateCardProps) => {
-  const { isLoggedIn } = useAppState();
   const { UserIcon } = getTemplateIcon(
     template.sandbox.title,
     template.iconUrl,
@@ -47,7 +45,7 @@ export const TemplateCard = ({
           return;
         }
 
-        if (evt.metaKey || evt.ctrlKey || !isLoggedIn) {
+        if (evt.metaKey || evt.ctrlKey) {
           onOpenTemplate(template);
         } else {
           onSelectTemplate(template);

--- a/packages/app/src/app/components/Create/TemplateList.tsx
+++ b/packages/app/src/app/components/Create/TemplateList.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { Button, Text, Stack } from '@codesandbox/components';
-import { useAppState, useActions } from 'app/overmind';
+import { Text, Stack } from '@codesandbox/components';
+import { useActions } from 'app/overmind';
 import { TemplateFragment } from 'app/graphql/types';
 import track from '@codesandbox/common/lib/utils/analytics';
 import { TemplateCard } from './TemplateCard';
@@ -29,10 +29,7 @@ export const TemplateList = ({
   searchQuery,
   type,
 }: TemplateListProps) => {
-  const { hasLogIn } = useAppState();
   const actions = useActions();
-
-  const requireLogin = !hasLogIn && type === 'devbox';
 
   return (
     <Stack direction="vertical" css={{ height: '100%' }} gap={4}>
@@ -50,30 +47,11 @@ export const TemplateList = ({
         </Text>
       </Stack>
 
-      {requireLogin ? (
-        <Stack direction="vertical" gap={4}>
-          <Text id="unauthenticated-label" css={{ color: '#999999' }} size={3}>
-            You need to be signed in to fork a devbox template.
-          </Text>
-          <Button
-            aria-describedby="unauthenticated-label"
-            css={{
-              width: '132px',
-            }}
-            onClick={() => actions.signInClicked()}
-            variant="primary"
-          >
-            Sign in
-          </Button>
-        </Stack>
-      ) : null}
-
       {templates.length > 0 && (
         <TemplateGrid>
           {templates.map(template => (
             <TemplateCard
               key={template.id}
-              disabled={requireLogin}
               template={template}
               onSelectTemplate={onSelectTemplate}
               onOpenTemplate={onOpenTemplate}


### PR DESCRIPTION
We don't really have a nice variety of devboxes on stream but I removed the sign in button from the templates list and I changed the action for `selectTemplate` to open for anonymous users and fork for signed in users.

Clicking on the template opens in the same window
Cmd+click still works to open in a new tab