### PR TITLE
fix: starting ~ in style paths

### DIFF
--- a/packages/app/src/sandbox/eval/transpilers/postcss/loader.ts
+++ b/packages/app/src/sandbox/eval/transpilers/postcss/loader.ts
@@ -45,7 +45,13 @@ export default async function (
     postcssImportPlugin({
       resolve: async (id: string, root: string) => {
         try {
-          const result = await resolveCSSFile(loaderContext, id, root);
+          // Angular specific, remove the ~ from the path to determine if it's a dependency
+          const sanitizedPath = id.replace(/^~/, '');
+          const result = await resolveCSSFile(
+            loaderContext,
+            sanitizedPath,
+            root
+          );
 
           return result.module.path;
         } catch (e) {


### PR DESCRIPTION
Angular uses `~` to define root paths, our resolver does not understand this. With this change we remove the `~` at the start.

Fixes https://github.com/codesandbox/codesandbox-client/issues/7411