### PR TITLE
feat: standardize last access at

### DIFF
--- a/packages/app/src/app/pages/Dashboard/Components/Branch/BranchCard.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Branch/BranchCard.tsx
@@ -6,6 +6,7 @@ import {
   Text,
   InteractiveOverlay,
 } from '@codesandbox/components';
+import { shortDistance } from '@codesandbox/common/lib/utils/short-distance';
 import { BranchProps } from './types';
 import { StyledCard } from '../shared/StyledCard';
 
@@ -16,6 +17,7 @@ export const BranchCard: React.FC<BranchProps> = ({
   selected,
   onContextMenu,
   showRepo,
+  lastAccessed,
   ...props
 }) => {
   const { name: branchName, project, contribution } = branch;
@@ -74,6 +76,11 @@ export const BranchCard: React.FC<BranchProps> = ({
               />
             </Stack>
           </Stack>
+          {lastAccessed && (
+            <Text size={12} variant="muted">
+              {shortDistance(lastAccessed)}
+            </Text>
+          )}
         </Stack>
       </StyledCard>
     </InteractiveOverlay>

--- a/packages/app/src/app/pages/Dashboard/Components/Branch/BranchListItem.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Branch/BranchListItem.tsx
@@ -19,6 +19,7 @@ export const BranchListItem = ({
   selected,
   isBeingRemoved,
   onContextMenu,
+  lastAccessed,
 }: BranchProps) => {
   const { name: branchName, project, contribution } = branch;
   const { repository } = project;
@@ -97,9 +98,14 @@ export const BranchListItem = ({
               </Element>
             </Stack>
           </Column>
-          <Column span={[0, 7, 8]} as={Stack} align="center">
+          <Column span={[0, 2, 2]} as={Stack} align="center">
             <Text size={3} variant="muted" maxWidth="100%">
               {repository.owner}/{repository.name}
+            </Text>
+          </Column>
+          <Column span={[0, 5, 6]} as={Stack} align="center">
+            <Text size={3} variant="muted" maxWidth="100%">
+              {lastAccessed}
             </Text>
           </Column>
         </Grid>

--- a/packages/app/src/app/pages/Dashboard/Components/Branch/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Branch/index.tsx
@@ -3,6 +3,8 @@ import { trackImprovedDashboardEvent } from '@codesandbox/common/lib/utils/analy
 import { useAppState } from 'app/overmind';
 import { PageTypes } from 'app/overmind/namespaces/dashboard/types';
 import React from 'react';
+import { formatDistanceStrict } from 'date-fns';
+import { zonedTimeToUtc } from 'date-fns-tz';
 import { DashboardBranch } from '../../types';
 import { useSelection } from '../Selection';
 import { BranchCard } from './BranchCard';
@@ -47,6 +49,16 @@ export const Branch: React.FC<BranchProps> = ({ branch, page }) => {
     removingRepository?.owner === project.repository.owner &&
     removingRepository?.name === project.repository.name;
 
+  const lastAccessed = branch.lastAccessedAt
+    ? formatDistanceStrict(
+        zonedTimeToUtc(branch.lastAccessedAt, 'Etc/UTC'),
+        new Date(),
+        {
+          addSuffix: true,
+        }
+      )
+    : null;
+
   const props = {
     branch,
     branchUrl,
@@ -56,6 +68,7 @@ export const Branch: React.FC<BranchProps> = ({ branch, page }) => {
     onContextMenu: handleContextMenu,
     onClick: handleClick,
     showRepo: page !== 'repository-branches',
+    lastAccessed,
     /**
      * If we ever need selection for branch entries, `data-selection-id` must be set
      * 'data-selection-id': branch.id,

--- a/packages/app/src/app/pages/Dashboard/Components/Branch/types.ts
+++ b/packages/app/src/app/pages/Dashboard/Components/Branch/types.ts
@@ -8,4 +8,5 @@ export type BranchProps = {
   onContextMenu: (evt: React.MouseEvent) => void;
   onClick: (evt: React.MouseEvent) => void;
   showRepo: boolean;
+  lastAccessed: string;
 };

--- a/packages/app/src/app/pages/Dashboard/Components/Sandbox/SandboxCard.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Sandbox/SandboxCard.tsx
@@ -143,7 +143,7 @@ type SandboxStatsProps = {
 const SandboxStats: React.FC<SandboxStatsProps> = React.memo(
   ({ isFrozen, noDrag, lastUpdated, PrivacyIcon, sandbox, restricted }) => {
     const boxType = sandbox.isV2 ? 'devbox' : 'sandbox';
-
+    console.log(lastUpdated);
     const lastUpdatedText = (
       <Text key="last-updated" size={12} truncate>
         {shortDistance(lastUpdated)}

--- a/packages/app/src/app/pages/Dashboard/Components/Sandbox/SandboxCard.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Sandbox/SandboxCard.tsx
@@ -138,15 +138,14 @@ type SandboxStatsProps = {
   isFrozen?: boolean;
 } & Pick<
   SandboxItemComponentProps,
-  'noDrag' | 'lastUpdated' | 'PrivacyIcon' | 'sandbox' | 'restricted'
+  'noDrag' | 'timeAgo' | 'PrivacyIcon' | 'sandbox' | 'restricted'
 >;
 const SandboxStats: React.FC<SandboxStatsProps> = React.memo(
-  ({ isFrozen, noDrag, lastUpdated, PrivacyIcon, sandbox, restricted }) => {
+  ({ isFrozen, noDrag, timeAgo, PrivacyIcon, sandbox, restricted }) => {
     const boxType = sandbox.isV2 ? 'devbox' : 'sandbox';
-    console.log(lastUpdated);
-    const lastUpdatedText = (
-      <Text key="last-updated" size={12} truncate>
-        {shortDistance(lastUpdated)}
+    const timeAgoText = (
+      <Text size={12} truncate>
+        {shortDistance(timeAgo)}
       </Text>
     );
 
@@ -165,7 +164,7 @@ const SandboxStats: React.FC<SandboxStatsProps> = React.memo(
           {isFrozen && (
             <Icon size={16} title={`Protected ${boxType}`} name="frozen" />
           )}
-          {noDrag ? null : lastUpdatedText}
+          {noDrag ? null : timeAgoText}
         </Stack>
         <SandboxBadge sandbox={sandbox} restricted={restricted} />
       </Stack>
@@ -176,7 +175,7 @@ const SandboxStats: React.FC<SandboxStatsProps> = React.memo(
 export const SandboxCard = ({
   sandbox,
   noDrag,
-  lastUpdated,
+  timeAgo,
   PrivacyIcon,
   screenshotUrl,
   restricted,
@@ -283,7 +282,7 @@ export const SandboxCard = ({
           <SandboxTitle brightness={thumbnail.brightness} {...props} />
           <SandboxStats
             noDrag={noDrag}
-            lastUpdated={lastUpdated}
+            timeAgo={timeAgo}
             isFrozen={sandbox.isFrozen && !sandbox.customTemplate}
             PrivacyIcon={PrivacyIcon}
             restricted={restricted}

--- a/packages/app/src/app/pages/Dashboard/Components/Sandbox/SandboxListItem.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Sandbox/SandboxListItem.tsx
@@ -174,9 +174,6 @@ export const SandboxListItem = ({
               variant={selected ? 'body' : 'muted'}
               maxWidth="100%"
             >
-              <Text css={css({ display: ['none', 'none', 'inline'] })}>
-                updated
-              </Text>{' '}
               {lastUpdated}
             </Text>
           )}

--- a/packages/app/src/app/pages/Dashboard/Components/Sandbox/SandboxListItem.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Sandbox/SandboxListItem.tsx
@@ -19,7 +19,7 @@ export const SandboxListItem = ({
   sandbox,
   sandboxTitle,
   sandboxLocation,
-  lastUpdated,
+  timeAgo,
   viewCount,
   TemplateIcon,
   PrivacyIcon,
@@ -174,7 +174,7 @@ export const SandboxListItem = ({
               variant={selected ? 'body' : 'muted'}
               maxWidth="100%"
             >
-              {lastUpdated}
+              {timeAgo}
             </Text>
           )}
         </Column>

--- a/packages/app/src/app/pages/Dashboard/Components/Sandbox/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Sandbox/index.tsx
@@ -76,9 +76,11 @@ const GenericSandbox = ({ isScrolling, item, page }: GenericSandboxProps) => {
   const sandboxTitle = sandbox.title || sandbox.alias || sandbox.id;
 
   const sandboxLocation = getFolderName(item);
+  const timeStampToUse =
+    page === 'recent' ? sandbox.lastAccessedAt : sandbox.updatedAt;
 
-  const lastUpdated = formatDistanceStrict(
-    zonedTimeToUtc(sandbox.updatedAt, 'Etc/UTC'),
+  const timeAgo = formatDistanceStrict(
+    zonedTimeToUtc(timeStampToUse, 'Etc/UTC'),
     new Date(),
     {
       addSuffix: true,
@@ -262,7 +264,7 @@ const GenericSandbox = ({ isScrolling, item, page }: GenericSandboxProps) => {
     noDrag,
     sandboxTitle,
     sandboxLocation,
-    lastUpdated,
+    timeAgo,
     viewCount,
     sandbox,
     TemplateIcon,

--- a/packages/app/src/app/pages/Dashboard/Components/Sandbox/types.ts
+++ b/packages/app/src/app/pages/Dashboard/Components/Sandbox/types.ts
@@ -5,7 +5,7 @@ export interface SandboxItemComponentProps {
   sandbox: DashboardSandbox['sandbox'] | DashboardTemplate['sandbox'];
   sandboxTitle: string;
   sandboxLocation?: string;
-  lastUpdated: string;
+  timeAgo: string;
   viewCount: number | string;
   TemplateIcon: React.FC<{
     width: string;


### PR DESCRIPTION
Shows `lastAccessedAt` for branches and sandboxes for the current user on the recent page

![image](https://github.com/codesandbox/codesandbox-client/assets/9945366/1abbc018-5d65-428e-8b39-92be46f0c664)

Shows `lastAccessedAt` for branches on the branch list page

![image](https://github.com/codesandbox/codesandbox-client/assets/9945366/40602cf9-c4bf-4f83-9131-66b16e816735)


Shows `lastUpdatedAt` for sandboxes on all other pages (as before)

![image](https://github.com/codesandbox/codesandbox-client/assets/9945366/2b393c04-6541-4bc7-b52c-f663def5e046)
