### PR TITLE
fix: improve sort order for org repos

### DIFF
--- a/packages/app/src/app/components/Create/ImportRepository/steps/AuthorizeGitHubPermissions.tsx
+++ b/packages/app/src/app/components/Create/ImportRepository/steps/AuthorizeGitHubPermissions.tsx
@@ -7,7 +7,7 @@ export const AuthorizeGitHubPermissions = () => {
   const { signInGithubClicked } = useActions();
 
   useEffect(() => {
-    track('Import repo - Permissions - Display');
+    track('Import repository - Permissions - Display');
   }, []);
 
   return (
@@ -31,7 +31,7 @@ export const AuthorizeGitHubPermissions = () => {
           size="large"
           onClick={() => {
             signInGithubClicked('private_repos');
-            track('Import repo - Permissions - Authorize all');
+            track('Import repository - Permissions - Authorize all');
           }}
         >
           Authorize access to public and private repositories
@@ -41,7 +41,7 @@ export const AuthorizeGitHubPermissions = () => {
           size="large"
           onClick={() => {
             signInGithubClicked('public_repos');
-            track('Import repo - Permissions - Authorize public');
+            track('Import repository - Permissions - Authorize public');
           }}
         >
           Authorize access to public repositories only

--- a/packages/app/src/app/components/Create/ImportRepository/steps/ConfigureRepo.tsx
+++ b/packages/app/src/app/components/Create/ImportRepository/steps/ConfigureRepo.tsx
@@ -84,6 +84,7 @@ export const ConfigureRepo: React.FC<ConfigureRepoProps> = ({
     setIsImporting(true);
     track('Import repository - Configure - Click import', {
       vmTier: selectedTier,
+      appInstalled: repository.appInstalled,
     });
 
     const result = await dashboard.importGitHubRepository({

--- a/packages/app/src/app/components/Create/ImportRepository/steps/FindByURL.tsx
+++ b/packages/app/src/app/components/Create/ImportRepository/steps/FindByURL.tsx
@@ -85,14 +85,14 @@ export const FindByURL: React.FC<FindByURLProps> = ({ onSelected }) => {
           isImported={isImported}
           onClicked={() => {
             if (isImported) {
-              track('Import repo - Find by URL - Open already imported');
+              track('Import repository - Find by URL - Open already imported');
               window.location.href = v2DefaultBranchUrl({
                 owner: githubRepo.data.owner.login,
                 repoName: githubRepo.data.name,
                 workspaceId: activeTeam,
               });
             } else {
-              track('Import repo - Find by URL - Import repo clicked');
+              track('Import repository - Find by URL - Import clicked');
               onSelected(githubRepo.data);
             }
           }}

--- a/packages/app/src/app/components/Create/ImportRepository/steps/ForkRepo.tsx
+++ b/packages/app/src/app/components/Create/ImportRepository/steps/ForkRepo.tsx
@@ -75,7 +75,7 @@ export const ForkRepo: React.FC<ForkRepoProps> = ({
     }
 
     setIsImporting(true);
-    track('Import repository - Configure - Click fork', {
+    track('Import repository - Fork - Click fork', {
       vmTier: selectedTier,
     });
 
@@ -93,7 +93,7 @@ export const ForkRepo: React.FC<ForkRepoProps> = ({
     });
 
     if (result.success) {
-      track('Import repository - Configure - Fork successful');
+      track('Import repository - Fork - Fork successful');
 
       window.location.href = v2BranchUrl({
         workspaceId: activeTeamInfo?.id,
@@ -152,7 +152,7 @@ export const ForkRepo: React.FC<ForkRepoProps> = ({
                 options={githubAccounts.all}
                 value={selectedOrg}
                 onChange={(account: string) => {
-                  track('Import repository - Configure - Change GH Org');
+                  track('Import repository - Fork - Change GH Org');
                   setSelectedOrg(account);
                 }}
                 variant="secondary"

--- a/packages/app/src/app/components/Create/ImportRepository/steps/SearchInOrganizations.tsx
+++ b/packages/app/src/app/components/Create/ImportRepository/steps/SearchInOrganizations.tsx
@@ -103,7 +103,7 @@ export const SearchInOrganizations: React.FC<SearchInOrganizationsProps> = ({
             value={selectedAccount}
             variant="solid"
             onChange={(account: string) => {
-              track('Import repo - Select - Change GH Org');
+              track('Import repository - Select - Change GH Org');
               setSelectedAccount(account);
             }}
           />
@@ -136,14 +136,14 @@ export const SearchInOrganizations: React.FC<SearchInOrganizationsProps> = ({
                 repo={repo}
                 onClicked={() => {
                   if (isImported) {
-                    track('Import repo - Select - Open already imported');
+                    track('Import repository - Select - Open already imported');
                     window.location.href = v2DefaultBranchUrl({
                       owner: repo.owner.login,
                       repoName: repo.name,
                       workspaceId: activeTeamInfo?.id,
                     });
                   } else {
-                    track('Import repo - Select - Import repo clicked');
+                    track('Import repository - Select - Import clicked');
                     onSelected(repo);
                   }
                 }}

--- a/packages/app/src/app/components/Create/hooks/useGithubRepos.ts
+++ b/packages/app/src/app/components/Create/hooks/useGithubRepos.ts
@@ -42,12 +42,10 @@ export const useGithubRepos = (
       ...cache,
       [orgName]: {
         state: newState,
-        repositories: repos
-          .map(r => ({
-            ...r,
-            appInstalled: undefined,
-          }))
-          .sort((a, b) => (b.pushedAt > a.pushedAt ? 1 : -1)),
+        repositories: repos.map(r => ({
+          ...r,
+          appInstalled: undefined,
+        })),
       },
     }));
   };

--- a/packages/app/src/app/overmind/effects/gql/dashboard/queries.ts
+++ b/packages/app/src/app/overmind/effects/gql/dashboard/queries.ts
@@ -344,7 +344,12 @@ export const getPartialOrganizationRepos: Query<
   GetPartialGitHubOrganizationReposQueryVariables
 > = gql`
   query GetPartialGitHubOrganizationRepos($organization: String!) {
-    githubOrganizationRepos(organization: $organization, perPage: 10, page: 1) {
+    githubOrganizationRepos(
+      organization: $organization
+      sort: PUSHED
+      perPage: 10
+      page: 1
+    ) {
       ...githubRepo
     }
   }
@@ -356,7 +361,7 @@ export const getFullOrganizationRepos: Query<
   GetFullGitHubOrganizationReposQueryVariables
 > = gql`
   query GetFullGitHubOrganizationRepos($organization: String!) {
-    githubOrganizationRepos(organization: $organization) {
+    githubOrganizationRepos(organization: $organization, sort: PUSHED) {
       ...githubRepo
     }
   }


### PR DESCRIPTION
Uses the new sort option for organizationRepos, so there's no more jumping around when the entire list is loaded

Also made some changes to the tracking events, to ensure consistency