### PR TITLE
fix: proper fork error handling in v1 editor

### DIFF
--- a/packages/app/src/app/pages/Dashboard/Content/routes/Recent/TopBanner.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Recent/TopBanner.tsx
@@ -14,6 +14,7 @@ export const TopBanner = () => {
   const { isPro, isFree } = useWorkspaceSubscription();
   const { hasVisited } = useDashboardVisit();
   const workspaceCreatedBeforeUBBRelease =
+    activeTeamInfo?.insertedAt &&
     new Date(activeTeamInfo.insertedAt) < new Date('2024-02-01');
 
   const [welcomeBannerDismissed, dismissWelcomeBanner] = useDismissible(


### PR DESCRIPTION
While the v1 editor is not used so much anymore, this ensures the draft limit fork error is handled properly with a nice message