### PR TITLE
feat: redirect /s to /dashboard when signed in

### DIFF
--- a/packages/app/src/app/pages/Dashboard/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/index.tsx
@@ -77,6 +77,8 @@ export const Dashboard: FunctionComponent = () => {
       actions.modalOpened({ modal: 'createSandbox' });
     } else if (JSON.parse(searchParams.get('create_devbox'))) {
       actions.modalOpened({ modal: 'createDevbox' });
+    } else if (JSON.parse(searchParams.get('create'))) {
+      actions.modalOpened({ modal: 'genericCreate' });
     } else if (searchParams.get('preferences')) {
       const toToOpen = searchParams.get('preferences');
       actions.preferences.openPreferencesModal(toToOpen);

--- a/packages/app/src/app/pages/Sandbox/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/index.tsx
@@ -4,6 +4,7 @@ import React, { useEffect } from 'react';
 import { Helmet } from 'react-helmet';
 
 import { useBetaSandboxEditor } from 'app/hooks/useBetaSandboxEditor';
+import { Redirect } from 'react-router-dom';
 import { Editor } from './Editor';
 import { OnBoarding } from './OnBoarding';
 
@@ -96,6 +97,10 @@ export const Sandbox = React.memo<Props>(
 
       return 'Loading...';
     };
+
+    if (state.hasLogIn && showNewSandboxModal) {
+      return <Redirect to="/dashboard/recent?create=true" />;
+    }
 
     return (
       <>

--- a/packages/app/src/app/pages/index.tsx
+++ b/packages/app/src/app/pages/index.tsx
@@ -164,7 +164,7 @@ const RoutesComponent: React.FC = () => {
       <Boundary>
         <Content>
           <Switch>
-            <Route exact path="/" render={() => <Redirect to="/s" />} />
+            <Route exact path="/" render={() => <Redirect to="/dashboard" />} />
             <Route exact path="/s/github" component={GitHub} />
             <Route exact path="/s/cli" component={CliInstructions} />
             <Route
@@ -181,7 +181,6 @@ const RoutesComponent: React.FC = () => {
 
             <Route path="/phew" component={Phew} />
             <Route path="/dashboard" component={Dashboard} />
-            <Route path="/new-dashboard" component={Dashboard} />
             <Route path="/s/:id*" component={Sandbox} />
             <Route path="/live/:roomId" component={Live} />
             <Route path="/signin" exact component={SignIn} />


### PR DESCRIPTION
/s is a bit more confusing for signed in users, so it's best that the modal opens on top of the dashboard

also changed the redirect from the `/` to `/dashboard`, but this affects only local development

we don't have significant traffic on it, but it is still used to quickly create something