### PR TITLE
fix: loop on gh app install

### DIFF
--- a/packages/app/src/app/components/Create/ImportRepository.tsx
+++ b/packages/app/src/app/components/Create/ImportRepository.tsx
@@ -105,12 +105,22 @@ export const ImportRepository: React.FC<
     }
   }, [preSelectedRepo, restrictsPublicRepos]);
 
-  const handleFetchFullGithubRepo = async (repo: {
-    owner: string;
-    name: string;
-  }) => {
+  const handleFetchFullGithubRepo = async (
+    repo: {
+      owner: string;
+      name: string;
+    },
+    options: { runInBackground: boolean } = { runInBackground: false }
+  ) => {
+    if (viewState === 'loading') {
+      return;
+    }
+
     try {
-      setViewState('loading');
+      if (!options.runInBackground) {
+        // Don't switch back to loading state when the repo is already fetched
+        setViewState('loading');
+      }
       const data = await effects.gql.queries.getGithubRepository({
         owner: repo.owner,
         name: repo.name,
@@ -251,7 +261,9 @@ export const ImportRepository: React.FC<
                 ) : (
                   <ConfigureRepo
                     repository={selectedRepo}
-                    onRefetchGithubRepo={handleFetchFullGithubRepo}
+                    onRefetchGithubRepo={repo =>
+                      handleFetchFullGithubRepo(repo, { runInBackground: true })
+                    }
                   />
                 )}
               </ModalContent>


### PR DESCRIPTION
https://github.com/codesandbox/codesandbox-client/assets/9945366/7cbaf633-ad78-4fb4-8658-37ebb296c950

There's a weird React re-render here, that I explicitly bypassed with a 2nd param to the function that re-fetches the github repo once the app was installed

Closes PC-1837