### PR TITLE
fix: absolute path file resolving

### DIFF
--- a/packages/sandpack-core/src/npm/dynamic/fetch-protocols/file.ts
+++ b/packages/sandpack-core/src/npm/dynamic/fetch-protocols/file.ts
@@ -17,7 +17,7 @@ export class FileFetcher implements FetchProtocol {
   private async getUrlFromFileProtocol(version: string) {
     const tarLocation = normalizePath(version.replace(/^file:/, ''));
 
-    const module = this.manager.transpiledModules['/' + tarLocation];
+    const module = this.manager.transpiledModules[tarLocation];
 
     if (!module) {
       throw new Error(`Could not find ${version} while resolving dependency`);


### PR DESCRIPTION
Officially we should support `file://` for absolute files. We parsed it as `file:/`. This change fixes that.