### PR TITLE
feat: clarify /s and create new pages as alternatives

### DIFF
--- a/packages/app/src/app/pages/Sandbox/Editor/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/index.tsx
@@ -23,6 +23,7 @@ import styled, { ThemeProvider } from 'styled-components';
 import { SubscriptionStatus } from 'app/graphql/types';
 import { UpgradeSSEToV2Stripe } from 'app/components/StripeMessages/UpgradeSSEToV2';
 import { useWorkspaceSubscription } from 'app/hooks/useWorkspaceSubscription';
+import { CreateBox } from 'app/components/Create/CreateBox';
 import { MainWorkspace as Content } from './Content';
 import { Container } from './elements';
 import ForkFrozenSandboxModal from './ForkFrozenSandboxModal';
@@ -34,7 +35,9 @@ import { Workspace } from './Workspace';
 import { CommentsAPI } from './Workspace/screens/Comments/API';
 import { FixedSignInBanner } from './FixedSignInBanner';
 
-type EditorTypes = { showNewSandboxModal?: boolean };
+type EditorTypes = {
+  showModalOnTop?: 'newSandbox' | 'newDevbox' | 'new';
+};
 
 const STATUS_BAR_SIZE = 22;
 
@@ -44,7 +47,7 @@ const StatusBar = styled.div`
   }
 `;
 
