### PR TITLE
Split TeamSidebarData query to reduce complexity

### DIFF
--- a/packages/app/src/app/graphql/types.ts
+++ b/packages/app/src/app/graphql/types.ts
@@ -5600,11 +5600,11 @@ export type SidebarProjectFragmentFragment = {
   };
 };
 
-export type TeamSidebarDataQueryVariables = Exact<{
+export type TeamSidebarFlagsQueryVariables = Exact<{
   id: Scalars['UUID4'];
 }>;
 
-export type TeamSidebarDataQuery = {
+export type TeamSidebarFlagsQuery = {
   __typename?: 'RootQueryType';
   me: {
     __typename?: 'CurrentUser';
@@ -5613,6 +5613,21 @@ export type TeamSidebarDataQuery = {
       __typename?: 'Team';
       syncedSandboxes: Array<{ __typename?: 'Sandbox'; id: string }>;
       templates: Array<{ __typename?: 'Template'; id: any | null }>;
+    } | null;
+  } | null;
+};
+
+export type TeamSidebarProjectsQueryVariables = Exact<{
+  id: Scalars['UUID4'];
+}>;
+
+export type TeamSidebarProjectsQuery = {
+  __typename?: 'RootQueryType';
+  me: {
+    __typename?: 'CurrentUser';
+    id: any;
+    team: {
+      __typename?: 'Team';
       projects: Array<{
         __typename?: 'Project';
         repository: {

--- a/packages/app/src/app/overmind/effects/gql/sidebar/queries.ts
+++ b/packages/app/src/app/overmind/effects/gql/sidebar/queries.ts
@@ -1,38 +1,53 @@
 import { gql, Query } from 'overmind-graphql';
 
 import {
-  TeamSidebarDataQuery,
-  TeamSidebarDataQueryVariables,
+  TeamSidebarFlagsQuery,
+  TeamSidebarFlagsQueryVariables,
+  TeamSidebarProjectsQuery,
+  TeamSidebarProjectsQueryVariables,
 } from 'app/graphql/types';
 
 import {
   sidebarProjectFragment,
-  sidebarSyncedSandboxFragment,
-  sidebarTemplateFragment,
 } from './fragments';
 
-export const getTeamSidebarData: Query<
-  TeamSidebarDataQuery,
-  TeamSidebarDataQueryVariables
+// Lightweight query for checking sidebar flags (hasSyncedSandboxes, hasTemplates)
+// Uses inline fields instead of fragments to minimize GraphQL overhead
+export const getTeamSidebarFlags: Query<
+  TeamSidebarFlagsQuery,
+  TeamSidebarFlagsQueryVariables
 > = gql`
-  query TeamSidebarData($id: UUID4!) {
+  query TeamSidebarFlags($id: UUID4!) {
     me {
       id
       
       team(id: $id) {
         syncedSandboxes: sandboxes(hasOriginalGit: true, limit: 1) {
-          ...sidebarSyncedSandboxFragment
+          id
         }
         templates {
-          ...sidebarTemplateFragment
+          id
         }
+      }
+    }
+  }
+`;
+
+// Separate query for projects to reduce query complexity
+export const getTeamSidebarProjects: Query<
+  TeamSidebarProjectsQuery,
+  TeamSidebarProjectsQueryVariables
+> = gql`
+  query TeamSidebarProjects($id: UUID4!) {
+    me {
+      id
+      
+      team(id: $id) {
         projects(syncData: false) {
           ...sidebarProjectFragment
         }
       }
     }
   }
-  ${sidebarSyncedSandboxFragment}
-  ${sidebarTemplateFragment}
   ${sidebarProjectFragment}
 `;


### PR DESCRIPTION
Splits the TeamSidebarData query into two separate queries (TeamSidebarFlags and TeamSidebarProjects) to prevent 'query too complex' errors when teams have many templates or projects.