### PR TITLE
chore(deps-dev): bump http-proxy-middleware from 1.1.2 to 2.0.7 (#8642)

### DIFF
--- a/packages/app/src/sandbox/eval/transpilers/reason/index.ts
+++ b/packages/app/src/sandbox/eval/transpilers/reason/index.ts
@@ -88,7 +88,7 @@ class ReasonTranspiler extends Transpiler {
         'https://cdn.jsdelivr.net/gh/jaredly/reason-react@more-docs/docs/bucklescript.js'
       );
       await addScript('https://reason.surge.sh/bucklescript-deps.js');
-      await addScript('https://unpkg.com/reason@3.3.4/refmt.js');
+      await addScript('https://cdn.jsdelivr.net/npm/reason@3.3.4/refmt.js');
     }
 
     const reasonModules = loaderContext

--- a/packages/app/src/sandbox/eval/transpilers/stencil/stencil-worker.ts
+++ b/packages/app/src/sandbox/eval/transpilers/stencil/stencil-worker.ts
@@ -24,12 +24,12 @@ const loadStencilVersion = (version: string) => {
     loadedStencilVersion = version;
 
     ctx.importScripts(
-      `https://unpkg.com/@stencil/core@${version}/compiler/stencil.js`
+      `https://cdn.jsdelivr.net/npm/@stencil/core@${version}/compiler/stencil.js`
     );
   }
 };
 
-ctx.importScripts('https://unpkg.com/typescript@3.5.3/lib/typescript.js');
+ctx.importScripts('https://cdn.jsdelivr.net/npm/typescript@3.5.3/lib/typescript.js');
 
 async function compileStencil(data) {
   const { code, path, stencilVersion } = data;

--- a/packages/app/src/sandbox/eval/transpilers/svelte/svelte-worker.ts
+++ b/packages/app/src/sandbox/eval/transpilers/svelte/svelte-worker.ts
@@ -8,7 +8,7 @@ const childHandler = new ChildHandler('svelte-worker');
 self.window = self;
 
 function getV3Code({ code, version, path }) {
-  self.importScripts(`https://unpkg.com/svelte@${version}/compiler.js`);
+  self.importScripts(`https://cdn.jsdelivr.net/npm/svelte@${version}/compiler.js`);
 
   // @ts-ignore
   const { js, warnings } = self.svelte.compile(code, {
@@ -38,7 +38,7 @@ function getV3Code({ code, version, path }) {
 }
 
 function getV2Code({ code, version, path }) {
-  self.importScripts(`https://unpkg.com/svelte@${version}/compiler/svelte.js`);
+  self.importScripts(`https://cdn.jsdelivr.net/npm/svelte@${version}/compiler/svelte.js`);
 
   let error = null;
   const warnings = [];
@@ -74,7 +74,7 @@ function getV2Code({ code, version, path }) {
 }
 
 function getV1Code({ code, version, path }) {
-  self.importScripts(`https://unpkg.com/svelte@${version}/compiler/svelte.js`);
+  self.importScripts(`https://cdn.jsdelivr.net/npm/svelte@${version}/compiler/svelte.js`);
 
   let error = null;
   const warnings = [];

--- a/packages/app/src/sandbox/eval/transpilers/typescript/typescript-worker.ts
+++ b/packages/app/src/sandbox/eval/transpilers/typescript/typescript-worker.ts
@@ -15,7 +15,7 @@ async function compile(data) {
 
   if (typescriptVersion !== '3.4.1') {
     self.importScripts(
-      `https://unpkg.com/typescript@${typescriptVersion}/lib/typescript.js`
+      `https://cdn.jsdelivr.net/npm/typescript@${typescriptVersion}/lib/typescript.js`
     );
   }
 

--- a/packages/common/src/utils/dependencies.ts
+++ b/packages/common/src/utils/dependencies.ts
@@ -39,7 +39,7 @@ const resolveVersionFromUnpkg = (
   version: string
 ): Promise<string> => {
   return fetchWithRetries(
-    `https://unpkg.com/${dep}@${encodeURIComponent(version)}/package.json`
+    `https://cdn.jsdelivr.net/npm/${dep}@${encodeURIComponent(version)}/package.json`
   ).then(x => x.version);
 };
 

--- a/standalone-packages/codesandbox-browserfs/src/backend/UNPKGRequest.ts
+++ b/standalone-packages/codesandbox-browserfs/src/backend/UNPKGRequest.ts
@@ -120,7 +120,7 @@ export default class UNPKGRequest extends BaseFileSystem implements FileSystem {
    * Construct an HTTPRequest file system backend with the given options.
    */
   public static Create(opts: UNPKGRequestOptions, cb: BFSCallback<UNPKGRequest>): void {
-    const URL = `https://unpkg.com/${opts.dependency}@${opts.version}`;
+    const URL = `https://cdn.jsdelivr.net/npm/${opts.dependency}@${opts.version}`;
 
     asyncDownloadFile(`${URL}/?meta`, "json", (e, data: UNPKGMeta) => {
       if (e) {
@@ -413,7 +413,7 @@ export default class UNPKGRequest extends BaseFileSystem implements FileSystem {
     if (filePath.charAt(0) === '/') {
       filePath = filePath.slice(1);
     }
-    return `https://unpkg.com/${this.dependency}@${this.version}/${filePath}`;
+    return `https://cdn.jsdelivr.net/npm/${this.dependency}@${this.version}/${filePath}`;
   }
 
   /**

--- a/standalone-packages/monaco-typescript/src/fetchDependencyTypings.ts
+++ b/standalone-packages/monaco-typescript/src/fetchDependencyTypings.ts
@@ -430,7 +430,7 @@ export async function fetchAndAddDependencies(
       let depVersion = version;
 
       try {
-        await doFetch(`https://unpkg.com/${dep}@${version}/package.json`)
+        await doFetch(`https://cdn.jsdelivr.net/npm/${dep}@${version}/package.json`)
           .then(x => JSON.parse(x))
           .then(x => {
             depVersion = x.version;


### PR DESCRIPTION
## What kind of change does this PR introduce?

UNPKG has not been actively maintained and has been down since `Mar 15, 2025` (https://github.com/unpkg/unpkg/issues/412). The PR changes a few UNPKG usage with jsDelivr.

## What is the current behavior?

Some assets and libraries are loaded through unpkg.

## What is the new behavior?

Those assets and libraries are now loaded through jsDelivr.

The `UnpkgFetcher` is **not touched**.

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
