### PR TITLE
feat: fetch repositories for sidebar

### DIFF
--- a/packages/app/src/app/graphql/types.ts
+++ b/packages/app/src/app/graphql/types.ts
@@ -6587,6 +6587,11 @@ export type SidebarTemplateFragmentFragment = {
   id: any | null;
 };
 
+export type SidebarProjectFragmentFragment = {
+  __typename?: 'Project';
+  repository: { __typename?: 'GitHubRepository'; name: string; owner: string };
+};
+
 export type TeamSidebarDataQueryVariables = Exact<{
   id: Scalars['UUID4'];
 }>;
@@ -6599,6 +6604,14 @@ export type TeamSidebarDataQuery = {
       __typename?: 'Team';
       sandboxes: Array<{ __typename?: 'Sandbox'; id: string }>;
       templates: Array<{ __typename?: 'Template'; id: any | null }>;
+      projects: Array<{
+        __typename?: 'Project';
+        repository: {
+          __typename?: 'GitHubRepository';
+          name: string;
+          owner: string;
+        };
+      }>;
     } | null;
   } | null;
 };

--- a/packages/app/src/app/overmind/effects/gql/sidebar/fragments.ts
+++ b/packages/app/src/app/overmind/effects/gql/sidebar/fragments.ts
@@ -11,3 +11,14 @@ export const sidebarTemplateFragment = gql`
     id
   }
 `;
+
+export const sidebarProjectFragment = gql`
+  fragment sidebarProjectFragment on Project {
+    repository {
+      ... on GitHubRepository {
+        name
+        owner
+      }
+    }
+  }
+`;

--- a/packages/app/src/app/overmind/effects/gql/sidebar/queries.ts
+++ b/packages/app/src/app/overmind/effects/gql/sidebar/queries.ts
@@ -6,6 +6,7 @@ import {
 } from 'app/graphql/types';
 
 import {
+  sidebarProjectFragment,
   sidebarSyncedSandboxFragment,
   sidebarTemplateFragment,
 } from './fragments';
@@ -23,9 +24,13 @@ export const getTeamSidebarData: Query<
         templates {
           ...sidebarTemplateFragment
         }
+        projects(syncData: false) {
+          ...sidebarProjectFragment
+        }
       }
     }
   }
   ${sidebarSyncedSandboxFragment}
   ${sidebarTemplateFragment}
