### PR TITLE
fix: revert change of file location

### DIFF
--- a/packages/sandpack-core/src/npm/dynamic/fetch-protocols/file.ts
+++ b/packages/sandpack-core/src/npm/dynamic/fetch-protocols/file.ts
@@ -17,7 +17,7 @@ export class FileFetcher implements FetchProtocol {
   private async getUrlFromFileProtocol(version: string) {
     const tarLocation = normalizePath(version.replace(/^file:/, ''));
 
-    const module = this.manager.transpiledModules[tarLocation];
+    const module = this.manager.transpiledModules['/' + tarLocation];
 
     if (!module) {
       throw new Error(`Could not find ${version} while resolving dependency`);


### PR DESCRIPTION
Actually... npm does not use uris as we know them, so it _is_ actually okay to use them this way.