### PR TITLE
refactor(dashboard): create RECENT_SANDBOX fragment for recent sandboxes query

### DIFF
--- a/packages/app/src/app/graphql/types.ts
+++ b/packages/app/src/app/graphql/types.ts
@@ -6263,6 +6263,29 @@ export type PathedSandboxesQuery = {
   } | null;
 };
 
+export type RecentSandboxFragment = {
+  __typename?: 'Sandbox';
+  id: string;
+  alias: string | null;
+  title: string | null;
+  lastAccessedAt: any;
+  screenshotUrl: string | null;
+  privacy: number;
+  teamId: any | null;
+  source: { __typename?: 'Source'; template: string | null };
+  customTemplate: { __typename?: 'Template'; id: any | null } | null;
+  forkedTemplate: {
+    __typename?: 'Template';
+    id: any | null;
+    color: string | null;
+  } | null;
+  collection: {
+    __typename?: 'Collection';
+    path: string;
+    teamId: any | null;
+  } | null;
+};
+
 export type RecentSandboxesQueryVariables = Exact<{
   orderField: Scalars['String'];
   orderDirection: Direction;
@@ -6278,12 +6301,9 @@ export type RecentSandboxesQuery = {
       id: string;
       alias: string | null;
       title: string | null;
-      description: string | null;
-      insertedAt: string;
-      updatedAt: string;
-      removedAt: string | null;
-      privacy: number;
+      lastAccessedAt: any;
       screenshotUrl: string | null;
+      privacy: number;
       teamId: any | null;
       source: { __typename?: 'Source'; template: string | null };
       customTemplate: { __typename?: 'Template'; id: any | null } | null;

--- a/packages/app/src/app/pages/Dashboard/queries.ts
+++ b/packages/app/src/app/pages/Dashboard/queries.ts
@@ -214,6 +214,37 @@ export const PATHED_SANDBOXES_CONTENT_QUERY = gql`
   ${SIDEBAR_COLLECTION_FRAGMENT}
 `;
 
+const RECENT_SANDBOX_FRAGMENT = gql`
+  fragment RecentSandbox on Sandbox {
+    id
+    alias
+    title
+    lastAccessedAt
+    screenshotUrl
+    privacy
+
+    source {
+      template
+    }
+
+    customTemplate {
+      id
+    }
+
+    forkedTemplate {
+      id
+      color
+    }
+
+    collection {
+      path
+      teamId
+    }
+
+    teamId
+  }
+`;
+
 export const RECENT_SANDBOXES_CONTENT_QUERY = gql`
   query RecentSandboxes($orderField: String!, $orderDirection: Direction!) {
     me {
@@ -223,11 +254,11 @@ export const RECENT_SANDBOXES_CONTENT_QUERY = gql`
         limit: 20
         orderBy: { field: $orderField, direction: $orderDirection }
       ) {
-        ...Sandbox
+        ...RecentSandbox
       }
     }
   }
-  ${SANDBOX_FRAGMENT}
+  ${RECENT_SANDBOX_FRAGMENT}
 `;
 
 export const SEARCH_SANDBOXES_QUERY = gql`


### PR DESCRIPTION
- Created `RECENT_SANDBOX_FRAGMENT`
- Updated `RECENT_SANDBOXES_CONTENT_QUERY` and replaced `...Sandbox` with `...RecentSandbox` and changed the fragment reference from `${SANDBOX_FRAGMENT}` to `${RECENT_SANDBOX_FRAGMENT}`.