+  ${sidebarProjectFragment}
 `;

--- a/packages/app/src/app/overmind/namespaces/dashboard/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/dashboard/actions.ts
@@ -1672,7 +1672,7 @@ export const removeRepositoryFromTeam = async (
   { actions, state, effects }: Context,
   { project, page }: RemoveRepositoryParams
 ) => {
-  const { activeTeam, dashboard } = state;
+  const { activeTeam, dashboard, sidebar } = state;
   if (!activeTeam) {
     return;
   }
@@ -1710,6 +1710,7 @@ export const removeRepositoryFromTeam = async (
     // 1. From repositories list
     // 2. From repository with branches cache
     // 3. Branches from recent page
+    // 4. From sidebar list
 
     const teamRepositories = dashboard.repositoriesByTeamId[activeTeam];
     if (teamRepositories) {
@@ -1736,6 +1737,10 @@ export const removeRepositoryFromTeam = async (
 
         return branchRepo.owner === owner && branchRepo.name === name;
       }) ?? [];
+
+    sidebar.repositories = sidebar.repositories.filter(
+      r => r.owner !== owner || r.name !== name
+    );
 
     // Refetch start page data in the background to fill the remaining slots
     if (page === 'recent') {

--- a/packages/app/src/app/overmind/namespaces/sidebar/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/sidebar/actions.ts
@@ -16,6 +16,11 @@ export const getSidebarData = async (
 
     const sandboxes = result.me?.team?.sandboxes || null;
     const templates = result.me?.team?.templates || null;
+    const repositories =
+      result.me?.team?.projects?.map(p => ({
+        owner: p.repository.owner,
+        name: p.repository.name,
+      })) || [];
 
     const hasSyncedSandboxes = sandboxes && sandboxes.length > 0;
     const hasTemplates = templates && templates.length > 0;
@@ -23,6 +28,7 @@ export const getSidebarData = async (
     state.sidebar = {
       hasSyncedSandboxes,
       hasTemplates,
+      repositories,
     };
   } catch {
     effects.notificationToast.error(

--- a/packages/app/src/app/overmind/namespaces/sidebar/state.ts
+++ b/packages/app/src/app/overmind/namespaces/sidebar/state.ts
@@ -7,6 +7,7 @@
 export interface State {
   hasSyncedSandboxes: boolean | null;
   hasTemplates: boolean | null;
+  repositories: Array<{ name: string; owner: string }>;
 }
 
 /**
@@ -15,4 +16,5 @@ export interface State {
 export const state: State = {
   hasSyncedSandboxes: null,
   hasTemplates: null,
+  repositories: [],
 };

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Repositories/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Repositories/index.tsx
@@ -46,7 +46,11 @@ export const RepositoriesPage = () => {
       return [{ type: 'skeleton-row' }, { type: 'skeleton-row' }];
     }
 
-    const repoItems: DashboardGridItem[] = teamRepos.map(repository => ({
+    const orderedRepos = [...teamRepos].sort((a, b) =>
+      a.repository.name.toLowerCase() < b.repository.name.toLowerCase() ? -1 : 1
+    );
+
+    const repoItems: DashboardGridItem[] = orderedRepos.map(repository => ({
       type: 'repository' as const,
       repository,
     }));

--- a/packages/app/src/app/pages/Dashboard/Content/routes/RepositoryBranches/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/RepositoryBranches/index.tsx
@@ -46,7 +46,7 @@ export const RepositoryBranchesPage = () => {
         name,
       });
     }
-  }, [activeTeam]);
+  }, [activeTeam, owner, name]);
 
   const pageType: PageTypes = 'repository-branches';
 

--- a/packages/app/src/app/pages/Dashboard/Sidebar/ExpandableReposRowItem.tsx
+++ b/packages/app/src/app/pages/Dashboard/Sidebar/ExpandableReposRowItem.tsx
@@ -11,10 +11,14 @@ import {
   Link,
   Stack,
 } from '@codesandbox/components';
+import { useGlobalPersistedState } from 'app/hooks/usePersistedState';
 import { RowItem } from './RowItem';
 
 export const ExpandableReposRowItem = () => {
-  const [isExpanded, setIsExpanded] = useState(false);
+  const [isExpanded, setIsExpanded] = useGlobalPersistedState(
+    'SIDEBAR_REPOS_EXPANDED',
+    false
+  );
   const { activeTeam, sidebar } = useAppState();
 
   return (

--- a/packages/app/src/app/pages/Dashboard/Sidebar/ExpandableReposRowItem.tsx
+++ b/packages/app/src/app/pages/Dashboard/Sidebar/ExpandableReposRowItem.tsx
@@ -1,0 +1,95 @@
+import React, { useState } from 'react';
+import { dashboard as dashboardUrls } from '@codesandbox/common/lib/utils/url-generator';
+import { AnimatePresence, motion } from 'framer-motion';
+import { orderBy } from 'lodash-es';
+import { Link as RouterLink } from 'react-router-dom';
+import { useAppState } from 'app/overmind';
+import {
+  Element,
+  Icon,
+  IconButton,
+  Link,
+  Stack,
+} from '@codesandbox/components';
+import { RowItem } from './RowItem';
+
+export const ExpandableReposRowItem = () => {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const { activeTeam, sidebar } = useAppState();
+
+  return (
+    <>
+      <RowItem
+        name="All repositories"
+        page="repositories"
+        path={dashboardUrls.repositories(activeTeam)}
+        icon="repository"
+      >
+        <Stack css={{ width: '100%', height: '100%' }}>
+          {sidebar.repositories.length > 0 ? (
+            <IconButton
+              name="caret"
+              size={8}
+              title="Toggle repositories"
+              onClick={event => {
+                setIsExpanded(!isExpanded);
+                event.stopPropagation();
+              }}
+              css={{
+                width: '16px',
+                height: '100%',
+                borderRadius: 0,
+                svg: {
+                  transform: isExpanded ? 'rotate(0deg)' : 'rotate(-90deg)',
+                  transition: 'transform 100ms ease-in-out',
+                },
+              }}
+            />
+          ) : (
+            <Element as="span" css={{ width: '16px', flexShrink: 0 }} />
+          )}
+          <Link
+            as={RouterLink}
+            css={{
+              display: 'flex',
+              flexGrow: 1,
+              padding: '10px 4px',
+              lineHeight: '16px',
+              textDecoration: 'none',
+              color: 'inherit',
+            }}
+            to={dashboardUrls.repositories(activeTeam)}
+          >
+            <Icon name="repository" size={16} css={{ marginRight: '8px' }} />
+            All repositories
+          </Link>
+        </Stack>
+      </RowItem>
+      <AnimatePresence>
+        {isExpanded && (
+          <motion.ul
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: 'auto', opacity: 1 }}
+            transition={{ duration: 0.2 }}
+            exit={{ height: 0, opacity: 0, transition: { duration: 0.15 } }}
+            style={{ paddingLeft: 0 }}
+          >
+            {orderBy(
+              sidebar.repositories,
+              repo => repo.name.toLowerCase(),
+              'asc'
+            ).map(repo => (
+              <RowItem
+                name={repo.name}
+                page="repositories"
+                path={dashboardUrls.repository(repo)}
+                icon="branch"
+                nestingLevel={1}
+              />
+            ))}
+          </motion.ul>
+        )}
+      </AnimatePresence>
+    </>
+  );
+};

--- a/packages/app/src/app/pages/Dashboard/Sidebar/ExpandableReposRowItem.tsx
+++ b/packages/app/src/app/pages/Dashboard/Sidebar/ExpandableReposRowItem.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { dashboard as dashboardUrls } from '@codesandbox/common/lib/utils/url-generator';
 import { AnimatePresence, motion } from 'framer-motion';
 import { orderBy } from 'lodash-es';

--- a/packages/app/src/app/pages/Dashboard/Sidebar/RowItem.tsx
+++ b/packages/app/src/app/pages/Dashboard/Sidebar/RowItem.tsx
@@ -175,10 +175,18 @@ export const RowItem: React.FC<RowItemProps> = ({
               return false;
             },
           }}
+          truncate
+          title={`Open ${name}`}
         >
           <Stack
             as="span"
-            css={{ width: '36px', paddingLeft: '8px', paddingRight: '4px' }}
+            css={{
+              width: '36px',
+              paddingLeft: '8px',
+              paddingRight: '4px',
+              flexShrink: 0,
+              overflow: 'hidden',
+            }}
             align="center"
             justify="center"
           >

--- a/packages/app/src/app/pages/Dashboard/Sidebar/RowItem.tsx
+++ b/packages/app/src/app/pages/Dashboard/Sidebar/RowItem.tsx
@@ -4,6 +4,7 @@ import {
   SidebarListAction,
   Stack,
   Icon,
+  Text,
 } from '@codesandbox/components';
 import { PageTypes } from 'app/overmind/namespaces/dashboard/types';
 import React from 'react';
@@ -175,7 +176,6 @@ export const RowItem: React.FC<RowItemProps> = ({
               return false;
             },
           }}
-          truncate
           title={`Open ${name}`}
         >
           <Stack
@@ -192,7 +192,7 @@ export const RowItem: React.FC<RowItemProps> = ({
           >
             <Icon name={icon} />
           </Stack>
-          {name}
+          <Text truncate>{name}</Text>
         </Link>
       )}
     </SidebarListAction>

--- a/packages/app/src/app/pages/Dashboard/Sidebar/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Sidebar/index.tsx
@@ -15,6 +15,7 @@ import { SIDEBAR_WIDTH } from './constants';
 import { SidebarContext } from './utils';
 import { RowItem } from './RowItem';
 import { NestableRowItem } from './NestableRowItem';
+import { ExpandableReposRowItem } from './ExpandableReposRowItem';
 
 interface SidebarProps {
   visible: boolean;
@@ -36,7 +37,6 @@ export const Sidebar: React.FC<SidebarProps> = ({
   React.useEffect(() => {
     // Used to fetch collections
     actions.dashboard.getAllFolders();
-    actions.dashboard.getStarredRepos();
   }, [state.activeTeam]);
 
   React.useEffect(() => {
@@ -194,21 +194,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
                 />
               )}
 
-              <RowItem
-                name="All repositories"
-                page="repositories"
-                path={dashboardUrls.repositories(activeTeam)}
-                icon="repository"
-              />
-              {dashboard.starredRepos.map(repo => (
-                <RowItem
-                  name={repo.name}
-                  page="repositories"
-                  path={dashboardUrls.repository(repo)}
-                  icon="star"
-                  nestingLevel={1}
-                />
-              ))}
+              <ExpandableReposRowItem />
             </>
           )}
 


### PR DESCRIPTION
![image](https://github.com/codesandbox/codesandbox-client/assets/9945366/b8ac26d4-e136-4e4c-8b46-1a74d4047847)

Core feature:
- show all repos under `All repositories`
- repos are ordered by name alphabetically
- the expanded state is persisted in local storage

Other fixes:
- switching from one repo to another triggers the data fetching
- repos shown alphabetically in list