### PR TITLE
feat: add slimmed-down fragment for recently accessed sandboxes

### DIFF
--- a/packages/app/src/app/graphql/types.ts
+++ b/packages/app/src/app/graphql/types.ts
@@ -4807,6 +4807,37 @@ export type _SearchTeamSandboxesQuery = {
   } | null;
 };
 
+export type RecentlyAccessedSandboxFragment = {
+  __typename?: 'Sandbox';
+  id: string;
+  alias: string | null;
+  title: string | null;
+  lastAccessedAt: any;
+  privacy: number;
+  restricted: boolean;
+  draft: boolean;
+  isV2: boolean;
+  screenshotUrl: string | null;
+  source: { __typename?: 'Source'; template: string | null };
+  customTemplate: {
+    __typename?: 'Template';
+    id: any | null;
+    iconUrl: string | null;
+  } | null;
+  forkedTemplate: {
+    __typename?: 'Template';
+    id: any | null;
+    color: string | null;
+    iconUrl: string | null;
+  } | null;
+  collection: {
+    __typename?: 'Collection';
+    path: string;
+    id: any | null;
+  } | null;
+  author: { __typename?: 'User'; username: string } | null;
+};
+
 export type RecentlyAccessedSandboxesLegacyQueryVariables = Exact<{
   limit: Scalars['Int'];
   teamId: InputMaybe<Scalars['UUID4']>;
@@ -4822,21 +4853,12 @@ export type RecentlyAccessedSandboxesLegacyQuery = {
       id: string;
       alias: string | null;
       title: string | null;
-      description: string | null;
       lastAccessedAt: any;
-      insertedAt: string;
-      updatedAt: string;
-      removedAt: string | null;
       privacy: number;
-      isFrozen: boolean;
-      screenshotUrl: string | null;
-      viewCount: number;
-      likeCount: number;
-      isV2: boolean;
-      draft: boolean;
       restricted: boolean;
-      authorId: any | null;
-      teamId: any | null;
+      draft: boolean;
+      isV2: boolean;
+      screenshotUrl: string | null;
       source: { __typename?: 'Source'; template: string | null };
       customTemplate: {
         __typename?: 'Template';
@@ -4855,11 +4877,6 @@ export type RecentlyAccessedSandboxesLegacyQuery = {
         id: any | null;
       } | null;
       author: { __typename?: 'User'; username: string } | null;
-      permissions: {
-        __typename?: 'SandboxProtectionSettings';
-        preventSandboxLeaving: boolean;
-        preventSandboxExport: boolean;
-      } | null;
     }>;
   } | null;
 };

