### PR TITLE
feat: allow only pro workspaces when moving out of current workspace

### DIFF
--- a/packages/app/src/app/components/WorkspaceSelect/WorkspaceSelect.tsx
+++ b/packages/app/src/app/components/WorkspaceSelect/WorkspaceSelect.tsx
@@ -19,10 +19,11 @@ interface WorkspaceSelectProps {
   disabled?: boolean;
   onSelect: (teamId: string) => void;
   selectedTeamId: string;
+  filterNonPro?: boolean;
 }
 
 export const WorkspaceSelect: React.FC<WorkspaceSelectProps> = React.memo(
-  ({ disabled, onSelect, selectedTeamId }) => {
+  ({ disabled, onSelect, selectedTeamId, filterNonPro }) => {
     const state = useAppState();
     const history = useHistory();
     const { dashboard } = state;
@@ -114,6 +115,11 @@ export const WorkspaceSelect: React.FC<WorkspaceSelectProps> = React.memo(
               {workspaces.map(team => {
                 const showPro =
                   team.subscription?.status === SubscriptionStatus.Active;
+
+                if (filterNonPro && team.id !== state.activeTeam && !showPro) {
+                  return null;
+                }
+
                 return (
                   <Stack
                     as={Menu.Item}

--- a/packages/app/src/app/pages/common/Modals/MoveSandboxFolderModal/index.tsx
+++ b/packages/app/src/app/pages/common/Modals/MoveSandboxFolderModal/index.tsx
@@ -94,6 +94,7 @@ export const MoveSandboxFolderModal: FunctionComponent = () => {
                   selectedTeamId={teamId}
                   disabled={preventSandboxLeaving}
                   onSelect={onWorkspaceSelect}
+                  filterNonPro
                 />
               </Element>
 


### PR DESCRIPTION
This is more of a business/product decision, but since we know some teams use this feature, should we allow moving content into other free workspaces? Could be a way to bypass restrictions, especially since we don't yet enforce a fixed number of free workspaces users can create. 

Before
![image](https://github.com/codesandbox/codesandbox-client/assets/9945366/c6d7a742-1d46-4e26-8536-8088952df11d)

After
![image](https://github.com/codesandbox/codesandbox-client/assets/9945366/07183512-286f-4669-afd1-d1e98e9a74c3)
