### PR TITLE
chore(ci): remove CodeSandbox CI configuration

### DIFF
--- a/standalone-packages/vscode-extensions/package.json
+++ b/standalone-packages/vscode-extensions/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "install-dependencies": "yarn decompress-extensions",
     "compress-extensions": "rm vscode-extensions.tar.zst && cd out/ && tar cf - extensions | zstd -10 -T0 -o ../vscode-extensions.tar.zst",
-    "decompress-extensions": "if command -v zstd >/dev/null 2>&1; then rm -rf out/extensions && mkdir -p out/extensions && cd out/ && zstd -d -T0 -c ../vscode-extensions.tar.zst | tar xf - -C .; elif [ -d \"out/extensions\" ] && [ \"$(ls -A out/extensions 2>/dev/null)\" ]; then echo \"Warning: zstd not found, but extensions directory already exists. Skipping decompression.\"; else echo \"Warning: zstd not found and extensions directory does not exist. Skipping decompression. Extensions will not be available until zstd is installed.\"; fi",
+    "decompress-extensions": "rm -rf out/extensions && mkdir out/extensions && cd out/ && zstd -d -T0 -c ../vscode-extensions.tar.zst | tar xf - -C .",
     "clean": "rimraf out",
     "copy": "yarn clean && mkdir out && cp -R ../vscode/extensions-bundle/ ./out/ && yarn rimraf out/draft",
     "compile": "cd out/extensions/ && node ../../../codesandbox-browserfs/build/scripts/make_http_index.js > index.json"


### PR DESCRIPTION
## Summary
Removes CodeSandbox CI from the repository. CodeSandbox CI was causing failures during yarn install because it didn't install `zstd` before running the postinstall script. Since CircleCI already handles CI/CD, CodeSandbox CI is redundant.

This error caused CodeSandbox CI to fail for a long time already.

## Changes
- Removed `.codesandbox/ci.json` — CodeSandbox CI configuration file
- Reverted `standalone-packages/vscode-extensions/package.json` — Restored original decompress-extensions script (no longer needed since CodeSandbox CI is removed)

## Why remove CodeSandbox CI?
- Redundant with CircleCI — CircleCI already provides full CI/CD coverage
- Caused CI failures — CodeSandbox CI didn't install `zstd` before `yarn install`, causing the vscode-extensions decompression step to fail
- Not blocking — CircleCI handles all necessary checks (build, test, lint, typecheck, deploy)

## Testing
- CircleCI builds should continue to work as before
- CodeSandbox CI will no longer run on PRs