### PR TITLE
WIP -- remove references to deprecated API fields

### DIFF
--- a/packages/app/src/app/components/Create/utils/queries.ts
+++ b/packages/app/src/app/components/Create/utils/queries.ts
@@ -14,7 +14,6 @@ const TEMPLATE_FRAGMENT = gql`
       insertedAt
       updatedAt
       isV2
-      isSse
       forkCount
       viewCount
 

--- a/packages/app/src/app/components/WorkspaceSetup/steps/SelectWorkspace.tsx
+++ b/packages/app/src/app/components/WorkspaceSetup/steps/SelectWorkspace.tsx
@@ -2,7 +2,6 @@ import React, { useState } from 'react';
 import { Button, Stack } from '@codesandbox/components';
 import { useActions, useAppState } from 'app/overmind';
 import {
-  SubscriptionPaymentProvider,
   SubscriptionStatus,
   TeamMemberAuthorization,
 } from 'app/graphql/types';
@@ -33,11 +32,6 @@ export const SelectWorkspace: React.FC<StepProps> = ({
           ua.userId === user?.id &&
           ua.authorization === TeamMemberAuthorization.Admin
       )
-    )
-    .filter(
-      // Filter out paddle teams (legacy)
-      t =>
-        t.subscription?.paymentProvider !== SubscriptionPaymentProvider.Paddle
     )
     .filter(
       // Filter out teams that are on ubb pro already

--- a/packages/app/src/app/graphql/types.ts
+++ b/packages/app/src/app/graphql/types.ts
@@ -4734,7 +4734,6 @@ export type TeamFragmentDashboardFragment = {
     origin: SubscriptionOrigin | null;
     type: SubscriptionType;
     status: SubscriptionStatus;
-    paymentProvider: SubscriptionPaymentProvider | null;
   } | null;
   featureFlags: {
     __typename?: 'TeamFeatureFlags';
@@ -4806,7 +4805,6 @@ export type CurrentTeamInfoFragmentFragment = {
     nextBillDate: any | null;
     origin: SubscriptionOrigin | null;
     paymentMethodAttached: boolean;
-    paymentProvider: SubscriptionPaymentProvider | null;
     quantity: number | null;
     status: SubscriptionStatus;
     trialEnd: any | null;
@@ -5028,7 +5026,6 @@ export type _CreateTeamMutation = {
       origin: SubscriptionOrigin | null;
       type: SubscriptionType;
       status: SubscriptionStatus;
-      paymentProvider: SubscriptionPaymentProvider | null;
     } | null;
     featureFlags: {
       __typename?: 'TeamFeatureFlags';
@@ -5414,7 +5411,6 @@ export type _AcceptTeamInvitationMutation = {
       origin: SubscriptionOrigin | null;
       type: SubscriptionType;
       status: SubscriptionStatus;
-      paymentProvider: SubscriptionPaymentProvider | null;
     } | null;
     featureFlags: {
       __typename?: 'TeamFeatureFlags';
@@ -5506,7 +5502,6 @@ export type _SetTeamNameMutation = {
       origin: SubscriptionOrigin | null;
       type: SubscriptionType;
       status: SubscriptionStatus;
-      paymentProvider: SubscriptionPaymentProvider | null;
     } | null;
     featureFlags: {
       __typename?: 'TeamFeatureFlags';
@@ -5762,7 +5757,6 @@ export type SetTeamMetadataMutation = {
       origin: SubscriptionOrigin | null;
       type: SubscriptionType;
       status: SubscriptionStatus;
-      paymentProvider: SubscriptionPaymentProvider | null;
     } | null;
     featureFlags: {
       __typename?: 'TeamFeatureFlags';
@@ -6190,7 +6184,6 @@ export type AllTeamsQuery = {
         origin: SubscriptionOrigin | null;
         type: SubscriptionType;
         status: SubscriptionStatus;
-        paymentProvider: SubscriptionPaymentProvider | null;
       } | null;
       featureFlags: {
         __typename?: 'TeamFeatureFlags';
@@ -6472,7 +6465,6 @@ export type GetTeamQuery = {
         nextBillDate: any | null;
         origin: SubscriptionOrigin | null;
         paymentMethodAttached: boolean;
-        paymentProvider: SubscriptionPaymentProvider | null;
         quantity: number | null;
         status: SubscriptionStatus;
         trialEnd: any | null;

--- a/packages/app/src/app/graphql/types.ts
+++ b/packages/app/src/app/graphql/types.ts
@@ -1125,7 +1125,6 @@ export enum SubscriptionOrigin {
 }
 
 export enum SubscriptionPaymentProvider {
-  Paddle = 'PADDLE',
   Stripe = 'STRIPE',
 }
 
@@ -2013,6 +2012,7 @@ export type RootMutationType = {
    * with Stripe in a way that is more appropriate for a mutation than a query.
    */
   previewConvertToUsageBilling: InvoicePreview;
+  /** @deprecated Subscription management no longer supported via GraphQL */
   previewUpdateSubscriptionBillingInterval: BillingPreview;
   reactivateSubscription: ProSubscription;
   redeemSandboxInvitation: Invitation;
@@ -2167,8 +2167,12 @@ export type RootMutationType = {
    * Not passing a specific argument will leave it unchanged, explicitly passing `null` will revert it to the default.
    */
   updateSandboxSettings: SandboxSettings;
-  /** update subscription details (not billing details) */
+  /**
+   * update subscription details (not billing details)
+   * @deprecated Subscription management no longer supported via GraphQL
+   */
   updateSubscription: ProSubscription;
+  /** @deprecated Subscription management no longer supported via GraphQL */
   updateSubscriptionBillingInterval: ProSubscription;
   /**
    * Update an active usage-based billing subscription.
@@ -2273,7 +2277,6 @@ export type RootMutationTypeCreateCollectionArgs = {
 };
 
 export type RootMutationTypeCreateCommentArgs = {
-  codeReference: InputMaybe<CodeReference>;
   codeReferences: InputMaybe<Array<CodeReference>>;
   content: Scalars['String'];
   id: InputMaybe<Scalars['ID']>;
@@ -3169,7 +3172,6 @@ export type TemplateFragment = {
     insertedAt: string;
     updatedAt: string;
     isV2: boolean;
-    isSse: boolean | null;
     forkCount: number;
     viewCount: number;
     team: { __typename?: 'TeamPreview'; name: string } | null;
@@ -3201,7 +3203,6 @@ export type RecentAndWorkspaceTemplatesQuery = {
         insertedAt: string;
         updatedAt: string;
         isV2: boolean;
-        isSse: boolean | null;
         forkCount: number;
         viewCount: number;
         team: { __typename?: 'TeamPreview'; name: string } | null;
@@ -3226,7 +3227,6 @@ export type RecentAndWorkspaceTemplatesQuery = {
           insertedAt: string;
           updatedAt: string;
           isV2: boolean;
-          isSse: boolean | null;
           forkCount: number;
           viewCount: number;
           team: { __typename?: 'TeamPreview'; name: string } | null;
@@ -4531,7 +4531,6 @@ export type SandboxFragmentDashboardFragment = {
   removedAt: string | null;
   privacy: number;
   isFrozen: boolean;
-  isSse: boolean | null;
   screenshotUrl: string | null;
   screenshotOutdated: boolean;
   viewCount: number;
@@ -4578,7 +4577,6 @@ export type RepoFragmentDashboardFragment = {
   removedAt: string | null;
   privacy: number;
   isFrozen: boolean;
-  isSse: boolean | null;
   screenshotUrl: string | null;
   screenshotOutdated: boolean;
   viewCount: number;
@@ -4653,7 +4651,6 @@ export type TemplateFragmentDashboardFragment = {
     removedAt: string | null;
     privacy: number;
     isFrozen: boolean;
-    isSse: boolean | null;
     screenshotUrl: string | null;
     screenshotOutdated: boolean;
     viewCount: number;
@@ -4703,11 +4700,9 @@ export type TeamFragmentDashboardFragment = {
   __typename?: 'Team';
   id: any;
   name: string;
-  type: TeamType;
   description: string | null;
   creatorId: any | null;
   avatarUrl: string | null;
-  legacy: boolean;
   frozen: boolean;
   insertedAt: string;
   settings: {
@@ -4765,9 +4760,7 @@ export type CurrentTeamInfoFragmentFragment = {
   description: string | null;
   inviteToken: string;
   name: string;
-  type: TeamType;
   avatarUrl: string | null;
-  legacy: boolean;
   frozen: boolean;
   insertedAt: string;
   users: Array<{
@@ -5001,11 +4994,9 @@ export type _CreateTeamMutation = {
     __typename?: 'Team';
     id: any;
     name: string;
-    type: TeamType;
     description: string | null;
     creatorId: any | null;
     avatarUrl: string | null;
-    legacy: boolean;
     frozen: boolean;
     insertedAt: string;
     settings: {
@@ -5125,7 +5116,6 @@ export type AddToFolderMutation = {
     removedAt: string | null;
     privacy: number;
     isFrozen: boolean;
-    isSse: boolean | null;
     screenshotUrl: string | null;
     screenshotOutdated: boolean;
     viewCount: number;
@@ -5178,7 +5168,6 @@ export type MoveToTrashMutation = {
     removedAt: string | null;
     privacy: number;
     isFrozen: boolean;
-    isSse: boolean | null;
     screenshotUrl: string | null;
     screenshotOutdated: boolean;
     viewCount: number;
@@ -5232,7 +5221,6 @@ export type ChangePrivacyMutation = {
     removedAt: string | null;
     privacy: number;
     isFrozen: boolean;
-    isSse: boolean | null;
     screenshotUrl: string | null;
     screenshotOutdated: boolean;
     viewCount: number;
@@ -5286,7 +5274,6 @@ export type ChangeFrozenMutation = {
     removedAt: string | null;
     privacy: number;
     isFrozen: boolean;
-    isSse: boolean | null;
     screenshotUrl: string | null;
     screenshotOutdated: boolean;
     viewCount: number;
@@ -5340,7 +5327,6 @@ export type _RenameSandboxMutation = {
     removedAt: string | null;
     privacy: number;
     isFrozen: boolean;
-    isSse: boolean | null;
     screenshotUrl: string | null;
     screenshotOutdated: boolean;
     viewCount: number;
@@ -5394,11 +5380,9 @@ export type _AcceptTeamInvitationMutation = {
     __typename?: 'Team';
     id: any;
     name: string;
-    type: TeamType;
     description: string | null;
     creatorId: any | null;
     avatarUrl: string | null;
-    legacy: boolean;
     frozen: boolean;
     insertedAt: string;
     settings: {
@@ -5488,11 +5472,9 @@ export type _SetTeamNameMutation = {
     __typename?: 'Team';
     id: any;
     name: string;
-    type: TeamType;
     description: string | null;
     creatorId: any | null;
     avatarUrl: string | null;
-    legacy: boolean;
     frozen: boolean;
     insertedAt: string;
     settings: {
@@ -5746,11 +5728,9 @@ export type SetTeamMetadataMutation = {
     __typename?: 'Team';
     id: any;
     name: string;
-    type: TeamType;
     description: string | null;
     creatorId: any | null;
     avatarUrl: string | null;
-    legacy: boolean;
     frozen: boolean;
     insertedAt: string;
     settings: {
@@ -5833,7 +5813,6 @@ export type RecentlyDeletedTeamSandboxesQuery = {
         removedAt: string | null;
         privacy: number;
         isFrozen: boolean;
-        isSse: boolean | null;
         screenshotUrl: string | null;
         screenshotOutdated: boolean;
         viewCount: number;
@@ -5901,7 +5880,6 @@ export type SandboxesByPathQuery = {
         removedAt: string | null;
         privacy: number;
         isFrozen: boolean;
-        isSse: boolean | null;
         screenshotUrl: string | null;
         screenshotOutdated: boolean;
         viewCount: number;
@@ -5961,7 +5939,6 @@ export type TeamDraftsQuery = {
         removedAt: string | null;
         privacy: number;
         isFrozen: boolean;
-        isSse: boolean | null;
         screenshotUrl: string | null;
         screenshotOutdated: boolean;
         viewCount: number;
@@ -6038,7 +6015,6 @@ export type GetTeamReposQuery = {
         removedAt: string | null;
         privacy: number;
         isFrozen: boolean;
-        isSse: boolean | null;
         screenshotUrl: string | null;
         screenshotOutdated: boolean;
         viewCount: number;
@@ -6121,7 +6097,6 @@ export type TeamTemplatesQuery = {
           removedAt: string | null;
           privacy: number;
           isFrozen: boolean;
-          isSse: boolean | null;
           screenshotUrl: string | null;
           screenshotOutdated: boolean;
           viewCount: number;
@@ -6181,11 +6156,9 @@ export type AllTeamsQuery = {
       __typename?: 'Team';
       id: any;
       name: string;
-      type: TeamType;
       description: string | null;
       creatorId: any | null;
       avatarUrl: string | null;
-      legacy: boolean;
       frozen: boolean;
       insertedAt: string;
       settings: {
@@ -6260,7 +6233,6 @@ export type _SearchTeamSandboxesQuery = {
         removedAt: string | null;
         privacy: number;
         isFrozen: boolean;
-        isSse: boolean | null;
         screenshotUrl: string | null;
         screenshotOutdated: boolean;
         viewCount: number;
@@ -6318,7 +6290,6 @@ export type RecentlyAccessedSandboxesQuery = {
       removedAt: string | null;
       privacy: number;
       isFrozen: boolean;
-      isSse: boolean | null;
       screenshotUrl: string | null;
       screenshotOutdated: boolean;
       viewCount: number;
@@ -6405,7 +6376,6 @@ export type SharedWithMeSandboxesQuery = {
       removedAt: string | null;
       privacy: number;
       isFrozen: boolean;
-      isSse: boolean | null;
       screenshotUrl: string | null;
       screenshotOutdated: boolean;
       viewCount: number;
@@ -6456,9 +6426,7 @@ export type GetTeamQuery = {
       description: string | null;
       inviteToken: string;
       name: string;
-      type: TeamType;
       avatarUrl: string | null;
-      legacy: boolean;
       frozen: boolean;
       insertedAt: string;
       users: Array<{
@@ -6999,7 +6967,6 @@ export type TeamSidebarDataQuery = {
         removedAt: string | null;
         privacy: number;
         isFrozen: boolean;
-        isSse: boolean | null;
         screenshotUrl: string | null;
         screenshotOutdated: boolean;
         viewCount: number;

--- a/packages/app/src/app/hooks/useWorkspaceAuthorization.ts
+++ b/packages/app/src/app/hooks/useWorkspaceAuthorization.ts
@@ -5,7 +5,6 @@ type WorkspaceAuthorizationReturn =
   | {
       isAdmin: undefined;
       isBillingManager: undefined;
-      isPersonalSpace: undefined;
       isPrimarySpace: undefined;
       isTeamAdmin: undefined;
       isTeamEditor: undefined;
@@ -15,7 +14,6 @@ type WorkspaceAuthorizationReturn =
   | {
       isAdmin: boolean;
       isBillingManager: boolean;
-      isPersonalSpace: boolean;
       isPrimarySpace: boolean;
       isTeamAdmin: boolean;
       isTeamEditor: boolean;
@@ -39,7 +37,6 @@ export const useWorkspaceAuthorization = (): WorkspaceAuthorizationReturn => {
     return {
       isAdmin: undefined,
       isBillingManager: undefined,
-      isPersonalSpace: undefined,
       isPrimarySpace: undefined,
       isTeamAdmin: undefined,
       isTeamEditor: undefined,
@@ -63,7 +60,6 @@ export const useWorkspaceAuthorization = (): WorkspaceAuthorizationReturn => {
   return {
     isBillingManager: Boolean(teamManager) || isAdmin,
     isAdmin,
-    isPersonalSpace: activeTeamInfo?.type === TeamType.Personal,
     isPrimarySpace: activeTeam === primaryWorkspaceId,
     isTeamAdmin,
     isTeamEditor,

--- a/packages/app/src/app/hooks/useWorkspaceSubscription.ts
+++ b/packages/app/src/app/hooks/useWorkspaceSubscription.ts
@@ -1,6 +1,6 @@
 import {
   CurrentTeamInfoFragmentFragment,
-  SubscriptionPaymentProvider,
+
   SubscriptionStatus,
 } from 'app/graphql/types';
 import { useAppState } from 'app/overmind';
@@ -52,15 +52,11 @@ export const useWorkspaceSubscription = (): WorkspaceSubscriptionReturn => {
 
   const hasPaymentMethod = subscription.paymentMethodAttached;
 
-  const isPaddle =
-    subscription.paymentProvider === SubscriptionPaymentProvider.Paddle;
-
   return {
     subscription,
     isPro,
     isFree,
     hasPaymentMethod,
-    isPaddle,
   };
 };
 
@@ -69,7 +65,6 @@ const NO_WORKSPACE = {
   isPro: undefined,
   isFree: undefined,
   hasPaymentMethod: undefined,
-  isPaddle: undefined,
 };
 
 const NO_SUBSCRIPTION = {
@@ -77,7 +72,6 @@ const NO_SUBSCRIPTION = {
   isPro: false,
   isFree: true,
   hasPaymentMethod: false,
-  isPaddle: false,
 };
 
 export type WorkspaceSubscriptionReturn =
@@ -88,5 +82,4 @@ export type WorkspaceSubscriptionReturn =
       isPro: boolean;
       isFree: boolean;
       hasPaymentMethod: boolean;
-      isPaddle: boolean;
     };

--- a/packages/app/src/app/overmind/effects/gql/dashboard/fragments.ts
+++ b/packages/app/src/app/overmind/effects/gql/dashboard/fragments.ts
@@ -12,7 +12,6 @@ export const sandboxFragmentDashboard = gql`
     removedAt
     privacy
     isFrozen
