### PR TITLE
SEC-520: npm registry token exposure

### DIFF
--- a/packages/app/src/sandbox/compile.ts
+++ b/packages/app/src/sandbox/compile.ts
@@ -375,7 +375,7 @@ async function initializeManager(
       enabled_scopes: string[];
       limit_to_scopes: true;
       proxy_enabled: false;
-      registry_auth_key: string;
+      registry_auth_key_configured: boolean;
       registry_type: string;
       registry_url: string;
     };
@@ -386,7 +386,7 @@ async function initializeManager(
       proxyEnabled: registry.proxy_enabled,
       registryUrl:
         registry.registry_url || `${domain}/api/v1/sandpack/registry/`,
-      registryAuthToken: registry.registry_auth_key || sandpackToken,
+      registryAuthTokenConfigured: registry.registry_auth_key_configured,
       registryAuthType: registry.auth_type,
     });
   }
@@ -416,10 +416,6 @@ async function initializeManager(
       // the tarball. So we proxy it.
       options.provideTarballUrl = (name: string, version: string) =>
         `${cleanUrl}/${name.replace('/', '%2f')}/${version}`;
-    }
-
-    if (registry.registryAuthToken) {
-      options.authToken = registry.registryAuthToken;
     }
 
     const protocol = new NpmRegistryFetcher(cleanUrl, options);

--- a/packages/common/src/types/index.ts
+++ b/packages/common/src/types/index.ts
@@ -346,7 +346,7 @@ export type NpmRegistry = {
   limitToScopes: boolean;
   registryUrl: string;
   proxyEnabled?: boolean;
-  registryAuthToken?: string;
+  registryAuthTokenConfigured?: boolean;
   registryAuthType?: string;
 };
 


### PR DESCRIPTION

## Security Fix: NPM Registry Token Exposure

**Issue**: NPM registry authentication tokens were exposed in the DOM on the Custom NPM Registry settings page, accessible to all workspace members including read-only users (SEC-520).

**Changes**:
- Modified `NpmRegistry` type 
- Updated `compile.ts` to handle the boolean flag instead of the actual token
- Removed client-side token handling from NPM registry fetcher

**Impact**:
- Auth tokens are no longer sent to the client
- Client only receives a boolean indicating if a token is configured
- Tokens cannot be extracted from DOM, network requests, or browser storage
- NPM package fetching continues to work as authentication is handled server-side


This fix will ensures sensitive NPM registry credentials remain server-side only, preventing unauthorized access by workspace members with limited permissions.

Associated tickets: 
1. [SEC-520](https://linear.app/together-ai/issue/SEC-520/npm-registry-token-exposed-in-dom-accessible-to-viewer-role)
2. [ENG-39975](https://linear.app/together-ai/issue/ENG-39975/vuln-npm-registry-token-exposed-in-dom-accessible-to-viewer-role)