### PR TITLE
feat: create sandbox from standalone modal

### DIFF
--- a/packages/app/src/app/components/Create/CreateBox.tsx
+++ b/packages/app/src/app/components/Create/CreateBox.tsx
@@ -18,8 +18,6 @@ import { pluralize } from 'app/utils/pluralize';
 import { ModalContentProps } from 'app/pages/common/Modals';
 import { useGlobalPersistedState } from 'app/hooks/usePersistedState';
 import { useWorkspaceLimits } from 'app/hooks/useWorkspaceLimits';
-import { SignInForTemplates } from 'app/pages/common/Modals/SignInForTemplates';
-import { SignIn } from 'app/pages/SignIn/SignIn';
 import {
   Container,
   Tab,

--- a/packages/app/src/app/components/Create/CreateBox.tsx
+++ b/packages/app/src/app/components/Create/CreateBox.tsx
@@ -42,6 +42,7 @@ import { TemplateInfo } from './CreateBox/TemplateInfo';
 import { useFeaturedTemplates } from './hooks/useFeaturedTemplates';
 import { useAllTemplates } from './hooks/useAllTemplates';
 import { mapSandboxGQLResponseToSandboxToFork } from './utils/api';
+import { WorkspaceSelect } from '../WorkspaceSelect';
 
 type CreateBoxProps = ModalContentProps & {
   collectionId?: string;
@@ -549,6 +550,16 @@ export const CreateBox: React.FC<CreateBoxProps> = ({
             <>
               <ModalSidebar>
                 <TemplateInfo template={selectedTemplate} />
+
+                {hasLogIn && (
+                  <WorkspaceSelect
+                    selectedTeamId={activeTeam}
+                    onSelect={teamId => {
+                      actions.setActiveTeam({ id: teamId });
+                      setCollectionId(undefined);
+                    }}
+                  />
+                )}
               </ModalSidebar>
 
               <ModalContent>

--- a/packages/app/src/app/components/Create/CreateBox.tsx
+++ b/packages/app/src/app/components/Create/CreateBox.tsx
@@ -193,7 +193,7 @@ export const CreateBox: React.FC<CreateBoxProps> = ({
         autoLaunchVSCode,
         hasBetaEditorExperiment,
         customVMTier,
-        preventNavigation: isStandalone,
+        redirectAfterFork: !isStandalone,
         body: {
           title: name,
           collectionId,

--- a/packages/app/src/app/components/Create/CreateBox.tsx
+++ b/packages/app/src/app/components/Create/CreateBox.tsx
@@ -70,7 +70,7 @@ function parsePrivacy(privacy: string | undefined): PrivacyLevel | undefined {
 
 export const CreateBox: React.FC<CreateBoxProps> = ({
   collectionId: initialCollectionId,
-  sandboxIdToFork: sandboxIdToForkProp,
+  sandboxIdToFork,
   type = 'devbox',
   closeModal,
   isStandalone,
@@ -84,8 +84,6 @@ export const CreateBox: React.FC<CreateBoxProps> = ({
   );
 
   const parsedUrl = new URL(window.location.href);
-  const sandboxIdToFork =
-    sandboxIdToForkProp ?? parsedUrl.searchParams.get('sandbox');
   const initialPrivacy = parsePrivacy(parsedUrl.searchParams.get('privacy'));
 
   const mediaQuery = window.matchMedia('screen and (max-width: 950px)');

--- a/packages/app/src/app/components/Create/CreateBox/CreateBoxForm.tsx
+++ b/packages/app/src/app/components/Create/CreateBox/CreateBoxForm.tsx
@@ -99,8 +99,6 @@ export const CreateBoxForm: React.FC<CreateBoxFormProps> = ({
     });
   }, []);
 
-  const availableTiers = allVmTiers.filter(t => t.tier <= highestAllowedVMTier);
-
   useEffect(() => {
     if (selectedTier > highestAllowedVMTier) {
       setSelectedTier(highestAllowedVMTier);
@@ -158,7 +156,7 @@ export const CreateBoxForm: React.FC<CreateBoxFormProps> = ({
           editor: type === 'sandbox' ? 'csb' : editor, // ensure 'csb' is always passed when creating a sandbox
           customVMTier:
             // Only pass customVMTier if user selects something else than the default
-            availableTiers.length > 0 && selectedTier !== defaultTier
+            allVmTiers.length > 0 && selectedTier !== defaultTier
               ? selectedTier
               : undefined,
         });
@@ -361,11 +359,15 @@ export const CreateBoxForm: React.FC<CreateBoxFormProps> = ({
             <>
               <Select
                 value={selectedTier}
-                disabled={availableTiers.length === 0}
+                disabled={allVmTiers.length === 0}
                 onChange={e => setSelectedTier(parseInt(e.target.value, 10))}
               >
-                {availableTiers.map(t => (
-                  <option key={t.shortid} value={t.tier}>
+                {allVmTiers.map(t => (
+                  <option
+                    disabled={t.tier > highestAllowedVMTier}
+                    key={t.shortid}
+                    value={t.tier}
+                  >
                     {t.name} ({t.cpu} vCPUs, {t.memory} GiB RAM, {t.storage} GB
                     Disk for {t.creditBasis} credits/hour)
                   </option>
@@ -381,12 +383,30 @@ export const CreateBoxForm: React.FC<CreateBoxFormProps> = ({
                       target="_blank"
                       rel="noopener noreferrer"
                     >
-                      Pro workspaces
+                      Pro & Enterprise workspaces
                     </a>
                     .
                   </Text>
                 </Stack>
               )}
+              {!activeTeamInfo.featureFlags.ubbBeta &&
+                activeTeamInfo.subscription.status && (
+                  <Stack gap={1} align="center" css={{ color: '#A8BFFA' }}>
+                    <Icon name="circleBang" />
+                    <Text size={3}>
+                      Better specs are available for our new team plan, you can
+                      upgrade{' '}
+                      <a
+                        href="/upgrade"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        here
+                      </a>
+                      .
+                    </Text>
+                  </Stack>
+                )}
             </>
           )}
         </Stack>

--- a/packages/app/src/app/components/Create/CreateBox/CreateBoxForm.tsx
+++ b/packages/app/src/app/components/Create/CreateBox/CreateBoxForm.tsx
@@ -79,7 +79,15 @@ export const CreateBoxForm: React.FC<CreateBoxFormProps> = ({
 
   const defaultTier = isFree ? 1 : 2;
   const [selectedTier, setSelectedTier] = useState<number>(defaultTier);
-  const [availableTiers, setAvailableTiers] = useState<VMTier[]>([]);
+  const [allVmTiers, setAllVmTiers] = useState<VMTier[]>([]);
+
+  useEffect(() => {
+    if (type === 'devbox') {
+      effects.api.getVMSpecs().then(res => {
+        setAllVmTiers(res.vmTiers);
+      });
+    }
+  }, [type]);
 
   useEffect(() => {
     effects.api.getSandboxTitle().then(({ title }) => {
@@ -89,14 +97,15 @@ export const CreateBoxForm: React.FC<CreateBoxFormProps> = ({
         nameInputRef.current.select();
       }
     });
-    if (type === 'devbox') {
-      effects.api.getVMSpecs().then(res => {
-        setAvailableTiers(
-          res.vmTiers.filter(t => t.tier <= highestAllowedVMTier)
-        );
-      });
-    }
   }, []);
+
+  const availableTiers = allVmTiers.filter(t => t.tier <= highestAllowedVMTier);
+
+  useEffect(() => {
+    if (selectedTier > highestAllowedVMTier) {
+      setSelectedTier(highestAllowedVMTier);
+    }
+  }, [selectedTier, highestAllowedVMTier]);
 
   const { data: collectionsData } = useQuery<
     PathedSandboxesFoldersQuery,
@@ -366,7 +375,15 @@ export const CreateBoxForm: React.FC<CreateBoxFormProps> = ({
                 <Stack gap={1} align="center" css={{ color: '#A8BFFA' }}>
                   <Icon name="circleBang" />
                   <Text size={3}>
-                    Better specs are available for Pro workspaces.
+                    Better specs are available for{' '}
+                    <a
+                      href="/pricing"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      Pro workspaces
+                    </a>
+                    .
                   </Text>
                 </Stack>
               )}

--- a/packages/app/src/app/components/Create/CreateBox/CreateBoxForm.tsx
+++ b/packages/app/src/app/components/Create/CreateBox/CreateBoxForm.tsx
@@ -389,8 +389,8 @@ export const CreateBoxForm: React.FC<CreateBoxFormProps> = ({
                   </Text>
                 </Stack>
               )}
-              {!activeTeamInfo.featureFlags.ubbBeta &&
-                activeTeamInfo.subscription.status && (
+              {!activeTeamInfo?.featureFlags.ubbBeta &&
+                activeTeamInfo?.subscription.status && (
                   <Stack gap={1} align="center" css={{ color: '#A8BFFA' }}>
                     <Icon name="circleBang" />
                     <Text size={3}>

--- a/packages/app/src/app/components/Create/CreateBox/CreateBoxForm.tsx
+++ b/packages/app/src/app/components/Create/CreateBox/CreateBoxForm.tsx
@@ -215,7 +215,7 @@ export const CreateBoxForm: React.FC<CreateBoxFormProps> = ({
                     <option value={collection.id}>
                       {collection.path === '/'
                         ? 'Root folder (/)'
-                        : collection.path.split('/').join(' / ')}
+                        : collection.path}
                     </option>
                   ))}
                 </Select>

--- a/packages/app/src/app/components/Create/CreateBox/CreateBoxForm.tsx
+++ b/packages/app/src/app/components/Create/CreateBox/CreateBoxForm.tsx
@@ -229,7 +229,7 @@ export const CreateBoxForm: React.FC<CreateBoxFormProps> = ({
                   <Select
                     icon={
                       isDraft
-                        ? PRIVACY_OPTIONS[0].icon
+                        ? PRIVACY_OPTIONS[2].icon
                         : PRIVACY_OPTIONS[permission].icon
                     }
                     defaultValue={permission}

--- a/packages/app/src/app/components/Create/CreateBox/CreateBoxForm.tsx
+++ b/packages/app/src/app/components/Create/CreateBox/CreateBoxForm.tsx
@@ -10,20 +10,24 @@ import {
 } from '@codesandbox/components';
 import { dashboard } from '@codesandbox/common/lib/utils/url-generator';
 
-import { useAppState, useEffects } from 'app/overmind';
+import { useActions, useAppState, useEffects } from 'app/overmind';
 import { useWorkspaceSubscription } from 'app/hooks/useWorkspaceSubscription';
 import { useGlobalPersistedState } from 'app/hooks/usePersistedState';
 import { PATHED_SANDBOXES_FOLDER_QUERY } from 'app/pages/Dashboard/queries';
-import { Query } from 'react-apollo';
 import { useWorkspaceLimits } from 'app/hooks/useWorkspaceLimits';
 import { useWorkspaceAuthorization } from 'app/hooks/useWorkspaceAuthorization';
 import { Link } from 'react-router-dom';
 import { VMTier } from 'app/overmind/effects/api/types';
-import { ROOT_COLLECTION_NAME } from 'app/pages/Dashboard/Sidebar';
+import { useQuery } from '@apollo/react-hooks';
+import {
+  PathedSandboxesFoldersQuery,
+  PathedSandboxesFoldersQueryVariables,
+} from 'app/graphql/types';
 import { CreateParams } from '../utils/types';
 
 interface CreateBoxFormProps {
   type: 'sandbox' | 'devbox';
+  initialPrivacy?: PrivacyLevel;
   collectionId: string | undefined;
   setCollectionId: (collectionId: string | undefined) => void;
   onCancel: () => void;
@@ -31,10 +35,11 @@ interface CreateBoxFormProps {
   onClose: () => void;
 }
 
-type PrivacyLevel = 0 | 1 | 2;
+export type PrivacyLevel = 0 | 1 | 2;
 
 export const CreateBoxForm: React.FC<CreateBoxFormProps> = ({
   type,
+  initialPrivacy,
   collectionId,
   setCollectionId,
   onCancel,
@@ -43,7 +48,8 @@ export const CreateBoxForm: React.FC<CreateBoxFormProps> = ({
 }) => {
   const label = type === 'sandbox' ? 'Sandbox' : 'Devbox';
 
-  const { activeTeamInfo, activeTeam } = useAppState();
+  const { activeTeamInfo, activeTeam, hasLogIn } = useAppState();
+  const { signInClicked } = useActions();
   const {
     hasReachedSandboxLimit,
     hasReachedDraftLimit,
@@ -55,17 +61,17 @@ export const CreateBoxForm: React.FC<CreateBoxFormProps> = ({
   const nameInputRef = useRef<HTMLInputElement>(null);
   const { isFree } = useWorkspaceSubscription();
   const isDraft = collectionId === undefined;
-  const canSetPrivacy = !isDraft;
   const canCreateDraft = !hasReachedDraftLimit;
   const canCreateInFolders = type === 'devbox' || !hasReachedSandboxLimit;
   const canCreate =
     (isDraft && canCreateDraft) || (!isDraft && canCreateInFolders);
 
-  const miniumPrivacy = canSetPrivacy
-    ? ((activeTeamInfo?.settings.minimumPrivacy || 0) as PrivacyLevel)
-    : 2;
+  const minimumPrivacy = Math.max(
+    initialPrivacy ?? 2,
+    activeTeamInfo?.settings.minimumPrivacy ?? 0
+  ) as PrivacyLevel;
 
-  const [permission, setPermission] = useState<PrivacyLevel>(miniumPrivacy);
+  const [permission, setPermission] = useState<PrivacyLevel>(minimumPrivacy);
   const [editor, setEditor] = useGlobalPersistedState<'csb' | 'vscode'>(
     'DEFAULT_EDITOR',
     'csb'
@@ -91,6 +97,37 @@ export const CreateBoxForm: React.FC<CreateBoxFormProps> = ({
       });
     }
   }, []);
+
+  const { data: collectionsData } = useQuery<
+    PathedSandboxesFoldersQuery,
+    PathedSandboxesFoldersQueryVariables
+  >(PATHED_SANDBOXES_FOLDER_QUERY, {
+    variables: {
+      teamId: activeTeam,
+    },
+    skip: !activeTeam || !hasLogIn,
+  });
+
+  const rootCollection = collectionsData?.me?.collections?.find(
+    collection => collection.path === '/'
+  );
+  useEffect(() => {
+    if (collectionsData?.me?.collections == null) {
+      return;
+    }
+
+    if (permission < 2) {
+      if (collectionId == null && rootCollection != null) {
+        setCollectionId(rootCollection.id);
+      }
+    }
+  }, [
+    collectionsData,
+    rootCollection,
+    permission,
+    collectionId,
+    setCollectionId,
+  ]);
 
   return (
     <Element
@@ -131,7 +168,7 @@ export const CreateBoxForm: React.FC<CreateBoxFormProps> = ({
         </Text>
         <Stack direction="vertical" gap={2}>
           <Text size={3} as="label">
-            Name
+            {label} Name
           </Text>
           <Input
             autoFocus
@@ -146,23 +183,19 @@ export const CreateBoxForm: React.FC<CreateBoxFormProps> = ({
           />
         </Stack>
 
-        <Stack direction="vertical" gap={2}>
-          <Text size={3} as="label">
-            Folder
-          </Text>
+        {hasLogIn && (
+          <Stack gap={2} direction="vertical">
+            <Stack gap={2}>
+              <Stack style={{ flex: 1 }} direction="vertical" gap={2}>
+                <Text size={3} as="label">
+                  Folder
+                </Text>
 
-          <Query
-            variables={{ teamId: activeTeam }}
-            query={PATHED_SANDBOXES_FOLDER_QUERY}
-            fetchPolicy="network-only"
-          >
-            {({ data }) => {
-              return (
                 <Select
                   icon={() => (
                     <Icon name={isDraft ? 'file' : 'folder'} size={12} />
                   )}
-                  value={collectionId}
+                  value={isDraft ? '$CSBDRAFTS' : collectionId}
                   onChange={({ target: { value } }) =>
                     value === '$CSBDRAFTS'
                       ? setCollectionId(undefined)
@@ -171,87 +204,103 @@ export const CreateBoxForm: React.FC<CreateBoxFormProps> = ({
                 >
                   <option value="$CSBDRAFTS">Drafts</option>
 
-                  {data?.me?.collections?.map(collection => (
+                  {collectionsData?.me?.collections?.map(collection => (
                     <option value={collection.id}>
                       {collection.path === '/'
-                        ? ROOT_COLLECTION_NAME
+                        ? 'Root folder (/)'
                         : collection.path.split('/').join(' / ')}
                     </option>
                   ))}
                 </Select>
-              );
-            }}
-          </Query>
+              </Stack>
 
-          {isDraft && canCreateDraft && (
-            <Stack gap={1} css={{ color: '#A8BFFA' }}>
-              <Icon name="circleBang" />
-              <Text size={3}>Drafts are private and only visible to you.</Text>
+              <Stack style={{ flex: 2 }} direction="vertical" gap={2}>
+                <Text size={3} as="label">
+                  Visibility
+                </Text>
+                <Stack direction="vertical" gap={2}>
+                  <Select
+                    icon={
+                      isDraft
+                        ? PRIVACY_OPTIONS[0].icon
+                        : PRIVACY_OPTIONS[permission].icon
+                    }
+                    defaultValue={permission}
+                    onChange={({ target: { value } }) => {
+                      if (value === 'DRAFT') {
+                        setCollectionId(undefined);
+                        setPermission(2);
+                      } else {
+                        setPermission(parseInt(value, 10) as 0 | 1 | 2);
+                        if (collectionId == null) {
+                          setCollectionId(rootCollection?.id);
+                        }
+                      }
+                    }}
+                    value={isDraft ? 'DRAFT' : permission}
+                  >
+                    <option value={0}>{PRIVACY_OPTIONS[0].description}</option>
+                    <option value={1}>{PRIVACY_OPTIONS[1].description}</option>
+                    <option value={2}>{PRIVACY_OPTIONS[2].description}</option>
+                    <option value="DRAFT">Draft (only you have access)</option>
+                  </Select>
+                </Stack>
+              </Stack>
             </Stack>
-          )}
 
-          {isDraft && !canCreateDraft && (
-            <Stack gap={1} css={{ color: '#F5A8A8' }}>
-              <Icon name="circleBang" />
-              <Text size={3}>
-                Your{' '}
-                <Link
-                  css={{ color: 'inherit' }}
-                  onClick={onClose}
-                  to={dashboard.drafts(activeTeam)}
-                >
-                  Drafts folder
-                </Link>{' '}
-                is full. Delete unneeded drafts, or{' '}
-                {isAdmin ? (
-                  <>
-                    <Link
-                      css={{ color: 'inherit' }}
-                      to={dashboard.upgradeUrl({
-                        workspaceId: activeTeam,
-                        source: 'create_draft_limit',
-                      })}
-                      onClick={onClose}
-                    >
-                      upgrade to Pro
-                    </Link>{' '}
-                    for unlimited drafts
-                  </>
-                ) : (
-                  'ask an admin to upgrade to Pro for unlimited drafts'
-                )}
-                .
-              </Text>
-            </Stack>
-          )}
+            {isDraft && canCreateDraft && (
+              <Stack gap={1} css={{ color: '#A8BFFA' }}>
+                <Icon name="circleBang" />
+                <Text size={3}>
+                  Drafts are private and only visible to you.
+                </Text>
+              </Stack>
+            )}
 
-          {!isDraft && !canCreateInFolders && (
-            <Stack gap={1} css={{ color: '#F5A8A8' }}>
-              <Icon name="circleBang" />
-              <Text size={3}>
-                You reached the maximum amount of shareable Sandboxes in this
-                workspace.
-              </Text>
-            </Stack>
-          )}
-        </Stack>
+            {isDraft && !canCreateDraft && (
+              <Stack gap={1} css={{ color: '#F5A8A8' }}>
+                <Icon name="circleBang" />
+                <Text size={3}>
+                  Your{' '}
+                  <Link
+                    css={{ color: 'inherit' }}
+                    onClick={onClose}
+                    to={dashboard.drafts(activeTeam)}
+                  >
+                    Drafts folder
+                  </Link>{' '}
+                  is full. Delete unneeded drafts, or{' '}
+                  {isAdmin ? (
+                    <>
+                      <Link
+                        css={{ color: 'inherit' }}
+                        to={dashboard.upgradeUrl({
+                          workspaceId: activeTeam,
+                          source: 'create_draft_limit',
+                        })}
+                        onClick={onClose}
+                      >
+                        upgrade to Pro
+                      </Link>{' '}
+                      for unlimited drafts
+                    </>
+                  ) : (
+                    'ask an admin to upgrade to Pro for unlimited drafts'
+                  )}
+                  .
+                </Text>
+              </Stack>
+            )}
 
-        {!isDraft && canCreate && (
-          <Stack direction="vertical" gap={2}>
-            <Text size={3} as="label">
-              Visibility
-            </Text>
-            <Stack direction="vertical" gap={2}>
-              <Select
-                icon={PRIVACY_OPTIONS[permission].icon}
-                defaultValue={permission}
-                onChange={({ target: { value } }) => setPermission(value)}
-              >
-                <option value={0}>{PRIVACY_OPTIONS[0].description}</option>
-                <option value={1}>{PRIVACY_OPTIONS[1].description}</option>
-                <option value={2}>{PRIVACY_OPTIONS[2].description}</option>
-              </Select>
-            </Stack>
+            {!isDraft && !canCreateInFolders && (
+              <Stack gap={1} css={{ color: '#F5A8A8' }}>
+                <Icon name="circleBang" />
+                <Text size={3}>
+                  You reached the maximum amount of shareable Sandboxes in this
+                  workspace.
+                </Text>
+              </Stack>
+            )}
           </Stack>
         )}
 
@@ -336,14 +385,20 @@ export const CreateBoxForm: React.FC<CreateBoxFormProps> = ({
           >
             Cancel
           </Button>
-          <Button
-            type="submit"
-            disabled={!canCreate}
-            variant="primary"
-            autoWidth
-          >
-            Create {label}
-          </Button>
+          {hasLogIn ? (
+            <Button
+              type="submit"
+              disabled={!canCreate}
+              variant="primary"
+              autoWidth
+            >
+              Create {label}
+            </Button>
+          ) : (
+            <Button autoWidth onClick={() => signInClicked()} type="button">
+              Sign in to create {label}
+            </Button>
+          )}
         </Stack>
       </Stack>
     </Element>
@@ -352,15 +407,15 @@ export const CreateBoxForm: React.FC<CreateBoxFormProps> = ({
 
 const PRIVACY_OPTIONS = {
   0: {
-    description: 'Public (Everyone can view)',
+    description: 'Public (everyone can view)',
     icon: () => <Icon size={12} name="globe" />,
   },
   1: {
-    description: 'Unlisted (Everyone with the link can view)',
+    description: 'Unlisted (everyone with the link can view)',
     icon: () => <Icon size={12} name="link" />,
   },
   2: {
-    description: 'Private (Only workspace members have access)',
+    description: 'Private (only workspace members have access)',
     icon: () => <Icon size={12} name="lock" />,
   },
 };

--- a/packages/app/src/app/components/Create/elements.tsx
+++ b/packages/app/src/app/components/Create/elements.tsx
@@ -38,9 +38,13 @@ export const ModalBody = styled.div`
 `;
 
 export const ModalSidebar = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
   width: 176px;
   flex-shrink: 0;
   padding: 0px 24px;
+  padding-bottom: 16px;
   overflow: auto;
 
   @media screen and (max-width: 950px) {

--- a/packages/app/src/app/hooks/useCookieConsent.ts
+++ b/packages/app/src/app/hooks/useCookieConsent.ts
@@ -7,6 +7,13 @@ import {
 import { cookieConsentConfig } from '../utils/cookieConsent/cookieConsentConfig';
 
 export const useCookieConsent = (amplitudeApiKey: string) => {
+  let isRenderedInIframe;
+  try {
+    isRenderedInIframe = window.self !== window.top;
+  } catch (e) {
+    isRenderedInIframe = true;
+  }
+
   const handleCookieConsent = (cookie: CookieConsent.CookieValue) => {
     const allowAnalytics = cookie?.categories?.includes('analytical') || false;
     if (allowAnalytics) {
@@ -18,6 +25,10 @@ export const useCookieConsent = (amplitudeApiKey: string) => {
 
   useEffect(() => {
     if (process.env.NODE_ENV !== 'production') {
+      return;
+    }
+
+    if (isRenderedInIframe) {
       return;
     }
 

--- a/packages/app/src/app/overmind/internalActions.ts
+++ b/packages/app/src/app/overmind/internalActions.ts
@@ -152,6 +152,15 @@ export const showUpdatedToSIfNeeded = ({ state, effects }: Context) => {
     ? new Date(state.user.insertedAt)
     : new Date();
 
+  // If we're in an iframe, don't show notification
+  try {
+    if (window.self !== window.top) {
+      return;
+    }
+  } catch (e) {
+    // Ignore errors
+  }
+
   if (registrationDate >= new Date('2024-03-10')) {
     // This means that the user has registered before we updated the ToS, and we need to notify
     // them that the ToS has changed.

--- a/packages/app/src/app/overmind/namespaces/editor/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/editor/actions.ts
@@ -756,6 +756,7 @@ export const forkExternalSandbox = async (
     hasBetaEditorExperiment,
     customVMTier,
     body,
+    preventNavigation,
   }: {
     sandboxId: string;
     openInNewWindow?: boolean;
@@ -763,6 +764,7 @@ export const forkExternalSandbox = async (
     autoLaunchVSCode?: boolean;
     hasBetaEditorExperiment?: boolean;
     customVMTier?: number;
+    preventNavigation?: boolean;
     body?: {
       collectionId: string;
       alias?: string;
@@ -796,11 +798,15 @@ export const forkExternalSandbox = async (
     } else {
       state.editor.sandboxes[forkedSandbox.id] = forkedSandbox;
 
-      effects.router.updateSandboxUrl(forkedSandbox, {
-        openInNewWindow,
-        hasBetaEditorExperiment,
-      });
+      if (!preventNavigation) {
+        effects.router.updateSandboxUrl(forkedSandbox, {
+          openInNewWindow,
+          hasBetaEditorExperiment,
+        });
+      }
     }
+
+    return forkedSandbox;
   } catch (error) {
     const errorMessage = actions.internal.getErrorMessage({ error });
 
@@ -818,6 +824,8 @@ export const forkExternalSandbox = async (
       });
     }
   }
+
+  return undefined;
 };
 
 // TODO: Look into

--- a/packages/app/src/app/overmind/namespaces/editor/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/editor/actions.ts
@@ -756,7 +756,7 @@ export const forkExternalSandbox = async (
     hasBetaEditorExperiment,
     customVMTier,
     body,
-    preventNavigation,
+    redirectAfterFork,
   }: {
     sandboxId: string;
     openInNewWindow?: boolean;
@@ -764,7 +764,7 @@ export const forkExternalSandbox = async (
     autoLaunchVSCode?: boolean;
     hasBetaEditorExperiment?: boolean;
     customVMTier?: number;
-    preventNavigation?: boolean;
+    redirectAfterFork?: boolean;
     body?: {
       collectionId: string;
       alias?: string;
@@ -798,7 +798,7 @@ export const forkExternalSandbox = async (
     } else {
       state.editor.sandboxes[forkedSandbox.id] = forkedSandbox;
 
-      if (!preventNavigation) {
+      if (redirectAfterFork) {
         effects.router.updateSandboxUrl(forkedSandbox, {
           openInNewWindow,
           hasBetaEditorExperiment,

--- a/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenus/SandboxMenu.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenus/SandboxMenu.tsx
@@ -104,6 +104,7 @@ export const SandboxMenu: React.FC<SandboxMenuProps> = ({
               sandboxId: sandbox.id,
               openInNewWindow: true,
               hasBetaEditorExperiment,
+              redirectAfterFork: true,
             });
           }}
         >
@@ -154,6 +155,7 @@ export const SandboxMenu: React.FC<SandboxMenuProps> = ({
               sandboxId: sandbox.id,
               openInNewWindow: true,
               hasBetaEditorExperiment,
+              redirectAfterFork: true,
             });
           }}
           disabled={restrictedFork}

--- a/packages/app/src/app/pages/Profile/ContextMenu.tsx
+++ b/packages/app/src/app/pages/Profile/ContextMenu.tsx
@@ -123,6 +123,7 @@ export const ContextMenu = () => {
           forkExternalSandbox({
             sandboxId,
             openInNewWindow: true,
+            redirectAfterFork: true,
           });
         }}
       >

--- a/packages/app/src/app/pages/Standalone/index.tsx
+++ b/packages/app/src/app/pages/Standalone/index.tsx
@@ -14,10 +14,30 @@ import { NotFound } from '../common/NotFound';
 const COMPONENT_MAP = {
   preferences: Preferences,
   create: GenericCreate,
-  createSandbox: () => (
-    <CreateBox isStandalone type="sandbox" isModal={false} />
-  ),
-  createDevbox: () => <CreateBox isStandalone type="devbox" isModal={false} />,
+  createSandbox: () => {
+    const parsedUrl = new URL(window.location.href);
+    const sandboxIdToFork = parsedUrl.searchParams.get('sandbox');
+    return (
+      <CreateBox
+        isStandalone
+        type="sandbox"
+        sandboxIdToFork={sandboxIdToFork}
+        isModal={false}
+      />
+    );
+  },
+  createDevbox: () => {
+    const parsedUrl = new URL(window.location.href);
+    const sandboxIdToFork = parsedUrl.searchParams.get('sandbox');
+    return (
+      <CreateBox
+        isStandalone
+        type="devbox"
+        sandboxIdToFork={sandboxIdToFork}
+        isModal={false}
+      />
+    );
+  },
   import: ImportRepository,
   'create-repo-files': CreateRepoFiles,
 };

--- a/packages/app/src/app/pages/Standalone/index.tsx
+++ b/packages/app/src/app/pages/Standalone/index.tsx
@@ -14,8 +14,10 @@ import { NotFound } from '../common/NotFound';
 const COMPONENT_MAP = {
   preferences: Preferences,
   create: GenericCreate,
-  createSandbox: () => <CreateBox type="sandbox" isModal={false} />,
-  createDevbox: () => <CreateBox type="devbox" isModal={false} />,
+  createSandbox: () => (
+    <CreateBox isStandalone type="sandbox" isModal={false} />
+  ),
+  createDevbox: () => <CreateBox isStandalone type="devbox" isModal={false} />,
   import: ImportRepository,
   'create-repo-files': CreateRepoFiles,
 };


### PR DESCRIPTION
Couple of changes:

- Folder & privacy are now coupled to each-other
- We can create sandboxes from the standalone modal
- We can pass in a minimum privacy