### PR TITLE
fix: use partitioned cookie for sandbox preview secret

### DIFF
--- a/packages/sandbox-hooks/preview-secret.js
+++ b/packages/sandbox-hooks/preview-secret.js
@@ -22,7 +22,7 @@ export const setPreviewSecret = secret => {
     cookieValue !== secret
   ) {
     if (secret) {
-      document.cookie = `${PREVIEW_SECRET_COOKIE_NAME}=${secret};samesite=none;secure;`;
+      document.cookie = `${PREVIEW_SECRET_COOKIE_NAME}=${secret};samesite=none;secure;partitioned;`;
 
       setTimeout(() => {
         location.reload();


### PR DESCRIPTION
This enables private previews for users with third party cookies disabled.