### PR TITLE
fix: drop babel/plugin-transform-async-to-generator

### DIFF
--- a/.codesandbox/tasks.json
+++ b/.codesandbox/tasks.json
@@ -35,7 +35,7 @@
     "app:fast:stream": {
       "name": "Application (fast + stream)",
       "command": "yarn start:fast:stream",
-      "runAtStart": true,
+      "runAtStart": false,
       "preview": {
         "port": 3000
       },

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,7 +1,6 @@
 module.exports = {
   presets: ['@babel/preset-env', '@babel/preset-flow', '@babel/preset-react'],
   plugins: [
-    '@babel/plugin-transform-async-to-generator',
     '@babel/plugin-proposal-object-rest-spread',
     '@babel/plugin-proposal-class-properties',
     '@babel/plugin-transform-runtime',

--- a/packages/app/config/babel.prod.js
+++ b/packages/app/config/babel.prod.js
@@ -26,7 +26,6 @@ module.exports = {
   plugins: [
     require.resolve('@babel/plugin-transform-template-literals'),
     require.resolve('@babel/plugin-transform-destructuring'),
-    require.resolve('@babel/plugin-transform-async-to-generator'),
     require.resolve('@babel/plugin-proposal-object-rest-spread'),
     require.resolve('@babel/plugin-proposal-class-properties'),
     require.resolve('@babel/plugin-proposal-optional-chaining'),

--- a/packages/app/config/webpack.common.js
+++ b/packages/app/config/webpack.common.js
@@ -185,7 +185,6 @@ module.exports = {
           plugins: [
             '@babel/plugin-transform-template-literals',
             '@babel/plugin-transform-destructuring',
-            '@babel/plugin-transform-async-to-generator',
             '@babel/plugin-proposal-object-rest-spread',
             '@babel/plugin-proposal-class-properties',
             '@babel/plugin-transform-runtime',

--- a/packages/common/babel.config.js
+++ b/packages/common/babel.config.js
@@ -7,7 +7,6 @@ module.exports = {
   ],
   plugins: [
     'lodash',
-    '@babel/plugin-transform-async-to-generator',
     '@babel/plugin-proposal-object-rest-spread',
     '@babel/plugin-proposal-class-properties',
     '@babel/plugin-transform-runtime',


### PR DESCRIPTION
This PR drops `plugin-transform-async-to-generator` in favor of using native async/await syntax. This plugin is especially annoying because it adds `import` statements inside workers that use async functions, but considering that most browsers already support such syntax, I believe it's safe to drop this Babel plugin.