### PR TITLE
fix: Change terminology

### DIFF
--- a/packages/app/src/app/components/Create/CreateBox/CreateBoxForm.tsx
+++ b/packages/app/src/app/components/Create/CreateBox/CreateBoxForm.tsx
@@ -274,7 +274,7 @@ export const CreateBoxForm: React.FC<CreateBoxFormProps> = ({
 
                 <Text size={3} variant="muted">
                   Ideal for any type of project, language or size. Runs on a
-                  server.
+                  MicroVM.
                 </Text>
 
                 {!runsOnVM && (

--- a/packages/app/src/app/components/Create/TemplateCard.tsx
+++ b/packages/app/src/app/components/Create/TemplateCard.tsx
@@ -84,7 +84,7 @@ export const TemplateCard = ({
               </Tooltip>
             )}
             {template.type === 'devbox' && (
-              <Tooltip content="Runs on server">
+              <Tooltip content="Runs on Devbox">
                 <Icon color="#999" size={16} name="server" />
               </Tooltip>
             )}


### PR DESCRIPTION
For consistency we should use the term `Devbox` when hovering the icon on the template cards. Cause that name is used by the icon on the next modal.

Also we should not use the term "server", but "MicroVM"... cause "server" is typically referred to as a single process running on a single machine. It is not the infrastructure we have for these Devboxes. "MicroVM" points to a specific type of infrastructure, which is the infrastructure we have 😄 

I was not part of this discussion, so consider the most important thing the consistency of the icon with Devbox 😄 