### PR TITLE
feat: make vite work in cra template

### DIFF
--- a/.codesandbox/tasks.json
+++ b/.codesandbox/tasks.json
@@ -35,7 +35,7 @@
     "app:fast:stream": {
       "name": "Application (fast + stream)",
       "command": "yarn start:fast:stream",
-      "runAtStart": true,
+      "runAtStart": false,
       "preview": {
         "port": 3000
       },

--- a/.codesandbox/tasks.json
+++ b/.codesandbox/tasks.json
@@ -35,7 +35,7 @@
     "app:fast:stream": {
       "name": "Application (fast + stream)",
       "command": "yarn start:fast:stream",
-      "runAtStart": false,
+      "runAtStart": true,
       "preview": {
         "port": 3000
       },

--- a/packages/common/src/templates/react-ts.ts
+++ b/packages/common/src/templates/react-ts.ts
@@ -15,5 +15,12 @@ export default new ReactTemplate(
     extraConfigurations: {
       '/tsconfig.json': configurations.tsconfig,
     },
+    mainFile: [
+      '/src/index.js',
+      '/src/index.tsx',
+      '/src/index.ts',
+      '/src/main.tsx',
+      '/src/main.ts',
+    ],
   }
 );

--- a/packages/common/src/templates/react.ts
+++ b/packages/common/src/templates/react.ts
@@ -13,7 +13,13 @@ export default new ReactTemplate(
     showOnHomePage: true,
     popular: true,
     main: true,
-    mainFile: ['/src/index.js', '/src/index.tsx', '/src/index.ts'],
+    mainFile: [
+      '/src/index.js',
+      '/src/index.tsx',
+      '/src/index.ts',
+      '/src/main.tsx',
+      '/src/main.ts',
+    ],
     extraConfigurations: {
       '/jsconfig.json': configurations.jsconfig,
       '/tsconfig.json': configurations.tsconfig,

--- a/packages/common/src/templates/react.ts
+++ b/packages/common/src/templates/react.ts
@@ -19,6 +19,7 @@ export default new ReactTemplate(
       '/src/index.ts',
       '/src/main.tsx',
       '/src/main.ts',
+      '/src/main.js',
     ],
     extraConfigurations: {
       '/jsconfig.json': configurations.jsconfig,


### PR DESCRIPTION
Our CRA bundler works already very similar to Vite, out of the box. Similar configuration, static files in the same place, transpilation logic is the same.
The only thing that is missing, is knowing that conventially `src/main.tsx` is the entrypoint.

With this change, we make the basic examples of Vite work, using our existing CRA bundler. When things get more advanced (Vite plugins, etc) it won't work, but then people can opt to export it to a Devbox. Until then, this should handle 90% of all cases.

One thing to note, is that maybe the `index.html` is not served properly by our static server. Could be the case. If it's loaded properly, it will try to load a JS file that's not there. The user will just get an error in the console, but nothing will happen to the preview itself.
