### PR TITLE
feat: add vm tier setting when creating a devbox

### DIFF
--- a/packages/app/src/app/components/Create/CreateBox.tsx
+++ b/packages/app/src/app/components/Create/CreateBox.tsx
@@ -129,16 +129,18 @@ export const CreateBox: React.FC<CreateBoxProps> = ({
 
   const createFromTemplate = (
     template: TemplateFragment,
-    { name, createAs, permission, editor }: CreateParams
+    { name, createAs, permission, editor, customVMTier }: CreateParams
   ) => {
     const { sandbox } = template;
     const openInVSCode = editor === 'vscode';
 
     track(`Create ${type} - Create`, {
       type: 'fork',
+      title: name,
       template_name:
         template.sandbox.title || template.sandbox.alias || template.sandbox.id,
       open_in_editor: editor,
+      ...(customVMTier ? { vm_tier: customVMTier } : {}),
     });
 
     actions.editor.forkExternalSandbox({
@@ -147,6 +149,7 @@ export const CreateBox: React.FC<CreateBoxProps> = ({
       openInVSCode,
       autoLaunchVSCode,
       hasBetaEditorExperiment,
+      customVMTier,
       body: {
         title: name,
         collectionId,

--- a/packages/app/src/app/components/Create/utils/types.ts
+++ b/packages/app/src/app/components/Create/utils/types.ts
@@ -5,6 +5,7 @@ export type CreateParams = {
   createAs: 'devbox' | 'sandbox';
   permission: 0 | 1 | 2;
   editor: 'csb' | 'vscode';
+  customVMTier?: number;
 };
 
 export interface TemplateCollection {

--- a/packages/app/src/app/graphql/types.ts
+++ b/packages/app/src/app/graphql/types.ts
@@ -2059,6 +2059,12 @@ export type RootMutationType = {
    */
   updateProjectSettings: ProjectSettings;
   /**
+   * Update the VM tier of a project. All branches will start using this new VM tier as soon as the user connects
+   * to the branch (also for running branches). To optimistically update a branch without reload/reconnect,
+   * you can pass a branch ID as well that we'll update immediately.
+   */
+  updateProjectVmTier: Resources;
+  /**
    * Update the settings for a sandbox. All settings are nullable.
    * Not passing a specific argument will leave it unchanged, explicitly passing `null` will revert it to the default.
    */
@@ -2621,6 +2627,12 @@ export type RootMutationTypeUpdateNotificationReadStatusArgs = {
 export type RootMutationTypeUpdateProjectSettingsArgs = {
   aiConsent: InputMaybe<Scalars['Boolean']>;
   projectId: Scalars['UUID4'];
+};
+
+export type RootMutationTypeUpdateProjectVmTierArgs = {
+  branchId: InputMaybe<Scalars['String']>;
+  projectId: Scalars['UUID4'];
+  vmTier: Scalars['Int'];
 };
 
 export type RootMutationTypeUpdateSandboxSettingsArgs = {
@@ -4719,6 +4731,7 @@ export type CurrentTeamInfoFragmentFragment = {
     includedCredits: number;
     includedSandboxes: number;
     includedDrafts: number;
+    includedVmTier: number;
     onDemandCreditLimit: number | null;
   };
   usage: { __typename?: 'TeamUsage'; sandboxes: number; credits: number };
@@ -6127,6 +6140,7 @@ export type GetTeamQuery = {
         includedCredits: number;
         includedSandboxes: number;
         includedDrafts: number;
+        includedVmTier: number;
         onDemandCreditLimit: number | null;
       };
       usage: { __typename?: 'TeamUsage'; sandboxes: number; credits: number };

--- a/packages/app/src/app/hooks/useWorkspaceLimits.ts
+++ b/packages/app/src/app/hooks/useWorkspaceLimits.ts
@@ -20,6 +20,7 @@ export const useWorkspaceLimits = (): WorkspaceLimitsReturn => {
       isFrozen: undefined,
       hasReachedSandboxLimit: undefined,
       hasReachedDraftLimit: undefined,
+      highestAllowedVMTier: undefined,
     };
   }
 
@@ -49,7 +50,11 @@ export const useWorkspaceLimits = (): WorkspaceLimitsReturn => {
   const userDrafts =
     userAuthorizations.find(ua => ua.userId === user.id)?.drafts ?? 0;
   const hasReachedDraftLimit =
-    applyUbbRestrictions && isFree === true && userDrafts >= limits.includedDrafts;
+    applyUbbRestrictions &&
+    isFree === true &&
+    userDrafts >= limits.includedDrafts;
+
+  const highestAllowedVMTier = limits.includedVmTier;
 
   return {
     isOutOfCredits,
@@ -64,6 +69,7 @@ export const useWorkspaceLimits = (): WorkspaceLimitsReturn => {
       isAtSpendingLimit ||
       isCloseToSpendingLimit,
     isFrozen: applyUbbRestrictions && frozen,
+    highestAllowedVMTier,
   };
 };
 
@@ -77,6 +83,7 @@ export type WorkspaceLimitsReturn =
       isFrozen: undefined;
       hasReachedSandboxLimit: undefined;
       hasReachedDraftLimit: undefined;
+      highestAllowedVMTier: undefined;
     }
   | {
       isOutOfCredits: boolean;
@@ -87,4 +94,5 @@ export type WorkspaceLimitsReturn =
       isFrozen: boolean;
       hasReachedSandboxLimit: boolean;
       hasReachedDraftLimit: boolean;
+      highestAllowedVMTier: number;
     };

--- a/packages/app/src/app/overmind/effects/api/index.ts
+++ b/packages/app/src/app/overmind/effects/api/index.ts
@@ -678,4 +678,12 @@ export default {
     // version null ensures no /v1 is in the URL
     return api.get('/vm_tiers', undefined, { version: null });
   },
+  setVMSpecs(sandboxId: string, vmTier: number) {
+    console.log('vm_tier', vmTier);
+    console.log('type', typeof vmTier);
+
+    return api.patch(`/sandboxes/${sandboxId}/vm_tier`, {
+      vmTier,
+    });
+  },
 };

--- a/packages/app/src/app/overmind/effects/api/types.ts
+++ b/packages/app/src/app/overmind/effects/api/types.ts
@@ -63,6 +63,7 @@ export type VMTier = {
   memory: number;
   storage: number;
   creditBasis: number;
+  tier: number;
 };
 
 export type APIPricingResult = {

--- a/packages/app/src/app/overmind/effects/gql/dashboard/fragments.ts
+++ b/packages/app/src/app/overmind/effects/gql/dashboard/fragments.ts
@@ -231,6 +231,7 @@ export const currentTeamInfoFragment = gql`
       includedCredits
       includedSandboxes
       includedDrafts
+      includedVmTier
       onDemandCreditLimit
     }
 

--- a/packages/app/src/app/overmind/namespaces/editor/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/editor/actions.ts
@@ -754,6 +754,7 @@ export const forkExternalSandbox = async (
     openInVSCode,
     autoLaunchVSCode,
     hasBetaEditorExperiment,
+    customVMTier,
     body,
   }: {
     sandboxId: string;
@@ -761,6 +762,7 @@ export const forkExternalSandbox = async (
     openInVSCode?: boolean;
     autoLaunchVSCode?: boolean;
     hasBetaEditorExperiment?: boolean;
+    customVMTier?: number;
     body?: {
       collectionId: string;
       alias?: string;
@@ -780,6 +782,11 @@ export const forkExternalSandbox = async (
 
   try {
     const forkedSandbox = await effects.api.forkSandbox(sandboxId, usedBody);
+
+    if (customVMTier) {
+      await effects.api.setVMSpecs(forkedSandbox.id, customVMTier);
+    }
+
     if (openInVSCode) {
       if (autoLaunchVSCode) {
         window.open(vsCodeUrl(forkedSandbox.id));

--- a/packages/app/src/app/utils/fuzzyMatchGithubToCsb.ts
+++ b/packages/app/src/app/utils/fuzzyMatchGithubToCsb.ts
@@ -17,17 +17,13 @@ export const fuzzyMatchGithubToCsb = (
 
   if (bestMatch) {
     track('Match GH to CSB - success', {
-      codesandbox: 'V1',
-      event_source: 'UI',
+      match: bestMatch.login,
     });
 
     return bestMatch;
   }
 
-  track('Match GH to CSB - fail', {
-    codesandbox: 'V1',
-    event_source: 'UI',
-  });
+  track('Match GH to CSB - fail');
 
   return accounts[0];
 };


### PR DESCRIPTION
Pro has up to `Medium` as a choice and `Micro` as default
![image](https://github.com/codesandbox/codesandbox-client/assets/9945366/c044e112-ef7d-4fa0-a2ca-1d007160ba23)

Free as up to `Micro` as a choice and `Nano` as default + mention of more specs on Pro
![image](https://github.com/codesandbox/codesandbox-client/assets/9945366/9bfb0a1d-5420-4177-ab70-811f5ba81fba)
