### PR TITLE
fix(queries): optimize RecentAndWorkspaceTemplates query

### DIFF
--- a/packages/app/src/app/components/Create/hooks/useTeamTemplates.ts
+++ b/packages/app/src/app/components/Create/hooks/useTeamTemplates.ts
@@ -33,7 +33,7 @@ type State = BaseState &
   );
 
 type UseTeamTemplatesParams = {
-  teamId: string;
+  teamId: string | null;
   hasLogIn: boolean;
 };
 
@@ -42,6 +42,7 @@ export const useTeamTemplates = ({
   hasLogIn,
 }: UseTeamTemplatesParams): State => {
   const skip = !hasLogIn;
+  const skipTeamTemplates = skip || !teamId; // Skip team templates if no teamId
 
   const {
     data: recentData,
@@ -62,9 +63,9 @@ export const useTeamTemplates = ({
     TeamTemplatesForCreateQuery,
     TeamTemplatesForCreateQueryVariables
   >(FETCH_TEAM_TEMPLATES, {
-    variables: { id: teamId },
+    variables: { id: teamId! }, // Safe to use ! here since we skip when teamId is null
     fetchPolicy: 'cache-and-network',
-    skip,
+    skip: skipTeamTemplates,
   });
 
   if (skip) {

--- a/packages/app/src/app/components/Create/utils/queries.ts
+++ b/packages/app/src/app/components/Create/utils/queries.ts
@@ -2,27 +2,18 @@ import gql from 'graphql-tag';
 
 const TEMPLATE_FRAGMENT = gql`
   fragment Template on Template {
-    id
-    color
     iconUrl
-    published
     sandbox {
       id
       alias
       title
       description
-      insertedAt
-      updatedAt
       isV2
       forkCount
       viewCount
 
       team {
         name
-      }
-
-      author {
-        username
       }
 
       source {
@@ -32,16 +23,26 @@ const TEMPLATE_FRAGMENT = gql`
   }
 `;
 
-export const FETCH_TEAM_TEMPLATES = gql`
-  query RecentAndWorkspaceTemplates($teamId: UUID4) {
+export const FETCH_RECENT_TEMPLATES = gql`
+  query RecentTemplates($teamId: UUID4) {
     me {
       id
       
       recentlyUsedTemplates(teamId: $teamId) {
         ...Template
       }
+    }
+  }
 
-      team(id: $teamId) {
+  ${TEMPLATE_FRAGMENT}
+`;
+
+export const FETCH_TEAM_TEMPLATES = gql`
+  query TeamTemplatesForCreate($id: UUID4!) {
+    me {
+      id
+      
+      team(id: $id) {
         templates {
           ...Template
         }

--- a/packages/app/src/app/graphql/types.ts
+++ b/packages/app/src/app/graphql/types.ts
@@ -3205,79 +3205,73 @@ export type TeamSubscriptionEvent = {
 
 export type TemplateFragment = {
   __typename?: 'Template';
-  id: any | null;
-  color: string | null;
   iconUrl: string | null;
-  published: boolean | null;
   sandbox: {
     __typename?: 'Sandbox';
     id: string;
     alias: string | null;
     title: string | null;
     description: string | null;
-    insertedAt: string;
-    updatedAt: string;
     isV2: boolean;
     forkCount: number;
     viewCount: number;
     team: { __typename?: 'TeamPreview'; name: string } | null;
-    author: { __typename?: 'User'; username: string } | null;
     source: { __typename?: 'Source'; template: string | null };
   } | null;
 };
 
-export type RecentAndWorkspaceTemplatesQueryVariables = Exact<{
+export type RecentTemplatesQueryVariables = Exact<{
   teamId: InputMaybe<Scalars['UUID4']>;
 }>;
 
-export type RecentAndWorkspaceTemplatesQuery = {
+export type RecentTemplatesQuery = {
   __typename?: 'RootQueryType';
   me: {
     __typename?: 'CurrentUser';
     id: any;
     recentlyUsedTemplates: Array<{
       __typename?: 'Template';
-      id: any | null;
-      color: string | null;
       iconUrl: string | null;
-      published: boolean | null;
       sandbox: {
         __typename?: 'Sandbox';
         id: string;
         alias: string | null;
         title: string | null;
         description: string | null;
-        insertedAt: string;
-        updatedAt: string;
         isV2: boolean;
         forkCount: number;
         viewCount: number;
         team: { __typename?: 'TeamPreview'; name: string } | null;
-        author: { __typename?: 'User'; username: string } | null;
         source: { __typename?: 'Source'; template: string | null };
       } | null;
     }>;
+  } | null;
+};
+
+export type TeamTemplatesForCreateQueryVariables = Exact<{
+  id: Scalars['UUID4'];
+}>;
+
+export type TeamTemplatesForCreateQuery = {
+  __typename?: 'RootQueryType';
+  me: {
+    __typename?: 'CurrentUser';
+    id: any;
     team: {
       __typename?: 'Team';
       templates: Array<{
         __typename?: 'Template';
-        id: any | null;
-        color: string | null;
         iconUrl: string | null;
-        published: boolean | null;
         sandbox: {
           __typename?: 'Sandbox';
           id: string;
           alias: string | null;
           title: string | null;
           description: string | null;
-          insertedAt: string;
-          updatedAt: string;
           isV2: boolean;
           forkCount: number;
           viewCount: number;
           team: { __typename?: 'TeamPreview'; name: string } | null;
-          author: { __typename?: 'User'; username: string } | null;
           source: { __typename?: 'Source'; template: string | null };
         } | null;
       }>;

--- a/packages/app/src/app/overmind/effects/api/index.ts
+++ b/packages/app/src/app/overmind/effects/api/index.ts
@@ -162,7 +162,7 @@ export default {
     return api.delete(`/users/current_user/integrations/github`);
   },
   preloadTeamTemplates(teamId: string) {
-    client.query({ query: FETCH_TEAM_TEMPLATES, variables: { teamId } });
+    client.query({ query: FETCH_TEAM_TEMPLATES, variables: { id: teamId } });
   },
   deleteTemplate(
     sandboxId: string,


### PR DESCRIPTION
Splits the complex query into two separate queries (RecentTemplates and TeamTemplatesForCreate) and removes unused fields to reduce query complexity and prevent 'query too complex' errors.