### PR TITLE
fix(esm-convert): read + write cases

### DIFF
--- a/packages/app/src/sandbox/eval/transpilers/babel/ast/__snapshots__/convert-esmodule.test.ts.snap
+++ b/packages/app/src/sandbox/eval/transpilers/babel/ast/__snapshots__/convert-esmodule.test.ts.snap
@@ -179,6 +179,27 @@ exports.default = $csb__default;
 "
 `;
 
+exports[`convert-esmodule can do -- assigns 1`] = `
+""use strict";
+exports.prev = exports.position = exports.characters = exports.character = void  0;
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.prev = prev;
+var character = 0;
+exports.character = character;
+var characters = '';
+exports.characters = characters;
+var position = 0;
+exports.position = position;
+function prev() {
+  exports.character = character = position > 0 ? charat(characters, --exports.position) : 0;
+  if ((column--, character === 10)) (column = 1, line--);
+  return character;
+}
+"
+`;
+
 exports[`convert-esmodule can do array exports 1`] = `
 ""use strict";
 exports.y = exports.x = void  0;

--- a/packages/app/src/sandbox/eval/transpilers/babel/ast/convert-esmodule.test.ts
+++ b/packages/app/src/sandbox/eval/transpilers/babel/ast/convert-esmodule.test.ts
@@ -592,4 +592,26 @@ export function test3() {
     const result = convertEsModule(code).code;
     expect(result).toMatchSnapshot();
   });
+
+  it('can do -- assigns', () => {
+    const code = `
+    export var character = 0
+    export var characters = ''
+    export var position = 0
+    /**
+     * @return {number}
+     */
+    export function prev () {
+      character = position > 0 ? charat(characters, --position) : 0
+    
+      if (column--, character === 10)
+        column = 1, line--
+    
+      return character
+    }
+    `;
+
+    const result = convertEsModule(code).code;
+    expect(result).toMatchSnapshot();
+  });
 });

--- a/packages/app/src/sandbox/eval/transpilers/babel/ast/convert-esmodule.ts
+++ b/packages/app/src/sandbox/eval/transpilers/babel/ast/convert-esmodule.ts
@@ -607,7 +607,12 @@ export function convertEsModule(ast: ESTreeAST): void {
           !ref.init
         ) {
           const name = trackedExports[ref.identifier.name];
-          ref.identifier.name = `exports.${name} = ${ref.identifier.name}`;
+          if (ref.isRead()) {
+            // If it's both a read and a write (e.g. --num), we can just use the name
+            ref.identifier.name = `exports.${name}`;
+          } else {
+            ref.identifier.name = `exports.${name} = ${ref.identifier.name}`;
+          }
         }
       });
     });


### PR DESCRIPTION
When converting ESM, and there's an expression like `--counter`, where `counter` is exported, we would wrongly convert it to `--exports.counter = counter`, which is invalid syntax. In this case, it's sufficient to do `--exports.counter`, and with this change we do that.