### PR TITLE
fix: redirect to workspace after invitation accepted

### DIFF
--- a/packages/app/src/app/overmind/actions.ts
+++ b/packages/app/src/app/overmind/actions.ts
@@ -502,8 +502,6 @@ export const acceptTeamInvitation = (
   effects.analytics.track('Team - Invitation Accepted', {});
 
   actions.internal.trackCurrentTeams();
-
-  effects.notificationToast.success(`Accepted invitation to ${teamName}`);
 };
 
 export const rejectTeamInvitation = (

--- a/packages/app/src/app/pages/TeamInvitation/TeamInvitation.tsx
+++ b/packages/app/src/app/pages/TeamInvitation/TeamInvitation.tsx
@@ -109,7 +109,7 @@ const TeamSignIn = ({ inviteToken }: { inviteToken: string }) => {
         <title>
           {data
             ? `Join ${data.teamByToken.name} on CodeSandbox`
-            : 'Join team on CodeSandbox'}
+            : 'Join workspace on CodeSandbox'}
         </title>
       </Helmet>
 
@@ -165,11 +165,11 @@ const JoinTeam = ({ inviteToken }: { inviteToken: string }) => {
   }
 
   if (loading || !team?.id) {
-    return <Text size={6}>Joining Team...</Text>;
+    return <Text size={6}>Joining workspace...</Text>;
   }
 
   // Ensure all endpoints for new team are fetched
-  window.location.href = dashboard.recent(team.id);
+  window.location.href = dashboard.recent(team.id, { new_join: 'true' });
   return null;
 };
 

--- a/packages/app/src/app/pages/WorkspaceFlows/CreateWorkspace.tsx
+++ b/packages/app/src/app/pages/WorkspaceFlows/CreateWorkspace.tsx
@@ -9,6 +9,7 @@ import { signInPageUrl } from '@codesandbox/common/lib/utils/url-generator';
 
 export const CreateWorkspace = () => {
   const actions = useActions();
+  const { activeTeam } = useAppState();
   const [freshWorkspaceId, , clearFreshWorkspaceId] = useGlobalPersistedState<
     string
   >('FRESH_WORKSPACE_ID', undefined);
@@ -26,7 +27,9 @@ export const CreateWorkspace = () => {
       steps={['create', 'plans', 'addons', 'spending-limit', 'finalize']}
       onComplete={() => {
         clearFreshWorkspaceId();
-        window.location.href = dashboardUrls.recent();
+        window.location.href = dashboardUrls.recent(activeTeam, {
+          new_workspace: 'true',
+        });
       }}
       onDismiss={() => {
         if (freshWorkspaceId) {

--- a/packages/app/src/app/pages/common/Modals/TeamInviteModal/index.tsx
+++ b/packages/app/src/app/pages/common/Modals/TeamInviteModal/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { teamOverviewUrl } from '@codesandbox/common/lib/utils/url-generator';
+import { recent } from '@codesandbox/common/lib/utils/url-generator/dashboard';
 import { useAppState, useActions } from 'app/overmind';
 import {
   REJECT_TEAM_INVITATION,
@@ -29,8 +29,7 @@ export const TeamInviteModal = () => {
     },
     onCompleted: () => {
       acceptTeamInvitation({ teamName, teamId });
-      modalClosed();
-      history.push(teamOverviewUrl(teamId));
+      window.location.href = recent(teamId, { new_join: 'true' });
     },
   });
   const [

--- a/packages/app/src/app/pages/common/Modals/TeamInviteModal/index.tsx
+++ b/packages/app/src/app/pages/common/Modals/TeamInviteModal/index.tsx
@@ -5,7 +5,6 @@ import {
   REJECT_TEAM_INVITATION,
   ACCEPT_TEAM_INVITATION,
 } from 'app/pages/Dashboard/queries';
-import history from 'app/utils/history';
 import { Element, Button, Text, Stack } from '@codesandbox/components';
 import { useMutation } from '@apollo/react-hooks';
 import { TeamAvatar } from 'app/components/TeamAvatar';


### PR DESCRIPTION
Noticed a bug yesterday on the stream, as accepted invitations were not redirecting you to the actual workspace.
Also added a query param for future welcome banners