### PR TITLE
fix: adjust spacing for notifications

### DIFF
--- a/packages/app/src/app/components/Notifications/Content.tsx
+++ b/packages/app/src/app/components/Notifications/Content.tsx
@@ -285,7 +285,7 @@ export const NotificationsContent = props => {
       {...props}
     >
       <Stack
-        css={{ padding: '12px 16px' }}
+        css={{ padding: '12px 10px 12px 16px' }}
         align="center"
         justify="space-between"
       >

--- a/packages/app/src/app/components/Notifications/index.tsx
+++ b/packages/app/src/app/components/Notifications/index.tsx
@@ -36,32 +36,25 @@ export const Notifications = ({ dashboard }: { dashboard?: boolean }) => {
         >
           <Button
             variant={dashboard ? 'ghost' : 'secondary'}
-            css={css({
-              ':hover .border-for-bell': {
-                background: theme =>
-                  theme.colors.secondaryButton.hoverBackground,
-              },
-            })}
+            css={{ position: 'relative' }}
             onClick={open}
           >
-            <Element css={{ position: 'relative' }}>
-              <Icon name="bell" size={16} title="Notifications" />
-              {unreadCount > 0 ? (
-                <Element
-                  css={css({
-                    width: '8px',
-                    height: '8px',
-                    borderRadius: '50%',
-                    backgroundColor: '#E4FC82',
-                    position: 'absolute',
-                    zIndex: 10,
-                    color: '#000',
-                    top: '-3px',
-                    right: '-6px',
-                  })}
-                />
-              ) : null}
-            </Element>
+            <Icon name="bell" size={16} title="Notifications" />
+            {unreadCount > 0 ? (
+              <Element
+                css={css({
+                  width: '8px',
+                  height: '8px',
+                  borderRadius: '50%',
+                  backgroundColor: '#E4FC82',
+                  position: 'absolute',
+                  zIndex: 10,
+                  color: '#000',
+                  top: '3px',
+                  right: '3px',
+                })}
+              />
+            ) : null}
           </Button>
         </Tooltip>
       )}


### PR DESCRIPTION
The more (dots) button aligned with the notification items
![image](https://github.com/codesandbox/codesandbox-client/assets/9945366/93af5808-05c3-4eac-b451-e07ff8e5165f)

The notification bell itself + the dot better aligned with the header
![Screenshot 2024-02-20 at 14 28 11](https://github.com/codesandbox/codesandbox-client/assets/9945366/83b3d436-8b77-454a-9a66-fdd27513fe7c)
