### PR TITLE
fix: add partitioned to the removal

### DIFF
--- a/packages/sandpack-core/src/sandpack-secret.ts
+++ b/packages/sandpack-core/src/sandpack-secret.ts
@@ -9,7 +9,7 @@ export const getSandpackSecret = () =>
   );
 
 export const removeSandpackSecret = () => {
-  document.cookie = `${SANDPACK_SECRET_COOKIE_NAME}=; expires=Thu, 01 Jan 1970 00:00:01 GMT;samesite=none;secure;`;
+  document.cookie = `${SANDPACK_SECRET_COOKIE_NAME}=; expires=Thu, 01 Jan 1970 00:00:01 GMT;samesite=none;secure;partitioned`;
 };
 
 export const setSandpackSecret = (secret: string) => {


### PR DESCRIPTION
We set partitioned for new cookies, but not when we remove them