### PR TITLE
chore: move deployment to deployer apis

### DIFF
--- a/packages/app/scripts/deploy.js
+++ b/packages/app/scripts/deploy.js
@@ -9,7 +9,7 @@ fetch(
       'CF-Access-Client-Id': process.env.CF_ZERO_TRUST_DEPLOYER_CLIENT_ID,
       'CF-Access-Client-Secret':
         process.env.CF_ZERO_TRUST_DEPLOYER_CLIENT_SECRET,
-      'Authorization': `Bearer${process.env.DEPLOYER_API_TOKEN }`
+      'Authorization': `Bearer ${process.env.DEPLOYER_API_TOKEN }`
     },
     body: JSON.stringify({
       environment: process.env.ENVIRONMENT

--- a/packages/app/scripts/deploy.js
+++ b/packages/app/scripts/deploy.js
@@ -9,7 +9,7 @@ fetch(
       'CF-Access-Client-Id': process.env.CF_ZERO_TRUST_DEPLOYER_CLIENT_ID,
       'CF-Access-Client-Secret':
         process.env.CF_ZERO_TRUST_DEPLOYER_CLIENT_SECRET,
-      'Authorization': `Bearer ${process.env.DEPLOYER_API_TOKEN }`
+      'Authorization': `Bearer ${process.env.DEPLOYER_API_TOKEN}`
     },
     body: JSON.stringify({
       environment: process.env.ENVIRONMENT

--- a/packages/app/scripts/deploy.js
+++ b/packages/app/scripts/deploy.js
@@ -1,20 +1,18 @@
 const fetch = require('cross-fetch');
 
 fetch(
-  `https://backstage.csbops.io/api/deploy/gitops/codesandbox/codesandbox-gitops/codesandbox-core/codesandbox/${process.env.ENVIRONMENT}/helm-chart-values/values.yaml`,
+  `https://deployer.csbops.io/apps/codesandbox-editor-v1`,
   {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      'CF-Access-Client-Id': process.env.CF_ZERO_TRUST_BACKSTAGE_DEPLOY_ID,
+      'CF-Access-Client-Id': process.env.CF_ZERO_TRUST_DEPLOYER_CLIENT_ID,
       'CF-Access-Client-Secret':
-        process.env.CF_ZERO_TRUST_BACKSTAGE_DEPLOY_TOKEN,
+        process.env.CF_ZERO_TRUST_DEPLOYER_CLIENT_SECRET,
+      'Authorization': `Bearer${process.env.DEPLOYER_API_TOKEN }`
     },
     body: JSON.stringify({
-      key: 'client.image.tag',
-      commitMessage: `Client V1: deploy to ${
-        process.env.ENVIRONMENT
-      } with ${process.env.CIRCLE_SHA1.substr(0, 7)}`,
+      environment: process.env.ENVIRONMENT
       value: process.env.CIRCLE_SHA1.substr(0, 7),
     }),
   }

--- a/packages/app/scripts/deploy.js
+++ b/packages/app/scripts/deploy.js
@@ -13,7 +13,7 @@ fetch(
     },
     body: JSON.stringify({
       environment: process.env.ENVIRONMENT
-      value: process.env.CIRCLE_SHA1.substr(0, 7),
+      tag: process.env.CIRCLE_SHA1.substr(0, 7),
     }),
   }
 )


### PR DESCRIPTION
This PR changes the deployment script to use the deployer apis (https://deployer.csbops.io). The required env vars is already added to Circle CI