### PR TITLE
feat: show that we've updated our ToS

### DIFF
--- a/packages/notifications/src/component/elements.ts
+++ b/packages/notifications/src/component/elements.ts
@@ -11,12 +11,15 @@ export const NotificationContainer = styled.div`
 
 export const StyledCrossIcon = styled(CrossIcon)`
   ${({ theme }) => css`
+    position: absolute;
+    top: 1rem;
+    right: 1rem;
     transition: 0.3s ease color;
     cursor: pointer;
-    color: ${theme.colors.grays[500]};
+    color: ${theme.colors.grays[400]};
 
     &:hover {
-      color: ${theme.colors.grays[400]};
+      color: ${theme.colors.grays[300]};
     }
   `}
 `;


### PR DESCRIPTION
With this change, we show users that registered before March 10th that our ToS has been updated. After we've shown the notification, we don't show it again.

<img width="1840" alt="image" src="https://github.com/codesandbox/codesandbox-client/assets/587016/c89a230a-5a86-4218-9d79-0f5a05e39718">

