### PR TITLE
fix: cache sidebar data per workspace to avoid slower requests overriding the state

### DIFF
--- a/packages/app/src/app/overmind/namespaces/dashboard/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/dashboard/actions.ts
@@ -625,6 +625,10 @@ export const makeTemplates = async (
     isOnRecentPage?: boolean;
   }
 ) => {
+  if (!state.activeTeam) {
+    return;
+  }
+
   effects.analytics.track('Dashboard - Make Template', {
     dashboardVersion: 2,
   });
@@ -642,7 +646,8 @@ export const makeTemplates = async (
       actions.dashboard.internal.deleteSandboxesFromState({ ids });
     }
 
-    const hadTemplatesBeforeFetching = state.sidebar.hasTemplates;
+    const hadTemplatesBeforeFetching =
+      state.sidebar[state.activeTeam]?.hasTemplates || false;
     await actions.sidebar.getSidebarData(state.activeTeam || undefined);
 
     if (!hadTemplatesBeforeFetching) {
@@ -1531,9 +1536,11 @@ export const removeRepositoryFromTeam = async (
         return branchRepo.owner === owner && branchRepo.name === name;
       }) ?? [];
 
-    sidebar.repositories = sidebar.repositories.filter(
-      r => r.owner !== owner || r.name !== name
-    );
+    if (state.sidebar[activeTeam]) {
+      sidebar[activeTeam].repositories = sidebar[
+        activeTeam
+      ].repositories.filter(r => r.owner !== owner || r.name !== name);
+    }
 
     // Refetch start page data in the background to fill the remaining slots
     if (page === 'recent') {

--- a/packages/app/src/app/overmind/namespaces/sidebar/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/sidebar/actions.ts
@@ -25,7 +25,7 @@ export const getSidebarData = async (
     const hasSyncedSandboxes = sandboxes && sandboxes.length > 0;
     const hasTemplates = templates && templates.length > 0;
 
-    state.sidebar = {
+    state.sidebar[teamId] = {
       hasSyncedSandboxes,
       hasTemplates,
       repositories,

--- a/packages/app/src/app/overmind/namespaces/sidebar/state.ts
+++ b/packages/app/src/app/overmind/namespaces/sidebar/state.ts
@@ -1,20 +1,9 @@
-/**
- * SidebarState, required to be named just State. Can be an interface instead
- * of a type though.
- *
- * ❗️ TODO: Add sidebar notification indicator state
- */
-export interface State {
+type SidebarState = {
   hasSyncedSandboxes: boolean | null;
   hasTemplates: boolean | null;
   repositories: Array<{ name: string; owner: string }>;
-}
-
-/**
- * Default state for the sidebar
- */
-export const state: State = {
-  hasSyncedSandboxes: null,
-  hasTemplates: null,
-  repositories: [],
 };
+
+export type State = Record<string, SidebarState>;
+
+export const state: State = {};

--- a/packages/app/src/app/pages/Dashboard/Sidebar/ExpandableReposRowItem.tsx
+++ b/packages/app/src/app/pages/Dashboard/Sidebar/ExpandableReposRowItem.tsx
@@ -11,7 +11,11 @@ import { RowItem } from './RowItem';
 export const ExpandableReposRowItem = () => {
   const { activeTeam, sidebar } = useAppState();
 
-  if (sidebar.repositories.length === 0) {
+  if (
+    !activeTeam ||
+    !sidebar[activeTeam] ||
+    sidebar[activeTeam].repositories.length === 0
+  ) {
     return (
       <RowItem
         name="All repositories"
@@ -26,7 +30,7 @@ export const ExpandableReposRowItem = () => {
     <RowItemWithExpandableRepos
       key={activeTeam} // Remount component on active workspace change to reset expanded state
       activeTeam={activeTeam}
-      repositories={sidebar.repositories}
+      repositories={sidebar[activeTeam].repositories}
     />
   );
 };

--- a/packages/app/src/app/pages/Dashboard/Sidebar/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Sidebar/index.tsx
@@ -82,6 +82,13 @@ export const Sidebar: React.FC<SidebarProps> = ({
 
   const { isPrimarySpace } = useWorkspaceAuthorization();
 
+  const showTemplates = state.activeTeam
+    ? state.sidebar[state.activeTeam]?.hasTemplates
+    : false;
+  const showSyncedSandboxes = state.activeTeam
+    ? state.sidebar[state.activeTeam]?.hasSyncedSandboxes
+    : false;
+
   return (
     <SidebarContext.Provider value={{ onSidebarToggle, menuState }}>
       <Stack
@@ -220,7 +227,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
             ]}
           />
 
-          {state.sidebar.hasTemplates ? (
+          {showTemplates ? (
             <RowItem
               name="Templates"
               page="templates"
@@ -229,7 +236,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
             />
           ) : null}
 
-          {state.sidebar.hasSyncedSandboxes ? (
+          {showSyncedSandboxes ? (
             <RowItem
               name="Imported templates"
               page="synced-sandboxes"


### PR DESCRIPTION
Noticed in production that the sidebar data request can be slow when you have a lot of repositories. When switching between workspaces while the sidebar data is still loading, you can get the responses in random order so the state would be overriden.

With this solution, each sidebar data is kept in a record indexed on the workspace id