### PR TITLE
fix: force commonjs resolving for chevrotain

### DIFF
--- a/packages/sandpack-core/src/resolver/utils/exports.ts
+++ b/packages/sandpack-core/src/resolver/utils/exports.ts
@@ -25,7 +25,8 @@ export function normalizePackageExport(
 
 export function extractPathFromExport(
   exportValue: PackageExportType,
-  pkgRoot: string
+  pkgRoot: string,
+  checkedExportKeys: string[] = EXPORTS_KEYS
 ): string | false {
   if (!exportValue) {
     return false;
@@ -46,13 +47,17 @@ export function extractPathFromExport(
   }
 
   if (typeof exportValue === 'object') {
-    for (const key of EXPORTS_KEYS) {
+    for (const key of checkedExportKeys) {
       const exportFilename = exportValue[key];
       if (exportFilename !== undefined) {
         if (typeof exportFilename === 'string') {
           return normalizePackageExport(exportFilename, pkgRoot);
         }
-        return extractPathFromExport(exportFilename, pkgRoot);
+        return extractPathFromExport(
+          exportFilename,
+          pkgRoot,
+          checkedExportKeys
+        );
       }
     }
     return false;

--- a/packages/sandpack-core/src/resolver/utils/pkg-json.ts
+++ b/packages/sandpack-core/src/resolver/utils/pkg-json.ts
@@ -8,6 +8,11 @@ const PKG_ALIAS_FIELDS = ['browser', 'alias'];
 
 type AliasesDict = { [key: string]: string };
 
+const COMMONJS_EXPORT_KEYS = ['browser', 'development', 'default', 'require'];
+function forceCommonJs(name: string, version: string): boolean {
+  return name === 'chevrotain' && version.startsWith('10.');
+}
+
 export interface ProcessedPackageJSON {
   aliases: AliasesDict;
   hasExports: boolean;
@@ -43,7 +48,15 @@ export function processPackageJSON(
     } else if (typeof content.exports === 'object') {
       const exportKeys = Object.keys(content.exports);
       if (!exportKeys[0].startsWith('.')) {
-        const resolvedExport = extractPathFromExport(content.exports, pkgRoot);
+        const checkedExportKeys = forceCommonJs(content.name, content.version)
+          ? COMMONJS_EXPORT_KEYS
+          : undefined;
+
+        const resolvedExport = extractPathFromExport(
+          content.exports,
+          pkgRoot,
+          checkedExportKeys
+        );
         if (!resolvedExport) {
           throw new Error(`Could not find a valid export for ${pkgRoot}`);
         }


### PR DESCRIPTION
After preferring esmodules in our export resolving, some sandboxes broke because of its reliance on `chevrotain@10.x.x`. This version of `chevrotain` has a version of ESM where `__esModule` is set to true, but where also a default export is set. This should not happen, if `__esModule` is set to true, all of its exports should be on the root.

Other bundlers also had issue with this, and as a result some libraries have updated `chevrotain` to v11, which fixes the issue. We want to keep backwards compatibility on our sandboxes, though, so we should instead force commonjs resolving for chevrotain 10.x.x.

An alternative solution is to alias chevrotain 10.x.x to 11.x.x