### PR TITLE
Remove deprecated fields from GQL fragments

### DIFF
--- a/packages/app/src/app/components/Create/utils/queries.ts
+++ b/packages/app/src/app/components/Create/utils/queries.ts
@@ -14,7 +14,6 @@ const TEMPLATE_FRAGMENT = gql`
       insertedAt
       updatedAt
       isV2
-      isSse
       forkCount
       viewCount
 

--- a/packages/app/src/app/graphql/types.ts
+++ b/packages/app/src/app/graphql/types.ts
@@ -3172,7 +3172,6 @@ export type TemplateFragment = {
     insertedAt: string;
     updatedAt: string;
     isV2: boolean;
-    isSse: boolean | null;
     forkCount: number;
     viewCount: number;
     team: { __typename?: 'TeamPreview'; name: string } | null;
@@ -3204,7 +3203,6 @@ export type RecentAndWorkspaceTemplatesQuery = {
         insertedAt: string;
         updatedAt: string;
         isV2: boolean;
-        isSse: boolean | null;
         forkCount: number;
         viewCount: number;
         team: { __typename?: 'TeamPreview'; name: string } | null;
@@ -3229,7 +3227,6 @@ export type RecentAndWorkspaceTemplatesQuery = {
           insertedAt: string;
           updatedAt: string;
           isV2: boolean;
-          isSse: boolean | null;
           forkCount: number;
           viewCount: number;
           team: { __typename?: 'TeamPreview'; name: string } | null;
@@ -3322,7 +3319,6 @@ export type SandboxFragmentDashboardFragment = {
   removedAt: string | null;
   privacy: number;
   isFrozen: boolean;
-  isSse: boolean | null;
   screenshotUrl: string | null;
   screenshotOutdated: boolean;
   viewCount: number;
@@ -3370,7 +3366,6 @@ export type RepoFragmentDashboardFragment = {
   removedAt: string | null;
   privacy: number;
   isFrozen: boolean;
-  isSse: boolean | null;
   screenshotUrl: string | null;
   screenshotOutdated: boolean;
   viewCount: number;
@@ -3446,7 +3441,6 @@ export type TemplateFragmentDashboardFragment = {
     removedAt: string | null;
     privacy: number;
     isFrozen: boolean;
-    isSse: boolean | null;
     screenshotUrl: string | null;
     screenshotOutdated: boolean;
     viewCount: number;
@@ -3917,7 +3911,6 @@ export type AddToFolderMutation = {
     removedAt: string | null;
     privacy: number;
     isFrozen: boolean;
-    isSse: boolean | null;
     screenshotUrl: string | null;
     screenshotOutdated: boolean;
     viewCount: number;
@@ -3971,7 +3964,6 @@ export type MoveToTrashMutation = {
     removedAt: string | null;
     privacy: number;
     isFrozen: boolean;
-    isSse: boolean | null;
     screenshotUrl: string | null;
     screenshotOutdated: boolean;
     viewCount: number;
@@ -4026,7 +4018,6 @@ export type ChangePrivacyMutation = {
     removedAt: string | null;
     privacy: number;
     isFrozen: boolean;
-    isSse: boolean | null;
     screenshotUrl: string | null;
     screenshotOutdated: boolean;
     viewCount: number;
@@ -4081,7 +4072,6 @@ export type ChangeFrozenMutation = {
     removedAt: string | null;
     privacy: number;
     isFrozen: boolean;
-    isSse: boolean | null;
     screenshotUrl: string | null;
     screenshotOutdated: boolean;
     viewCount: number;
@@ -4136,7 +4126,6 @@ export type _RenameSandboxMutation = {
     removedAt: string | null;
     privacy: number;
     isFrozen: boolean;
-    isSse: boolean | null;
     screenshotUrl: string | null;
     screenshotOutdated: boolean;
     viewCount: number;
@@ -4624,7 +4613,6 @@ export type RecentlyDeletedTeamSandboxesQuery = {
         removedAt: string | null;
         privacy: number;
         isFrozen: boolean;
-        isSse: boolean | null;
         screenshotUrl: string | null;
         screenshotOutdated: boolean;
         viewCount: number;
@@ -4693,7 +4681,6 @@ export type SandboxesByPathQuery = {
         removedAt: string | null;
         privacy: number;
         isFrozen: boolean;
-        isSse: boolean | null;
         screenshotUrl: string | null;
         screenshotOutdated: boolean;
         viewCount: number;
@@ -4754,7 +4741,6 @@ export type TeamDraftsQuery = {
         removedAt: string | null;
         privacy: number;
         isFrozen: boolean;
-        isSse: boolean | null;
         screenshotUrl: string | null;
         screenshotOutdated: boolean;
         viewCount: number;
@@ -4832,7 +4818,6 @@ export type GetTeamReposQuery = {
         removedAt: string | null;
         privacy: number;
         isFrozen: boolean;
-        isSse: boolean | null;
         screenshotUrl: string | null;
         screenshotOutdated: boolean;
         viewCount: number;
@@ -4916,7 +4901,6 @@ export type TeamTemplatesQuery = {
           removedAt: string | null;
           privacy: number;
           isFrozen: boolean;
-          isSse: boolean | null;
           screenshotUrl: string | null;
           screenshotOutdated: boolean;
           viewCount: number;
@@ -5053,7 +5037,6 @@ export type _SearchTeamSandboxesQuery = {
         removedAt: string | null;
         privacy: number;
         isFrozen: boolean;
-        isSse: boolean | null;
         screenshotUrl: string | null;
         screenshotOutdated: boolean;
         viewCount: number;
@@ -5112,7 +5095,6 @@ export type RecentlyAccessedSandboxesQuery = {
       removedAt: string | null;
       privacy: number;
       isFrozen: boolean;
-      isSse: boolean | null;
       screenshotUrl: string | null;
       screenshotOutdated: boolean;
       viewCount: number;
@@ -5201,7 +5183,6 @@ export type SharedWithMeSandboxesQuery = {
       removedAt: string | null;
       privacy: number;
       isFrozen: boolean;
-      isSse: boolean | null;
       screenshotUrl: string | null;
       screenshotOutdated: boolean;
       viewCount: number;
@@ -5798,7 +5779,6 @@ export type TeamSidebarDataQuery = {
         removedAt: string | null;
         privacy: number;
         isFrozen: boolean;
-        isSse: boolean | null;
         screenshotUrl: string | null;
         screenshotOutdated: boolean;
         viewCount: number;

--- a/packages/app/src/app/graphql/types.ts
+++ b/packages/app/src/app/graphql/types.ts
@@ -3496,11 +3496,9 @@ export type TeamFragmentDashboardFragment = {
   __typename?: 'Team';
   id: any;
   name: string;
-  type: TeamType;
   description: string | null;
   creatorId: any | null;
   avatarUrl: string | null;
-  legacy: boolean;
   frozen: boolean;
   insertedAt: string;
   settings: {
@@ -3797,11 +3795,9 @@ export type _CreateTeamMutation = {
     __typename?: 'Team';
     id: any;
     name: string;
-    type: TeamType;
     description: string | null;
     creatorId: any | null;
     avatarUrl: string | null;
-    legacy: boolean;
     frozen: boolean;
     insertedAt: string;
     settings: {
@@ -4195,11 +4191,9 @@ export type _AcceptTeamInvitationMutation = {
     __typename?: 'Team';
     id: any;
     name: string;
-    type: TeamType;
     description: string | null;
     creatorId: any | null;
     avatarUrl: string | null;
-    legacy: boolean;
     frozen: boolean;
     insertedAt: string;
     settings: {
@@ -4289,11 +4283,9 @@ export type _SetTeamNameMutation = {
     __typename?: 'Team';
     id: any;
     name: string;
-    type: TeamType;
     description: string | null;
     creatorId: any | null;
     avatarUrl: string | null;
-    legacy: boolean;
     frozen: boolean;
     insertedAt: string;
     settings: {
@@ -4547,11 +4539,9 @@ export type SetTeamMetadataMutation = {
     __typename?: 'Team';
     id: any;
     name: string;
-    type: TeamType;
     description: string | null;
     creatorId: any | null;
     avatarUrl: string | null;
-    legacy: boolean;
     frozen: boolean;
     insertedAt: string;
     settings: {
@@ -4986,11 +4976,9 @@ export type AllTeamsQuery = {
       __typename?: 'Team';
       id: any;
       name: string;
-      type: TeamType;
       description: string | null;
       creatorId: any | null;
       avatarUrl: string | null;
-      legacy: boolean;
       frozen: boolean;
       insertedAt: string;
       settings: {

--- a/packages/app/src/app/hooks/useWorkspaceAuthorization.ts
+++ b/packages/app/src/app/hooks/useWorkspaceAuthorization.ts
@@ -1,11 +1,10 @@
-import { TeamMemberAuthorization, TeamType } from 'app/graphql/types';
+import { TeamMemberAuthorization } from 'app/graphql/types';
 import { useAppState } from 'app/overmind';
 
 type WorkspaceAuthorizationReturn =
   | {
       isAdmin: undefined;
       isBillingManager: undefined;
-      isPersonalSpace: undefined;
       isPrimarySpace: undefined;
       isTeamAdmin: undefined;
       isTeamEditor: undefined;
@@ -15,7 +14,6 @@ type WorkspaceAuthorizationReturn =
   | {
       isAdmin: boolean;
       isBillingManager: boolean;
-      isPersonalSpace: boolean;
       isPrimarySpace: boolean;
       isTeamAdmin: boolean;
       isTeamEditor: boolean;
@@ -39,7 +37,6 @@ export const useWorkspaceAuthorization = (): WorkspaceAuthorizationReturn => {
     return {
       isAdmin: undefined,
       isBillingManager: undefined,
-      isPersonalSpace: undefined,
       isPrimarySpace: undefined,
       isTeamAdmin: undefined,
       isTeamEditor: undefined,
@@ -63,7 +60,6 @@ export const useWorkspaceAuthorization = (): WorkspaceAuthorizationReturn => {
   return {
     isBillingManager: Boolean(teamManager) || isAdmin,
     isAdmin,
-    isPersonalSpace: activeTeamInfo?.type === TeamType.Personal,
     isPrimarySpace: activeTeam === primaryWorkspaceId,
     isTeamAdmin,
     isTeamEditor,

--- a/packages/app/src/app/overmind/effects/gql/dashboard/fragments.ts
+++ b/packages/app/src/app/overmind/effects/gql/dashboard/fragments.ts
@@ -126,7 +126,6 @@ export const teamFragmentDashboard = gql`
     description
     creatorId
     avatarUrl
