### PR TITLE
FIX: check for billing manager and admin on upgrade page

### DIFF
--- a/packages/app/src/app/components/WorkspaceSetup/steps/SelectWorkspace.tsx
+++ b/packages/app/src/app/components/WorkspaceSetup/steps/SelectWorkspace.tsx
@@ -23,11 +23,12 @@ export const SelectWorkspace: React.FC<StepProps> = ({
 
   const workspacesEligibleForUpgrade = dashboard.teams
     .filter(t =>
-      // Only teams where you are admin
+      // Only teams where you are billing manager or admin
       t.userAuthorizations.find(
         ua =>
           ua.userId === user?.id &&
-          ua.authorization === TeamMemberAuthorization.Admin
+          (ua.teamManager === true ||
+            ua.authorization === TeamMemberAuthorization.Admin)
       )
     )
     .filter(


### PR DESCRIPTION
Folks with billing permissions should be able to upgrade a workspace, not only admins.

<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?

<!-- Is it a Bug fix, feature, docs update, ... -->

## What is the current behavior?

<!-- You can also link to an open issue here -->

## What is the new behavior?

<!-- if this is a feature change -->

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. Step A
2. Step B
3. Step C

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Testing <!-- We can only merge the PR if this is checked -->
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
