### PR TITLE
refactor: add me.id to queries and rename recent queries for future refactor

### DIFF
--- a/packages/app/src/app/components/Create/utils/queries.ts
+++ b/packages/app/src/app/components/Create/utils/queries.ts
@@ -35,6 +35,8 @@ const TEMPLATE_FRAGMENT = gql`
 export const FETCH_TEAM_TEMPLATES = gql`
   query RecentAndWorkspaceTemplates($teamId: UUID4) {
     me {
+      id
+      
       recentlyUsedTemplates(teamId: $teamId) {
         ...Template
       }
@@ -86,6 +88,8 @@ const ORGANIZATION_FRAGMENT = gql`
 export const GET_GITHUB_ACCOUNTS = gql`
   query GetGithubAccounts {
     me {
+      id
+      
       githubProfile {
         ...Profile
       }

--- a/packages/app/src/app/graphql/types.ts
+++ b/packages/app/src/app/graphql/types.ts
@@ -3234,6 +3234,7 @@ export type RecentAndWorkspaceTemplatesQuery = {
   __typename?: 'RootQueryType';
   me: {
     __typename?: 'CurrentUser';
+    id: any;
     recentlyUsedTemplates: Array<{
       __typename?: 'Template';
       id: any | null;
@@ -3327,6 +3328,7 @@ export type GetGithubAccountsQuery = {
   __typename?: 'RootQueryType';
   me: {
     __typename?: 'CurrentUser';
+    id: any;
     githubProfile: {
       __typename?: 'GithubProfile';
       id: string;
@@ -4642,6 +4644,7 @@ export type RecentlyDeletedTeamSandboxesQuery = {
   __typename?: 'RootQueryType';
   me: {
     __typename?: 'CurrentUser';
+    id: any;
     team: {
       __typename?: 'Team';
       sandboxes: Array<{
@@ -4701,6 +4704,7 @@ export type SandboxesByPathQuery = {
   __typename?: 'RootQueryType';
   me: {
     __typename?: 'CurrentUser';
+    id: any;
     collections: Array<{
       __typename?: 'Collection';
       id: any | null;
@@ -4768,6 +4772,7 @@ export type TeamDraftsQuery = {
   __typename?: 'RootQueryType';
   me: {
     __typename?: 'CurrentUser';
+    id: any;
     team: {
       __typename?: 'Team';
       drafts: Array<{
@@ -4826,6 +4831,7 @@ export type AllCollectionsQuery = {
   __typename?: 'RootQueryType';
   me: {
     __typename?: 'CurrentUser';
+    id: any;
     collections: Array<{
       __typename?: 'Collection';
       id: any | null;
@@ -4843,6 +4849,7 @@ export type GetTeamReposQuery = {
   __typename?: 'RootQueryType';
   me: {
     __typename?: 'CurrentUser';
+    id: any;
     team: {
       __typename?: 'Team';
       sandboxes: Array<{
@@ -4918,6 +4925,7 @@ export type TeamTemplatesQuery = {
   __typename?: 'RootQueryType';
   me: {
     __typename?: 'CurrentUser';
+    id: any;
     team: {
       __typename?: 'Team';
       id: any;
@@ -4993,6 +5001,7 @@ export type AllTeamsQuery = {
   __typename?: 'RootQueryType';
   me: {
     __typename?: 'CurrentUser';
+    id: any;
     primaryWorkspaceId: any | null;
     workspaces: Array<{
       __typename?: 'Team';
@@ -5059,6 +5068,7 @@ export type _SearchTeamSandboxesQuery = {
   __typename?: 'RootQueryType';
   me: {
     __typename?: 'CurrentUser';
+    id: any;
     team: {
       __typename?: 'Team';
       sandboxes: Array<{
@@ -5109,15 +5119,16 @@ export type _SearchTeamSandboxesQuery = {
   } | null;
 };
 
-export type RecentlyAccessedSandboxesQueryVariables = Exact<{
+export type RecentlyAccessedSandboxesLegacyQueryVariables = Exact<{
   limit: Scalars['Int'];
   teamId: InputMaybe<Scalars['UUID4']>;
 }>;
 
-export type RecentlyAccessedSandboxesQuery = {
+export type RecentlyAccessedSandboxesLegacyQuery = {
   __typename?: 'RootQueryType';
   me: {
     __typename?: 'CurrentUser';
+    id: any;
     recentlyAccessedSandboxes: Array<{
       __typename?: 'Sandbox';
       id: string;
@@ -5165,15 +5176,16 @@ export type RecentlyAccessedSandboxesQuery = {
   } | null;
 };
 
-export type RecentlyAccessedBranchesQueryVariables = Exact<{
+export type RecentlyAccessedBranchesLegacyQueryVariables = Exact<{
   limit: Scalars['Int'];
   teamId: InputMaybe<Scalars['UUID4']>;
 }>;
 
-export type RecentlyAccessedBranchesQuery = {
+export type RecentlyAccessedBranchesLegacyQuery = {
   __typename?: 'RootQueryType';
   me: {
     __typename?: 'CurrentUser';
+    id: any;
     recentBranches: Array<{
       __typename?: 'Branch';
       id: string;
@@ -5205,6 +5217,7 @@ export type SharedWithMeSandboxesQuery = {
   __typename?: 'RootQueryType';
   me: {
     __typename?: 'CurrentUser';
+    id: any;
     collaboratorSandboxes: Array<{
       __typename?: 'Sandbox';
       id: string;
@@ -5260,6 +5273,7 @@ export type GetTeamQuery = {
   __typename?: 'RootQueryType';
   me: {
     __typename?: 'CurrentUser';
+    id: any;
     team: {
       __typename?: 'Team';
       id: any;
@@ -5383,6 +5397,7 @@ export type ContributionBranchesQuery = {
   __typename?: 'RootQueryType';
   me: {
     __typename?: 'CurrentUser';
+    id: any;
     recentBranches: Array<{
       __typename?: 'Branch';
       id: string;
@@ -5415,6 +5430,7 @@ export type RepositoriesByTeamQuery = {
   __typename?: 'RootQueryType';
   me: {
     __typename?: 'CurrentUser';
+    id: any;
     team: {
       __typename?: 'Team';
       id: any;
@@ -5625,6 +5641,7 @@ export type GetEligibleWorkspacesQuery = {
   __typename?: 'RootQueryType';
   me: {
     __typename?: 'CurrentUser';
+    id: any;
     eligibleWorkspaces: Array<{
       __typename?: 'TeamPreview';
       id: any;
@@ -5722,6 +5739,7 @@ export type EmailPreferencesQuery = {
   __typename?: 'RootQueryType';
   me: {
     __typename?: 'CurrentUser';
+    id: any;
     notificationPreferences: {
       __typename?: 'NotificationPreferences';
       emailCommentMention: boolean;
@@ -5746,6 +5764,7 @@ export type RecentNotificationsQuery = {
   __typename?: 'RootQueryType';
   me: {
     __typename?: 'CurrentUser';
+    id: any;
     notifications: Array<{
       __typename?: 'Notification';
       id: any;
@@ -5785,6 +5804,7 @@ export type TeamSidebarDataQuery = {
   __typename?: 'RootQueryType';
   me: {
     __typename?: 'CurrentUser';
+    id: any;
     team: {
       __typename?: 'Team';
       syncedSandboxes: Array<{ __typename?: 'Sandbox'; id: string }>;
@@ -5852,6 +5872,7 @@ export type TeamsQuery = {
   __typename?: 'RootQueryType';
   me: {
     __typename?: 'CurrentUser';
+    id: any;
     workspaces: Array<{ __typename?: 'Team'; id: any; name: string }>;
   } | null;
 };
@@ -5916,6 +5937,7 @@ export type TeamsSidebarQuery = {
   __typename?: 'RootQueryType';
   me: {
     __typename?: 'CurrentUser';
+    id: any;
     teams: Array<{ __typename?: 'Team'; id: any; name: string }>;
   } | null;
 };
@@ -5928,6 +5950,7 @@ export type PathedSandboxesFoldersQuery = {
   __typename?: 'RootQueryType';
   me: {
     __typename?: 'CurrentUser';
+    id: any;
     collections: Array<{
       __typename?: 'Collection';
       id: any | null;
@@ -6130,6 +6153,7 @@ export type PathedSandboxesQuery = {
   __typename?: 'RootQueryType';
   me: {
     __typename?: 'CurrentUser';
+    id: any;
     collections: Array<{
       __typename?: 'Collection';
       id: any | null;
@@ -6177,6 +6201,7 @@ export type RecentSandboxesQuery = {
   __typename?: 'RootQueryType';
   me: {
     __typename?: 'CurrentUser';
+    id: any;
     sandboxes: Array<{
       __typename?: 'Sandbox';
       id: string;
@@ -6211,6 +6236,7 @@ export type SearchSandboxesQuery = {
   __typename?: 'RootQueryType';
   me: {
     __typename?: 'CurrentUser';
+    id: any;
     sandboxes: Array<{
       __typename?: 'Sandbox';
       id: string;
@@ -6245,6 +6271,7 @@ export type DeletedSandboxesQuery = {
   __typename?: 'RootQueryType';
   me: {
     __typename?: 'CurrentUser';
+    id: any;
     sandboxes: Array<{
       __typename?: 'Sandbox';
       id: string;
@@ -6281,6 +6308,7 @@ export type TeamQuery = {
   __typename?: 'RootQueryType';
   me: {
     __typename?: 'CurrentUser';
+    id: any;
     team: {
       __typename?: 'Team';
       id: any;

--- a/packages/app/src/app/overmind/effects/gql/dashboard/queries.ts
+++ b/packages/app/src/app/overmind/effects/gql/dashboard/queries.ts
@@ -7,8 +7,8 @@ import {
   SandboxesByPathQueryVariables,
   AllTeamsQuery,
   AllTeamsQueryVariables,
-  RecentlyAccessedSandboxesQuery,
-  RecentlyAccessedSandboxesQueryVariables,
+  RecentlyAccessedSandboxesLegacyQuery,
+  RecentlyAccessedSandboxesLegacyQueryVariables,
   AllCollectionsQuery,
   AllCollectionsQueryVariables,
   _SearchTeamSandboxesQuery,
@@ -21,8 +21,8 @@ import {
   GetTeamReposQuery,
   SharedWithMeSandboxesQuery,
   SharedWithMeSandboxesQueryVariables,
-  RecentlyAccessedBranchesQuery,
-  RecentlyAccessedBranchesQueryVariables,
+  RecentlyAccessedBranchesLegacyQuery,
+  RecentlyAccessedBranchesLegacyQueryVariables,
   ContributionBranchesQuery,
   ContributionBranchesQueryVariables,
   RepositoriesByTeamQuery,
@@ -66,6 +66,8 @@ export const deletedTeamSandboxes: Query<
 > = gql`
   query recentlyDeletedTeamSandboxes($teamId: UUID4!) {
     me {
+      id
+      
       team(id: $teamId) {
         sandboxes(
           showDeleted: true
@@ -85,6 +87,8 @@ export const sandboxesByPath: Query<
 > = gql`
   query SandboxesByPath($path: String!, $teamId: ID) {
     me {
+      id
+      
       collections(teamId: $teamId) {
         ...sidebarCollectionDashboard
       }
@@ -107,6 +111,8 @@ export const getTeamDrafts: Query<
 > = gql`
   query TeamDrafts($teamId: UUID4!, $authorId: UUID4) {
     me {
+      id
+      
       team(id: $teamId) {
         drafts(authorId: $authorId) {
           ...sandboxFragmentDashboard
@@ -123,6 +129,8 @@ export const getCollections: Query<
 > = gql`
   query AllCollections($teamId: ID) {
     me {
+      id
+      
       collections(teamId: $teamId) {
         ...sidebarCollectionDashboard
       }
@@ -137,6 +145,8 @@ export const getTeamRepos: Query<
 > = gql`
   query getTeamRepos($id: UUID4!) {
     me {
+      id
+      
       team(id: $id) {
         sandboxes(hasOriginalGit: true) {
           ...repoFragmentDashboard
@@ -153,6 +163,8 @@ export const teamTemplates: Query<
 > = gql`
   query TeamTemplates($id: UUID4!) {
     me {
+      id
+      
       team(id: $id) {
         id
         name
@@ -169,6 +181,8 @@ export const teamTemplates: Query<
 export const getTeams: Query<AllTeamsQuery, AllTeamsQueryVariables> = gql`
   query AllTeams {
     me {
+      id
+      
       primaryWorkspaceId
       workspaces {
         ...teamFragmentDashboard
@@ -184,6 +198,8 @@ export const searchTeamSandboxes: Query<
 > = gql`
   query _SearchTeamSandboxes($teamId: UUID4!) {
     me {
+      id
+      
       team(id: $teamId) {
         sandboxes(orderBy: { field: "updated_at", direction: DESC }) {
           ...sandboxFragmentDashboard
@@ -194,12 +210,19 @@ export const searchTeamSandboxes: Query<
   ${sandboxFragmentDashboard}
 `;
 
+/**
+ * @deprecated This query is being replaced by Apollo queries in the Recent page.
+ * Will be removed once migration is complete.
+ * See: packages/app/src/app/pages/Dashboard/Content/routes/Recent/queries.ts
+ */
 export const recentlyAccessedSandboxes: Query<
-  RecentlyAccessedSandboxesQuery,
-  RecentlyAccessedSandboxesQueryVariables
+  RecentlyAccessedSandboxesLegacyQuery,
+  RecentlyAccessedSandboxesLegacyQueryVariables
 > = gql`
-  query RecentlyAccessedSandboxes($limit: Int!, $teamId: UUID4) {
+  query RecentlyAccessedSandboxesLegacy($limit: Int!, $teamId: UUID4) {
     me {
+      id
+      
       recentlyAccessedSandboxes(limit: $limit, teamId: $teamId) {
         ...sandboxFragmentDashboard
       }
@@ -208,12 +231,19 @@ export const recentlyAccessedSandboxes: Query<
   ${sandboxFragmentDashboard}
 `;
 
+/**
+ * @deprecated This query is being replaced by Apollo queries in the Recent page.
+ * Will be removed once migration is complete.
+ * See: packages/app/src/app/pages/Dashboard/Content/routes/Recent/queries.ts
+ */
 export const recentlyAccessedBranches: Query<
-  RecentlyAccessedBranchesQuery,
-  RecentlyAccessedBranchesQueryVariables
+  RecentlyAccessedBranchesLegacyQuery,
+  RecentlyAccessedBranchesLegacyQueryVariables
 > = gql`
-  query RecentlyAccessedBranches($limit: Int!, $teamId: UUID4) {
+  query RecentlyAccessedBranchesLegacy($limit: Int!, $teamId: UUID4) {
     me {
+      id
+      
       recentBranches(limit: $limit, teamId: $teamId) {
         ...branch
       }
@@ -228,6 +258,8 @@ export const sharedWithmeSandboxes: Query<
 > = gql`
   query SharedWithMeSandboxes {
     me {
+      id
+      
       collaboratorSandboxes {
         ...sandboxFragmentDashboard
       }
@@ -239,6 +271,8 @@ export const sharedWithmeSandboxes: Query<
 export const getTeam: Query<GetTeamQuery, GetTeamQueryVariables> = gql`
   query getTeam($teamId: UUID4!) {
     me {
+      id
+      
       team(id: $teamId) {
         ...currentTeamInfoFragment
       }
@@ -253,6 +287,8 @@ export const getContributionBranches: Query<
 > = gql`
   query ContributionBranches {
     me {
+      id
+      
       recentBranches(contribution: true, limit: 1000) {
         ...branch
       }
@@ -267,6 +303,8 @@ export const getRepositoriesByTeam: Query<
 > = gql`
   query RepositoriesByTeam($teamId: UUID4!, $syncData: Boolean) {
     me {
+      id
+      
       team(id: $teamId) {
         id
         name
@@ -408,6 +446,8 @@ export const getEligibleWorkspaces: Query<
 > = gql`
   query GetEligibleWorkspaces {
     me {
+      id
+      
       eligibleWorkspaces {
         id
         avatarUrl

--- a/packages/app/src/app/overmind/effects/gql/notifications/queries.ts
+++ b/packages/app/src/app/overmind/effects/gql/notifications/queries.ts
@@ -14,6 +14,8 @@ export const getEmailPreferences: Query<
 > = gql`
   query EmailPreferences {
     me {
+      id
+      
       notificationPreferences {
         emailCommentMention
         emailCommentReply
@@ -34,6 +36,8 @@ export const getRecentNotifications: Query<
 > = gql`
   query RecentNotifications($type: [String]) {
     me {
+      id
+      
       notifications(
         limit: 20
         type: $type

--- a/packages/app/src/app/overmind/effects/gql/sidebar/queries.ts
+++ b/packages/app/src/app/overmind/effects/gql/sidebar/queries.ts
@@ -18,6 +18,8 @@ export const getTeamSidebarData: Query<
 > = gql`
   query TeamSidebarData($id: UUID4!) {
     me {
+      id
+      
       team(id: $id) {
         syncedSandboxes: sandboxes(hasOriginalGit: true) {
           ...sidebarSyncedSandboxFragment

--- a/packages/app/src/app/overmind/effects/gql/teams/queries.ts
+++ b/packages/app/src/app/overmind/effects/gql/teams/queries.ts
@@ -4,6 +4,8 @@ import { gql, Query } from 'overmind-graphql';
 export const teams: Query<TeamsQuery, TeamsQueryVariables> = gql`
   query Teams {
     me {
+      id
+      
       workspaces {
         id
         name

--- a/packages/app/src/app/pages/Dashboard/queries.ts
+++ b/packages/app/src/app/pages/Dashboard/queries.ts
@@ -81,6 +81,8 @@ const TEAM_FRAGMENT = gql`
 export const TEAMS_QUERY = gql`
   query TeamsSidebar {
     me {
+      id
+      
       teams {
         id
         name
@@ -92,6 +94,8 @@ export const TEAMS_QUERY = gql`
 export const PATHED_SANDBOXES_FOLDER_QUERY = gql`
   query PathedSandboxesFolders($teamId: ID) {
     me {
+      id
+      
       collections(teamId: $teamId) {
         ...SidebarCollection
       }
@@ -192,6 +196,8 @@ export const PERMANENTLY_DELETE_SANDBOXES_MUTATION = gql`
 export const PATHED_SANDBOXES_CONTENT_QUERY = gql`
   query PathedSandboxes($path: String!, $teamId: ID) {
     me {
+      id
+      
       collections(teamId: $teamId) {
         ...SidebarCollection
       }
@@ -211,6 +217,8 @@ export const PATHED_SANDBOXES_CONTENT_QUERY = gql`
 export const RECENT_SANDBOXES_CONTENT_QUERY = gql`
   query RecentSandboxes($orderField: String!, $orderDirection: Direction!) {
     me {
+      id
+      
       sandboxes(
         limit: 20
         orderBy: { field: $orderField, direction: $orderDirection }
@@ -225,6 +233,8 @@ export const RECENT_SANDBOXES_CONTENT_QUERY = gql`
 export const SEARCH_SANDBOXES_QUERY = gql`
   query SearchSandboxes {
     me {
+      id
+      
       sandboxes(orderBy: { field: "updated_at", direction: DESC }) {
         ...Sandbox
       }
@@ -236,6 +246,8 @@ export const SEARCH_SANDBOXES_QUERY = gql`
 export const DELETED_SANDBOXES_CONTENT_QUERY = gql`
   query DeletedSandboxes {
     me {
+      id
+      
       sandboxes(
         showDeleted: true
         orderBy: { field: "updated_at", direction: DESC }
@@ -407,6 +419,8 @@ export function setSandboxesPrivacy(
 export const TEAM_QUERY = gql`
   query Team($id: UUID4!) {
     me {
+      id
+      
       team(id: $id) {
         ...Team
       }

--- a/packages/app/src/app/pages/common/Modals/MoveSandboxFolderModal/DirectoryPicker/SandboxesItem/queries.ts
+++ b/packages/app/src/app/pages/common/Modals/MoveSandboxFolderModal/DirectoryPicker/SandboxesItem/queries.ts
@@ -10,6 +10,8 @@ const SIDEBAR_COLLECTION_FRAGMENT = gql`
 export const PATHED_SANDBOXES_FOLDER_QUERY = gql`
   query PathedSandboxesFolders($teamId: ID) {
     me {
+      id
+      
       collections(teamId: $teamId) {
         ...SidebarCollection
       }
@@ -55,6 +57,8 @@ export const SANDBOX_FRAGMENT = gql`
 export const PATHED_SANDBOXES_CONTENT_QUERY = gql`
   query PathedSandboxes($path: String!, $teamId: ID) {
     me {
+      id
+      
       collections(teamId: $teamId) {
         ...SidebarCollection
       }


### PR DESCRIPTION
Adds `id` fields to the `me` field for better caching. Also renamed the recent queries for a future refactor where we're able to remove a bunch of fields we're not using.