### PR TITLE
feat: update conditions for showing home banners

### DIFF
--- a/packages/app/src/app/graphql/types.ts
+++ b/packages/app/src/app/graphql/types.ts
@@ -378,6 +378,7 @@ export type Team = {
    */
   frozen: Scalars['Boolean'];
   id: Scalars['UUID4'];
+  insertedAt: Scalars['String'];
   invitees: Array<User>;
   inviteToken: Scalars['String'];
   /** @deprecated There's no such thing as a pilot team anymore */
@@ -4602,6 +4603,7 @@ export type TeamFragmentDashboardFragment = {
   avatarUrl: string | null;
   legacy: boolean;
   frozen: boolean;
+  insertedAt: string;
   settings: {
     __typename?: 'WorkspaceSandboxSettings';
     minimumPrivacy: number;
@@ -4651,6 +4653,7 @@ export type CurrentTeamInfoFragmentFragment = {
   avatarUrl: string | null;
   legacy: boolean;
   frozen: boolean;
+  insertedAt: string;
   users: Array<{
     __typename?: 'User';
     id: any;
@@ -4799,6 +4802,7 @@ export type _CreateTeamMutation = {
     avatarUrl: string | null;
     legacy: boolean;
     frozen: boolean;
+    insertedAt: string;
     settings: {
       __typename?: 'WorkspaceSandboxSettings';
       minimumPrivacy: number;
@@ -5160,6 +5164,7 @@ export type _AcceptTeamInvitationMutation = {
     avatarUrl: string | null;
     legacy: boolean;
     frozen: boolean;
+    insertedAt: string;
     settings: {
       __typename?: 'WorkspaceSandboxSettings';
       minimumPrivacy: number;
@@ -5243,6 +5248,7 @@ export type _SetTeamNameMutation = {
     avatarUrl: string | null;
     legacy: boolean;
     frozen: boolean;
+    insertedAt: string;
     settings: {
       __typename?: 'WorkspaceSandboxSettings';
       minimumPrivacy: number;
@@ -5850,6 +5856,7 @@ export type AllTeamsQuery = {
       avatarUrl: string | null;
       legacy: boolean;
       frozen: boolean;
+      insertedAt: string;
       settings: {
         __typename?: 'WorkspaceSandboxSettings';
         minimumPrivacy: number;
@@ -6150,6 +6157,7 @@ export type GetTeamQuery = {
       avatarUrl: string | null;
       legacy: boolean;
       frozen: boolean;
+      insertedAt: string;
       users: Array<{
         __typename?: 'User';
         id: any;

--- a/packages/app/src/app/overmind/effects/gql/dashboard/fragments.ts
+++ b/packages/app/src/app/overmind/effects/gql/dashboard/fragments.ts
@@ -125,6 +125,7 @@ export const teamFragmentDashboard = gql`
     avatarUrl
     legacy
     frozen
+    insertedAt
     settings {
       minimumPrivacy
     }
@@ -174,6 +175,7 @@ export const currentTeamInfoFragment = gql`
     avatarUrl
     legacy
     frozen
+    insertedAt
     users {
       id
       avatarUrl

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Recent/TopBanner.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Recent/TopBanner.tsx
@@ -2,27 +2,31 @@ import React from 'react';
 import { useDismissible } from 'app/hooks';
 import { useWorkspaceFeatureFlags } from 'app/hooks/useWorkspaceFeatureFlags';
 import { useWorkspaceSubscription } from 'app/hooks/useWorkspaceSubscription';
-// import { useDashboardVisit } from 'app/hooks/useDashboardVisit';
+import { useDashboardVisit } from 'app/hooks/useDashboardVisit';
 import { useAppState } from 'app/overmind';
-// import { FreeUpgradeBanner } from './Banners/FreeUpgradeBanner';
+import { FreeUpgradeBanner } from './Banners/FreeUpgradeBanner';
 import { UBBWelcomeBanner } from './Banners/UBBWelcomeBanner';
 import { LegacyProConvertBanner } from './Banners/LegacyProConvertBanner';
 
 export const TopBanner = () => {
   const { ubbBeta } = useWorkspaceFeatureFlags();
-  const { activeTeam } = useAppState();
-  const { isPro } = useWorkspaceSubscription();
-  // const { hasVisited } = useDashboardVisit();
+  const { activeTeam, activeTeamInfo } = useAppState();
+  const { isPro, isFree } = useWorkspaceSubscription();
+  const { hasVisited } = useDashboardVisit();
+  const workspaceCreatedBeforeUBBRelease =
+    new Date(activeTeamInfo.insertedAt) < new Date('2024-02-01');
 
   const [welcomeBannerDismissed, dismissWelcomeBanner] = useDismissible(
     `${activeTeam}_UBB_WELCOME`
   );
+
   const [legacyProBannerDismissed, dismissLegacyProBanner] = useDismissible(
     `${activeTeam}_LEGACY_PRO_CONVERT_BANNER`
   );
-  // const [upsellProBannerDismissed, dismissUpsellProBanner] = useDismissible(
-  //   `${activeTeam}_UPSELL_PRO_BANNER`
-  // );
+
+  const [upsellProBannerDismissed, dismissUpsellProBanner] = useDismissible(
+    `${activeTeam}_UPSELL_PRO_BANNER`
+  );
 
   if (!ubbBeta) {
     // Legacy case for seat-based Pro accounts
@@ -33,13 +37,21 @@ export const TopBanner = () => {
     return null;
   }
 
-  if (!welcomeBannerDismissed) {
+  // Workspaces created before the ubb release see the welcome banner
+  if (workspaceCreatedBeforeUBBRelease && !welcomeBannerDismissed) {
     return <UBBWelcomeBanner onDismiss={dismissWelcomeBanner} />;
   }
 
-  // if (isFree && !upsellProBannerDismissed && hasVisited) {
-  //   return <FreeUpgradeBanner onDismiss={dismissUpsellProBanner} />;
-  // }
+  // Workspaces created after the release don't see the welcome banner
+  // However, free workspaces see the upsell to pro banner after the first visit
+  if (
+    !workspaceCreatedBeforeUBBRelease &&
+    isFree &&
+    !upsellProBannerDismissed &&
+    hasVisited
+  ) {
+    return <FreeUpgradeBanner onDismiss={dismissUpsellProBanner} />;
+  }
 
   return null;
 };


### PR DESCRIPTION
After some discussions with Ed, I adjusted the logic for our 3 possible banners on the home page:

1. Welcome to UBB (only for workspaces that were created BEFORE Feb 1st)
2. Upsell Pro UBB (only for FREE workspaces created AFTER Feb 1st)
3. Convert to UBB (only for seat-based PRO workspaces)

In a few weeks, we can change the content of the welcome to ubb to a more generic welcome banner for the dashboard.