### PR TITLE
fix(dashboard): show folders in root

### DIFF
--- a/packages/app/src/app/pages/Dashboard/Content/routes/Sandboxes/useFilteredItems.ts
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Sandboxes/useFilteredItems.ts
@@ -40,9 +40,6 @@ export const useFilteredItems = (
     const sandboxesForPath = getFilteredSandboxes(folderSandboxes || []);
     const normalizedPath = normalizePath(path);
 
-    console.log(normalizedPath);
-    console.log(allCollections);
-
     const folderFolders =
       allCollections?.filter(
         collection =>

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Sandboxes/useFilteredItems.ts
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Sandboxes/useFilteredItems.ts
@@ -39,9 +39,14 @@ export const useFilteredItems = (
   useEffect(() => {
     const sandboxesForPath = getFilteredSandboxes(folderSandboxes || []);
     const normalizedPath = normalizePath(path);
+
+    console.log(normalizedPath);
+    console.log(allCollections);
+
     const folderFolders =
       allCollections?.filter(
-        collection => getParentPath(collection.path) === normalizedPath
+        collection =>
+          normalizePath(getParentPath(collection.path)) === normalizedPath
       ) || [];
 
     const sortedFolders = orderBy(folderFolders, 'name').sort(a => 1);


### PR DESCRIPTION
Because of the `normalize` function, folders created in the root folder were not recognized when iterating on the items in the dashboard

Before
![image](https://github.com/user-attachments/assets/0075765c-1204-43d6-951e-3cbc2a01782a)

After
![image](https://github.com/user-attachments/assets/2195932c-272c-4c91-bb48-51912a33be05)