-export const Editor = ({ showNewSandboxModal }: EditorTypes) => {
+export const Editor = ({ showModalOnTop }: EditorTypes) => {
   const state = useAppState();
   const actions = useActions();
   const effects = useEffects();
@@ -220,11 +223,11 @@ export const Editor = ({ showNewSandboxModal }: EditorTypes) => {
               {state.workspace.workspaceHidden ? <div /> : <Workspace />}
               <Content theme={localState.theme} />
             </SplitPane>
-            {showSkeleton || showNewSandboxModal ? (
+            {showSkeleton || showModalOnTop ? (
               <ComponentsThemeProvider theme={localState.theme.vscodeTheme}>
                 <ContentSkeleton
                   style={
-                    state.editor.hasLoadedInitialModule && !showNewSandboxModal
+                    state.editor.hasLoadedInitialModule && !showModalOnTop
                       ? {
                           opacity: 0,
                         }
@@ -233,7 +236,7 @@ export const Editor = ({ showNewSandboxModal }: EditorTypes) => {
                         }
                   }
                 />
-                {showNewSandboxModal ? (
+                {showModalOnTop ? (
                   <Element
                     css={css({
                       width: '100vw',
@@ -271,7 +274,15 @@ export const Editor = ({ showNewSandboxModal }: EditorTypes) => {
                           },
                         })}
                       >
-                        <GenericCreate />
+                        {showModalOnTop === 'newSandbox' && (
+                          <CreateBox isModal={false} type="sandbox" />
+                        )}
+                        {showModalOnTop === 'newDevbox' && (
+                          <CreateBox isModal={false} type="devbox" />
+                        )}
+                        {showModalOnTop === 'new' && (
+                          <GenericCreate isModal={false} />
+                        )}
                       </Element>
                     </Element>
                   </Element>

--- a/packages/app/src/app/pages/Sandbox/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/index.tsx
@@ -9,7 +9,7 @@ import { Editor } from './Editor';
 import { OnBoarding } from './OnBoarding';
 
 interface Props {
-  showNewSandboxModal?: boolean;
+  showModalOnTop?: 'newSandbox' | 'newDevbox' | 'new';
   match?: {
     params: {
       id: string;
@@ -18,7 +18,7 @@ interface Props {
 }
 
 export const Sandbox = React.memo<Props>(
-  ({ match, showNewSandboxModal }) => {
+  ({ match, showModalOnTop }) => {
     const state = useAppState();
     const actions = useActions();
     const [hasBetaEditorExperiment] = useBetaSandboxEditor();
@@ -45,7 +45,7 @@ export const Sandbox = React.memo<Props>(
     }, [sandboxPageMounted]);
 
     useEffect(() => {
-      if (!showNewSandboxModal) {
+      if (!showModalOnTop) {
         if (window.screen.availWidth < 800) {
           if (!document.location.search.includes('from-embed')) {
             const addedSign = document.location.search ? '&' : '?';
@@ -72,7 +72,7 @@ export const Sandbox = React.memo<Props>(
       actions.live,
       actions.editor,
       actions.preferences,
-      showNewSandboxModal,
+      showModalOnTop,
       // eslint-disable-next-line react-hooks/exhaustive-deps
       match?.params,
     ]);
@@ -87,8 +87,10 @@ export const Sandbox = React.memo<Props>(
     const sandbox = state.editor.currentSandbox;
 
     const getTitle = () => {
-      if (showNewSandboxModal) {
-        return 'Create a new Sandbox';
+      if (showModalOnTop) {
+        return 'Create ' + showModalOnTop === 'newSandbox'
+          ? 'Sandbox'
+          : 'Devbox';
       }
 
       if (sandbox) {
@@ -98,8 +100,18 @@ export const Sandbox = React.memo<Props>(
       return 'Loading...';
     };
 
-    if (state.hasLogIn && showNewSandboxModal) {
-      return <Redirect to="/dashboard/recent?create=true" />;
+    if (state.hasLogIn) {
+      if (showModalOnTop === 'newSandbox') {
+        return <Redirect to="/dashboard/recent?create_sandbox=true" />;
+      }
+
+      if (showModalOnTop === 'newDevbox') {
+        return <Redirect to="/dashboard/recent?create_devbox=true" />;
+      }
+
+      if (showModalOnTop === 'new') {
+        return <Redirect to="/dashboard/recent?create=true" />;
+      }
     }
 
     return (
@@ -108,7 +120,7 @@ export const Sandbox = React.memo<Props>(
           <title>{getTitle()} - CodeSandbox</title>
         </Helmet>
         <OnBoarding />
-        <Editor showNewSandboxModal={showNewSandboxModal} />
+        <Editor showModalOnTop={showModalOnTop} />
       </>
     );
   },

--- a/packages/app/src/app/pages/index.tsx
+++ b/packages/app/src/app/pages/index.tsx
@@ -170,12 +170,17 @@ const RoutesComponent: React.FC = () => {
             <Route
               exact
               path="/s"
-              component={() => <Sandbox showNewSandboxModal />}
+              component={() => <Sandbox showModalOnTop="newSandbox" />}
             />
             <Route
               exact
-              path="/s2"
-              component={() => <Sandbox showNewSandboxModal />}
+              path="/d"
+              component={() => <Sandbox showModalOnTop="newDevbox" />}
+            />
+            <Route
+              exact
+              path="/new"
+              component={() => <Sandbox showModalOnTop="new" />}
             />
             <Route path="/invite/:token" component={TeamInvitation} />
 


### PR DESCRIPTION
This PR clarifies the old /s page with introducing 3 version of it.

/s -> shows directly the sandbox templates
/d -> shows directly the devbox templates
/new -> shows the generic create modal with the 3 buttons (the previous /s)

Running this on stream (not a lot of templates available)

![Screenshot 2024-02-06 at 15 52 43](https://github.com/codesandbox/codesandbox-client/assets/9945366/4132b056-8012-4ce5-88fa-31488549163e)
![image](https://github.com/codesandbox/codesandbox-client/assets/9945366/4972e889-7eb3-4cb4-8920-503ba1abfc39)
![image](https://github.com/codesandbox/codesandbox-client/assets/9945366/bfa2bbf0-f790-4ad6-a531-a0c657118dab)

Keep in mind that in all of this "shortcut" pages, there's a redirect to the dashboard for signed in users to provide better context into the current workspace where things are created