### PR TITLE
fix: ensure cards are always rendered on recent page

### DIFF
--- a/packages/app/src/app/pages/Dashboard/Components/Branch/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Branch/index.tsx
@@ -21,11 +21,15 @@ type BranchProps = DashboardBranch & {
   page: PageTypes;
 };
 export const Branch: React.FC<BranchProps> = ({ branch, page }) => {
-  const {
-    dashboard: { removingBranch, removingRepository, viewMode },
-  } = useAppState();
+  const { dashboard } = useAppState();
   const { selectedIds, onRightClick, onMenuEvent } = useSelection();
   const { name, project } = branch;
+  const { removingBranch, removingRepository } = dashboard;
+  let viewMode = dashboard.viewMode;
+
+  if (page === 'recent') {
+    viewMode = 'grid';
+  }
 
   const branchUrl = v2BranchUrl({
     owner: project.repository.owner,

--- a/packages/app/src/app/pages/Dashboard/Components/Sandbox/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Sandbox/index.tsx
@@ -124,6 +124,10 @@ const GenericSandbox = ({ isScrolling, item, page }: GenericSandboxProps) => {
     viewMode = 'list';
   }
 
+  if (page === 'recent') {
+    viewMode = 'grid';
+  }
+
   const Component: React.FC<SandboxItemComponentProps> =
     viewMode === 'list' ? SandboxListItem : SandboxCard;
 


### PR DESCRIPTION
There was a regression because I removed the list/grid toggle on the recent items on Friday