### PR TITLE
feat: add support for pkg#imports

### DIFF
--- a/packages/sandpack-core/src/resolver/utils/__snapshots__/pkg-json.test.ts.snap
+++ b/packages/sandpack-core/src/resolver/utils/__snapshots__/pkg-json.test.ts.snap
@@ -19,6 +19,7 @@ exports[`process package.json Should correctly handle nested pkg#exports fields 
     "/node_modules/solid-js/web/dist/*": "/node_modules/solid-js/web/dist/$1",
   },
   "hasExports": true,
+  "imports": {},
 }
 `;
 
@@ -41,6 +42,7 @@ exports[`process package.json Should correctly handle root pkg.json 1`] = `
     "something/*": "/nested/test.js/$1",
   },
   "hasExports": false,
+  "imports": {},
 }
 `;
 
@@ -230,5 +232,6 @@ exports[`process package.json Should correctly process pkg.exports from @babel/r
     "/node_modules/@babel/runtime/regenerator/*.js": "/node_modules/@babel/runtime/regenerator/$1.js",
   },
   "hasExports": true,
+  "imports": {},
 }
 `;

--- a/packages/sandpack-core/src/resolver/utils/exports.ts
+++ b/packages/sandpack-core/src/resolver/utils/exports.ts
@@ -3,16 +3,16 @@ import { normalizeAliasFilePath } from './alias';
 // exports keys, sorted from high to low priority
 const EXPORTS_KEYS = ['browser', 'development', 'default', 'require', 'import'];
 
-type PackageExportType =
+export type PackageExportType =
   | string
   | null
   | false
   | PackageExportObj
   | PackageExportArr;
 
-type PackageExportArr = Array<PackageExportObj | string>;
+export type PackageExportArr = Array<PackageExportObj | string>;
 
-type PackageExportObj = {
+export type PackageExportObj = {
   [key: string]: string | null | false | PackageExportType;
 };
 

--- a/packages/sandpack-core/src/resolver/utils/glob.test.ts
+++ b/packages/sandpack-core/src/resolver/utils/glob.test.ts
@@ -1,0 +1,24 @@
+import { replaceGlob } from './glob';
+
+describe('glob utils', () => {
+  it('replace glob at the end', () => {
+    expect(
+      replaceGlob('#test/*', './something/*/index.js', '#test/hello')
+    ).toBe('./something/hello/index.js');
+  });
+
+  it('replaces glob and target at the end', () => {
+    const input = replaceGlob(
+      '/@test/foo/*',
+      '/@test/foo/dist/*',
+      '/@test/foo/dist/index'
+    );
+    expect(input).toBe('/@test/foo/dist/index');
+  });
+
+  it('replace glob in the middle', () => {
+    expect(replaceGlob('#test/*.js', './test/*.js', '#test/hello.js')).toBe(
+      './test/hello.js'
+    );
+  });
+});

--- a/packages/sandpack-core/src/resolver/utils/glob.ts
+++ b/packages/sandpack-core/src/resolver/utils/glob.ts
@@ -1,0 +1,43 @@
+export function replaceGlob(
+  source: string,
+  target: string,
+  specifier: string
+): false | string {
+  const starIndex = source.indexOf('*');
+  if (starIndex < 0) {
+    return false;
+  }
+
+  const prefix = source.substring(0, starIndex);
+  const suffix = source.substring(starIndex + 1);
+  if (
+    !specifier.startsWith(prefix) ||
+    (suffix && !specifier.endsWith(suffix))
+  ) {
+    return false;
+  }
+
+  const targetStarLocation = target.indexOf('*');
+  const targetBeforeStar = target.substring(0, targetStarLocation);
+
+  if (specifier.indexOf(targetBeforeStar) > -1) {
+    return (
+      targetBeforeStar +
+      specifier.substring(targetBeforeStar.length, specifier.length)
+    );
+  }
+
+  if (targetStarLocation < 0) {
+    return target;
+  }
+
+  const globPart = specifier.substring(
+    prefix.length,
+    specifier.length - suffix.length
+  );
+  return (
+    target.substring(0, targetStarLocation) +
+    globPart +
+    target.substring(targetStarLocation + 1)
+  );
+}

--- a/packages/sandpack-core/src/resolver/utils/imports.ts
+++ b/packages/sandpack-core/src/resolver/utils/imports.ts
@@ -1,0 +1,49 @@
+type PackageImportArr = Array<PackageImportObj | string>;
+type PackageImportType =
+  | string
+  | null
+  | false
+  | PackageImportObj
+  | PackageImportArr;
+type PackageImportObj = {
+  [key: string]: string | null | false | PackageImportType;
+};
+
+export function extractSpecifierFromImport(
+  importValue: PackageImportType,
+  pkgRoot: string,
+  importKeys: string[]
+): string | false {
+  if (!importValue) {
+    return false;
+  }
+
+  if (typeof importValue === 'string') {
+    return importValue;
+  }
+
+  if (Array.isArray(importValue)) {
+    const foundPaths = importValue
+      .map(v => extractSpecifierFromImport(v, pkgRoot, importKeys))
+      .filter(Boolean);
+    if (!foundPaths.length) {
+      return false;
+    }
+    return foundPaths[0];
+  }
+
+  if (typeof importValue === 'object') {
+    for (const key of importKeys) {
+      const importFilename = importValue[key];
+      if (importFilename !== undefined) {
+        if (typeof importFilename === 'string') {
+          return importFilename;
+        }
+        return extractSpecifierFromImport(importFilename, pkgRoot, importKeys);
+      }
+    }
+    return false;
+  }
+
+  throw new Error(`Unsupported imports type ${typeof importValue}`);
+}


### PR DESCRIPTION
Sandpack seems to be lacking support for pkg#imports, our sandpack-resolver already supports this, so this just copies over that logic to here

Reference: https://github.com/codesandbox/sandpack-resolver

Broken sandbox as reference: https://codesandbox.io/p/sandbox/zds-react-sandbox-forked-6v9mwh