### PR TITLE
feat(dashboard): remove repositories feature from dashboard UI

### DIFF
--- a/packages/app/src/app/pages/Dashboard/Components/shared/RepositoriesRemovedStripe.tsx
+++ b/packages/app/src/app/pages/Dashboard/Components/shared/RepositoriesRemovedStripe.tsx
@@ -1,0 +1,19 @@
+import { MessageStripe } from '@codesandbox/components';
+import React from 'react';
+
+export const RepositoriesRemovedStripe: React.FC = () => {
+  return (
+    <MessageStripe justify="space-between" variant="warning">
+      The repositories product has been removed since July 15th and is no longer
+      available in the dashboard.
+      <MessageStripe.Action
+        as="a"
+        href="https://codesandbox.io/docs/learn/repositories/migration-guide"
+        target="_blank"
+        rel="noreferrer noopener"
+      >
+        Migration guide
+      </MessageStripe.Action>
+    </MessageStripe>
+  );
+};

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Recent/EmptyCTAs.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Recent/EmptyCTAs.tsx
@@ -19,16 +19,6 @@ export const EmptyCTAs: React.FC<{ isFrozen: boolean }> = ({ isFrozen }) => {
         >
           Explore templates
         </Button>
-        <Button
-          onClick={() => {
-            actions.modalOpened({ modal: 'import' });
-          }}
-          disabled={isFrozen}
-          variant="secondary"
-          autoWidth
-        >
-          Import repository
-        </Button>
       </Stack>
     </Stack>
   );

--- a/packages/app/src/app/pages/Dashboard/Content/routes/Recent/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Content/routes/Recent/index.tsx
@@ -2,14 +2,13 @@ import React, { useEffect } from 'react';
 import { useAppState, useActions } from 'app/overmind';
 import { sandboxesTypes } from 'app/overmind/namespaces/dashboard/types';
 import { Helmet } from 'react-helmet';
-import { DashboardBranch, DashboardSandbox } from 'app/pages/Dashboard/types';
+import { DashboardSandbox } from 'app/pages/Dashboard/types';
 import { Loading, Stack } from '@codesandbox/components';
-import { RepoInfo } from 'app/overmind/namespaces/sidebar/types';
 import { StyledContentWrapper } from 'app/pages/Dashboard/Components/shared/elements';
 import { ContentSection } from 'app/pages/Dashboard/Components/shared/ContentSection';
+import { RepositoriesRemovedStripe } from 'app/pages/Dashboard/Components/shared/RepositoriesRemovedStripe';
 import { useWorkspaceLimits } from 'app/hooks/useWorkspaceLimits';
 import { TopBanner } from './TopBanner';
-import { CreateBranchesRow } from './CreateBranchesRow';
 import { ItemsGrid } from './ItemsGrid';
 import { EmptyCTAs } from './EmptyCTAs';
 
@@ -71,59 +70,27 @@ export const Recent = () => {
     );
   }
 
-  const recentItems: (DashboardSandbox | DashboardBranch)[] = [
-    ...(sandboxes.RECENT_SANDBOXES || []).map(sandbox => ({
+  // Repositories have been removed from the dashboard (deprecated July 15th),
+  // so "Pick up where you left off" only shows sandboxes/devboxes and excludes
+  // any repository branches.
+  const recentItems: DashboardSandbox[] = (sandboxes.RECENT_SANDBOXES || [])
+    .map(sandbox => ({
       type: 'sandbox' as const,
       sandbox,
-    })),
-    ...(sandboxes.RECENT_BRANCHES || []).map(branch => ({
-      type: 'branch' as const,
-      branch,
-    })),
-  ]
-    .sort((a, b) => {
-      const dateA =
-        a.type === 'branch'
-          ? a.branch.lastAccessedAt
-          : a.sandbox.lastAccessedAt;
-      const dateB =
-        b.type === 'branch'
-          ? b.branch.lastAccessedAt
-          : b.sandbox.lastAccessedAt;
-
-      return new Date(dateA) < new Date(dateB) ? 1 : -1;
-      // Merge the two data sources and show only the first 18 most recent entries
-    })
+    }))
+    .sort((a, b) =>
+      new Date(a.sandbox.lastAccessedAt) < new Date(b.sandbox.lastAccessedAt)
+        ? 1
+        : -1
+    )
+    // Show only the first 18 most recent entries
     .slice(0, 18);
 
-  const recentBranches = recentItems.filter(
-    item => item.type === 'branch'
-  ) as DashboardBranch[];
-
-  const recentRepos: RepoInfo[] = recentBranches
-    .map(br => ({
-      owner: br.branch.project.repository.owner,
-      name: br.branch.project.repository.name,
-      defaultBranch: br.branch.project.repository.defaultBranch,
-    }))
-    .reduce((acc, repo) => {
-      if (!acc.some(r => r.owner === repo.owner && r.name === repo.name)) {
-        acc.push(repo);
-      }
-      return acc;
-    }, []);
-
-  const allWorkspaceRepos = sidebar[activeTeam]?.repositories || [];
-  const otherRepos = allWorkspaceRepos.filter(
-    wr => !recentRepos.find(r => r.owner === wr.owner && r.name === wr.name)
-  );
+  // Used to surface the removal banner to anyone who still has imported repos.
+  const hasRepositories = (sidebar[activeTeam]?.repositories || []).length > 0;
 
   // Filter out sandboxes that are already in recentItems
