### PR TITLE
feat: standalone Sandbox to GitHub converter

### DIFF
--- a/packages/app/src/app/components/Create/CreateRepoFiles.tsx
+++ b/packages/app/src/app/components/Create/CreateRepoFiles.tsx
@@ -1,4 +1,3 @@
-import { Sandbox } from 'app/graphql/types';
 import { useActions } from 'app/overmind';
 import { useEffect } from 'react';
 

--- a/packages/app/src/app/components/Create/CreateRepoFiles.tsx
+++ b/packages/app/src/app/components/Create/CreateRepoFiles.tsx
@@ -1,0 +1,35 @@
+import { Sandbox } from 'app/graphql/types';
+import { useActions } from 'app/overmind';
+import { useEffect } from 'react';
+
+export function CreateRepoFiles() {
+  const actions = useActions();
+
+  useEffect(() => {
+    window.addEventListener('message', event => {
+      if (event.data.type === 'create-repo-files') {
+        actions.git
+          .createRepoFiles(event.data.sandbox)
+          .then(data => {
+            window.parent.postMessage(
+              { type: 'create-repo-files-success', message: data },
+              '*'
+            );
+          })
+          .catch(error => {
+            window.parent.postMessage(
+              {
+                type: 'create-repo-files-error',
+                message: 'Could not create - ' + String(error),
+              },
+              '*'
+            );
+          });
+      }
+    });
+
+    window.parent.postMessage({ type: 'create-repo-files-ready' }, '*');
+  }, []);
+
+  return null;
+}

--- a/packages/app/src/app/overmind/namespaces/git/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/git/actions.ts
@@ -17,6 +17,7 @@ import { Context } from 'app/overmind';
 import { debounce, pipe } from 'overmind';
 import { CSBProjectGitHubRepository } from '@codesandbox/common/lib/utils/url-generator';
 
+import { Sandbox } from 'app/graphql/types';
 import * as internalActions from './internalActions';
 import { createDiff } from './utils';
 
@@ -119,6 +120,17 @@ export const loadGitSource = async ({ state, actions, effects }: Context) => {
 
   actions.git._setGitChanges();
   state.git.isFetching = false;
+};
+
+export const createRepoFiles = async (
+  { effects }: Context,
+  sandbox: Sandbox
+) => {
+  if (!sandbox) {
+    return;
+  }
+
+  return effects.git.export(sandbox);
 };
 
 export const createRepoClicked = async ({

--- a/packages/app/src/app/overmind/namespaces/git/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/git/actions.ts
@@ -5,6 +5,7 @@ import {
   GitInfo,
   Module,
   SandboxGitState,
+  Sandbox,
 } from '@codesandbox/common/lib/types';
 import {
   captureException,
@@ -17,7 +18,6 @@ import { Context } from 'app/overmind';
 import { debounce, pipe } from 'overmind';
 import { CSBProjectGitHubRepository } from '@codesandbox/common/lib/utils/url-generator';
 
-import { Sandbox } from 'app/graphql/types';
 import * as internalActions from './internalActions';
 import { createDiff } from './utils';
 

--- a/packages/app/src/app/overmind/namespaces/git/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/git/actions.ts
@@ -122,14 +122,7 @@ export const loadGitSource = async ({ state, actions, effects }: Context) => {
   state.git.isFetching = false;
 };
 
-export const createRepoFiles = async (
-  { effects }: Context,
-  sandbox: Sandbox
-) => {
-  if (!sandbox) {
-    return;
-  }
-
+export const createRepoFiles = ({ effects }: Context, sandbox: Sandbox) => {
   return effects.git.export(sandbox);
 };
 

--- a/packages/app/src/app/pages/Standalone/index.tsx
+++ b/packages/app/src/app/pages/Standalone/index.tsx
@@ -6,6 +6,8 @@ import { useParams } from 'react-router-dom';
 import { CreateBox } from 'app/components/Create/CreateBox';
 import { ImportRepository } from 'app/components/Create/ImportRepository';
 import { GenericCreate } from 'app/components/Create/GenericCreate';
+
+import { CreateRepoFiles } from 'app/components/Create/CreateRepoFiles';
 import { Preferences } from '../common/Modals/PreferencesModal';
 import { NotFound } from '../common/NotFound';
 
@@ -15,6 +17,7 @@ const COMPONENT_MAP = {
   createSandbox: () => <CreateBox type="sandbox" isModal={false} />,
   createDevbox: () => <CreateBox type="devbox" isModal={false} />,
   import: ImportRepository,
+  'create-repo-files': CreateRepoFiles,
 };
 
 export const StandalonePage = withTheme(({ theme }) => {


### PR DESCRIPTION
Add createRepoFiles function to handle creation of repo files in the app/overmind/namespaces/git/actions.ts file and add CreateRepoFiles component with functionality to create repo files in the app/components/Create/CreateRepoFiles.tsx file

Because the logic for creating the payload to create a repo from a Sandbox has so many dependencies we use an iFrame to convert a Sandbox from the V2 editor.