### PR TITLE
chore: add tracking for requesting repo access

### DIFF
--- a/packages/app/src/app/components/Create/ImportRepository/AuthorizeForSuggested.tsx
+++ b/packages/app/src/app/components/Create/ImportRepository/AuthorizeForSuggested.tsx
@@ -2,9 +2,14 @@ import React from 'react';
 
 import { Stack, Text, Icon, Button, Element } from '@codesandbox/components';
 import { useActions } from 'app/overmind';
+import track from '@codesandbox/common/lib/utils/analytics';
 
 export const AuthorizeForSuggested = () => {
   const { signInGithubClicked } = useActions();
+
+  React.useEffect(() => {
+    track('Import Repo - Ask for private repo access');
+  }, []);
 
   return (
     <Stack gap={2} align="center">

--- a/packages/app/src/app/overmind/internalActions.ts
+++ b/packages/app/src/app/overmind/internalActions.ts
@@ -75,6 +75,7 @@ export const signIn = async (
 ) => {
   effects.analytics.track('Sign In', {
     provider: options.provider,
+    scope: options.provider === 'github' ? options.includedScopes : '',
   });
   try {
     await actions.internal.runProviderAuth(options);

--- a/packages/app/src/app/pages/Dashboard/Components/shared/RestrictedPublicReposImport.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/shared/RestrictedPublicReposImport.tsx
@@ -1,12 +1,17 @@
 import { MessageStripe } from '@codesandbox/components';
 import { useActions, useAppState } from 'app/overmind';
 import React from 'react';
+import track from '@codesandbox/common/lib/utils/analytics';
 
 export const RestrictedPublicReposImport: React.FC<{
   onDismiss?: () => void;
 }> = ({ onDismiss }) => {
   const { signInGithubClicked } = useActions();
   const { isLoadingGithub } = useAppState();
+
+  React.useEffect(() => {
+    track('Import Repo - Ask for public & private repo access');
+  }, []);
 
   return (
     <MessageStripe


### PR DESCRIPTION
Minor PR that will give us more insight into the drop-off rate of users when asked to sign in for repo access