### PR TITLE
feat: small improvements for the branch listing in the repository page

### DIFF
--- a/packages/app/src/app/graphql/types.ts
+++ b/packages/app/src/app/graphql/types.ts
@@ -242,6 +242,7 @@ export type Album = {
 export type Sandbox = {
   __typename?: 'Sandbox';
   alias: Maybe<Scalars['String']>;
+  /** @deprecated No longer supported */
   alwaysOn: Maybe<Scalars['Boolean']>;
   author: Maybe<User>;
   authorId: Maybe<Scalars['UUID4']>;
@@ -264,6 +265,7 @@ export type Sandbox = {
   insertedAt: Scalars['String'];
   invitations: Array<Invitation>;
   isFrozen: Scalars['Boolean'];
+  /** @deprecated No longer supported */
   isSse: Maybe<Scalars['Boolean']>;
   isV2: Scalars['Boolean'];
   /** Depending on the context, this may be the last access of the current user or the aggregate last access for all users */
@@ -2038,8 +2040,6 @@ export type RootMutationType = {
   setPreventSandboxesLeavingWorkspace: Array<Sandbox>;
   /** Change the primary workspace for the current user */
   setPrimaryWorkspace: Scalars['String'];
-  /** set sandbox always on status */
-  setSandboxAlwaysOn: Sandbox;
   setSandboxesFrozen: Array<Sandbox>;
   setSandboxesPrivacy: Array<Sandbox>;
   /** Configure consent for AI features in this team. Can be overridden for specific repositories or sandboxes. */
@@ -2538,11 +2538,6 @@ export type RootMutationTypeSetPreventSandboxesLeavingWorkspaceArgs = {
 
 export type RootMutationTypeSetPrimaryWorkspaceArgs = {
   primaryWorkspaceId: Scalars['UUID4'];
-};
-
-export type RootMutationTypeSetSandboxAlwaysOnArgs = {
-  alwaysOn: Scalars['Boolean'];
-  sandboxId: Scalars['ID'];
 };
 
 export type RootMutationTypeSetSandboxesFrozenArgs = {
@@ -4791,6 +4786,33 @@ export type BranchFragment = {
   };
 };
 
+export type BranchWithPrFragment = {
+  __typename?: 'Branch';
+  id: string;
+  name: string;
+  contribution: boolean;
+  lastAccessedAt: string | null;
+  upstream: boolean;
+  project: {
+    __typename?: 'Project';
+    repository: {
+      __typename?: 'GitHubRepository';
+      defaultBranch: string;
+      name: string;
+      owner: string;
+      private: boolean;
+    };
+    team: { __typename?: 'Team'; id: any } | null;
+  };
+  pullRequests: Array<{
+    __typename?: 'PullRequest';
+    title: string;
+    number: number;
+    additions: number | null;
+    deletions: number | null;
+  }>;
+};
+
 export type ProjectFragment = {
   __typename?: 'Project';
   appInstalled: boolean;
@@ -4827,6 +4849,13 @@ export type ProjectWithBranchesFragment = {
       };
       team: { __typename?: 'Team'; id: any } | null;
     };
+    pullRequests: Array<{
+      __typename?: 'PullRequest';
+      title: string;
+      number: number;
+      additions: number | null;
+      deletions: number | null;
+    }>;
   }>;
   repository: {
     __typename?: 'GitHubRepository';
@@ -6341,6 +6370,13 @@ export type RepositoryByDetailsQuery = {
         };
         team: { __typename?: 'Team'; id: any } | null;
       };
+      pullRequests: Array<{
+        __typename?: 'PullRequest';
+        title: string;
+        number: number;
+        additions: number | null;
+        deletions: number | null;
+      }>;
     }>;
     repository: {
       __typename?: 'GitHubRepository';

--- a/packages/app/src/app/overmind/effects/gql/dashboard/fragments.ts
+++ b/packages/app/src/app/overmind/effects/gql/dashboard/fragments.ts
@@ -294,6 +294,35 @@ export const branchFragment = gql`
   }
 `;
 
+export const branchWithPRFragment = gql`
+  fragment branchWithPR on Branch {
+    id
+    name
+    contribution
+    lastAccessedAt
+    upstream
+    project {
+      repository {
+        ... on GitHubRepository {
+          defaultBranch
+          name
+          owner
+          private
+        }
+      }
+      team {
+        id
+      }
+    }
+    pullRequests {
+      title
+      number
+      additions
+      deletions
+    }
+  }
+`;
+
 export const projectFragment = gql`
   fragment project on Project {
     appInstalled
@@ -317,7 +346,7 @@ export const projectWithBranchesFragment = gql`
   fragment projectWithBranches on Project {
     appInstalled
     branches {
-      ...branch
+      ...branchWithPR
     }
     repository {
       ... on GitHubRepository {
@@ -331,7 +360,7 @@ export const projectWithBranchesFragment = gql`
       id
     }
   }
-  ${branchFragment}
+  ${branchWithPRFragment}
 `;
 
 export const githubRepoFragment = gql`

--- a/packages/app/src/app/overmind/effects/gql/dashboard/queries.ts
+++ b/packages/app/src/app/overmind/effects/gql/dashboard/queries.ts
@@ -52,6 +52,7 @@ import {
   currentTeamInfoFragment,
   teamFragmentDashboard,
   branchFragment,
+  branchWithPRFragment,
   projectFragment,
   projectWithBranchesFragment,
   githubRepoFragment,
@@ -286,7 +287,7 @@ export const getRepositoryByDetails: Query<
     }
   }
   ${projectWithBranchesFragment}
-  ${branchFragment}
+  ${branchWithPRFragment}
 `;
 
 export const getGithubRepository: Query<

--- a/packages/app/src/app/overmind/namespaces/dashboard/utils.ts
+++ b/packages/app/src/app/overmind/namespaces/dashboard/utils.ts
@@ -2,6 +2,7 @@ import {
   BranchFragment,
   ProjectFragment,
   SidebarCollectionDashboardFragment as Collection,
+  BranchWithPrFragment,
 } from 'app/graphql/types';
 import { DELETE_ME_COLLECTION } from './types';
 
@@ -20,8 +21,8 @@ export function getDecoratedCollection(
 }
 
 export function sortByLastAccessed(
-  a: ProjectFragment | BranchFragment,
-  b: ProjectFragment | BranchFragment
+  a: ProjectFragment | BranchFragment | BranchWithPrFragment,
+  b: ProjectFragment | BranchFragment | BranchWithPrFragment
 ): number {
   if (!a.lastAccessedAt || !b.lastAccessedAt) {
     return 1;

--- a/packages/app/src/app/pages/Dashboard/Components/Branch/BranchCard.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Branch/BranchCard.tsx
@@ -40,7 +40,7 @@ export const BranchCard: React.FC<BranchProps> = ({
                 </Text>
               )}
 
-              <Stack gap={3}>
+              <Stack gap={2}>
                 {contribution ? (
                   <Icon color="#EDFFA5" name="contribution" size={16} />
                 ) : (

--- a/packages/app/src/app/pages/Dashboard/Components/Branch/BranchListItem.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Branch/BranchListItem.tsx
@@ -7,7 +7,6 @@ import {
   Text,
   ListAction,
   IconButton,
-  Tooltip,
   Icon,
 } from '@codesandbox/components';
 import css from '@styled-system/css';
@@ -21,8 +20,16 @@ export const BranchListItem = ({
   onContextMenu,
   lastAccessed,
 }: BranchProps) => {
-  const { name: branchName, project, contribution } = branch;
+  const { name: branchName, project } = branch;
   const { repository } = project;
+
+  const pullRequest =
+    branchName !== repository.defaultBranch &&
+    'pullRequests' in branch &&
+    branch.pullRequests.length > 0
+      ? branch.pullRequests[0]
+      : null;
+
   return (
     <ListAction
       align="center"
@@ -72,38 +79,33 @@ export const BranchListItem = ({
               paddingTop: 4,
             }}
           >
-            <Stack gap={4} align="center" marginLeft={2}>
-              {contribution ? (
-                <Icon
-                  color="#EDFFA5"
-                  name="contribution"
-                  size={16}
-                  width="32px"
-                />
+            <Stack gap={2} align="center" paddingLeft={4}>
+              {pullRequest ? (
+                <Icon color="#E5E5E5" name="github" size={16} />
               ) : (
-                <Icon name="branch" color="#999" size={16} width="32px" />
+                <Icon name="branch" color="#E5E5E5" size={16} />
               )}
 
               <Element css={{ overflow: 'hidden' }}>
-                <Tooltip label={branchName}>
-                  <Text
-                    size={3}
-                    weight="medium"
-                    maxWidth="100%"
-                    css={{ color: '#E5E5E5' }}
-                  >
-                    {branchName}
-                  </Text>
-                </Tooltip>
+                <Text
+                  size={3}
+                  weight="medium"
+                  maxWidth="100%"
+                  css={{ color: '#E5E5E5' }}
+                >
+                  {branchName}
+                </Text>
               </Element>
             </Stack>
           </Column>
-          <Column span={[0, 2, 2]} as={Stack} align="center">
-            <Text size={3} variant="muted" maxWidth="100%">
-              {repository.owner}/{repository.name}
-            </Text>
+          <Column span={[0, 5, 5]} as={Stack} align="center">
+            {pullRequest && (
+              <Text size={13} color="#E5E5E5" truncate>
+                #{pullRequest.number} - {pullRequest.title}
+              </Text>
+            )}
           </Column>
-          <Column span={[0, 5, 6]} as={Stack} align="center">
+          <Column span={[0, 2, 3]} as={Stack} align="center">
             <Text size={3} variant="muted" maxWidth="100%">
               {lastAccessed}
             </Text>

--- a/packages/app/src/app/pages/Dashboard/Components/Branch/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Branch/index.tsx
@@ -31,6 +31,10 @@ export const Branch: React.FC<BranchProps> = ({ branch, page }) => {
     viewMode = 'grid';
   }
 
+  if (page === 'repository-branches') {
+    viewMode = 'list';
+  }
+
   const branchUrl = v2BranchUrl({
     owner: project.repository.owner,
     repoName: project.repository.name,

--- a/packages/app/src/app/pages/Dashboard/Components/Branch/types.ts
+++ b/packages/app/src/app/pages/Dashboard/Components/Branch/types.ts
@@ -1,7 +1,10 @@
-import { BranchFragment as Branch } from 'app/graphql/types';
+import {
+  BranchWithPrFragment as BranchWithPR,
+  BranchFragment as Branch,
+} from 'app/graphql/types';
 
 export type BranchProps = {
-  branch: Branch;
+  branch: Branch | BranchWithPR;
   branchUrl: string;
   isBeingRemoved: boolean;
   selected: boolean;

--- a/packages/app/src/app/pages/Dashboard/Components/Header/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Header/index.tsx
@@ -98,30 +98,28 @@ export const Header = ({
           </Button>
         )}
 
-        {repositoryBranchesPage &&
-          dashboard.viewMode === 'list' &&
-          selectedRepo && (
-            <Button
-              onClick={() => {
-                dashboardActions.createDraftBranch({
-                  owner: selectedRepo.owner,
-                  name: selectedRepo.name,
-                  teamId: selectedRepo.assignedTeamId,
-                });
-              }}
-              variant="ghost"
-              disabled={readOnly}
-              autoWidth
-            >
-              <Icon
-                name="branch"
-                size={16}
-                title="Create branch"
-                css={{ marginRight: '8px' }}
-              />
-              Create branch
-            </Button>
-          )}
+        {repositoryBranchesPage && selectedRepo && (
+          <Button
+            onClick={() => {
+              dashboardActions.createDraftBranch({
+                owner: selectedRepo.owner,
+                name: selectedRepo.name,
+                teamId: selectedRepo.assignedTeamId,
+              });
+            }}
+            variant="ghost"
+            disabled={readOnly}
+            autoWidth
+          >
+            <Icon
+              name="branch"
+              size={16}
+              title="Create branch"
+              css={{ marginRight: '8px' }}
+            />
+            Create branch
+          </Button>
+        )}
 
         <Stack gap={1}>
           {showSortOptions && <SortOptions />}

--- a/packages/app/src/app/pages/Dashboard/Components/VariableGrid/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/VariableGrid/index.tsx
@@ -248,10 +248,10 @@ export const VariableGrid: React.FC<VariableGridProps> = ({
   viewMode: propViewMode,
 }) => {
   const { dashboard } = useAppState();
-  const location = useLocation();
 
   let viewMode: 'grid' | 'list';
-  if (location.pathname.includes('deleted')) viewMode = 'list';
+
+  if (page === 'deleted' || page === 'repository-branches') viewMode = 'list';
   else viewMode = propViewMode || dashboard.viewMode;
 
   const ITEM_HEIGHT = viewMode === 'list' ? ITEM_HEIGHT_LIST : ITEM_HEIGHT_GRID;

--- a/packages/app/src/app/pages/Dashboard/Components/VariableGrid/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/VariableGrid/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link as RouterLink, useLocation } from 'react-router-dom';
+import { Link as RouterLink } from 'react-router-dom';
 import { useAppState } from 'app/overmind';
 import { Element, Stack, Text, Link } from '@codesandbox/components';
 import css from '@styled-system/css';


### PR DESCRIPTION
A few main changes (along with css tweaks)
- allow only list view for branch listing, as branch cards are not really working with long branch names and long pr titles
- show PR titles when they are attached to the branch
- show branches with PRs first, before other branches
- don't show draft branches (not pushed on GH) that the user has not visited

![image](https://github.com/codesandbox/codesandbox-client/assets/9945366/4d8acc74-878b-4226-9ea6-95a635fbd2d4)