-  const recentSandboxIds = new Set(
-    recentItems
-      .filter((item): item is DashboardSandbox => item.type === 'sandbox')
-      .map(item => item.sandbox.id)
-  );
+  const recentSandboxIds = new Set(recentItems.map(item => item.sandbox.id));
 
   const otherSandboxes: DashboardSandbox[] = (
     sandboxes.WORKSPACE_SANDBOXES || []
@@ -143,16 +110,9 @@ export const Recent = () => {
 
       <TopBanner />
 
-      <ContentSection title="Recent">
-        {recentRepos.length > 0 && (
-          <CreateBranchesRow
-            title="Create a new branch"
-            isFrozen={isFrozen}
-            repos={recentRepos}
-            trackEvent="Recent Page - Repositories - Create new branch"
-          />
-        )}
+      {hasRepositories && <RepositoriesRemovedStripe />}
 
+      <ContentSection title="Recent">
         {recentItems.length > 0 ? (
           <ItemsGrid
             title="Pick up where you left off"
@@ -166,18 +126,9 @@ export const Recent = () => {
       </ContentSection>
 
       {recentItems.length === 0 &&
-        otherRepos.length > 0 &&
+        hasRepositories &&
         otherSandboxes.length > 0 && (
           <ContentSection title="Explore workspace activity">
-            {otherRepos.length > 0 && (
-              <CreateBranchesRow
-                title="Create a branch from a workspace repository"
-                repos={otherRepos}
-                isFrozen={isFrozen}
-                trackEvent="Recent Page - Explore workspace - Create new branch"
-              />
-            )}
-
             {otherSandboxes.length > 0 && (
               <ItemsGrid
                 title="Open a workspace Sandbox or Devbox"

--- a/packages/app/src/app/pages/Dashboard/Header/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Header/index.tsx
@@ -11,7 +11,6 @@ import { UserMenu } from 'app/pages/common/UserMenu';
 
 import { Notifications } from 'app/components/Notifications';
 import { dashboard as dashboardUrls } from '@codesandbox/common/lib/utils/url-generator';
-import { useWorkspaceLimits } from 'app/hooks/useWorkspaceLimits';
 import { TeamAvatar } from 'app/components/TeamAvatar';
 import { WorkspaceSelect } from 'app/components/WorkspaceSelect';
 import { SkeletonTextBlock } from 'app/components/Skeleton/elements';
@@ -24,7 +23,6 @@ export const Header: React.FC<HeaderProps> = React.memo(
   ({ onSidebarToggle }) => {
     const history = useHistory();
     const actions = useActions();
-    const { isFrozen } = useWorkspaceLimits();
     const {
       activeWorkspaceAuthorization,
       hasLogIn,
@@ -96,19 +94,6 @@ export const Header: React.FC<HeaderProps> = React.memo(
 
         <Stack align="center" gap={2}>
           <SearchInputGroup />
-          <Button
-            variant="secondary"
-            disabled={activeWorkspaceAuthorization === 'READ' || isFrozen}
-            onClick={() => {
-              track('Dashboard - Topbar - Import');
-              actions.modalOpened({ modal: 'import' });
-            }}
-            autoWidth
-          >
-            <Icon name="github" size={16} css={{ marginRight: '4px' }} />
-            Import
-          </Button>
-
           <Button
             variant="primary"
             disabled={activeWorkspaceAuthorization === 'READ'}

--- a/packages/app/src/app/pages/Dashboard/Sidebar/index.tsx
+++ b/packages/app/src/app/pages/Dashboard/Sidebar/index.tsx
@@ -76,7 +76,8 @@ export const Sidebar: React.FC<SidebarProps> = ({
     setNewFolderPath,
   };
 
-  const showRespositories = !state.environment.isOnPrem;
+  // Repositories have been removed from the dashboard (deprecated July 15th).
+  const showRespositories = false;
 
   const { ubbBeta } = useWorkspaceFeatureFlags();
   const { isPrimarySpace, hasAdminAccess, hasEditorAccess } = useWorkspaceAuthorization();


### PR DESCRIPTION
## Summary

The repositories product is being retired. This PR makes it inaccessible from the dashboard UI **without removing the underlying code** (the `/dashboard/repositories` route, import modal, and related components remain in place, just unlinked).

### Changes
- **Remove the Import button** — deleted the topbar "Import" button (`Header`) and the empty-recents "Import repository" button (`EmptyCTAs`).
- **Remove Repositories from the left sidebar** — `showRespositories = false` hides the "Repositories" section header, the all-repositories/expandable list, and "My contributions".
- **Remove "Create a new branch" from Recents** — dropped both `CreateBranchesRow` carousels.
- **Filter branches/repos out of "Pick up where you left off"** — `recentItems` is now built from `RECENT_SANDBOXES` only, so the grid shows only sandboxes/devboxes.
- **Removal banner** — new `RepositoriesRemovedStripe` shown at the top of the Recent page, gated on the workspace still having at least one imported repository (`sidebar[activeTeam].repositories.length > 0`).

### Notes
- Underlying code is intentionally preserved per the requirement to only make the feature inaccessible.
- `getSidebarData` still populates the repositories list independently of the sidebar UI, so banner detection continues to work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)