### PR TITLE
feat: allow managing addons from the checkout flow

### DIFF
--- a/packages/app/src/app/components/WorkspaceSetup/Layout.tsx
+++ b/packages/app/src/app/components/WorkspaceSetup/Layout.tsx
@@ -2,11 +2,13 @@ import React from 'react';
 import { Stack, ThemeProvider } from '@codesandbox/components';
 import styled, { keyframes } from 'styled-components';
 import { Summary } from './Summary';
+import { WorkspaceFlow } from './types';
 
 export const WorkspaceFlowLayout: React.FC<{
+  flow: WorkspaceFlow;
   showSummary: boolean;
   allowSummaryChanges: boolean;
-}> = ({ children, showSummary, allowSummaryChanges }) => {
+}> = ({ children, showSummary, allowSummaryChanges, flow }) => {
   return (
     <ThemeProvider>
       <Stack
@@ -48,7 +50,10 @@ export const WorkspaceFlowLayout: React.FC<{
           </Stack>
           {showSummary && (
             <SlidePanel>
-              <Summary allowChanges={allowSummaryChanges} />
+              <Summary
+                allowAnual={flow !== 'manage-addons'}
+                allowChanges={allowSummaryChanges}
+              />
             </SlidePanel>
           )}
         </Stack>

--- a/packages/app/src/app/components/WorkspaceSetup/Layout.tsx
+++ b/packages/app/src/app/components/WorkspaceSetup/Layout.tsx
@@ -51,10 +51,7 @@ export const WorkspaceFlowLayout: React.FC<{
           </Stack>
           {showSummary && (
             <SlidePanel>
-              <Summary
-                allowAnual={flow !== 'manage-addons'}
-                allowChanges={allowSummaryChanges}
-              />
+              <Summary flow={flow} allowChanges={allowSummaryChanges} />
             </SlidePanel>
           )}
         </Stack>

--- a/packages/app/src/app/components/WorkspaceSetup/Summary.tsx
+++ b/packages/app/src/app/components/WorkspaceSetup/Summary.tsx
@@ -7,29 +7,28 @@ import { useWorkspaceSubscription } from 'app/hooks/useWorkspaceSubscription';
 import { useLocation } from 'react-router-dom';
 import { fadeAnimation } from './elements';
 
-export const Summary: React.FC<{ allowChanges: boolean }> = ({
-  allowChanges,
-}) => {
+export const Summary: React.FC<{
+  allowChanges: boolean;
+  allowAnual: boolean;
+}> = ({ allowChanges, allowAnual }) => {
   const actions = useActions();
   const { isPro } = useWorkspaceSubscription();
   const { pathname } = useLocation();
   const isUpgrading = pathname.includes('upgrade');
   const { checkout } = useAppState();
   const {
-    selectedPlan,
+    basePlan,
     creditAddons,
     totalCredits,
     totalPrice,
     spendingLimit,
-    availableBasePlans,
   } = checkout;
-
-  const basePlan = availableBasePlans[selectedPlan];
-  const isAnnual = selectedPlan === 'flex-annual';
 
   if (!basePlan) {
     return null;
   }
+
+  const isAnnual = basePlan.id === 'flex-annual';
 
   return (
     <Stack
@@ -106,27 +105,29 @@ export const Summary: React.FC<{ allowChanges: boolean }> = ({
         <Text color="#fff">${totalPrice}</Text>
       </Stack>
 
-      <Stack css={{ gap: '8px' }}>
-        <Switch
-          id="recurring"
-          on={isAnnual}
-          onChange={() => {
-            actions.checkout.selectPlan(isAnnual ? 'flex' : 'flex-annual');
+      {allowAnual && (
+        <Stack css={{ gap: '8px' }}>
+          <Switch
+            id="recurring"
+            on={isAnnual}
+            onChange={() => {
+              actions.checkout.selectPlan(isAnnual ? 'flex' : 'flex-annual');
 
-            track('Checkout - Toggle recurring type', {
-              from: 'summary',
-              newValue: isAnnual ? 'annual' : 'monthly',
-            });
-          }}
-        />
-        <Stack direction="vertical" css={{ marginTop: -3 }}>
-          <Text color="#fff" as="label" htmlFor="recurring">
-            Annual (Save 30%)
-          </Text>
+              track('Checkout - Toggle recurring type', {
+                from: 'summary',
+                newValue: isAnnual ? 'annual' : 'monthly',
+              });
+            }}
+          />
+          <Stack direction="vertical" css={{ marginTop: -3 }}>
+            <Text color="#fff" as="label" htmlFor="recurring">
+              Annual (Save 30%)
+            </Text>
 
-          {isAnnual && <Text>24 hour processing time</Text>}
+            {isAnnual && <Text>24 hour processing time</Text>}
+          </Stack>
         </Stack>
-      </Stack>
+      )}
 
       <Text size={3}>
         Additional VM credits are available on-demand for $0.018/credit.

--- a/packages/app/src/app/components/WorkspaceSetup/WorkspaceSetup.tsx
+++ b/packages/app/src/app/components/WorkspaceSetup/WorkspaceSetup.tsx
@@ -40,6 +40,7 @@ export const WorkspaceSetup: React.FC<WorkspaceSetupProps> = ({
     <WorkspaceFlowLayout
       showSummary={STEPS_WITH_CHECKOUT.includes(currentStep)}
       allowSummaryChanges={currentStep === 'addons'}
+      flow={flow}
     >
       <Component
         flow={flow}

--- a/packages/app/src/app/components/WorkspaceSetup/WorkspaceSetup.tsx
+++ b/packages/app/src/app/components/WorkspaceSetup/WorkspaceSetup.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { WorkspaceFlowLayout } from './Layout';
-import { StepProps, WorkspaceSetupStep } from './types';
+import { StepProps, WorkspaceSetupStep, WorkspaceFlow } from './types';
 import { Create } from './steps/Create';
 import { Plans } from './steps/Plans';
 import { SpendingLimit } from './steps/SpendingLimit';
@@ -9,6 +9,7 @@ import { Addons } from './steps/Addons';
 import { Finalize } from './steps/Finalize';
 
 export type WorkspaceSetupProps = {
+  flow: WorkspaceFlow;
   steps: WorkspaceSetupStep[];
   startFrom?: WorkspaceSetupStep; // when this isn't passed, first one from the array is used
   onComplete: (fullReload?: boolean) => void;
@@ -16,6 +17,7 @@ export type WorkspaceSetupProps = {
 };
 
 export const WorkspaceSetup: React.FC<WorkspaceSetupProps> = ({
+  flow,
   steps,
   startFrom,
   onComplete,
@@ -40,6 +42,7 @@ export const WorkspaceSetup: React.FC<WorkspaceSetupProps> = ({
       allowSummaryChanges={currentStep === 'addons'}
     >
       <Component
+        flow={flow}
         currentStep={currentStepIndex}
         numberOfSteps={steps.length}
         onPrevStep={() => setCurrentStepIndex(crtStepIndex => crtStepIndex - 1)}

--- a/packages/app/src/app/components/WorkspaceSetup/WorkspaceSetup.tsx
+++ b/packages/app/src/app/components/WorkspaceSetup/WorkspaceSetup.tsx
@@ -7,6 +7,7 @@ import { SpendingLimit } from './steps/SpendingLimit';
 import { SelectWorkspace } from './steps/SelectWorkspace';
 import { Addons } from './steps/Addons';
 import { Finalize } from './steps/Finalize';
+import { ChangeAddons } from './steps/ChangeAddons';
 
 export type WorkspaceSetupProps = {
   flow: WorkspaceFlow;
@@ -62,6 +63,11 @@ const STEP_COMPONENTS: Record<WorkspaceSetupStep, React.FC<StepProps>> = {
   'spending-limit': SpendingLimit,
   addons: Addons,
   finalize: Finalize,
+  'change-addons-confirmation': ChangeAddons,
 };
 
-const STEPS_WITH_CHECKOUT: WorkspaceSetupStep[] = ['spending-limit', 'addons'];
+const STEPS_WITH_CHECKOUT: WorkspaceSetupStep[] = [
+  'spending-limit',
+  'addons',
+  'change-addons-confirmation',
+];

--- a/packages/app/src/app/components/WorkspaceSetup/steps/Addons.tsx
+++ b/packages/app/src/app/components/WorkspaceSetup/steps/Addons.tsx
@@ -19,14 +19,12 @@ export const Addons: React.FC<StepProps> = ({
   numberOfSteps,
 }) => {
   const {
-    checkout: { availableCreditAddons, addonChanges },
+    checkout: { availableCreditAddons },
   } = useAppState();
   const { isPro } = useWorkspaceSubscription();
   const { checkout } = useActions();
   const { getQueryParam } = useURLSearchParams();
   const urlWorkspaceId = getQueryParam('workspace');
-
-  const disableActions = flow === 'manage-addons' && addonChanges.length === 0;
 
   const handleSubmit = () => {
     if (isPro) {
@@ -45,7 +43,6 @@ export const Addons: React.FC<StepProps> = ({
       <Stack direction="vertical" gap={12}>
         <StepHeader
           onPrevStep={() => {
-            checkout.clearCheckout();
             onPrevStep();
           }}
           onDismiss={onDismiss}
@@ -100,7 +97,6 @@ export const Addons: React.FC<StepProps> = ({
         <Stack gap={2}>
           {flow === 'manage-addons' && (
             <Button
-              disabled={disableActions}
               variant="secondary"
               type="button"
               autoWidth
@@ -112,12 +108,7 @@ export const Addons: React.FC<StepProps> = ({
               Reset changes
             </Button>
           )}
-          <Button
-            disabled={disableActions}
-            autoWidth
-            size="large"
-            onClick={handleSubmit}
-          >
+          <Button autoWidth size="large" onClick={handleSubmit}>
             Next
           </Button>
         </Stack>

--- a/packages/app/src/app/components/WorkspaceSetup/steps/Addons.tsx
+++ b/packages/app/src/app/components/WorkspaceSetup/steps/Addons.tsx
@@ -19,12 +19,14 @@ export const Addons: React.FC<StepProps> = ({
   numberOfSteps,
 }) => {
   const {
-    checkout: { availableCreditAddons },
+    checkout: { availableCreditAddons, addonChanges },
   } = useAppState();
   const { isPro } = useWorkspaceSubscription();
   const { checkout } = useActions();
   const { getQueryParam } = useURLSearchParams();
   const urlWorkspaceId = getQueryParam('workspace');
+
+  const disableActions = flow === 'manage-addons' && addonChanges.length === 0;
 
   const handleSubmit = () => {
     if (isPro) {
@@ -50,7 +52,9 @@ export const Addons: React.FC<StepProps> = ({
           currentStep={currentStep}
           numberOfSteps={numberOfSteps}
           title={
-            flow === 'manage-addons' ? 'Update plan' : 'Choose your add-ons (optional)'
+            flow === 'manage-addons'
+              ? 'Update plan'
+              : 'Choose your add-ons (optional)'
           }
         />
 
@@ -92,9 +96,30 @@ export const Addons: React.FC<StepProps> = ({
           </Element>
         </Stack>
 
-        <Button autoWidth size="large" onClick={handleSubmit}>
-          Next
-        </Button>
+        <Stack gap={2}>
+          {flow === 'manage-addons' && (
+            <Button
+              disabled={disableActions}
+              variant="secondary"
+              type="button"
+              autoWidth
+              size="large"
+              onClick={() => {
+                checkout.initializeCartFromExistingSubscription();
+              }}
+            >
+              Reset changes
+            </Button>
+          )}
+          <Button
+            disabled={disableActions}
+            autoWidth
+            size="large"
+            onClick={handleSubmit}
+          >
+            Next
+          </Button>
+        </Stack>
       </Stack>
     </AnimatedStep>
   );

--- a/packages/app/src/app/components/WorkspaceSetup/steps/ChangeAddons.tsx
+++ b/packages/app/src/app/components/WorkspaceSetup/steps/ChangeAddons.tsx
@@ -20,9 +20,12 @@ export const ChangeAddons: React.FC<StepProps> = ({
   const { checkout } = useAppState();
   const { getQueryParam } = useURLSearchParams();
   const urlWorkspaceId = getQueryParam('workspace');
+  const [isSubmitting, setSubmitting] = React.useState(false);
 
   const handleSubmit = async e => {
     e.preventDefault();
+    setSubmitting(true);
+
     const result = await actions.checkout.updateSubscriptionAddons({
       workspaceId: urlWorkspaceId,
     });
@@ -37,6 +40,7 @@ export const ChangeAddons: React.FC<StepProps> = ({
         type: 'error',
         timeAlive: 10,
       });
+      setSubmitting(false);
     }
   };
 
@@ -63,7 +67,7 @@ export const ChangeAddons: React.FC<StepProps> = ({
               Current plan
             </Text>
             <Text size={5} color="#e5e5e5">
-              ${checkout.currentSubscriptionTotalPrice}
+              ${checkout.currentSubscription.totalPrice}
             </Text>
           </Stack>
 
@@ -98,16 +102,16 @@ export const ChangeAddons: React.FC<StepProps> = ({
                 New total per month
               </Text>
               <Text size={5} color="#e5e5e5">
-                ${checkout.totalPrice}
+                ${checkout.newSubscription.totalPrice}
               </Text>
             </Stack>
             <Text size={4} color="inherit">
-              * tax not included
+              tax not included
             </Text>
           </Stack>
         </Stack>
 
-        <Button autoWidth size="large" type="submit">
+        <Button autoWidth size="large" type="submit" disabled={isSubmitting}>
           Confirm changes
         </Button>
       </Stack>

--- a/packages/app/src/app/components/WorkspaceSetup/steps/ChangeAddons.tsx
+++ b/packages/app/src/app/components/WorkspaceSetup/steps/ChangeAddons.tsx
@@ -5,7 +5,6 @@ import * as dashboardUrls from '@codesandbox/common/lib/utils/url-generator/dash
 
 import { useURLSearchParams } from 'app/hooks/useURLSearchParams';
 import { useActions, useAppState } from 'app/overmind';
-import { AddonItem } from 'app/overmind/namespaces/checkout/types';
 import { StepProps } from '../types';
 import { StepHeader } from '../StepHeader';
 import { AnimatedStep } from '../elements';
@@ -15,26 +14,30 @@ export const ChangeAddons: React.FC<StepProps> = ({
   onDismiss,
   currentStep,
   numberOfSteps,
+  flow,
 }) => {
+  const actions = useActions();
   const { checkout } = useAppState();
   const { getQueryParam } = useURLSearchParams();
   const urlWorkspaceId = getQueryParam('workspace');
 
   const handleSubmit = async e => {
     e.preventDefault();
-    // const result = await actions.checkout.convertToUsageBilling({
-    //   workspaceId: urlWorkspaceId,
-    // });
-    // if (result.success) {
-    //   track('Checkout - Change Pro Plan');
-    //   window.location.href = dashboardUrls.portalOverview(urlWorkspaceId);
-    // } else {
-    //   actions.addNotification({
-    //     message: result.error,
-    //     type: 'error',
-    //     timeAlive: 10,
-    //   });
-    // }
+    const result = await actions.checkout.updateSubscriptionAddons({
+      workspaceId: urlWorkspaceId,
+    });
+    if (result.success) {
+      track('Checkout - Update subscription addons', {
+        from: flow,
+      });
+      window.location.href = dashboardUrls.portalOverview(urlWorkspaceId);
+    } else {
+      actions.addNotification({
+        message: result.error,
+        type: 'error',
+        timeAlive: 10,
+      });
+    }
   };
 
   return (

--- a/packages/app/src/app/components/WorkspaceSetup/steps/ChangeAddons.tsx
+++ b/packages/app/src/app/components/WorkspaceSetup/steps/ChangeAddons.tsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import track from '@codesandbox/common/lib/utils/analytics';
+import { Stack, Button, Text, Element } from '@codesandbox/components';
+import * as dashboardUrls from '@codesandbox/common/lib/utils/url-generator/dashboard';
+
+import { useURLSearchParams } from 'app/hooks/useURLSearchParams';
+import { useActions, useAppState } from 'app/overmind';
+import { AddonItem } from 'app/overmind/namespaces/checkout/types';
+import { StepProps } from '../types';
+import { StepHeader } from '../StepHeader';
+import { AnimatedStep } from '../elements';
+
+export const ChangeAddons: React.FC<StepProps> = ({
+  onPrevStep,
+  onDismiss,
+  currentStep,
+  numberOfSteps,
+}) => {
+  const { checkout } = useAppState();
+  const { getQueryParam } = useURLSearchParams();
+  const urlWorkspaceId = getQueryParam('workspace');
+
+  const handleSubmit = async e => {
+    e.preventDefault();
+    // const result = await actions.checkout.convertToUsageBilling({
+    //   workspaceId: urlWorkspaceId,
+    // });
+    // if (result.success) {
+    //   track('Checkout - Change Pro Plan');
+    //   window.location.href = dashboardUrls.portalOverview(urlWorkspaceId);
+    // } else {
+    //   actions.addNotification({
+    //     message: result.error,
+    //     type: 'error',
+    //     timeAlive: 10,
+    //   });
+    // }
+  };
+
+  return (
+    <AnimatedStep>
+      <Stack
+        direction="vertical"
+        css={{ minWidth: '400px' }}
+        gap={12}
+        as="form"
+        onSubmit={handleSubmit}
+      >
+        <StepHeader
+          onPrevStep={onPrevStep}
+          onDismiss={onDismiss}
+          currentStep={currentStep}
+          numberOfSteps={numberOfSteps}
+          title="Review changes"
+        />
+
+        <Stack direction="vertical" gap={6}>
+          <Stack justify="space-between" gap={4}>
+            <Text size={5} color="#e5e5e5">
+              Current plan (per month)
+            </Text>
+            <Text size={5} color="#e5e5e5">
+              ${checkout.currentSubscriptionTotalPrice}
+            </Text>
+          </Stack>
+
+          {checkout.addonChanges.map(change => {
+            const changePrefix = change.quantity > 0 ? 'Added' : 'Removed';
+            const changeSign = change.quantity > 0 ? '+' : '-';
+
+            return (
+              <Stack justify="space-between" key={change.addon.id} gap={4}>
+                <Text size={5} color="#e5e5e5">
+                  {changePrefix}{' '}
+                  {Math.abs(change.quantity) > 1
+                    ? `${Math.abs(change.quantity)} x `
+                    : ''}
+                  {change.addon.credits} VM credits
+                </Text>
+                <Text
+                  size={5}
+                  color={change.quantity > 0 ? '#A3EC98' : '#DD5F5F'}
+                >
+                  {changeSign}${change.addon.price * Math.abs(change.quantity)}
+                </Text>
+              </Stack>
+            );
+          })}
+
+          <Element as="hr" css={{ width: '100%' }} />
+
+          <Stack justify="space-between" gap={4}>
+            <Text size={5} color="#e5e5e5">
+              New total (per month)
+            </Text>
+            <Text size={5} color="#e5e5e5">
+              ${checkout.totalPrice}
+            </Text>
+          </Stack>
+        </Stack>
+
+        <Button autoWidth size="large" type="submit">
+          Confirm changes
+        </Button>
+      </Stack>
+    </AnimatedStep>
+  );
+};

--- a/packages/app/src/app/components/WorkspaceSetup/steps/ChangeAddons.tsx
+++ b/packages/app/src/app/components/WorkspaceSetup/steps/ChangeAddons.tsx
@@ -60,7 +60,7 @@ export const ChangeAddons: React.FC<StepProps> = ({
         <Stack direction="vertical" gap={6}>
           <Stack justify="space-between" gap={4}>
             <Text size={5} color="#e5e5e5">
-              Current plan (per month)
+              Current plan
             </Text>
             <Text size={5} color="#e5e5e5">
               ${checkout.currentSubscriptionTotalPrice}
@@ -92,12 +92,17 @@ export const ChangeAddons: React.FC<StepProps> = ({
 
           <Element as="hr" css={{ width: '100%' }} />
 
-          <Stack justify="space-between" gap={4}>
-            <Text size={5} color="#e5e5e5">
-              New total (per month)
-            </Text>
-            <Text size={5} color="#e5e5e5">
-              ${checkout.totalPrice}
+          <Stack direction="vertical">
+            <Stack justify="space-between" gap={4}>
+              <Text size={5} color="#e5e5e5">
+                New total per month
+              </Text>
+              <Text size={5} color="#e5e5e5">
+                ${checkout.totalPrice}
+              </Text>
+            </Stack>
+            <Text size={4} color="inherit">
+              * tax not included
             </Text>
           </Stack>
         </Stack>

--- a/packages/app/src/app/components/WorkspaceSetup/steps/ChangePlan.tsx
+++ b/packages/app/src/app/components/WorkspaceSetup/steps/ChangePlan.tsx
@@ -56,10 +56,10 @@ export const ChangePlan: React.FC<StepProps> = ({
             <Text size={6} color="#e5e5e5">
               Pro plan
             </Text>
-            <Text>{checkout.totalCredits} VM credits</Text>
+            <Text>{checkout.newSubscription.totalCredits} VM credits</Text>
           </Stack>
           <Text size={6} color="#e5e5e5">
-            ${checkout.totalPrice} / month
+            ${checkout.newSubscription.totalPrice} / month
           </Text>
         </Stack>
 

--- a/packages/app/src/app/components/WorkspaceSetup/steps/Finalize.tsx
+++ b/packages/app/src/app/components/WorkspaceSetup/steps/Finalize.tsx
@@ -34,13 +34,7 @@ const AnnualForm = ({
   refreshParentSelectedPlan,
 }: StepProps & { refreshParentSelectedPlan: () => void }) => {
   const { checkout } = useAppState();
-  const {
-    selectedPlan,
-    totalPrice,
-    totalCredits,
-    spendingLimit,
-    availableBasePlans,
-  } = checkout;
+  const { basePlan, totalPrice, totalCredits, spendingLimit } = checkout;
   const [country, setCountry] = React.useState('');
   const [zipCode, setZipCode] = React.useState('');
   const [success, setSuccess] = React.useState(false);
@@ -50,8 +44,7 @@ const AnnualForm = ({
   const { getQueryParam } = useURLSearchParams();
   const workspaceId = getQueryParam('workspace');
 
-  const basePlan = availableBasePlans[selectedPlan];
-  const isAnnual = selectedPlan === 'flex-annual';
+  const isAnnual = basePlan.id === 'flex-annual';
   const disabled = !country || !zipCode;
 
   useEffect(() => {
@@ -75,7 +68,7 @@ const AnnualForm = ({
             [
               '',
               workspaceId,
-              checkout.selectedPlan,
+              basePlan.id,
               addons === '' ? 'N/A' : addons,
               checkout.spendingLimit,
               country,
@@ -267,14 +260,14 @@ export const Finalize: React.FC<StepProps> = props => {
   // This internal state is used to avoid unnecessary rerenders
   // and show the wrong step while the user is recurring plan
   const [_stepSelectedPlan, setStepSelectedPlan] = React.useState<PlanType>(
-    checkout.selectedPlan
+    checkout.basePlan.id
   );
 
   if (_stepSelectedPlan === 'flex-annual') {
     return (
       <AnnualForm
         refreshParentSelectedPlan={() =>
-          setStepSelectedPlan(checkout.selectedPlan)
+          setStepSelectedPlan(checkout.basePlan.id)
         }
         {...props}
       />

--- a/packages/app/src/app/components/WorkspaceSetup/steps/Finalize.tsx
+++ b/packages/app/src/app/components/WorkspaceSetup/steps/Finalize.tsx
@@ -34,7 +34,7 @@ const AnnualForm = ({
   refreshParentSelectedPlan,
 }: StepProps & { refreshParentSelectedPlan: () => void }) => {
   const { checkout } = useAppState();
-  const { basePlan, totalPrice, totalCredits, spendingLimit } = checkout;
+  const { newSubscription, spendingLimit } = checkout;
   const [country, setCountry] = React.useState('');
   const [zipCode, setZipCode] = React.useState('');
   const [success, setSuccess] = React.useState(false);
@@ -44,19 +44,19 @@ const AnnualForm = ({
   const { getQueryParam } = useURLSearchParams();
   const workspaceId = getQueryParam('workspace');
 
-  const isAnnual = basePlan.id === 'flex-annual';
+  const isAnnual = newSubscription.basePlan.id === 'flex-annual';
   const disabled = !country || !zipCode;
 
   useEffect(() => {
     actions.checkout.recomputeTotals();
   }, []);
 
-  if (!basePlan) {
+  if (!newSubscription) {
     return null;
   }
 
   const annualSendRequest = async () => {
-    const addons = checkout.creditAddons
+    const addons = newSubscription.addonItems
       .map(item => `${item.addon.credits} x ${item.quantity}`)
       .join(', ');
 
@@ -68,7 +68,7 @@ const AnnualForm = ({
             [
               '',
               workspaceId,
-              basePlan.id,
+              newSubscription.basePlan.id,
               addons === '' ? 'N/A' : addons,
               checkout.spendingLimit,
               country,
@@ -174,12 +174,12 @@ const AnnualForm = ({
           </Text>
 
           <Text size={6} color="#fff">
-            ${totalPrice} {isAnnual ? ' / year' : '/ month'}
+            ${newSubscription.totalPrice} {isAnnual ? ' / year' : '/ month'}
           </Text>
         </Stack>
 
         <Text color="#CCCCCC" size={4}>
-          {totalCredits} VM credits/month
+          {newSubscription.totalCredits} VM credits/month
         </Text>
 
         <Text color="#CCCCCC" size={4}>
@@ -261,14 +261,14 @@ export const Finalize: React.FC<StepProps> = props => {
   // This internal state is used to avoid unnecessary rerenders
   // and show the wrong step while the user is recurring plan
   const [_stepSelectedPlan, setStepSelectedPlan] = React.useState<PlanType>(
-    checkout.basePlan.id
+    checkout.newSubscription.basePlan.id
   );
 
   if (_stepSelectedPlan === 'flex-annual') {
     return (
       <AnnualForm
         refreshParentSelectedPlan={() =>
-          setStepSelectedPlan(checkout.basePlan.id)
+          setStepSelectedPlan(checkout.newSubscription.basePlan.id)
         }
         {...props}
       />

--- a/packages/app/src/app/components/WorkspaceSetup/steps/Payment.tsx
+++ b/packages/app/src/app/components/WorkspaceSetup/steps/Payment.tsx
@@ -21,7 +21,7 @@ export const Payment: React.FC<StepProps> = ({
 }) => {
   const { api } = useEffects();
   const {
-    checkout: { basePlan },
+    checkout: { newSubscription },
   } = useAppState();
   const actions = useActions();
   const { getQueryParam } = useURLSearchParams();
@@ -50,7 +50,7 @@ export const Payment: React.FC<StepProps> = ({
         success_path: successPath,
         cancel_path: cancelPath,
         team_id: workspaceId,
-        plan: basePlan.id,
+        plan: newSubscription.basePlan.id,
         addons: actions.checkout.getFlatAddonsList(),
       });
 

--- a/packages/app/src/app/components/WorkspaceSetup/steps/Payment.tsx
+++ b/packages/app/src/app/components/WorkspaceSetup/steps/Payment.tsx
@@ -21,7 +21,7 @@ export const Payment: React.FC<StepProps> = ({
 }) => {
   const { api } = useEffects();
   const {
-    checkout: { selectedPlan },
+    checkout: { basePlan },
   } = useAppState();
   const actions = useActions();
   const { getQueryParam } = useURLSearchParams();
@@ -50,7 +50,7 @@ export const Payment: React.FC<StepProps> = ({
         success_path: successPath,
         cancel_path: cancelPath,
         team_id: workspaceId,
-        plan: selectedPlan,
+        plan: basePlan.id,
         addons: actions.checkout.getFlatAddonsList(),
       });
 

--- a/packages/app/src/app/components/WorkspaceSetup/steps/Plans.tsx
+++ b/packages/app/src/app/components/WorkspaceSetup/steps/Plans.tsx
@@ -56,9 +56,10 @@ export const Plans: React.FC<StepProps> = ({
       'flex-annual': proAnnualPlan,
       free: freePlan,
     },
+    basePlan,
   } = checkout;
 
-  const annualPlan = checkout.selectedPlan === 'flex-annual';
+  const annualPlan = basePlan.id === 'flex-annual';
   const currentProPlan = annualPlan ? proAnnualPlan : proPlan;
 
   // For new workspaces

--- a/packages/app/src/app/components/WorkspaceSetup/steps/Plans.tsx
+++ b/packages/app/src/app/components/WorkspaceSetup/steps/Plans.tsx
@@ -14,7 +14,6 @@ import styled from 'styled-components';
 import { useURLSearchParams } from 'app/hooks/useURLSearchParams';
 import { useActions, useAppState, useEffects } from 'app/overmind';
 import { VMTier } from 'app/overmind/effects/api/types';
-import { useLocation } from 'react-router-dom';
 import { useWorkspaceSubscription } from 'app/hooks/useWorkspaceSubscription';
 import { PricingPlan } from 'app/overmind/namespaces/checkout/types';
 import { StepProps } from '../types';
@@ -35,6 +34,7 @@ export const Plans: React.FC<StepProps> = ({
   onDismiss,
   currentStep,
   numberOfSteps,
+  flow,
 }) => {
   const { getQueryParam } = useURLSearchParams();
   const { activeTeam, checkout } = useAppState();
@@ -42,11 +42,8 @@ export const Plans: React.FC<StepProps> = ({
   const actions = useActions();
   const effects = useEffects();
   const urlWorkspaceId = getQueryParam('workspace');
-  const planFromUrl = getQueryParam('plan');
-  const { pathname } = useLocation();
   const [tiers, setTiers] = useState<VMTier[]>([]);
   const { isFree } = useWorkspaceSubscription();
-  const isUpgrading = pathname.includes('upgrade');
   const showFreePlan = isFree;
 
   const {
@@ -56,24 +53,18 @@ export const Plans: React.FC<StepProps> = ({
       'flex-annual': proAnnualPlan,
       free: freePlan,
     },
-    basePlan,
+    newSubscription,
   } = checkout;
 
-  const annualPlan = basePlan.id === 'flex-annual';
+  const annualPlan = newSubscription?.basePlan.id === 'flex-annual';
   const currentProPlan = annualPlan ? proAnnualPlan : proPlan;
 
   // For new workspaces
-  const freeButtonCTA = isUpgrading
-    ? 'Continue on Free'
-    : 'Get started for free';
+  const freeButtonCTA =
+    flow === 'create-workspace' ? 'Get started for free' : 'Continue on Free';
 
   useEffect(() => {
-    if (planFromUrl === 'flex' || planFromUrl === 'flex-annual') {
-      actions.checkout.selectPlan(planFromUrl);
-    }
-
     actions.checkout.fetchPrices();
-    actions.checkout.recomputeTotals();
     effects.api.getVMSpecs().then(res => setTiers(res.vmTiers));
   }, []);
 
@@ -84,8 +75,9 @@ export const Plans: React.FC<StepProps> = ({
   }, [urlWorkspaceId, activeTeam, actions]);
 
   const handleProPlanSelection = async () => {
+    actions.checkout.selectPlan(annualPlan ? 'flex-annual' : 'flex');
     track('Checkout - Select Pro Plan', {
-      from: isUpgrading ? 'upgrade' : 'create-workspace',
+      from: flow,
       currentPlan: isFree ? 'free' : 'pro',
     });
     onNextStep();
@@ -118,7 +110,7 @@ export const Plans: React.FC<StepProps> = ({
           </Stack>
 
           <HorizontalScroller css={{ width: '100%' }}>
-            <Stack gap={6} >
+            <Stack gap={6}>
               {showFreePlan && (
                 <StyledCard
                   direction="vertical"
@@ -145,7 +137,7 @@ export const Plans: React.FC<StepProps> = ({
                     size="large"
                     onClick={() => {
                       track('Checkout - Select Free Plan', {
-                        from: isUpgrading ? 'upgrade' : 'create-workspace',
+                        from: flow,
                         currentPlan: isFree ? 'free' : 'pro',
                       });
                       onEarlyExit();
@@ -226,7 +218,7 @@ export const Plans: React.FC<StepProps> = ({
                   href={ORGANIZATION_CONTACT_LINK}
                   onClick={() => {
                     track('Checkout - Select Enterprise Plan', {
-                      from: isUpgrading ? 'upgrade' : 'create-workspace',
+                      from: flow,
                       currentPlan: isFree ? 'free' : 'pro',
                     });
                   }}

--- a/packages/app/src/app/components/WorkspaceSetup/steps/SpendingLimit.tsx
+++ b/packages/app/src/app/components/WorkspaceSetup/steps/SpendingLimit.tsx
@@ -5,7 +5,6 @@ import { InputText } from 'app/components/dashboard/InputText';
 import { useURLSearchParams } from 'app/hooks/useURLSearchParams';
 import { useActions, useAppState } from 'app/overmind';
 import { useWorkspaceSubscription } from 'app/hooks/useWorkspaceSubscription';
-import { useLocation } from 'react-router-dom';
 import { StepProps } from '../types';
 import { StepHeader } from '../StepHeader';
 import { AnimatedStep } from '../elements';
@@ -16,6 +15,7 @@ export const SpendingLimit: React.FC<StepProps> = ({
   onDismiss,
   currentStep,
   numberOfSteps,
+  flow,
 }) => {
   const actions = useActions();
   const { checkout } = useAppState();
@@ -23,8 +23,6 @@ export const SpendingLimit: React.FC<StepProps> = ({
   const urlWorkspaceId = getQueryParam('workspace');
   const [error, setError] = React.useState<React.ReactNode>('');
   const { isPro } = useWorkspaceSubscription();
-  const { pathname } = useLocation();
-  const isUpgrading = pathname.includes('upgrade');
 
   const handleChange = e => {
     setError('');
@@ -68,7 +66,7 @@ export const SpendingLimit: React.FC<StepProps> = ({
         as="form"
         onSubmit={() => {
           track('Checkout - Proceed to checkout', {
-            from: isUpgrading ? 'upgrade' : 'create-workspace',
+            from: flow,
             currentPlan: isPro ? 'pro' : 'free',
           });
           onNextStep();
@@ -84,11 +82,11 @@ export const SpendingLimit: React.FC<StepProps> = ({
         />
 
         <Text color="#a6a6a6">
-          Your plan will include {checkout.totalCredits} credits/month. If your
-          usage exceeds that amount, we will automatically bill you for
-          on-demand credits at $0.018/credit. You can set a monthly spend limit
-          for on-demand credits to control your spend. You can change this limit
-          at any time.
+          Your plan will include {checkout.newSubscription.totalCredits}{' '}
+          credits/month. If your usage exceeds that amount, we will
+          automatically bill you for on-demand credits at $0.018/credit. You can
+          set a monthly spend limit for on-demand credits to control your spend.
+          You can change this limit at any time.
         </Text>
 
         <Stack direction="vertical" gap={2}>

--- a/packages/app/src/app/components/WorkspaceSetup/types.ts
+++ b/packages/app/src/app/components/WorkspaceSetup/types.ts
@@ -3,6 +3,7 @@ export type WorkspaceSetupStep =
   | 'select-workspace'
   | 'plans'
   | 'addons'
+  | 'change-addons-confirmation'
   | 'spending-limit'
   | 'finalize';
 

--- a/packages/app/src/app/components/WorkspaceSetup/types.ts
+++ b/packages/app/src/app/components/WorkspaceSetup/types.ts
@@ -7,6 +7,7 @@ export type WorkspaceSetupStep =
   | 'finalize';
 
 export interface StepProps {
+  flow: WorkspaceFlow;
   currentStep: number;
   numberOfSteps: number;
   onNextStep: () => void;
@@ -14,3 +15,5 @@ export interface StepProps {
   onEarlyExit: (fullReload?: boolean) => void;
   onDismiss: () => void;
 }
+
+export type WorkspaceFlow = 'create-workspace' | 'upgrade' | 'manage-addons';

--- a/packages/app/src/app/graphql/types.ts
+++ b/packages/app/src/app/graphql/types.ts
@@ -1128,9 +1128,7 @@ export type SubscriptionItem = {
   name: Scalars['String'];
   /** Quanity is null for metered items, such as the on-demand credit usage. */
   quantity: Maybe<Scalars['Int']>;
-  /** Price per unit in cents */
   unitAmount: Maybe<Scalars['Int']>;
-  /** Price in fractions of a cent (currently only for on-demand credits) */
   unitAmountDecimal: Maybe<Scalars['String']>;
 };
 
@@ -5521,6 +5519,16 @@ export type ConvertToUsageBillingMutationVariables = Exact<{
 export type ConvertToUsageBillingMutation = {
   __typename?: 'RootMutationType';
   convertToUsageBilling: boolean;
+};
+
+export type UpdateUsageSubscriptionMutationVariables = Exact<{
+  teamId: Scalars['UUID4'];
+  addons: Array<Scalars['String']> | Scalars['String'];
+}>;
+
+export type UpdateUsageSubscriptionMutation = {
+  __typename?: 'RootMutationType';
+  updateUsageSubscription: boolean;
 };
 
 export type UpdateProjectVmTierMutationVariables = Exact<{

--- a/packages/app/src/app/graphql/types.ts
+++ b/packages/app/src/app/graphql/types.ts
@@ -196,6 +196,7 @@ export type RootQueryTypeGithubOrganizationReposArgs = {
   organization: Scalars['String'];
   page: InputMaybe<Scalars['Int']>;
   perPage: InputMaybe<Scalars['Int']>;
+  sort: InputMaybe<UserRepoSort>;
 };
 
 export type RootQueryTypeGithubRepoArgs = {
@@ -405,6 +406,7 @@ export type Team = {
   settings: Maybe<WorkspaceSandboxSettings>;
   shortid: Scalars['String'];
   subscription: Maybe<ProSubscription>;
+  subscriptionSchedule: Maybe<SubscriptionSchedule>;
   templates: Array<Template>;
   /** @deprecated All teams are teams now */
   type: TeamType;
@@ -1108,6 +1110,26 @@ export enum SubscriptionType {
   TeamPro = 'TEAM_PRO',
 }
 
+export type SubscriptionSchedule = {
+  __typename?: 'SubscriptionSchedule';
+  current: Maybe<SubscriptionSchedulePhase>;
+  upcoming: Maybe<SubscriptionSchedulePhase>;
+};
+
+export type SubscriptionSchedulePhase = {
+  __typename?: 'SubscriptionSchedulePhase';
+  endDate: Maybe<Scalars['String']>;
+  items: Array<SubscriptionItem>;
+  startDate: Maybe<Scalars['String']>;
+};
+
+export type SubscriptionItem = {
+  __typename?: 'SubscriptionItem';
+  name: Scalars['String'];
+  /** Quanity is null for metered items, such as the on-demand credit usage. */
+  quantity: Maybe<Scalars['Int']>;
+};
+
 export enum TeamType {
   Personal = 'PERSONAL',
   Team = 'TEAM',
@@ -1323,6 +1345,14 @@ export type LiveSessionHost = {
   username: Scalars['String'];
 };
 
+/** Sorting key for repositories */
+export enum UserRepoSort {
+  Created = 'CREATED',
+  FullName = 'FULL_NAME',
+  Pushed = 'PUSHED',
+  Updated = 'UPDATED',
+}
+
 /** Details about a repository as it appears on GitHub (Open API `repository`) */
 export type GithubRepo = {
   __typename?: 'GithubRepo';
@@ -1515,14 +1545,6 @@ export enum UserRepoAffiliation {
   Collaborator = 'COLLABORATOR',
   OrganizationMember = 'ORGANIZATION_MEMBER',
   Owner = 'OWNER',
-}
-
-/** Sorting key for repositories */
-export enum UserRepoSort {
-  Created = 'CREATED',
-  FullName = 'FULL_NAME',
-  Pushed = 'PUSHED',
-  Updated = 'UPDATED',
 }
 
 export type NotificationPreferences = {
@@ -2088,6 +2110,14 @@ export type RootMutationType = {
   /** update subscription details (not billing details) */
   updateSubscription: ProSubscription;
   updateSubscriptionBillingInterval: ProSubscription;
+  /**
+   * Update an active usage-based billing subscription.
+   *
+   * This mutation requires the caller to be an admin of the team. Otherwise, an error will be
+   * returned `"Not an admin"`. This return value will always be `true`. Clients should observe
+   * the `teamEvents` subscription for updates to the workspace subscription.
+   */
+  updateUsageSubscription: Scalars['Boolean'];
 };
 
 export type RootMutationTypeAcceptTeamInvitationArgs = {
@@ -2665,6 +2695,11 @@ export type RootMutationTypeUpdateSubscriptionArgs = {
 export type RootMutationTypeUpdateSubscriptionBillingIntervalArgs = {
   billingInterval: SubscriptionInterval;
   subscriptionId: Scalars['UUID4'];
+  teamId: Scalars['UUID4'];
+};
+
+export type RootMutationTypeUpdateUsageSubscriptionArgs = {
+  addons: Array<Scalars['String']>;
   teamId: Scalars['UUID4'];
 };
 
@@ -4691,6 +4726,29 @@ export type CurrentTeamInfoFragmentFragment = {
     unitPrice: number | null;
     updateBillingUrl: string | null;
   } | null;
+  subscriptionSchedule: {
+    __typename?: 'SubscriptionSchedule';
+    current: {
+      __typename?: 'SubscriptionSchedulePhase';
+      startDate: string | null;
+      endDate: string | null;
+      items: Array<{
+        __typename?: 'SubscriptionItem';
+        name: string;
+        quantity: number | null;
+      }>;
+    } | null;
+    upcoming: {
+      __typename?: 'SubscriptionSchedulePhase';
+      startDate: string | null;
+      endDate: string | null;
+      items: Array<{
+        __typename?: 'SubscriptionItem';
+        name: string;
+        quantity: number | null;
+      }>;
+    } | null;
+  } | null;
   limits: {
     __typename?: 'TeamLimits';
     includedCredits: number;
@@ -6131,6 +6189,29 @@ export type GetTeamQuery = {
         type: SubscriptionType;
         unitPrice: number | null;
         updateBillingUrl: string | null;
+      } | null;
+      subscriptionSchedule: {
+        __typename?: 'SubscriptionSchedule';
+        current: {
+          __typename?: 'SubscriptionSchedulePhase';
+          startDate: string | null;
+          endDate: string | null;
+          items: Array<{
+            __typename?: 'SubscriptionItem';
+            name: string;
+            quantity: number | null;
+          }>;
+        } | null;
+        upcoming: {
+          __typename?: 'SubscriptionSchedulePhase';
+          startDate: string | null;
+          endDate: string | null;
+          items: Array<{
+            __typename?: 'SubscriptionItem';
+            name: string;
+            quantity: number | null;
+          }>;
+        } | null;
       } | null;
       limits: {
         __typename?: 'TeamLimits';

--- a/packages/app/src/app/graphql/types.ts
+++ b/packages/app/src/app/graphql/types.ts
@@ -1128,6 +1128,10 @@ export type SubscriptionItem = {
   name: Scalars['String'];
   /** Quanity is null for metered items, such as the on-demand credit usage. */
   quantity: Maybe<Scalars['Int']>;
+  /** Price per unit in cents */
+  unitAmount: Maybe<Scalars['Int']>;
+  /** Price in fractions of a cent (currently only for on-demand credits) */
+  unitAmountDecimal: Maybe<Scalars['String']>;
 };
 
 export enum TeamType {
@@ -4736,6 +4740,8 @@ export type CurrentTeamInfoFragmentFragment = {
         __typename?: 'SubscriptionItem';
         name: string;
         quantity: number | null;
+        unitAmount: number | null;
+        unitAmountDecimal: string | null;
       }>;
     } | null;
     upcoming: {
@@ -4746,6 +4752,8 @@ export type CurrentTeamInfoFragmentFragment = {
         __typename?: 'SubscriptionItem';
         name: string;
         quantity: number | null;
+        unitAmount: number | null;
+        unitAmountDecimal: string | null;
       }>;
     } | null;
   } | null;
@@ -6200,6 +6208,8 @@ export type GetTeamQuery = {
             __typename?: 'SubscriptionItem';
             name: string;
             quantity: number | null;
+            unitAmount: number | null;
+            unitAmountDecimal: string | null;
           }>;
         } | null;
         upcoming: {
@@ -6210,6 +6220,8 @@ export type GetTeamQuery = {
             __typename?: 'SubscriptionItem';
             name: string;
             quantity: number | null;
+            unitAmount: number | null;
+            unitAmountDecimal: string | null;
           }>;
         } | null;
       } | null;

--- a/packages/app/src/app/overmind/effects/gql/dashboard/fragments.ts
+++ b/packages/app/src/app/overmind/effects/gql/dashboard/fragments.ts
@@ -227,6 +227,26 @@ export const currentTeamInfoFragment = gql`
       updateBillingUrl
     }
 
+    subscriptionSchedule {
+      current {
+        items {
+          name
+          quantity
+        }
+        startDate
+        endDate
+      }
+
+      upcoming {
+        items {
+          name
+          quantity
+        }
+        startDate
+        endDate
+      }
+    }
+
     limits {
       includedCredits
       includedSandboxes

--- a/packages/app/src/app/overmind/effects/gql/dashboard/fragments.ts
+++ b/packages/app/src/app/overmind/effects/gql/dashboard/fragments.ts
@@ -232,6 +232,8 @@ export const currentTeamInfoFragment = gql`
         items {
           name
           quantity
+          unitAmount
+          unitAmountDecimal
         }
         startDate
         endDate
@@ -241,6 +243,8 @@ export const currentTeamInfoFragment = gql`
         items {
           name
           quantity
+          unitAmount
+          unitAmountDecimal
         }
         startDate
         endDate

--- a/packages/app/src/app/overmind/effects/gql/dashboard/mutations.ts
+++ b/packages/app/src/app/overmind/effects/gql/dashboard/mutations.ts
@@ -59,6 +59,8 @@ import {
   ConvertToUsageBillingMutationVariables,
   UpdateProjectVmTierMutationVariables,
   UpdateProjectVmTierMutation,
+  UpdateUsageSubscriptionMutationVariables,
+  UpdateUsageSubscriptionMutation,
 } from 'app/graphql/types';
 import { gql, Query } from 'overmind-graphql';
 
@@ -450,6 +452,15 @@ export const convertToUsageBilling: Query<
     $plan: String!
   ) {
     convertToUsageBilling(plan: $plan, addons: $addons, teamId: $teamId)
+  }
+`;
+
+export const updateSubscriptionAddons: Query<
+  UpdateUsageSubscriptionMutation,
+  UpdateUsageSubscriptionMutationVariables
+> = gql`
+  mutation UpdateUsageSubscription($teamId: UUID4!, $addons: [String!]!) {
+    updateUsageSubscription(addons: $addons, teamId: $teamId)
   }
 `;
 

--- a/packages/app/src/app/overmind/namespaces/checkout/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/checkout/actions.ts
@@ -30,7 +30,10 @@ export const selectPlan = ({ state, actions }: Context, plan: PlanType) => {
   actions.checkout.recomputeTotals();
 };
 
-export const setExistingPlan = ({ state, actions }: Context) => {
+export const initializeCartFromExistingSubscription = ({
+  state,
+  actions,
+}: Context) => {
   if (!state.activeTeamInfo?.subscriptionSchedule.current) {
     return;
   }
@@ -38,7 +41,24 @@ export const setExistingPlan = ({ state, actions }: Context) => {
   const { items } = state.activeTeamInfo.subscriptionSchedule.current;
 
   state.checkout.selectedPlan = 'flex';
-  items.forEach(item => {});
+  items.forEach(item => {
+    if (!item.name.startsWith('credits_')) {
+      return;
+    }
+
+    const standardAddon = state.checkout.availableCreditAddons[item.name];
+
+    state.checkout.creditAddons.push({
+      quantity: item.quantity,
+      addon: {
+        id: item.name as CreditAddonType,
+        price: parseInt(item.unitAmountDecimal ?? standardAddon.price, 10),
+        credits: standardAddon.credits,
+      },
+    });
+  });
+
+  actions.checkout.recomputeTotals();
 };
 
 export const addCreditsPackage = (

--- a/packages/app/src/app/overmind/namespaces/checkout/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/checkout/actions.ts
@@ -31,6 +31,17 @@ export const selectPlan = ({ state, actions }: Context, plan: PlanType) => {
   actions.checkout.recomputeTotals();
 };
 
+export const setExistingPlan = ({ state, actions }: Context) => {
+  if (!state.activeTeamInfo?.subscriptionSchedule.current) {
+    return;
+  }
+
+  const { items } = state.activeTeamInfo.subscriptionSchedule.current;
+
+  state.checkout.selectedPlan = 'flex';
+  items.forEach(item => {});
+};
+
 export const addCreditsPackage = (
   { state, actions }: Context,
   addon: CreditAddon

--- a/packages/app/src/app/overmind/namespaces/checkout/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/checkout/actions.ts
@@ -310,3 +310,25 @@ export const recomputeAddonChanges = ({ state }: Context): void => {
 
   state.checkout.addonChanges = changes;
 };
+
+export const updateSubscriptionAddons = async (
+  { effects, actions }: Context,
+  { workspaceId }: { workspaceId: string }
+): Promise<{ success: boolean; error?: string }> => {
+  try {
+    await effects.gql.mutations.updateSubscriptionAddons({
+      teamId: workspaceId,
+      addons: actions.checkout.getFlatAddonsList(),
+    });
+
+    return { success: true };
+  } catch (e) {
+    if (e.response && e.response.errors) {
+      return { success: false, error: e.response.errors[0].message };
+    }
+    return {
+      success: false,
+      error: 'Unexpected error. Please try again later',
+    };
+  }
+};

--- a/packages/app/src/app/overmind/namespaces/checkout/constants.ts
+++ b/packages/app/src/app/overmind/namespaces/checkout/constants.ts
@@ -93,14 +93,12 @@ export const ENTERPRISE_PLAN: PricingPlan = {
 
 export const ADDON_CREDITS_500: CreditAddon = {
   id: 'credits_500',
-  type: 'credits',
   credits: 500,
   price: 9,
 };
 
 export const ADDON_CREDITS_4000: CreditAddon = {
   id: 'credits_4000',
-  type: 'credits',
   credits: 4000,
   price: 50,
   fullPrice: 72,
@@ -109,7 +107,6 @@ export const ADDON_CREDITS_4000: CreditAddon = {
 
 export const ADDON_CREDITS_24000: CreditAddon = {
   id: 'credits_24000',
-  type: 'credits',
   credits: 24000,
   price: 216,
   fullPrice: 432,

--- a/packages/app/src/app/overmind/namespaces/checkout/state.ts
+++ b/packages/app/src/app/overmind/namespaces/checkout/state.ts
@@ -1,5 +1,11 @@
 import { InvoicePreview } from 'app/graphql/types';
-import { CreditAddon, CreditAddonType, PlanType, PricingPlan } from './types';
+import {
+  AddonItem,
+  CreditAddon,
+  CreditAddonType,
+  PlanType,
+  PricingPlan,
+} from './types';
 import {
   FREE_PLAN,
   PRO_PLAN,
@@ -13,10 +19,14 @@ import {
 
 export interface State {
   basePlan: { id: PlanType; name: string; price: number; credits: number };
-  creditAddons: Array<{ addon: CreditAddon; quantity: number }>;
+  creditAddons: Array<AddonItem>;
   spendingLimit: number;
   totalCredits: number;
   totalPrice: number;
+  currentSubscriptionTotalCredits: number;
+  currentSubscriptionTotalPrice: number;
+  currentSubscriptionAddons: Array<AddonItem>;
+  addonChanges: Array<AddonItem>;
   convertProToUBBCharge: InvoicePreview | null;
   availableBasePlans: Record<PlanType, PricingPlan>;
   availableCreditAddons: Record<CreditAddonType, CreditAddon>;
@@ -33,6 +43,10 @@ export const state: State = {
   spendingLimit: DEFAULT_SPENDING_LIMIT,
   totalCredits: 0,
   totalPrice: 0,
+  currentSubscriptionTotalCredits: 0, // Used only for existing UBB Pro when managing addons
+  currentSubscriptionTotalPrice: 0, // Used only for existing UBB Pro when managing addons
+  currentSubscriptionAddons: [], // Used only for existing UBB Pro when managing addons, to compare addons
+  addonChanges: [], // Recomputed everytime an addon is changed
   convertProToUBBCharge: null,
   availableBasePlans: {
     free: FREE_PLAN,

--- a/packages/app/src/app/overmind/namespaces/checkout/state.ts
+++ b/packages/app/src/app/overmind/namespaces/checkout/state.ts
@@ -5,6 +5,7 @@ import {
   CreditAddonType,
   PlanType,
   PricingPlan,
+  SubscriptionPackage,
 } from './types';
 import {
   FREE_PLAN,
@@ -18,14 +19,10 @@ import {
 } from './constants';
 
 export interface State {
-  basePlan: { id: PlanType; name: string; price: number; credits: number };
-  creditAddons: Array<AddonItem>;
   spendingLimit: number;
-  totalCredits: number;
-  totalPrice: number;
-  currentSubscriptionTotalCredits: number;
-  currentSubscriptionTotalPrice: number;
-  currentSubscriptionAddons: Array<AddonItem>;
+  newSubscription: SubscriptionPackage | null;
+  currentSubscription: SubscriptionPackage | null;
+  hasUpcomingChange: boolean;
   addonChanges: Array<AddonItem>;
   convertProToUBBCharge: InvoicePreview | null;
   availableBasePlans: Record<PlanType, PricingPlan>;
@@ -33,20 +30,14 @@ export interface State {
 }
 
 export const state: State = {
-  basePlan: {
-    id: PRO_PLAN_ANNUAL.id,
-    name: PRO_PLAN_ANNUAL.name,
-    price: PRO_PLAN_ANNUAL.price,
-    credits: PRO_PLAN_ANNUAL.credits,
-  },
-  creditAddons: [],
   spendingLimit: DEFAULT_SPENDING_LIMIT,
-  totalCredits: 0,
-  totalPrice: 0,
-  currentSubscriptionTotalCredits: 0, // Used only for existing UBB Pro when managing addons
-  currentSubscriptionTotalPrice: 0, // Used only for existing UBB Pro when managing addons
-  currentSubscriptionAddons: [], // Used only for existing UBB Pro when managing addons, to compare addons
+
+  newSubscription: null,
+  currentSubscription: null,
+  hasUpcomingChange: false,
+
   addonChanges: [], // Recomputed everytime an addon is changed
+
   convertProToUBBCharge: null,
   availableBasePlans: {
     free: FREE_PLAN,

--- a/packages/app/src/app/overmind/namespaces/checkout/state.ts
+++ b/packages/app/src/app/overmind/namespaces/checkout/state.ts
@@ -12,7 +12,7 @@ import {
 } from './constants';
 
 export interface State {
-  selectedPlan: PlanType;
+  basePlan: { id: PlanType; name: string; price: number; credits: number };
   creditAddons: Array<{ addon: CreditAddon; quantity: number }>;
   spendingLimit: number;
   totalCredits: number;
@@ -23,7 +23,12 @@ export interface State {
 }
 
 export const state: State = {
-  selectedPlan: 'flex-annual',
+  basePlan: {
+    id: PRO_PLAN_ANNUAL.id,
+    name: PRO_PLAN_ANNUAL.name,
+    price: PRO_PLAN_ANNUAL.price,
+    credits: PRO_PLAN_ANNUAL.credits,
+  },
   creditAddons: [],
   spendingLimit: DEFAULT_SPENDING_LIMIT,
   totalCredits: 0,

--- a/packages/app/src/app/overmind/namespaces/checkout/types.ts
+++ b/packages/app/src/app/overmind/namespaces/checkout/types.ts
@@ -22,3 +22,5 @@ export type CreditAddon = {
   fullPrice?: number;
   discount?: number;
 };
+
+export type AddonItem = { addon: CreditAddon; quantity: number };

--- a/packages/app/src/app/overmind/namespaces/checkout/types.ts
+++ b/packages/app/src/app/overmind/namespaces/checkout/types.ts
@@ -15,6 +15,13 @@ export type PricingPlan = {
   usage: string[];
 };
 
+export type SubscriptionPackage = {
+  basePlan: { id: PlanType; name: string; price: number; credits: number };
+  totalCredits: number;
+  totalPrice: number;
+  addonItems: AddonItem[];
+};
+
 export type CreditAddon = {
   id: CreditAddonType;
   credits: number;

--- a/packages/app/src/app/overmind/namespaces/checkout/types.ts
+++ b/packages/app/src/app/overmind/namespaces/checkout/types.ts
@@ -16,7 +16,6 @@ export type PricingPlan = {
 };
 
 export type CreditAddon = {
-  type: 'credits';
   id: CreditAddonType;
   credits: number;
   price: number;

--- a/packages/app/src/app/pages/WorkspaceFlows/CreateWorkspace.tsx
+++ b/packages/app/src/app/pages/WorkspaceFlows/CreateWorkspace.tsx
@@ -25,6 +25,7 @@ export const CreateWorkspace = () => {
   return (
     <WorkspaceSetup
       steps={['create', 'plans', 'addons', 'spending-limit', 'finalize']}
+      flow="create-workspace"
       onComplete={() => {
         clearFreshWorkspaceId();
         window.location.href = dashboardUrls.recent(activeTeam, {

--- a/packages/app/src/app/pages/WorkspaceFlows/ManageAddons.tsx
+++ b/packages/app/src/app/pages/WorkspaceFlows/ManageAddons.tsx
@@ -10,7 +10,7 @@ import { signInPageUrl } from '@codesandbox/common/lib/utils/url-generator';
 import { useWorkspaceSubscription } from 'app/hooks/useWorkspaceSubscription';
 
 export const ManageAddons = () => {
-  const { hasLogIn, activeTeam } = useAppState();
+  const { hasLogIn, activeTeam, activeTeamInfo } = useAppState();
   const { isPro } = useWorkspaceSubscription();
   const { getQueryParam, setQueryParam } = useURLSearchParams();
   const workspaceId = getQueryParam('workspace');
@@ -25,6 +25,14 @@ export const ManageAddons = () => {
     dashboardMounted();
     checkout.fetchPrices();
   }, [dashboardMounted]);
+
+  useEffect(() => {
+    if (!activeTeamInfo) {
+      return;
+    }
+
+    checkout.initializeCartFromExistingSubscription();
+  }, [activeTeamInfo]);
 
   useEffect(() => {
     if (!activeTeam) {
@@ -57,6 +65,7 @@ export const ManageAddons = () => {
   return (
     <WorkspaceSetup
       steps={steps}
+      flow="manage-addons"
       onComplete={fullReload => {
         if (fullReload) {
           window.location.href = dashboardUrls.recent(workspaceId);

--- a/packages/app/src/app/pages/WorkspaceFlows/ManageAddons.tsx
+++ b/packages/app/src/app/pages/WorkspaceFlows/ManageAddons.tsx
@@ -46,7 +46,10 @@ export const ManageAddons = () => {
 
   const [steps] = useState(() => {
     // Ensure this is run only once
-    const initialSteps: WorkspaceSetupStep[] = ['addons', 'finalize'];
+    const initialSteps: WorkspaceSetupStep[] = [
+      'addons',
+      'change-addons-confirmation',
+    ];
 
     return initialSteps;
   });

--- a/packages/app/src/app/pages/WorkspaceFlows/ManageAddons.tsx
+++ b/packages/app/src/app/pages/WorkspaceFlows/ManageAddons.tsx
@@ -1,0 +1,73 @@
+import React, { useEffect, useState } from 'react';
+import { WorkspaceSetup } from 'app/components/WorkspaceSetup';
+import track from '@codesandbox/common/lib/utils/analytics';
+import * as dashboardUrls from '@codesandbox/common/lib/utils/url-generator/dashboard';
+import { Redirect, useHistory } from 'react-router-dom';
+import { useURLSearchParams } from 'app/hooks/useURLSearchParams';
+import { WorkspaceSetupStep } from 'app/components/WorkspaceSetup/types';
+import { useActions, useAppState } from 'app/overmind';
+import { signInPageUrl } from '@codesandbox/common/lib/utils/url-generator';
+import { useWorkspaceSubscription } from 'app/hooks/useWorkspaceSubscription';
+
+export const ManageAddons = () => {
+  const { hasLogIn, activeTeam } = useAppState();
+  const { isPro } = useWorkspaceSubscription();
+  const { getQueryParam, setQueryParam } = useURLSearchParams();
+  const workspaceId = getQueryParam('workspace');
+  const history = useHistory();
+
+  const {
+    dashboard: { dashboardMounted },
+    checkout,
+  } = useActions();
+
+  useEffect(() => {
+    dashboardMounted();
+    checkout.fetchPrices();
+  }, [dashboardMounted]);
+
+  useEffect(() => {
+    if (!activeTeam) {
+      return;
+    }
+
+    if (!workspaceId || workspaceId !== activeTeam) {
+      setQueryParam('workspace', activeTeam);
+    }
+  }, [workspaceId, activeTeam]);
+
+  const [steps] = useState(() => {
+    // Ensure this is run only once
+    const initialSteps: WorkspaceSetupStep[] = ['addons', 'finalize'];
+
+    return initialSteps;
+  });
+
+  if (!hasLogIn) {
+    return (
+      <Redirect to={signInPageUrl(`${location.pathname}${location.search}`)} />
+    );
+  }
+
+  if (!workspaceId || isPro === false) {
+    // Page was accessed by a non-admin or workpace cannot be upgraded
+    return <Redirect to={dashboardUrls.recent(workspaceId)} />;
+  }
+
+  return (
+    <WorkspaceSetup
+      steps={steps}
+      onComplete={fullReload => {
+        if (fullReload) {
+          window.location.href = dashboardUrls.recent(workspaceId);
+        } else {
+          history.push(dashboardUrls.recent(workspaceId));
+        }
+      }}
+      onDismiss={() => {
+        track('Manage Addons Flow - Dismissed');
+        history.push(dashboardUrls.recent(workspaceId));
+      }}
+    />
+  );
+};

--- a/packages/app/src/app/pages/WorkspaceFlows/ManageAddons.tsx
+++ b/packages/app/src/app/pages/WorkspaceFlows/ManageAddons.tsx
@@ -31,6 +31,11 @@ export const ManageAddons = () => {
       return;
     }
 
+    if (!activeTeamInfo.subscriptionSchedule?.current) {
+      window.location.href = dashboardUrls.recent(workspaceId);
+      return;
+    }
+
     checkout.initializeCartFromExistingSubscription();
   }, [activeTeamInfo]);
 

--- a/packages/app/src/app/pages/WorkspaceFlows/UpgradeWorkspace.tsx
+++ b/packages/app/src/app/pages/WorkspaceFlows/UpgradeWorkspace.tsx
@@ -22,13 +22,14 @@ export const UpgradeWorkspace = () => {
   const plan = getQueryParam('plan');
   const history = useHistory();
 
-  const proPlanPreSelected = plan === 'pro' && workspaceId;
+  const proPlanPreSelected =
+    (plan === 'flex' || plan === 'flex-annual') && workspaceId;
 
   // Cannot upgrade if already on ubb or legacy paddle
   const cannotUpgradeToUbb = (ubbBeta && isPro) || isPaddle;
 
-  if (proPlanPreSelected && !checkout.basePlan) {
-    actions.checkout.selectPlan('flex-annual');
+  if (proPlanPreSelected && !checkout.newSubscription) {
+    actions.checkout.selectPlan(plan);
   }
 
   const {

--- a/packages/app/src/app/pages/WorkspaceFlows/UpgradeWorkspace.tsx
+++ b/packages/app/src/app/pages/WorkspaceFlows/UpgradeWorkspace.tsx
@@ -69,6 +69,7 @@ export const UpgradeWorkspace = () => {
   return (
     <WorkspaceSetup
       steps={steps}
+      flow="upgrade"
       onComplete={fullReload => {
         if (fullReload) {
           window.location.href = dashboardUrls.recent(workspaceId);

--- a/packages/app/src/app/pages/WorkspaceFlows/UpgradeWorkspace.tsx
+++ b/packages/app/src/app/pages/WorkspaceFlows/UpgradeWorkspace.tsx
@@ -27,8 +27,8 @@ export const UpgradeWorkspace = () => {
   // Cannot upgrade if already on ubb or legacy paddle
   const cannotUpgradeToUbb = (ubbBeta && isPro) || isPaddle;
 
-  if (proPlanPreSelected && !checkout.selectedPlan) {
-    actions.checkout.selectPlan('flex');
+  if (proPlanPreSelected && !checkout.basePlan) {
+    actions.checkout.selectPlan('flex-annual');
   }
 
   const {

--- a/packages/app/src/app/pages/WorkspaceFlows/index.ts
+++ b/packages/app/src/app/pages/WorkspaceFlows/index.ts
@@ -1,2 +1,3 @@
 export { CreateWorkspace } from './CreateWorkspace';
 export { UpgradeWorkspace } from './UpgradeWorkspace';
+export { ManageAddons } from './ManageAddons';

--- a/packages/app/src/app/pages/index.tsx
+++ b/packages/app/src/app/pages/index.tsx
@@ -13,7 +13,11 @@ import { ErrorBoundary } from './common/ErrorBoundary';
 import { Modals } from './common/Modals';
 import { DevAuthPage } from './DevAuth';
 import { StandalonePage } from './Standalone';
-import { CreateWorkspace, UpgradeWorkspace } from './WorkspaceFlows';
+import {
+  CreateWorkspace,
+  UpgradeWorkspace,
+  ManageAddons,
+} from './WorkspaceFlows';
 import { Container, Content } from './elements';
 import { Dashboard } from './Dashboard';
 import { Sandbox } from './Sandbox';
@@ -212,6 +216,7 @@ const RoutesComponent: React.FC = () => {
             <Route path="/standalone/:componentId" component={StandalonePage} />
             <Route path="/create-workspace" component={CreateWorkspace} />
             <Route path="/upgrade" component={UpgradeWorkspace} />
+            <Route path="/manage-addons" component={ManageAddons} />
 
             {environment.isOnPrem ? (
               <Redirect from="/pro" to="/dashboard" />


### PR DESCRIPTION
Still working on some details, but the core feature is there.

New page on `/manage-addons` which will be linked from the portal

It shows the first step where it populates the checkout with the existing subscription and allows users to add/remove addons
![image](https://github.com/codesandbox/codesandbox-client/assets/9945366/d9f00499-a727-4b84-8b0f-c341937571a2)

Then you get a comparison of the old and new plans to confirm the change
![image](https://github.com/codesandbox/codesandbox-client/assets/9945366/29b907ad-cb45-42f6-a380-c072cec1b7db)
