### PR TITLE
feat(dashboard): optimize collection queries

### DIFF
--- a/packages/app/src/app/graphql/types.ts
+++ b/packages/app/src/app/graphql/types.ts
@@ -3355,6 +3355,12 @@ export type RepositoryTeamsQuery = {
   }>;
 };
 
+export type CollectionBasicFragment = {
+  __typename?: 'Collection';
+  id: any | null;
+  path: string;
+};
+
 export type SandboxFragmentDashboardFragment = {
   __typename?: 'Sandbox';
   id: string;
@@ -3460,12 +3466,6 @@ export type RepoFragmentDashboardFragment = {
     preventSandboxLeaving: boolean;
     preventSandboxExport: boolean;
   } | null;
-};
-
-export type SidebarCollectionDashboardFragment = {
-  __typename?: 'Collection';
-  id: any | null;
-  path: string;
 };
 
 export type CollectionDashboardFragment = {
@@ -4508,11 +4508,11 @@ export type TeamDraftsQuery = {
   } | null;
 };
 
-export type AllCollectionsQueryVariables = Exact<{
+export type SidebarCollectionsQueryVariables = Exact<{
   teamId: InputMaybe<Scalars['ID']>;
 }>;
 
-export type AllCollectionsQuery = {
+export type SidebarCollectionsQuery = {
   __typename?: 'RootQueryType';
   me: {
     __typename?: 'CurrentUser';
@@ -5563,6 +5563,23 @@ export type RecentNotificationsQuery = {
   } | null;
 };
 
+export type ProfileCollectionsQueryVariables = Exact<{
+  teamId: InputMaybe<Scalars['ID']>;
+}>;
+
+export type ProfileCollectionsQuery = {
+  __typename?: 'RootQueryType';
+  me: {
+    __typename?: 'CurrentUser';
+    id: any;
+    collections: Array<{
+      __typename?: 'Collection';
+      id: any | null;
+      path: string;
+    }>;
+  } | null;
+};
+
 export type SidebarSyncedSandboxFragmentFragment = {
   __typename?: 'Sandbox';
   id: string;
@@ -5618,12 +5635,6 @@ export type TeamsQuery = {
     id: any;
     workspaces: Array<{ __typename?: 'Team'; id: any; name: string }>;
   } | null;
-};
-
-export type SidebarCollectionFragment = {
-  __typename?: 'Collection';
-  id: any | null;
-  path: string;
 };
 
 export type TeamFragment = {

--- a/packages/app/src/app/graphql/types.ts
+++ b/packages/app/src/app/graphql/types.ts
@@ -3466,6 +3466,12 @@ export type SidebarCollectionDashboardFragment = {
   __typename?: 'Collection';
   id: any | null;
   path: string;
+};
+
+export type CollectionDashboardFragment = {
+  __typename?: 'Collection';
+  id: any | null;
+  path: string;
   sandboxCount: number;
 };
 
@@ -4515,7 +4521,6 @@ export type AllCollectionsQuery = {
       __typename?: 'Collection';
       id: any | null;
       path: string;
-      sandboxCount: number;
     }>;
   } | null;
 };

--- a/packages/app/src/app/overmind/effects/gql/common/fragments.ts
+++ b/packages/app/src/app/overmind/effects/gql/common/fragments.ts
@@ -1,0 +1,19 @@
+import { gql } from 'overmind-graphql';
+
+/**
+ * Shared fragments used across multiple namespaces
+ * These fragments are not specific to a single namespace and can be reused
+ */
+
+/**
+ * Minimal collection fields - contains only id and path
+ * Used for navigation and folder structure display
+ * Optimized without sandboxCount to avoid query complexity
+ */
+export const COLLECTION_BASIC = gql`
+  fragment collectionBasic on Collection {
+    id
+    path
+  }
+`;
+

--- a/packages/app/src/app/overmind/effects/gql/dashboard/fragments.ts
+++ b/packages/app/src/app/overmind/effects/gql/dashboard/fragments.ts
@@ -76,17 +76,6 @@ export const repoFragmentDashboard = gql`
 `;
 
 /**
- * Fragment for sidebar collections - minimal fields needed for sidebar navigation
- * Optimized without sandboxCount to avoid query complexity
- */
-export const sidebarCollectionDashboard = gql`
-  fragment sidebarCollectionDashboard on Collection {
-    id
-    path
-  }
-`;
-
-/**
  * Fragment for general collection queries (content area, mutations, etc.)
  * Includes sandboxCount for display in content area
  */

--- a/packages/app/src/app/overmind/effects/gql/dashboard/fragments.ts
+++ b/packages/app/src/app/overmind/effects/gql/dashboard/fragments.ts
@@ -75,8 +75,23 @@ export const repoFragmentDashboard = gql`
   ${sandboxFragmentDashboard}
 `;
 
+/**
+ * Fragment for sidebar collections - minimal fields needed for sidebar navigation
+ * Optimized without sandboxCount to avoid query complexity
+ */
 export const sidebarCollectionDashboard = gql`
   fragment sidebarCollectionDashboard on Collection {
+    id
+    path
+  }
+`;
+
+/**
+ * Fragment for general collection queries (content area, mutations, etc.)
+ * Includes sandboxCount for display in content area
+ */
+export const collectionDashboard = gql`
+  fragment collectionDashboard on Collection {
     id
     path
     sandboxCount

--- a/packages/app/src/app/overmind/effects/gql/dashboard/mutations.ts
+++ b/packages/app/src/app/overmind/effects/gql/dashboard/mutations.ts
@@ -72,7 +72,7 @@ import { gql, Query } from 'overmind-graphql';
 
 import {
   teamFragmentDashboard,
-  sidebarCollectionDashboard,
+  collectionDashboard,
 } from './fragments';
 
 export const createTeam: Query<
@@ -93,10 +93,10 @@ export const createFolder: Query<
 > = gql`
   mutation createFolder($path: String!, $teamId: UUID4) {
     createCollection(path: $path, teamId: $teamId) {
-      ...sidebarCollectionDashboard
+      ...collectionDashboard
     }
   }
-  ${sidebarCollectionDashboard}
+  ${collectionDashboard}
 `;
 
 export const deleteFolder: Query<
@@ -105,10 +105,10 @@ export const deleteFolder: Query<
 > = gql`
   mutation deleteFolder($path: String!, $teamId: UUID4) {
     deleteCollection(path: $path, teamId: $teamId) {
-      ...sidebarCollectionDashboard
+      ...collectionDashboard
     }
   }
-  ${sidebarCollectionDashboard}
+  ${collectionDashboard}
 `;
 
 export const renameFolder: Query<
@@ -127,10 +127,10 @@ export const renameFolder: Query<
       teamId: $teamId
       newTeamId: $newTeamId
     ) {
-      ...sidebarCollectionDashboard
+      ...collectionDashboard
     }
   }
-  ${sidebarCollectionDashboard}
+  ${collectionDashboard}
 `;
 
 export const addSandboxToFolder: Query<

--- a/packages/app/src/app/overmind/effects/gql/dashboard/queries.ts
+++ b/packages/app/src/app/overmind/effects/gql/dashboard/queries.ts
@@ -50,6 +50,7 @@ import { gql, Query } from 'overmind-graphql';
 
 import {
   sidebarCollectionDashboard,
+  collectionDashboard,
   templateFragmentDashboard,
   repoFragmentDashboard,
   currentTeamInfoFragment,
@@ -154,7 +155,7 @@ export const sandboxesByPath: Query<
       id
       
       collections(teamId: $teamId) {
-        ...sidebarCollectionDashboard
+        ...collectionDashboard
       }
       collection(path: $path, teamId: $teamId) {
         id
@@ -166,7 +167,7 @@ export const sandboxesByPath: Query<
     }
   }
   ${SANDBOX_BY_PATH_FRAGMENT}
-  ${sidebarCollectionDashboard}
+  ${collectionDashboard}
 `;
 
 const DRAFT_SANDBOX_FRAGMENT = gql`

--- a/packages/app/src/app/overmind/effects/gql/dashboard/queries.ts
+++ b/packages/app/src/app/overmind/effects/gql/dashboard/queries.ts
@@ -9,8 +9,8 @@ import {
   AllTeamsQueryVariables,
   RecentlyAccessedSandboxesLegacyQuery,
   RecentlyAccessedSandboxesLegacyQueryVariables,
-  AllCollectionsQuery,
-  AllCollectionsQueryVariables,
+  SidebarCollectionsQuery,
+  SidebarCollectionsQueryVariables,
   _SearchTeamSandboxesQuery,
   _SearchTeamSandboxesQueryVariables,
   GetTeamQuery,
@@ -49,7 +49,6 @@ import {
 import { gql, Query } from 'overmind-graphql';
 
 import {
-  sidebarCollectionDashboard,
   collectionDashboard,
   templateFragmentDashboard,
   repoFragmentDashboard,
@@ -61,6 +60,7 @@ import {
   projectWithBranchesFragment,
   githubRepoFragment,
 } from './fragments';
+import { COLLECTION_BASIC } from '../common/fragments';
 
 const RECENTLY_DELETED_TEAM_SANDBOXES_FRAGMENT = gql`
 fragment recentlyDeletedTeamSandboxes on Sandbox {
@@ -236,20 +236,20 @@ export const getTeamDrafts: Query<
   ${DRAFT_SANDBOX_FRAGMENT}
 `;
 
-export const getCollections: Query<
-  AllCollectionsQuery,
-  AllCollectionsQueryVariables
+export const getSidebarCollections: Query<
+  SidebarCollectionsQuery,
+  SidebarCollectionsQueryVariables
 > = gql`
-  query AllCollections($teamId: ID) {
+  query SidebarCollections($teamId: ID) {
     me {
       id
       
       collections(teamId: $teamId) {
-        ...sidebarCollectionDashboard
+        ...collectionBasic
       }
     }
   }
-  ${sidebarCollectionDashboard}
+  ${COLLECTION_BASIC}
 `;
 
 export const getTeamRepos: Query<

--- a/packages/app/src/app/overmind/effects/gql/index.ts
+++ b/packages/app/src/app/overmind/effects/gql/index.ts
@@ -10,12 +10,15 @@ import * as sidebarQueries from './sidebar/queries';
 import * as notificationsQueries from './notifications/queries';
 import * as notificationsMutations from './notifications/mutations';
 
+import * as profileQueries from './profile/queries';
+
 export default graphql({
   queries: {
     ...teamsQueries,
     ...dashboardQueries,
     ...sidebarQueries,
     ...notificationsQueries,
+    ...profileQueries,
   },
   mutations: {
     ...dashboardMutations,

--- a/packages/app/src/app/overmind/effects/gql/profile/queries.ts
+++ b/packages/app/src/app/overmind/effects/gql/profile/queries.ts
@@ -1,0 +1,24 @@
+import {
+  ProfileCollectionsQuery,
+  ProfileCollectionsQueryVariables,
+} from 'app/graphql/types';
+import { gql, Query } from 'overmind-graphql';
+
+import { COLLECTION_BASIC } from '../common/fragments';
+
+export const getProfileCollections: Query<
+  ProfileCollectionsQuery,
+  ProfileCollectionsQueryVariables
+> = gql`
+  query ProfileCollections($teamId: ID) {
+    me {
+      id
+      
+      collections(teamId: $teamId) {
+        ...collectionBasic
+      }
+    }
+  }
+  ${COLLECTION_BASIC}
+`;
+

--- a/packages/app/src/app/overmind/namespaces/dashboard/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/dashboard/actions.ts
@@ -264,6 +264,21 @@ export const getSandboxesByPath = async (
     dashboard.sandboxes.ALL[cleanPath] = data.me.collection.sandboxes.filter(
       s => !s.customTemplate
     );
+
+    // Update sandboxCount in allCollections from the collections query result
+    // (which uses collectionDashboard fragment with sandboxCount)
+    if (dashboard.allCollections && data.me.collections) {
+      const collectionsMap = new Map(
+        data.me.collections.map((c: any) => [c.path, c.sandboxCount])
+      );
+      dashboard.allCollections = dashboard.allCollections.map(collection => {
+        const sandboxCount = collectionsMap.get(collection.path);
+        if (sandboxCount !== undefined) {
+          return { ...collection, sandboxCount };
+        }
+        return collection;
+      });
+    }
   } catch (error) {
     effects.notificationToast.error(
       'There was a problem getting your sandboxes'

--- a/packages/app/src/app/overmind/namespaces/dashboard/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/dashboard/actions.ts
@@ -148,7 +148,7 @@ export const getTeams = async ({ state, effects }: Context) => {
 
 export const getAllFolders = async ({ state, effects }: Context) => {
   try {
-    const data = await effects.gql.queries.getCollections({
+    const data = await effects.gql.queries.getSidebarCollections({
       teamId: state.activeTeam,
     });
     if (!data || !data.me || !data.me.collections) {
@@ -888,7 +888,7 @@ export const addSandboxesToFolder = async (
     f => f.path === collectionPath
   );
   if (existingCollection) {
-    existingCollection.sandboxCount += sandboxIds.length;
+    existingCollection.sandboxCount = (existingCollection.sandboxCount ?? 0) + sandboxIds.length;
   }
 
   if (teamId !== state.activeTeam) {

--- a/packages/app/src/app/overmind/namespaces/dashboard/types.ts
+++ b/packages/app/src/app/overmind/namespaces/dashboard/types.ts
@@ -1,5 +1,5 @@
 import {
-  SidebarCollectionDashboardFragment as Collection,
+  CollectionBasicFragment as Collection,
   SandboxFragmentDashboardFragment,
   SandboxByPathFragment,
   DraftSandboxFragment,

--- a/packages/app/src/app/overmind/namespaces/dashboard/types.ts
+++ b/packages/app/src/app/overmind/namespaces/dashboard/types.ts
@@ -40,6 +40,7 @@ export type DELETE_ME_COLLECTION = Collection & {
   name: string;
   level: number;
   parent: string;
+  sandboxCount: number;
 };
 
 export enum sandboxesTypes {

--- a/packages/app/src/app/overmind/namespaces/dashboard/types.ts
+++ b/packages/app/src/app/overmind/namespaces/dashboard/types.ts
@@ -40,7 +40,7 @@ export type DELETE_ME_COLLECTION = Collection & {
   name: string;
   level: number;
   parent: string;
-  sandboxCount: number;
+  sandboxCount?: number;
 };
 
 export enum sandboxesTypes {

--- a/packages/app/src/app/overmind/namespaces/dashboard/utils.ts
+++ b/packages/app/src/app/overmind/namespaces/dashboard/utils.ts
@@ -1,19 +1,20 @@
 import {
   BranchFragment,
   ProjectFragment,
-  SidebarCollectionDashboardFragment as Collection,
+  SidebarCollectionDashboardFragment,
+  CollectionDashboardFragment,
   BranchWithPrFragment,
 } from 'app/graphql/types';
 import { DELETE_ME_COLLECTION } from './types';
 
 export function getDecoratedCollection(
-  collection: Collection
+  collection: SidebarCollectionDashboardFragment | CollectionDashboardFragment
 ): DELETE_ME_COLLECTION {
   const split = collection.path.split('/');
   return {
     path: collection.path,
     id: collection.id,
-    sandboxCount: collection.sandboxCount,
+    sandboxCount: 'sandboxCount' in collection ? collection.sandboxCount : 0,
     parent: split[split.length - 2] || '',
     level: split.length - 2,
     name: split[split.length - 1],

--- a/packages/app/src/app/overmind/namespaces/dashboard/utils.ts
+++ b/packages/app/src/app/overmind/namespaces/dashboard/utils.ts
@@ -14,7 +14,7 @@ export function getDecoratedCollection(
   return {
     path: collection.path,
     id: collection.id,
-    sandboxCount: 'sandboxCount' in collection ? collection.sandboxCount : 0,
+    sandboxCount: 'sandboxCount' in collection ? collection.sandboxCount : undefined,
     parent: split[split.length - 2] || '',
     level: split.length - 2,
     name: split[split.length - 1],

--- a/packages/app/src/app/overmind/namespaces/dashboard/utils.ts
+++ b/packages/app/src/app/overmind/namespaces/dashboard/utils.ts
@@ -1,14 +1,14 @@
 import {
   BranchFragment,
   ProjectFragment,
-  SidebarCollectionDashboardFragment,
+  CollectionBasicFragment,
   CollectionDashboardFragment,
   BranchWithPrFragment,
 } from 'app/graphql/types';
 import { DELETE_ME_COLLECTION } from './types';
 
 export function getDecoratedCollection(
-  collection: SidebarCollectionDashboardFragment | CollectionDashboardFragment
+  collection: CollectionBasicFragment | CollectionDashboardFragment
 ): DELETE_ME_COLLECTION {
   const split = collection.path.split('/');
   return {

--- a/packages/app/src/app/overmind/namespaces/profile/actions.ts
+++ b/packages/app/src/app/overmind/namespaces/profile/actions.ts
@@ -554,7 +554,7 @@ export const fetchCollections = async ({ state, effects }: Context) => {
   if (!state.profile.current) return;
 
   try {
-    const data = await effects.gql.queries.getCollections({
+    const data = await effects.gql.queries.getProfileCollections({
       teamId: state.profile.current.personalWorkspaceId,
     });
     if (!data || !data.me || !data.me.collections) {

--- a/packages/app/src/app/overmind/namespaces/profile/state.ts
+++ b/packages/app/src/app/overmind/namespaces/profile/state.ts
@@ -8,10 +8,8 @@ import { Context } from 'app/overmind';
 import { derived } from 'overmind';
 import { SandboxType } from 'app/pages/Profile/constants';
 
-export type ProfileCollection = Pick<
-  Collection,
-  'id' | 'path' | 'sandboxCount'
-> & {
+export type ProfileCollection = Pick<Collection, 'id' | 'path'> & {
+  sandboxCount?: number;
   sandboxes: (CollectionSandbox | SandboxByPathFragment)[];
 };
 

--- a/packages/app/src/app/pages/Dashboard/Components/Folder/FolderCard.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Folder/FolderCard.tsx
@@ -6,6 +6,7 @@ import {
   Icon,
   IconButton,
   InteractiveOverlay,
+  SkeletonText,
 } from '@codesandbox/components';
 import { useWorkspaceAuthorization } from 'app/hooks/useWorkspaceAuthorization';
 import { FolderItemComponentProps } from './types';
@@ -38,6 +39,23 @@ export const FolderCard: React.FC<FolderItemComponentProps> = ({
   ...props
 }) => {
   const { hasEditorAccess } = useWorkspaceAuthorization();
+
+  const renderSandboxCount = () => {
+    if (isNewFolder) {
+      return null;
+    }
+
+    if (numberOfSandboxes === undefined) {
+      return <SkeletonText css={{ width: '60px', height: '12px' }} />;
+    }
+
+    return (
+      <Text size={12} variant="muted">
+        {numberOfSandboxes}{' '}
+        {numberOfSandboxes === 1 ? 'item' : 'items'}
+      </Text>
+    );
+  };
 
   return (
   <InteractiveOverlay>
@@ -94,12 +112,7 @@ export const FolderCard: React.FC<FolderItemComponentProps> = ({
             </Text>
           </InteractiveOverlay.Button>
         )}
-        {!isNewFolder ? (
-          <Text size={12} variant="muted">
-            {numberOfSandboxes || 0}{' '}
-            {numberOfSandboxes === 1 ? 'item' : 'items'}
-          </Text>
-        ) : null}
+        {renderSandboxCount()}
       </Stack>
     </StyledCard>
   </InteractiveOverlay>

--- a/packages/app/src/app/pages/Dashboard/Components/Folder/FolderListItem.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Folder/FolderListItem.tsx
@@ -8,6 +8,7 @@ import {
   IconButton,
   Grid,
   Column,
+  SkeletonText,
 } from '@codesandbox/components';
 import css from '@styled-system/css';
 import { FolderItemComponentProps } from './types';
@@ -41,6 +42,23 @@ export const FolderListItem = ({
   } else if (showDropStyles) {
     backgroundColor = 'list.hoverBackground';
   }
+
+  const renderSandboxCount = () => {
+    if (isNewFolder) {
+      return null;
+    }
+
+    if (numberOfSandboxes === undefined) {
+      return <SkeletonText css={{ width: '60px', height: '16px' }} />;
+    }
+    
+    return (
+      <Text size={3} block variant={selected ? 'body' : 'muted'}>
+        {numberOfSandboxes}{' '}
+        {numberOfSandboxes === 1 ? 'item' : 'items'}
+      </Text>
+    );
+  };
 
   return (
     <ListAction
@@ -106,12 +124,7 @@ export const FolderListItem = ({
           </Stack>
         </Column>
         <Column span={[0, 2, 3]} as={Stack} align="center">
-          {!isNewFolder ? (
-            <Text size={3} block variant={selected ? 'body' : 'muted'}>
-              {numberOfSandboxes || 0}{' '}
-              {numberOfSandboxes === 1 ? 'item' : 'items'}
-            </Text>
-          ) : null}
+          {renderSandboxCount()}
         </Column>
         <Column span={[0, 3, 3]} as={Stack} align="center">
           {/* empty column to align with sandbox list items */}

--- a/packages/app/src/app/pages/Dashboard/Components/Folder/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/Folder/index.tsx
@@ -24,7 +24,7 @@ export const Folder = (folderItem: DashboardFolder) => {
   const {
     name = '',
     path = null,
-    sandboxCount = 0,
+    sandboxCount,
     type,
     ...props
   } = folderItem;

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Search/searchItems.ts
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Search/searchItems.ts
@@ -1,7 +1,7 @@
 import {
   Collection,
   SandboxFragmentDashboardFragment,
-  SidebarCollectionDashboardFragment,
+  CollectionBasicFragment,
   ProjectFragment as Repository,
 } from 'app/graphql/types';
 import { useAppState, useActions } from 'app/overmind';
@@ -11,7 +11,7 @@ import { sandboxesTypes } from 'app/overmind/namespaces/dashboard/types';
 
 type DashboardItem =
   | SandboxFragmentDashboardFragment
-  | SidebarCollectionDashboardFragment;
+  | CollectionBasicFragment;
 
 // Type guard to check if an item is a sandbox
 function isSandbox(

--- a/packages/app/src/app/pages/Dashboard/queries.ts
+++ b/packages/app/src/app/pages/Dashboard/queries.ts
@@ -1,12 +1,6 @@
 import { client } from 'app/graphql/client';
 import gql from 'graphql-tag';
-
-const SIDEBAR_COLLECTION_FRAGMENT = gql`
-  fragment SidebarCollection on Collection {
-    id
-    path
-  }
-`;
+import { COLLECTION_BASIC } from 'app/overmind/effects/gql/common/fragments';
 
 const TEAM_FRAGMENT = gql`
   fragment Team on Team {
@@ -50,29 +44,29 @@ export const PATHED_SANDBOXES_FOLDER_QUERY = gql`
       id
       
       collections(teamId: $teamId) {
-        ...SidebarCollection
+        ...collectionBasic
       }
     }
   }
-  ${SIDEBAR_COLLECTION_FRAGMENT}
+  ${COLLECTION_BASIC}
 `;
 
 export const CREATE_FOLDER_MUTATION = gql`
   mutation createCollection($path: String!, $teamId: UUID4) {
     createCollection(path: $path, teamId: $teamId) {
-      ...SidebarCollection
+      ...collectionBasic
     }
   }
-  ${SIDEBAR_COLLECTION_FRAGMENT}
+  ${COLLECTION_BASIC}
 `;
 
 export const DELETE_FOLDER_MUTATION = gql`
   mutation deleteCollection($path: String!, $teamId: UUID4) {
     deleteCollection(path: $path, teamId: $teamId) {
-      ...SidebarCollection
+      ...collectionBasic
     }
   }
-  ${SIDEBAR_COLLECTION_FRAGMENT}
+  ${COLLECTION_BASIC}
 `;
 
 export const RENAME_FOLDER_MUTATION = gql`
@@ -88,10 +82,10 @@ export const RENAME_FOLDER_MUTATION = gql`
       teamId: $teamId
       newTeamId: $newTeamId
     ) {
-      ...SidebarCollection
+      ...collectionBasic
     }
   }
-  ${SIDEBAR_COLLECTION_FRAGMENT}
+  ${COLLECTION_BASIC}
 `;
 
 export const ADD_SANDBOXES_TO_FOLDER_MUTATION = gql`

--- a/packages/app/src/app/pages/common/Modals/MoveSandboxFolderModal/DirectoryPicker/SandboxesItem/queries.ts
+++ b/packages/app/src/app/pages/common/Modals/MoveSandboxFolderModal/DirectoryPicker/SandboxesItem/queries.ts
@@ -1,11 +1,5 @@
 import gql from 'graphql-tag';
-
-const SIDEBAR_COLLECTION_FRAGMENT = gql`
-  fragment SidebarCollection on Collection {
-    id
-    path
-  }
-`;
+import { COLLECTION_BASIC } from 'app/overmind/effects/gql/common/fragments';
 
 export const PATHED_SANDBOXES_FOLDER_QUERY = gql`
   query PathedSandboxesFolders($teamId: ID) {
@@ -13,29 +7,29 @@ export const PATHED_SANDBOXES_FOLDER_QUERY = gql`
       id
       
       collections(teamId: $teamId) {
-        ...SidebarCollection
+        ...collectionBasic
       }
     }
   }
-  ${SIDEBAR_COLLECTION_FRAGMENT}
+  ${COLLECTION_BASIC}
 `;
 
 export const CREATE_FOLDER_MUTATION = gql`
   mutation createCollection($path: String!, $teamId: UUID4) {
     createCollection(path: $path, teamId: $teamId) {
-      ...SidebarCollection
+      ...collectionBasic
     }
   }
-  ${SIDEBAR_COLLECTION_FRAGMENT}
+  ${COLLECTION_BASIC}
 `;
 
 export const DELETE_FOLDER_MUTATION = gql`
   mutation deleteCollection($path: String!, $teamId: UUID4) {
     deleteCollection(path: $path, teamId: $teamId) {
-      ...SidebarCollection
+      ...collectionBasic
     }
   }
-  ${SIDEBAR_COLLECTION_FRAGMENT}
+  ${COLLECTION_BASIC}
 `;
 
 export const RENAME_FOLDER_MUTATION = gql`
@@ -51,8 +45,8 @@ export const RENAME_FOLDER_MUTATION = gql`
       teamId: $teamId
       newTeamId: $newTeamId
     ) {
-      ...SidebarCollection
+      ...collectionBasic
     }
   }
-  ${SIDEBAR_COLLECTION_FRAGMENT}
+  ${COLLECTION_BASIC}
 `;


### PR DESCRIPTION
Optimizes collection queries by conditionally fetching sandboxCount and shows skeleton loader during loading state. Separates sidebar and profile collections queries for better semantic clarity and consolidates duplicate fragments.

**Query Optimization:**
- `AllCollections` query (used by sidebar) uses `sidebarCollectionDashboard` fragment without `sandboxCount` to reduce query complexity
- Content area queries (`SandboxesByPath`) use `collectionDashboard` fragment with `sandboxCount` when needed
- Mutations use `collectionDashboard` fragment to return updated counts

**Query Separation:**
- Split `getCollections` into `getSidebarCollections` (dashboard) and `getProfileCollections` (profile)
- Created `common/fragments.ts` for shared fragments used across multiple namespaces
- Consolidated three duplicate fragments (`sidebarCollectionDashboard`, `SidebarCollection` in Dashboard/queries.ts, and `SidebarCollection` in MoveSandboxFolderModal) into single `COLLECTION_BASIC` fragment
- Fragment naming follows upper snake case convention (`COLLECTION_BASIC`)

**UI Improvements:**
- Shows skeleton loader instead of "0 items" when sandbox count is still being fetched
- Distinguishes between loading state (undefined) and actually having 0 items
- `sandboxCount` is now optional in `DELETE_ME_COLLECTION` type
- `getSandboxesByPath` updates `allCollections` with `sandboxCount` from query results

