### PR TITLE
fix: issue with npm fetcher in sandpack, looks stuck in a loop

### DIFF
--- a/packages/sandpack-core/src/manager.ts
+++ b/packages/sandpack-core/src/manager.ts
@@ -21,7 +21,8 @@ import {
   SerializedTranspiledModule,
 } from './transpiled-module/transpiled-module';
 import { Preset } from './preset';
-import fetchModule, {
+import {
+  fetchModule,
   setCombinedMetas,
   combinedMetas,
 } from './npm/dynamic/fetch-npm-module';

--- a/packages/sandpack-core/src/npm/dynamic/fetch-npm-module.ts
+++ b/packages/sandpack-core/src/npm/dynamic/fetch-npm-module.ts
@@ -133,8 +133,6 @@ export function downloadDependency(
   version: string,
   path: string
 ): Promise<Module> {
-  console.log('downloadDependency', name, version, path);
-
   const [depName, depVersion] = resolveNPMAlias(name, version);
   const id = depName + depVersion + path;
   const foundPkg = packages.get(id);
@@ -184,8 +182,6 @@ function resolvePath(
   ignoreDepNameVersion: string = ''
 ): Promise<string> {
   invalidatePendingPackages(manager);
-
-  console.log('resolvePath', path);
 
   const currentPath = currentTModule.module.path;
 
@@ -290,8 +286,6 @@ async function getDependencyVersion(
   dependencyName: string
 ): Promise<DependencyVersionResult | null> {
   const { manifest } = manager;
-
-  console.log('getDependencyVersion', dependencyName);
 
   try {
     const filepath = pathUtils.join(dependencyName, 'package.json');

--- a/packages/sandpack-core/src/resolver/resolver.ts
+++ b/packages/sandpack-core/src/resolver/resolver.ts
@@ -15,6 +15,18 @@ import {
 
 export type ResolverCache = Map<string, any>;
 
+export function invalidatePackageFromCache(
+  pkgName: string,
+  cache: ResolverCache
+): void {
+  const lowerPkgName = pkgName.toLowerCase();
+  for (const [key] of cache) {
+    if (key.toLowerCase().includes(lowerPkgName)) {
+      cache.delete(key);
+    }
+  }
+}
+
 export interface IResolveOptionsInput {
   filename: string;
   extensions: string[];

--- a/packages/sandpack-core/src/resolver/resolver.ts
+++ b/packages/sandpack-core/src/resolver/resolver.ts
@@ -207,14 +207,14 @@ function* resolveNodeModule(
             : yield* loadNearestPackageJSON(pkgFilePath, opts, rootDir);
         if (pkgJson) {
           try {
-            return yield* resolver(pkgFilePath, {
+            return yield* resolve(pkgFilePath, {
               ...opts,
               filename: pkgJson.filepath,
               pkgJson,
             });
           } catch (err) {
             if (!pkgSpecifierParts.filepath) {
-              return yield* resolver(pathUtils.join(pkgFilePath, 'index'), {
+              return yield* resolve(pathUtils.join(pkgFilePath, 'index'), {
                 ...opts,
                 filename: pkgJson.filepath,
               });
@@ -331,19 +331,14 @@ function* getTSConfig(
   return config;
 }
 
-export const resolver = gensync<
-  (
-    moduleSpecifier: string,
-    inputOpts: IResolveOptionsInput,
-    skipIndexExpansion?: boolean
-  ) => string
->(function* resolve(
-  moduleSpecifier,
-  inputOpts,
-  skipIndexExpansion = false
+function* resolve(
+  moduleSpecifier: string,
+  inputOpts: IResolveOptionsInput,
+  skipIndexExpansion: boolean = false
 ): Generator<any, string, any> {
   const normalizedSpecifier = normalizeModuleSpecifier(moduleSpecifier);
   const opts = normalizeResolverOptions(inputOpts);
+
   const modulePath = yield* resolveModule(normalizedSpecifier, opts);
 
   if (modulePath[0] !== '/') {
@@ -366,7 +361,8 @@ export const resolver = gensync<
     }
 
     try {
-      return yield* resolveNodeModule(modulePath, opts);
+      const resolved = yield* resolveNodeModule(modulePath, opts);
+      return resolved;
     } catch (e) {
       throw new ModuleNotFoundError(normalizedSpecifier, opts.filename);
     }
@@ -395,7 +391,15 @@ export const resolver = gensync<
   }
 
   return foundFile;
-});
+}
+
+export const resolver = gensync<
+  (
+    moduleSpecifier: string,
+    inputOpts: IResolveOptionsInput,
+    skipIndexExpansion?: boolean
+  ) => string
+>(resolve);
 
 export const resolveSync = resolver.sync;
 export const resolveAsync = resolver.async;


### PR DESCRIPTION
Work in progress to figure out best approach on fixing this without breaking existing functionality

Next steps:

- [x] Figure out best approach to maintain backwards compatibility
- [ ] ~Figure out ways to improve performance here, downloading file by file in a waterfall manner isn't the best approach, especially given the amount of resolving overhead this code uses~
  - ~Either reduce resolver overhead~
  - ~Find a way to download all files at once (sandpack-cdn?)~

Broken sandbox http://localhost:3000/#yrncs3