### PR TITLE
FIX: set undefined collection id instead of 'Drafts'

### DIFF
--- a/packages/app/src/app/components/Create/CreateBox/CreateBoxForm.tsx
+++ b/packages/app/src/app/components/Create/CreateBox/CreateBoxForm.tsx
@@ -198,10 +198,12 @@ export const CreateBoxForm: React.FC<CreateBoxFormProps> = ({
                   icon={() => <Icon name="folder" size={12} />}
                   value={collectionId}
                   onChange={({ target: { value } }) => {
-                    setCollectionId(value);
+                    value === 'drafts'
+                      ? setCollectionId(undefined)
+                      : setCollectionId(value);
                   }}
                 >
-                  <option key="drafts" value={null}>
+                  <option key="drafts" value="drafts">
                     Drafts
                   </option>
                   {collectionsData?.me?.collections?.map(collection => (


### PR DESCRIPTION
Closes a recurring API Sentry Error.

TIL that if you have something like this:
```
<option key="drafts" value={null}>
  Drafts
</option>
```

It does _not_ actually give you `null` when you try accessing the value but it uses the text that's inside the tag. This explains why we keep getting API requests that have `collection_id: "Drafts"`. (I was suspicious and confirmed in the console)/

To make it explicit I added a value of `drafts` that we can check against, but open to alternatives! 

The reason that it's so intermittent and tricky to reproduce is that this _only_ happens when you select a different folder and then go back and select `Drafts` -- If you never select anything _other_ than `Drafts` it remains correctly initialised.

<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?

<!-- Is it a Bug fix, feature, docs update, ... -->

## What is the current behavior?

<!-- You can also link to an open issue here -->

## What is the new behavior?

<!-- if this is a feature change -->

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Step A
2. Step B
3. Step C

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Testing <!-- We can only merge the PR if this is checked -->
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
