### PR TITLE
fix(dashboard): folders with same name but different parents

### DIFF
--- a/packages/app/src/app/pages/Dashboard/Content/routes/Sandboxes/useFilteredItems.ts
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Sandboxes/useFilteredItems.ts
@@ -8,6 +8,8 @@ import {
   DashboardSkeletonRow,
 } from 'app/pages/Dashboard/types';
 
+import { getParentPath, normalizePath } from '../../../utils/path';
+
 const skeletonRow = {
   type: 'skeleton-row' as 'skeleton-row',
 };
@@ -36,10 +38,10 @@ export const useFilteredItems = (
 
   useEffect(() => {
     const sandboxesForPath = getFilteredSandboxes(folderSandboxes || []);
-    const parent = path.split('/').pop();
+    const normalizedPath = normalizePath(path);
     const folderFolders =
       allCollections?.filter(
-        collection => collection.level === level && collection.parent === parent
+        collection => getParentPath(collection.path) === normalizedPath
       ) || [];
 
     const sortedFolders = orderBy(folderFolders, 'name').sort(a => 1);

--- a/packages/app/src/app/pages/Dashboard/Sidebar/NestableRowItem.tsx
+++ b/packages/app/src/app/pages/Dashboard/Sidebar/NestableRowItem.tsx
@@ -27,6 +27,7 @@ import {
 } from './utils';
 import { NEW_FOLDER_ID } from './constants';
 import { RowItem } from './RowItem';
+import { getParentPath } from '../utils/path';
 
 interface NestableRowItemProps {
   name: string;
@@ -101,6 +102,7 @@ export const NestableRowItem: React.FC<NestableRowItemProps> = ({
   };
 
   let subFolders: DashboardBaseFolder[];
+  console.log({ folders });
   if (folderPath === '/') {
     subFolders = folders.filter(folder => {
       if (folder.path === newFolderPath) {
@@ -110,7 +112,7 @@ export const NestableRowItem: React.FC<NestableRowItemProps> = ({
     });
   } else {
     subFolders = folders.filter(folder => {
-      const parentPath = folder.path.split('/').slice(0, -1).join('/');
+      const parentPath = getParentPath(folder.path);
 
       return parentPath === folderPath;
     });

--- a/packages/app/src/app/pages/Dashboard/Sidebar/NestableRowItem.tsx
+++ b/packages/app/src/app/pages/Dashboard/Sidebar/NestableRowItem.tsx
@@ -102,7 +102,6 @@ export const NestableRowItem: React.FC<NestableRowItemProps> = ({
   };
 
   let subFolders: DashboardBaseFolder[];
-  console.log({ folders });
   if (folderPath === '/') {
     subFolders = folders.filter(folder => {
       if (folder.path === newFolderPath) {

--- a/packages/app/src/app/pages/Dashboard/utils/path.ts
+++ b/packages/app/src/app/pages/Dashboard/utils/path.ts
@@ -1,0 +1,17 @@
+export function getParentPath(path: string) {
+  if (path === '/' || path === '') {
+    return '/';
+  }
+
+  const split = path.split('/');
+  split.pop();
+
+  return split.join('/');
+}
+
+export function normalizePath(path: string) {
+  if (!path.startsWith('/')) {
+    return '/' + path;
+  }
+  return path;
+}


### PR DESCRIPTION
When creating a folder structure in the dashbboard like

- `/test/a/b`
- `/test2/b/b`

Then if you would open `/test/a`, it would show two `b` folders in the overview. It was a small logic error, which is fixed in this PR.