### PR TITLE
fix: create branch with cmd+click

### DIFF
--- a/packages/app/src/app/overmind/namespaces/dashboard/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/dashboard/actions.ts
@@ -1882,6 +1882,8 @@ export const createDraftBranch = async (
       title: 'Failed to create branch',
       status: NotificationStatus.ERROR,
     });
+  } finally {
+    state.dashboard.creatingBranch = false;
   }
 };
 


### PR DESCRIPTION
Ok, this was lacking a flag cleanup, so a secondary cmd+click on the create branch was not doing anything