### PR TITLE
Revert "Sanne/perf remove unused gql fields"

### DIFF
--- a/packages/app/src/app/overmind/effects/gql/dashboard/fragments.ts
+++ b/packages/app/src/app/overmind/effects/gql/dashboard/fragments.ts
@@ -15,6 +15,7 @@ export const sandboxFragmentDashboard = gql`
     screenshotUrl
     screenshotOutdated
     viewCount
+    likeCount
     isV2
     draft
     restricted

--- a/packages/app/src/app/overmind/effects/gql/sidebar/queries.ts
+++ b/packages/app/src/app/overmind/effects/gql/sidebar/queries.ts
@@ -28,10 +28,14 @@ export const getTeamSidebarData: Query<
         projects(syncData: false) {
           ...sidebarProjectFragment
         }
+        sandboxes(limit: 10, orderBy: { field: "updatedAt", direction: DESC }) {
+          ...sandboxFragmentDashboard
+        }
       }
     }
   }
   ${sidebarSyncedSandboxFragment}
   ${sidebarTemplateFragment}
   ${sidebarProjectFragment}
+  ${sandboxFragmentDashboard}
 `;

--- a/packages/app/src/app/overmind/namespaces/sidebar/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/sidebar/actions.ts
@@ -15,6 +15,7 @@ export const getSidebarData = async (
     const result = await queries.getTeamSidebarData({ id: teamId });
 
     const syncedSandboxes = result.me?.team?.syncedSandboxes || null;
+    const sandboxes = result.me?.team?.sandboxes || [];
     const templates = result.me?.team?.templates || null;
     const repositories =
       result.me?.team?.projects?.map(p => ({
@@ -29,6 +30,7 @@ export const getSidebarData = async (
     state.sidebar[teamId] = {
       hasSyncedSandboxes,
       hasTemplates,
+      sandboxes,
       repositories,
     };
   } catch {

--- a/packages/app/src/app/overmind/namespaces/sidebar/state.ts
+++ b/packages/app/src/app/overmind/namespaces/sidebar/state.ts
@@ -5,6 +5,7 @@ type SidebarState = {
   hasSyncedSandboxes: boolean | null;
   hasTemplates: boolean | null;
   repositories: Array<RepoInfo>;
+  sandboxes: Array<Sandbox>;
 };
 
 export type State = Record<string, SidebarState>;


### PR DESCRIPTION
Reverts codesandbox/codesandbox-client#8799

There's a type error that I don't understand, so it won't deploy anyway. Making me think maybe we _do_ use these sandboxes? I don't have time to properly look into it.

`src/app/pages/Dashboard/Content/routes/Recent/index.tsx(92,30): error TS2339: Property 'sandboxes' does not exist on type 'SidebarState'.` <- this is the type error, but I don't understand because when I deployed to stream it did just work and showed me recent sandboxes. Here we're trying to read the sandboxes from the sidebar state, but I'm pretty sure we have them _elsewhere_ ij ust don't know where.

(The linting errors were related to unused variables, but those are easily fixed)