-    isSse
     screenshotUrl
     screenshotOutdated
     viewCount

--- a/packages/app/src/app/overmind/effects/gql/dashboard/fragments.ts
+++ b/packages/app/src/app/overmind/effects/gql/dashboard/fragments.ts
@@ -119,7 +119,6 @@ export const teamFragmentDashboard = gql`
   fragment teamFragmentDashboard on Team {
     id
     name
-    type
     description
     creatorId
     avatarUrl
@@ -181,7 +180,6 @@ export const currentTeamInfoFragment = gql`
     description
     inviteToken
     name
-    type
     avatarUrl
     legacy
     frozen

--- a/packages/app/src/app/overmind/effects/gql/dashboard/fragments.ts
+++ b/packages/app/src/app/overmind/effects/gql/dashboard/fragments.ts
@@ -152,7 +152,6 @@ export const teamFragmentDashboard = gql`
       origin
       type
       status
-      paymentProvider
     }
 
     featureFlags {
@@ -223,7 +222,6 @@ export const currentTeamInfoFragment = gql`
       nextBillDate
       origin
       paymentMethodAttached
-      paymentProvider
       quantity
       status
       trialEnd

--- a/packages/app/src/app/overmind/effects/gql/dashboard/fragments.ts
+++ b/packages/app/src/app/overmind/effects/gql/dashboard/fragments.ts
@@ -122,7 +122,6 @@ export const teamFragmentDashboard = gql`
     description
     creatorId
     avatarUrl
-    legacy
     frozen
     insertedAt
     settings {
@@ -181,7 +180,6 @@ export const currentTeamInfoFragment = gql`
     inviteToken
     name
     avatarUrl