--- a/packages/app/src/app/overmind/effects/gql/dashboard/queries.ts
+++ b/packages/app/src/app/overmind/effects/gql/dashboard/queries.ts
@@ -47,7 +47,6 @@ import {
 import { gql, Query } from 'overmind-graphql';
 
 import {
-  sandboxFragmentDashboard,
   sidebarCollectionDashboard,
   templateFragmentDashboard,
   repoFragmentDashboard,
@@ -355,11 +354,44 @@ export const searchTeamSandboxes: Query<
   ${SEARCH_TEAM_SANDBOX_FRAGMENT}
 `;
 
-/**
- * @deprecated This query is being replaced by Apollo queries in the Recent page.
- * Will be removed once migration is complete.
- * See: packages/app/src/app/pages/Dashboard/Content/routes/Recent/queries.ts
- */
+const RECENTLY_ACCESSED_SANDBOX_FRAGMENT = gql`
+  fragment recentlyAccessedSandbox on Sandbox {
+    id
+    alias
+    title
+    lastAccessedAt
+    privacy
+    restricted
+    draft
+    isV2
+    screenshotUrl
+
+    source {
+      template
+    }
+
+    customTemplate {
+      id
+      iconUrl
+    }
+
+    forkedTemplate {
+      id
+      color
+      iconUrl
+    }
+
+    collection {
+      path
+      id
+    }
+
+    author {
+      username
+    }
+  }
+`;
+
 export const recentlyAccessedSandboxes: Query<
   RecentlyAccessedSandboxesLegacyQuery,
   RecentlyAccessedSandboxesLegacyQueryVariables
@@ -369,18 +401,13 @@ export const recentlyAccessedSandboxes: Query<
       id
       
       recentlyAccessedSandboxes(limit: $limit, teamId: $teamId) {
-        ...sandboxFragmentDashboard
+        ...recentlyAccessedSandbox
       }
     }
   }
-  ${sandboxFragmentDashboard}
+  ${RECENTLY_ACCESSED_SANDBOX_FRAGMENT}
 `;
 
-/**
- * @deprecated This query is being replaced by Apollo queries in the Recent page.
- * Will be removed once migration is complete.
- * See: packages/app/src/app/pages/Dashboard/Content/routes/Recent/queries.ts
- */
 export const recentlyAccessedBranches: Query<
   RecentlyAccessedBranchesLegacyQuery,
   RecentlyAccessedBranchesLegacyQueryVariables

--- a/packages/app/src/app/overmind/namespaces/dashboard/state.ts
+++ b/packages/app/src/app/overmind/namespaces/dashboard/state.ts
@@ -11,6 +11,7 @@ import {
   RecentlyDeletedTeamSandboxesFragment,
   SearchTeamSandboxFragment,
   CollaboratorSandboxFragment,
+  RecentlyAccessedSandboxFragment,
 } from 'app/graphql/types';
 import isSameWeek from 'date-fns/isSameWeek';
 import { sortBy } from 'lodash-es';
@@ -23,7 +24,7 @@ export type DashboardSandboxStructure = {
   DRAFTS: DraftSandboxFragment[] | null;
   TEMPLATES: Template[] | null;
   DELETED: RecentlyDeletedTeamSandboxesFragment[] | null;
-  RECENT_SANDBOXES: (Sandbox | DraftSandboxFragment)[] | null;
+  RECENT_SANDBOXES: (RecentlyAccessedSandboxFragment | DraftSandboxFragment)[] | null;
   RECENT_BRANCHES: Branch[] | null;
   SEARCH: (Sandbox | DraftSandboxFragment | SearchTeamSandboxFragment)[] | null;
   TEMPLATE_HOME: Template[] | null;

--- a/packages/app/src/app/overmind/namespaces/dashboard/types.ts
+++ b/packages/app/src/app/overmind/namespaces/dashboard/types.ts
@@ -5,6 +5,7 @@ import {
   DraftSandboxFragment,
   SearchTeamSandboxFragment,
   CollaboratorSandboxFragment,
+  RecentlyAccessedSandboxFragment,
 } from 'app/graphql/types';
 
 export type DashboardSandboxFragment =
@@ -12,7 +13,8 @@ export type DashboardSandboxFragment =
   | SandboxByPathFragment
   | DraftSandboxFragment
   | SearchTeamSandboxFragment
-  | CollaboratorSandboxFragment;
+  | CollaboratorSandboxFragment
+  | RecentlyAccessedSandboxFragment;
 
 export type PageTypes =
   | 'search'

--- a/packages/app/src/app/pages/Dashboard/types.ts
+++ b/packages/app/src/app/pages/Dashboard/types.ts
@@ -6,6 +6,7 @@ import {
   ProjectFragment as Repository,
   RecentlyDeletedTeamSandboxesFragment,
   DraftSandboxFragment,
+  RecentlyAccessedSandboxFragment,
 } from 'app/graphql/types';
 import { Context } from 'app/overmind';
 import {
@@ -29,7 +30,8 @@ export type DashboardSandbox = {
         originalGit?: RepoFragmentDashboardFragment['originalGit'];
       })
     | RecentlyDeletedTeamSandboxesFragment
-    | DraftSandboxFragment;
+    | DraftSandboxFragment
+    | RecentlyAccessedSandboxFragment;
   noDrag?: boolean;
 };
 


### PR DESCRIPTION
### Summary
Creates a minimal GraphQL fragment for `recentlyAccessedSandboxes`, removing fields not used on the Recent page.

### Changes
- **Created `RECENTLY_ACCESSED_SANDBOX_FRAGMENT`** colocated with the query (similar to `searchTeamSandboxes`)
- **Removed unused fields** from `sandboxFragmentDashboard`:
  - `description`, `insertedAt`, `updatedAt`, `removedAt`, `isFrozen`, `viewCount`, `likeCount`, `authorId`, `teamId`, `permissions`
- **Kept essential fields** for Recent page display:
  - `id`, `alias`, `title`, `lastAccessedAt`, `privacy`, `restricted`, `draft`, `isV2`, `screenshotUrl`
  - Template info (`source`, `customTemplate`, `forkedTemplate`)
  - `collection` and `author` for display
- **Updated TypeScript types** to include `RecentlyAccessedSandboxFragment` in:
  - `DashboardSandboxStructure.RECENT_SANDBOXES`
  - `DashboardSandbox` union type
  - `DashboardSandboxFragment` union type

### Impact
Reduces payload size for the recently accessed sandboxes query by fetching only fields used on the Recent page.