-    legacy
     frozen
     insertedAt
     settings {

--- a/packages/app/src/app/overmind/effects/gql/dashboard/fragments.ts
+++ b/packages/app/src/app/overmind/effects/gql/dashboard/fragments.ts
@@ -123,7 +123,6 @@ export const teamFragmentDashboard = gql`
   fragment teamFragmentDashboard on Team {
     id
     name
-    type
     description
     creatorId
     avatarUrl

--- a/packages/app/src/app/overmind/effects/gql/dashboard/fragments.ts
+++ b/packages/app/src/app/overmind/effects/gql/dashboard/fragments.ts
@@ -12,7 +12,6 @@ export const sandboxFragmentDashboard = gql`
     removedAt
     privacy
     isFrozen
-    isSse
     screenshotUrl
     screenshotOutdated
     viewCount

--- a/packages/common/src/types/index.ts
+++ b/packages/common/src/types/index.ts
@@ -445,7 +445,6 @@ export type Sandbox = {
   git: GitInfo | null;
   tags: string[];
   isFrozen: boolean;
-  isSse?: boolean;
   environmentVariables: {
     [key: string]: string;
   } | null;
@@ -779,7 +778,6 @@ export type SandboxUrlSourceData = {
   alias?: string | null;
   git?: GitInfo | null;
   isV2?: boolean;
-  isSse?: boolean;
   query?: Record<string, string> | URLSearchParams;
 };
 


### PR DESCRIPTION
Now the _huge_ houskeeping PR has been merged, I can do some more tiny cleanup.

These fields have been deprecated / resolved to a hard-coded value in the API for months already, and their values are no longer actually _used_ anywhere, so I removed them from the queries and regenerated the types.

<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?

<!-- Is it a Bug fix, feature, docs update, ... -->

## What is the current behavior?

<!-- You can also link to an open issue here -->

## What is the new behavior?

<!-- if this is a feature change -->

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Step A
2. Step B
3. Step C

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Testing <!-- We can only merge the PR if this is checked -->
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
