### PR TITLE
fix(editor mode): flag to load v1 editor

### DIFF
--- a/packages/app/src/app/hooks/useBetaSandboxEditor.ts
+++ b/packages/app/src/app/hooks/useBetaSandboxEditor.ts
@@ -1,5 +1,15 @@
-// This will be removed in the first cleanup post release, but for now
-// it is the simplesy way to ensure everyone is on the v2 editor
-export const useBetaSandboxEditor = (): [boolean] => {
-  return [true];
+import { useAppState } from "app/overmind";
+import { useGlobalPersistedState } from "./usePersistedState";
+
+export const useBetaSandboxEditor = (): [
+  boolean,
+  React.Dispatch<React.SetStateAction<boolean>>,
+  () => void
+] => {
+  const { hasLogIn } = useAppState();
+
+  const defaultValue =
+    hasLogIn && !document.location.search.includes("editor=v1");
+
+  return useGlobalPersistedState<boolean>("BETA_SANDBOX_EDITOR", defaultValue);
 };

--- a/packages/app/src/app/pages/common/Modals/PreferencesModal/Experiments/BetaSandboxEditor.tsx
+++ b/packages/app/src/app/pages/common/Modals/PreferencesModal/Experiments/BetaSandboxEditor.tsx
@@ -1,0 +1,36 @@
+import { Stack, Text } from "@codesandbox/components";
+import React from "react";
+
+import { useBetaSandboxEditor } from "app/hooks/useBetaSandboxEditor";
+import track from "@codesandbox/common/lib/utils/analytics";
+import { PaddedPreference } from "../elements";
+
+export const BetaSandboxEditor = () => {
+  const [betaSandboxEditor, setBetaSandboxEditor] = useBetaSandboxEditor();
+
+  return (
+    <>
+      <PaddedPreference
+        setValue={() => {
+          if (!betaSandboxEditor) {
+            track("Enable new sandbox editor - User preferences");
+          } else {
+            track("Disable new sandbox editor - User preferences");
+          }
+
+          setBetaSandboxEditor(!betaSandboxEditor);
+        }}
+        title="Unified Platform Editor"
+        tooltip="Use Unified Platform Editor"
+        type="boolean"
+        value={betaSandboxEditor}
+      />
+
+      <Stack gap={3} direction="vertical">
+        <Text block marginTop={2} size={3} variant="muted">
+          Run your sandboxes in a faster and more stable editor.
+        </Text>
+      </Stack>
+    </>
+  );
+};

--- a/packages/app/src/app/pages/common/Modals/PreferencesModal/Experiments/index.tsx
+++ b/packages/app/src/app/pages/common/Modals/PreferencesModal/Experiments/index.tsx
@@ -1,7 +1,8 @@
-import { Text, Element } from '@codesandbox/components';
-import React, { FunctionComponent } from 'react';
+import { Text, Element } from "@codesandbox/components";
+import React, { FunctionComponent } from "react";
 
-import { SubContainer } from '../elements';
+import { SubContainer } from "../elements";
+import { BetaSandboxEditor } from "./BetaSandboxEditor";
 
 export const Experiments: FunctionComponent = () => (
   <>
@@ -11,9 +12,10 @@ export const Experiments: FunctionComponent = () => (
 
     <SubContainer>
       <Element paddingTop={2}>
-        <Text size={13} variant="muted">
+        <BetaSandboxEditor />
+        {/* <Text size={13} variant="muted">
           No experiements available at the moment
-        </Text>
+        </Text> */}
       </Element>
     </SubContainer>
   </>


### PR DESCRIPTION
- Introduce back the Experiment to toggle on/off the new editor
- Introduce `editor=v1` query param to force loading v1