-    legacy
     frozen
     insertedAt
     users {

--- a/packages/app/src/app/overmind/effects/router.ts
+++ b/packages/app/src/app/overmind/effects/router.ts
@@ -24,13 +24,11 @@ export default new (class RouterEffect {
       alias,
       git,
       v2,
-      isSse,
     }: {
       id?: string | null;
       alias?: string | null;
       git?: GitInfo | null;
       v2?: boolean;
-      isSse?: boolean;
     },
     {
       openInNewWindow = false,
@@ -38,13 +36,13 @@ export default new (class RouterEffect {
     }: { openInNewWindow?: boolean; hasBetaEditorExperiment?: boolean } = {}
   ) {
     const url = sandboxUrl(
-      { id, alias, isV2: v2, isSse },
+      { id, alias, isV2: v2},
       hasBetaEditorExperiment
     );
 
     if (openInNewWindow) {
       window.open(url, '_blank');
-    } else if (v2 || (!isSse && hasBetaEditorExperiment)) {
+    } else if (v2 || hasBetaEditorExperiment) {
       window.location.href = url;
     } else {
       history.push(url);

--- a/packages/app/src/app/overmind/namespaces/deployment/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/deployment/actions.ts
@@ -108,15 +108,6 @@ export const deployPreviewClicked = async ({
     const zip = await effects.zip.create(sandbox);
     const contents = await effects.jsZip.loadAsync(zip.file);
 
-    if (sandbox.isSse && state.editor.currentSandbox) {
-      const envs = await effects.api.getEnvironmentVariables(
-        state.editor.currentSandbox.id
-      );
-      if (envs) {
-        await effects.vercel.checkEnvironmentVariables(sandbox, envs);
-      }
-    }
-
     state.deployment.vercel.url = await effects.vercel.deploy(
       contents,
       sandbox
@@ -147,15 +138,6 @@ export const deployProductionClicked = async ({
     state.deployment.deploying = true;
     const zip = await effects.zip.create(sandbox);
     const contents = await effects.jsZip.loadAsync(zip.file);
-
-    if (sandbox.isSse && state.editor.currentSandbox) {
-      const envs = await effects.api.getEnvironmentVariables(
-        state.editor.currentSandbox.id
-      );
-      if (envs) {
-        await effects.vercel.checkEnvironmentVariables(sandbox, envs);
-      }
-    }
 
     state.deployment.vercel.url = await effects.vercel.deploy(
       contents,

--- a/packages/app/src/app/overmind/namespaces/editor/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/editor/actions.ts
@@ -317,7 +317,7 @@ export const sandboxChanged = withLoadApp<{
 
       // Failsafe, in case someone types in the URL to load a v2 sandbox in v1
       // or if they have the experimental v2 editor enabled
-      if (sandbox.v2 || (!sandbox.isSse && hasBetaEditorExperiment)) {
+      if (sandbox.v2 || hasBetaEditorExperiment) {
         // Only pass githubInfo for the URL if the URL in v1 is based on GH
         const githubInfoForURL =
           sandbox.git && url.pathname.startsWith('/s/github')
@@ -330,7 +330,6 @@ export const sandboxChanged = withLoadApp<{
             alias: sandbox.alias,
             git: githubInfoForURL,
             isV2: sandbox.v2,
-            isSse: sandbox.isSse,
             query: url.searchParams,
           },
           hasBetaEditorExperiment

--- a/packages/app/src/app/pages/Dashboard/Components/Sandbox/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Sandbox/index.tsx
@@ -90,7 +90,7 @@ const GenericSandbox = ({ isScrolling, item, page }: GenericSandboxProps) => {
   const viewCount = formatNumber(sandbox.viewCount);
 
   const url = sandboxUrl(sandbox, hasBetaEditorExperiment);
-  const linksToV2 = sandbox.isV2 || (!sandbox.isSse && hasBetaEditorExperiment);
+  const linksToV2 = sandbox.isV2 || hasBetaEditorExperiment;
 
   const TemplateIcon = getTemplateIcon(sandbox);
   const PrivacyIcon = PrivacyIcons[sandbox.privacy];

--- a/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenus/SandboxMenu.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Selection/ContextMenus/SandboxMenu.tsx
@@ -41,7 +41,7 @@ export const SandboxMenu: React.FC<SandboxMenuProps> = ({
   const { isFrozen } = useWorkspaceLimits();
 
   const url = sandboxUrl(sandbox, hasBetaEditorExperiment);
-  const linksToV2 = sandbox.isV2 || (!sandbox.isSse && hasBetaEditorExperiment);
+  const linksToV2 = sandbox.isV2 || hasBetaEditorExperiment;
   const folderUrl = getFolderUrl(item, activeTeam);
   const boxType = sandbox.isV2 ? 'devbox' : 'sandbox';
 

--- a/packages/app/src/app/pages/Dashboard/Components/Selection/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Selection/index.tsx
@@ -335,8 +335,7 @@ export const SelectionProvider: React.FC<SelectionProviderProps> = ({
         );
         url = sandboxUrl(selectedItem.sandbox, hasBetaEditorExperiment);
         linksToV2 =
-          selectedItem.sandbox.isV2 ||
-          (!selectedItem.sandbox.isSse && hasBetaEditorExperiment);
+          selectedItem.sandbox.isV2 || hasBetaEditorExperiment;
       }
 
       if (event.ctrlKey || event.metaKey) {

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Recent/Banners/LegacyProConvertBanner.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Recent/Banners/LegacyProConvertBanner.tsx
@@ -21,7 +21,6 @@ export const LegacyProConvertBanner: React.FC<BannerProps> = ({
 }) => {
   const { activeTeam } = useAppState();
   const { isAdmin } = useWorkspaceAuthorization();
-  const { isPaddle } = useWorkspaceSubscription();
 
   return (
     <Banner
@@ -44,7 +43,7 @@ export const LegacyProConvertBanner: React.FC<BannerProps> = ({
           </Stack>
 
           <Stack align="center" gap={6}>
-            {isAdmin && !isPaddle && (
+            {isAdmin && (
               <RouterLink
                 to={upgradeUrl({
                   workspaceId: activeTeam,
@@ -61,15 +60,6 @@ export const LegacyProConvertBanner: React.FC<BannerProps> = ({
                   Upgrade to Pro
                 </Button>
               </RouterLink>
-            )}
-            {isAdmin && isPaddle && (
-              <Button
-                as="a"
-                href="mailto:support@codesandbox.io?subject=Convert to usage based billing"
-                autoWidth
-              >
-                Contact us
-              </Button>
             )}
             <Link
               href={docsUrl(

--- a/packages/app/src/app/pages/WorkspaceFlows/UpgradeWorkspace.tsx
+++ b/packages/app/src/app/pages/WorkspaceFlows/UpgradeWorkspace.tsx
@@ -16,7 +16,7 @@ export const UpgradeWorkspace = () => {
   const { hasLogIn, checkout } = useAppState();
   const actions = useActions();
   const { isAdmin } = useWorkspaceAuthorization();
-  const { isPro, isPaddle } = useWorkspaceSubscription();
+  const { isPro } = useWorkspaceSubscription();
   const { ubbBeta } = useWorkspaceFeatureFlags();
   const { getQueryParam } = useURLSearchParams();
   const workspaceId = getQueryParam('workspace');
@@ -29,8 +29,8 @@ export const UpgradeWorkspace = () => {
     (interval === 'month' || interval === 'year') &&
     workspaceId;
 
-  // Cannot upgrade if already on ubb or legacy paddle
-  const cannotUpgradeToUbb = (ubbBeta && isPro) || isPaddle;
+  // Cannot upgrade if already on ubb
+  const cannotUpgradeToUbb = ubbBeta && isPro;
 
   if (proPlanPreSelected && !checkout.newSubscription) {
     actions.checkout.selectPlan({

--- a/packages/common/src/utils/url-generator.ts
+++ b/packages/common/src/utils/url-generator.ts
@@ -118,7 +118,7 @@ export const sandboxUrl = (
 
   if (sandboxDetails.isV2) {
     baseUrl = `${newEditorUrlPrefix()}devbox/`;
-  } else if (!sandboxDetails.isSse && hasBetaEditorExperiment) {
+  } else if (hasBetaEditorExperiment) {
     baseUrl = `${newEditorUrlPrefix()}sandbox/`;
   }
 


### PR DESCRIPTION
HOUSEKEEPING 🧹 

Removed all checks and queries for the below fields, since they are deprecated on the API and always return the same value so are useless anyway.

- `isSSE` is always `false`
- `team.type` is always `TEAM`
- `team.legacy` is always `false`
- `paymentProvider` is always `STRIPE`

<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?

<!-- Is it a Bug fix, feature, docs update, ... -->

## What is the current behavior?

<!-- You can also link to an open issue here -->

## What is the new behavior?

<!-- if this is a feature change -->

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Step A
2. Step B
3. Step C

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Testing <!-- We can only merge the PR if this is checked -->
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
