### PR TITLE
fix(sandpack): prefer import over require for exports resolving

### DIFF
--- a/packages/sandpack-core/src/resolver/utils/exports.ts
+++ b/packages/sandpack-core/src/resolver/utils/exports.ts
@@ -1,7 +1,7 @@
 import { normalizeAliasFilePath } from './alias';
 
 // exports keys, sorted from high to low priority
-const EXPORTS_KEYS = ['browser', 'development', 'default', 'require', 'import'];
+const EXPORTS_KEYS = ['browser', 'development', 'default', 'import', 'require'];
 
 type PackageExportType =
   | string


### PR DESCRIPTION
Similar to how we should nowadays prioritize `module` over `main`, we should also prioritize `import` over `require`. It will be a bit slower (as we need to transpile esmodules to commonjs to run it in the browser), but these days all bundlers prioritize esmodules over commonjs, and so not defaulting to it on CSB introduces some subtle bugs.